### PR TITLE
fix: rename global.css to globals.css and update import to prevent build errors and warnings

### DIFF
--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 :root {
     --primary-100: #fdecec;


### PR DESCRIPTION
This PR renames global.css to globals.css so the existing import in layout.tsx works correctly, and updates the CSS import syntax to avoid warnings. Could you review this small fix @kckagancan @gulcetahtasiz ?