### PR TITLE
feat: add resend verification email endpoint

### DIFF
--- a/backend/src/modules/auth/controller.js
+++ b/backend/src/modules/auth/controller.js
@@ -7,6 +7,7 @@ const {
   getHelpRequestsForAdmin,
   getAnnouncementsForAdmin,
   getStatsForAdmin,
+  resendVerificationEmail,
 } = require('./service');
 const {
   validateSignupInput,
@@ -174,6 +175,37 @@ async function getAdminStats(_req, res) {
   }
 }
 
+async function resendVerification(req, res) {
+  try {
+    const { email } = req.body;
+
+    if (!email) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: 'Email is required',
+      });
+    }
+
+    const result = await resendVerificationEmail(email);
+    return res.status(200).json(result);
+  } catch (error) {
+    if (
+      error.code === 'USER_NOT_FOUND' ||
+      error.code === 'EMAIL_ALREADY_VERIFIED'
+    ) {
+      return res.status(400).json({
+        code: error.code,
+        message: error.message,
+      });
+    }
+
+    return res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      message: 'Something went wrong',
+    });
+  }
+}
+
 module.exports = {
   getAuthInfo,
   signup,
@@ -184,4 +216,5 @@ module.exports = {
   getAdminHelpRequests,
   getAdminAnnouncements,
   getAdminStats,
+  resendVerification,
 };

--- a/backend/src/modules/auth/routes.js
+++ b/backend/src/modules/auth/routes.js
@@ -20,6 +20,7 @@ const {
   getAdminHelpRequests,
   getAdminAnnouncements,
   getAdminStats,
+  resendVerification,
 } = require('./controller');
 const { requireAuth, requireAdmin } = require('./middleware');
 
@@ -30,6 +31,7 @@ authRouter.get('/', getAuthInfo);
 authRouter.post('/signup', authLimiter, signup);
 authRouter.post('/login', authLimiter, login);
 authRouter.get('/verify-email', verifyEmail);
+authRouter.post('/resend-verification', authLimiter, resendVerification);
 
 authRouter.get('/me', requireAuth, getMe);
 

--- a/backend/src/modules/auth/service.js
+++ b/backend/src/modules/auth/service.js
@@ -202,6 +202,30 @@ async function getStatsForAdmin() {
   return getBasicStats();
 }
 
+async function resendVerificationEmail(email) {
+  const normalizedEmail = email.toLowerCase().trim();
+  const user = await findUserByEmail(normalizedEmail);
+
+  if (!user || user.is_deleted) {
+    const error = new Error('User not found');
+    error.code = 'USER_NOT_FOUND';
+    throw error;
+  }
+
+  if (user.is_email_verified) {
+    const error = new Error('Email is already verified');
+    error.code = 'EMAIL_ALREADY_VERIFIED';
+    throw error;
+  }
+
+  const verificationToken = signEmailVerificationToken(user);
+  await sendVerificationEmail(user.email, verificationToken);
+
+  return {
+    message: 'Verification email sent. Please check your inbox.',
+  };
+}
+
 module.exports = {
   signupUser,
   loginUser,
@@ -211,4 +235,5 @@ module.exports = {
   getHelpRequestsForAdmin,
   getAnnouncementsForAdmin,
   getStatsForAdmin,
+  resendVerificationEmail,
 };


### PR DESCRIPTION
Adds POST /api/auth/resend-verification endpoint. Users who didn't receive or lost their verification email can request a new one. Note: old tokens remain valid until expiry — token invalidation requires a DB schema change, to be discussed.