### PR TITLE
fix: replace hardcoded colors with tailwind classes

### DIFF
--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -9,13 +9,13 @@ type AppShellProps = {
 
 export function AppShell({ title, children }: AppShellProps) {
     return (
-        <div className="min-h-screen bg-[#F8F8F9]">
+        <div className="min-h-screen bg-gray-50">
             <TopNavbar />
             <main className="py-8">
                 <PageContainer>
                     {title ? (
                         <div className="mb-6">
-                            <h1 className="text-3xl font-bold text-[#2B2B33]">{title}</h1>
+                            <h1 className="text-3xl font-bold text-gray-800">{title}</h1>
                         </div>
                     ) : null}
                     {children}

--- a/web/src/components/layout/AuthLayout.tsx
+++ b/web/src/components/layout/AuthLayout.tsx
@@ -10,16 +10,16 @@ type AuthLayoutProps = {
 
 export function AuthLayout({ title, subtitle, children }: AuthLayoutProps) {
     return (
-        <div className="min-h-screen bg-[#F8F8F9]">
+        <div className="min-h-screen bg-gray-50]">
             <PageContainer className="flex min-h-screen items-center justify-center py-10">
                 <AuthCard>
                     <div className="mb-6 flex flex-col items-center text-center">
-                        <div className="mb-4 text-2xl font-bold text-[#D84A4A]">NEPH</div>
+                        <div className="mb-4 text-2xl font-bold text-red-500">NEPH</div>
                         {title ? (
-                            <h1 className="text-3xl font-bold text-[#2B2B33]">{title}</h1>
+                            <h1 className="text-3xl font-bold text-gray-800">{title}</h1>
                         ) : null}
                         {subtitle ? (
-                            <p className="mt-2 text-sm text-[#737380]">{subtitle}</p>
+                            <p className="mt-2 text-sm text-gray-500">{subtitle}</p>
                         ) : null}
                     </div>
 

--- a/web/src/components/layout/TopNavbar.tsx
+++ b/web/src/components/layout/TopNavbar.tsx
@@ -9,9 +9,9 @@ const navItems = [
 
 export function TopNavbar() {
     return (
-        <header className="border-b border-[#E7E7EA] bg-white">
+        <header className="border-b border-gray-200 bg-white">
             <PageContainer className="flex h-16 items-center justify-between">
-                <Link href="/" className="text-lg font-bold text-[#D84A4A]">
+                <Link href="/" className="text-lg font-bold text-red-500">
                     NEPH
                 </Link>
 
@@ -20,14 +20,14 @@ export function TopNavbar() {
                         <Link
                             key={item.href}
                             href={item.href}
-                            className="text-sm font-medium text-[#2B2B33] transition-colors hover:text-[#D84A4A]"
+                            className="text-sm font-medium text-gray-800 transition-colors hover:text-red-500"
                         >
                             {item.label}
                         </Link>
                     ))}
                 </nav>
 
-                <button className="text-sm font-medium text-[#D84A4A]">Logout</button>
+                <button className="text-sm font-medium text-red-500">Logout</button>
             </PageContainer>
         </header>
     );

--- a/web/src/components/ui/buttons/PrimaryButton.tsx
+++ b/web/src/components/ui/buttons/PrimaryButton.tsx
@@ -16,8 +16,8 @@ export function PrimaryButton({
         <button
             className={cn(
                 "inline-flex h-11 w-full items-center justify-center rounded-[10px]",
-                "bg-[#D84A4A] px-4 text-sm font-semibold text-white",
-                "transition-colors hover:bg-[#C53E3E] active:bg-[#A93232]",
+                "bg-red-500 px-4 text-sm font-semibold text-white",
+                "transition-colors hover:bg-red-600 active:bg-red-700",
                 "disabled:cursor-not-allowed disabled:opacity-60",
                 className
             )}

--- a/web/src/components/ui/buttons/SecondaryButton.tsx
+++ b/web/src/components/ui/buttons/SecondaryButton.tsx
@@ -12,8 +12,8 @@ export function SecondaryButton({
         <button
             className={cn(
                 "inline-flex h-11 w-full items-center justify-center rounded-[10px]",
-                "border border-[#D84A4A] bg-white px-4 text-sm font-semibold text-[#D84A4A]",
-                "transition-colors hover:bg-[#FDECEC] active:bg-[#F9DDDD]",
+                "border border-red-500 bg-white px-4 text-sm font-semibold text-red-500",
+                "transition-colors hover:bg-red-50 active:bg-red-100",
                 "disabled:cursor-not-allowed disabled:opacity-60",
                 className
             )}

--- a/web/src/components/ui/display/AuthCard.tsx
+++ b/web/src/components/ui/display/AuthCard.tsx
@@ -7,7 +7,7 @@ export function AuthCard({ className, children, ...props }: AuthCardProps) {
     return (
         <div
             className={cn(
-                "w-full max-w-md rounded-[16px] border border-[#E7E7EA] bg-white p-8 shadow-[0_10px_30px_rgba(0,0,0,0.06)]",
+                "w-full max-w-md rounded-[16px] border border-gray-200 bg-white p-8 shadow-[0_10px_30px_rgba(0,0,0,0.06)]",
                 className
             )}
             {...props}

--- a/web/src/components/ui/display/Divider.tsx
+++ b/web/src/components/ui/display/Divider.tsx
@@ -6,7 +6,7 @@ type DividerProps = React.HTMLAttributes<HTMLHRElement>;
 export function Divider({ className, ...props }: DividerProps) {
     return (
         <hr
-            className={cn("border-0 border-t border-[#EEEEF1]", className)}
+            className={cn("border-0 border-t border-gray-100", className)}
             {...props}
         />
     );

--- a/web/src/components/ui/display/SectionHeader.tsx
+++ b/web/src/components/ui/display/SectionHeader.tsx
@@ -14,9 +14,9 @@ export function SectionHeader({
 }: SectionHeaderProps) {
     return (
         <div className={cn("mb-4 flex flex-col gap-1", className)}>
-            <h2 className="text-xl font-semibold text-[#2B2B33]">{title}</h2>
+            <h2 className="text-xl font-semibold text-gray-800">{title}</h2>
             {subtitle ? (
-                <p className="text-sm text-[#737380]">{subtitle}</p>
+                <p className="text-sm text-gray-500">{subtitle}</p>
             ) : null}
         </div>
     );

--- a/web/src/components/ui/inputs/PasswordInput.tsx
+++ b/web/src/components/ui/inputs/PasswordInput.tsx
@@ -20,7 +20,7 @@ export function PasswordInput({
     return (
         <div className="flex w-full flex-col gap-2">
             {label ? (
-                <label htmlFor={id} className="text-sm font-medium text-[#2B2B33]">
+                <label htmlFor={id} className="text-sm font-medium text-gray-800">
                     {label}
                 </label>
             ) : null}
@@ -30,10 +30,10 @@ export function PasswordInput({
                     id={id}
                     type={show ? "text" : "password"}
                     className={cn(
-                        "h-11 w-full rounded-[10px] border bg-white px-3 pr-12 text-sm text-[#2B2B33]",
-                        "border-[#E7E7EA] placeholder:text-[#A3A3AD]",
-                        "outline-none transition-colors focus:border-[#D84A4A]",
-                        error && "border-[#D84A4A]",
+                        "h-11 w-full rounded-[10px] border bg-white px-3 pr-12 text-sm text-gray-800",
+                        "border-gray-200 placeholder:text-gray-400",
+                        "outline-none transition-colors focus:border-red-500",
+                        error && "border-red-500",
                         className
                     )}
                     {...props}
@@ -42,13 +42,15 @@ export function PasswordInput({
                 <button
                     type="button"
                     onClick={() => setShow((prev) => !prev)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-medium text-[#737380]"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-medium text-gray-500"
                 >
                     {show ? "Hide" : "Show"}
                 </button>
             </div>
 
-            {error ? <p className="text-xs text-[#D84A4A]">{error}</p> : null}
+            {error ? (
+                <p className="text-xs text-red-500">{error}</p>
+            ) : null}
         </div>
     );
 }

--- a/web/src/components/ui/inputs/SelectInput.tsx
+++ b/web/src/components/ui/inputs/SelectInput.tsx
@@ -25,7 +25,7 @@ export function SelectInput({
     return (
         <div className="flex w-full flex-col gap-2">
             {label ? (
-                <label htmlFor={id} className="text-sm font-medium text-[#2B2B33]">
+                <label htmlFor={id} className="text-sm font-medium text-gray-800">
                     {label}
                 </label>
             ) : null}
@@ -33,9 +33,9 @@ export function SelectInput({
             <select
                 id={id}
                 className={cn(
-                    "h-11 w-full rounded-[10px] border bg-white px-3 text-sm text-[#2B2B33]",
-                    "border-[#E7E7EA] outline-none transition-colors focus:border-[#D84A4A]",
-                    error && "border-[#D84A4A]",
+                    "h-11 w-full rounded-[10px] border bg-white px-3 text-sm text-gray-800",
+                    "border-gray-200 outline-none transition-colors focus:border-red-500",
+                    error && "border-red-500",
                     className
                 )}
                 {...props}
@@ -48,7 +48,9 @@ export function SelectInput({
                 ))}
             </select>
 
-            {error ? <p className="text-xs text-[#D84A4A]">{error}</p> : null}
+            {error ? (
+                <p className="text-xs text-red-500">{error}</p>
+            ) : null}
         </div>
     );
 }

--- a/web/src/components/ui/inputs/TextArea.tsx
+++ b/web/src/components/ui/inputs/TextArea.tsx
@@ -16,7 +16,7 @@ export function TextArea({
     return (
         <div className="flex w-full flex-col gap-2">
             {label ? (
-                <label htmlFor={id} className="text-sm font-medium text-[#2B2B33]">
+                <label htmlFor={id} className="text-sm font-medium text-gray-800">
                     {label}
                 </label>
             ) : null}
@@ -24,17 +24,19 @@ export function TextArea({
             <textarea
                 id={id}
                 className={cn(
-                    "min-h-[110px] w-full rounded-[10px] border bg-white px-3 py-3 text-sm text-[#2B2B33]",
-                    "border-[#E7E7EA] placeholder:text-[#A3A3AD]",
-                    "outline-none transition-colors focus:border-[#D84A4A]",
+                    "min-h-[110px] w-full rounded-[10px] border bg-white px-3 py-3 text-sm text-gray-800",
+                    "border-gray-200 placeholder:text-gray-400",
+                    "outline-none transition-colors focus:border-red-500",
                     "resize-none",
-                    error && "border-[#D84A4A]",
+                    error && "border-red-500",
                     className
                 )}
                 {...props}
             />
 
-            {error ? <p className="text-xs text-[#D84A4A]">{error}</p> : null}
+            {error ? (
+                <p className="text-xs text-red-500">{error}</p>
+            ) : null}
         </div>
     );
 }

--- a/web/src/components/ui/inputs/TextInput.tsx
+++ b/web/src/components/ui/inputs/TextInput.tsx
@@ -16,7 +16,7 @@ export function TextInput({
     return (
         <div className="flex w-full flex-col gap-2">
             {label ? (
-                <label htmlFor={id} className="text-sm font-medium text-[#2B2B33]">
+                <label htmlFor={id} className="text-sm font-medium text-gray-800">
                     {label}
                 </label>
             ) : null}
@@ -24,16 +24,18 @@ export function TextInput({
             <input
                 id={id}
                 className={cn(
-                    "h-11 w-full rounded-[10px] border bg-white px-3 text-sm text-[#2B2B33]",
-                    "border-[#E7E7EA] placeholder:text-[#A3A3AD]",
-                    "outline-none transition-colors focus:border-[#D84A4A]",
-                    error && "border-[#D84A4A]",
+                    "h-11 w-full rounded-[10px] border bg-white px-3 text-sm text-gray-800",
+                    "border-gray-200 placeholder:text-gray-400",
+                    "outline-none transition-colors focus:border-red-500",
+                    error && "border-red-500",
                     className
                 )}
                 {...props}
             />
 
-            {error ? <p className="text-xs text-[#D84A4A]">{error}</p> : null}
+            {error ? (
+                <p className="text-xs text-red-500">{error}</p>
+            ) : null}
         </div>
     );
 }

--- a/web/src/components/ui/inputs/VerificationCodeInput.tsx
+++ b/web/src/components/ui/inputs/VerificationCodeInput.tsx
@@ -56,7 +56,7 @@ export function VerificationCodeInput({
                     value={digit}
                     onChange={(e) => handleChange(index, e.target.value)}
                     onKeyDown={(e) => handleKeyDown(index, e)}
-                    className="h-12 w-12 rounded-[10px] border border-[#E7E7EA] bg-white text-center text-lg font-semibold text-[#2B2B33] outline-none transition-colors focus:border-[#D84A4A]"
+                    className="h-12 w-12 rounded-[10px] border border-gray-200 bg-white text-center text-lg font-semibold text-gray-800 outline-none transition-colors focus:border-red-500"
                 />
             ))}
         </div>

--- a/web/src/components/ui/selection/Checkbox.tsx
+++ b/web/src/components/ui/selection/Checkbox.tsx
@@ -25,7 +25,7 @@ export function Checkbox({
             <label
                 htmlFor={id}
                 className={cn(
-                    "flex items-center gap-3 text-sm text-[#2B2B33]",
+                    "flex items-center gap-3 text-sm text-gray-800",
                     disabled && "cursor-not-allowed opacity-60"
                 )}
             >
@@ -35,12 +35,14 @@ export function Checkbox({
                     checked={checked}
                     disabled={disabled}
                     onChange={(e) => onCheckedChange(e.target.checked)}
-                    className="h-4 w-4 rounded border-[#E7E7EA] accent-[#D84A4A]"
+                    className="h-4 w-4 rounded border-gray-200 accent-red-500"
                 />
                 <span>{label}</span>
             </label>
 
-            {error ? <p className="text-xs text-[#D84A4A]">{error}</p> : null}
+            {error ? (
+                <p className="text-xs text-red-500">{error}</p>
+            ) : null}
         </div>
     );
 }

--- a/web/src/components/ui/selection/RadioGroup.tsx
+++ b/web/src/components/ui/selection/RadioGroup.tsx
@@ -28,7 +28,9 @@ export function RadioGroup({
     return (
         <div className="flex flex-col gap-2">
             {label ? (
-                <span className="text-sm font-medium text-[#2B2B33]">{label}</span>
+                <span className="text-sm font-medium text-gray-800">
+                    {label}
+                </span>
             ) : null}
 
             <div
@@ -40,7 +42,7 @@ export function RadioGroup({
                 {options.map((option) => (
                     <label
                         key={option.value}
-                        className="flex items-center gap-2 text-sm text-[#2B2B33]"
+                        className="flex items-center gap-2 text-sm text-gray-800"
                     >
                         <input
                             type="radio"
@@ -48,7 +50,7 @@ export function RadioGroup({
                             value={option.value}
                             checked={value === option.value}
                             onChange={() => onValueChange(option.value)}
-                            className="h-4 w-4 accent-[#D84A4A]"
+                            className="h-4 w-4 accent-red-500"
                         />
                         <span>{option.label}</span>
                     </label>

--- a/web/src/components/ui/selection/ToggleSwitch.tsx
+++ b/web/src/components/ui/selection/ToggleSwitch.tsx
@@ -22,7 +22,7 @@ export function ToggleSwitch({
             onClick={() => onCheckedChange(!checked)}
             className={cn(
                 "relative inline-flex h-6 w-11 items-center rounded-full transition-colors",
-                checked ? "bg-[#D84A4A]" : "bg-[#D1D5DB]",
+                checked ? "bg-red-500" : "bg-gray-300",
                 disabled && "cursor-not-allowed opacity-60"
             )}
         >


### PR DESCRIPTION
Replaced hardcoded hex color values with Tailwind color classes across shared components.
This improves consistency and maintainability.
Note: The project defines semantic color tokens in documentation, but they are not yet integrated into Tailwind config. The closest matching Tailwind colors were used.
@erinc00 @kckagancan  could you please review this PR?
closes [#96](https://github.com/bounswe/bounswe2026group6/issues/96)