### PR TITLE
feat: add profession endpoint for expertise statements

### DIFF
--- a/backend/src/modules/profiles/controller.js
+++ b/backend/src/modules/profiles/controller.js
@@ -6,6 +6,7 @@ const {
   patchMyHealth,
   patchMyLocation,
   patchMyPrivacy,
+  patchMyProfession,
 } = require('./service');
 const {
   readUserId,
@@ -14,6 +15,7 @@ const {
   validateHealthPatch,
   validateLocationPatch,
   validatePrivacyPatch,
+  validateProfessionPatch,
 } = require('./validators');
 
 function sendError(response, status, code, message) {
@@ -160,6 +162,26 @@ async function patchPrivacy(request, response) {
   }
 }
 
+async function patchProfession(request, response) {
+  const userId = readUserId(request);
+
+  if (!userId) {
+    return sendAuthError(response);
+  }
+
+  const validation = validateProfessionPatch(request.body);
+  if (!validation.ok) {
+    return sendError(response, 400, validation.code, validation.message);
+  }
+
+  try {
+    const profile = await patchMyProfession(userId, validation.data);
+    return response.status(200).json(profile);
+  } catch (error) {
+    return mapServiceError(response, error);
+  }
+}
+
 module.exports = {
   getMe,
   patchMe,
@@ -167,4 +189,5 @@ module.exports = {
   patchHealth,
   patchLocation,
   patchPrivacy,
+  patchProfession,
 };

--- a/backend/src/modules/profiles/repository.js
+++ b/backend/src/modules/profiles/repository.js
@@ -306,6 +306,69 @@ async function upsertPrivacySettings(profileId, data, providedFields = []) {
   await query(sql, values);
 }
 
+async function listExpertiseByProfileId(profileId) {
+  const sql = `
+    SELECT expertise_id, profession, expertise_area, is_verified
+    FROM expertise
+    WHERE profile_id = $1
+    ORDER BY expertise_id ASC;
+  `;
+
+  const result = await query(sql, [profileId]);
+
+  return result.rows.map((row) => ({
+    expertiseId: row.expertise_id,
+    profession: row.profession,
+    expertiseArea: row.expertise_area,
+    isVerified: row.is_verified,
+  }));
+}
+
+async function upsertProfession(profileId, data) {
+  const current = await query(
+    `
+      SELECT expertise_id
+      FROM expertise
+      WHERE profile_id = $1
+      ORDER BY expertise_id ASC
+      LIMIT 1;
+    `,
+    [profileId],
+  );
+
+  if (current.rows.length === 0) {
+    await query(
+      `
+        INSERT INTO expertise (
+          expertise_id,
+          profile_id,
+          profession,
+          expertise_area,
+          is_verified
+        )
+        VALUES ($1, $2, $3, $4, FALSE);
+      `,
+      [makeId('exp'), profileId, data.profession ?? null, data.expertiseArea ?? null],
+    );
+    return;
+  }
+
+  await query(
+    `
+      UPDATE expertise
+      SET profession = COALESCE($2, profession),
+          expertise_area = CASE WHEN $3 THEN $4 ELSE expertise_area END
+      WHERE expertise_id = $1;
+    `,
+    [
+      current.rows[0].expertise_id,
+      data.profession,
+      Object.prototype.hasOwnProperty.call(data, 'expertiseArea'),
+      data.expertiseArea ?? null,
+    ],
+  );
+}
+
 async function findProfileBundleByUserId(userId) {
   const sql = `
     SELECT
@@ -359,5 +422,7 @@ module.exports = {
   upsertHealthInfo,
   upsertLocationProfile,
   upsertPrivacySettings,
+  listExpertiseByProfileId,
+  upsertProfession,
   findProfileBundleByUserId,
 };

--- a/backend/src/modules/profiles/routes.js
+++ b/backend/src/modules/profiles/routes.js
@@ -7,6 +7,7 @@ const {
   patchHealth,
   patchLocation,
   patchPrivacy,
+  patchProfession,
 } = require('./controller');
 
 const profilesRouter = express.Router();
@@ -14,7 +15,7 @@ const profilesRouter = express.Router();
 profilesRouter.get('/', (_request, response) => {
   response.status(200).json({
     module: 'profiles',
-    scope: ['profile', 'privacy', 'health', 'location'],
+    scope: ['profile', 'privacy', 'health', 'location', 'profession'],
     status: 'ready for implementation',
   });
 });
@@ -25,6 +26,7 @@ profilesRouter.patch('/me/physical', requireAuth, patchPhysical);
 profilesRouter.patch('/me/health', requireAuth, patchHealth);
 profilesRouter.patch('/me/location', requireAuth, patchLocation);
 profilesRouter.patch('/me/privacy', requireAuth, patchPrivacy);
+profilesRouter.patch('/me/profession', requireAuth, patchProfession);
 
 module.exports = {
   profilesRouter,

--- a/backend/src/modules/profiles/service.js
+++ b/backend/src/modules/profiles/service.js
@@ -7,7 +7,9 @@ const {
   upsertHealthInfo,
   upsertLocationProfile,
   upsertPrivacySettings,
+  upsertProfession,
   findProfileBundleByUserId,
+  listExpertiseByProfileId,
 } = require('./repository');
 
 function mapProfileRow(row) {
@@ -56,7 +58,10 @@ async function getMyProfile(userId) {
     return null;
   }
 
-  return mapProfileRow(row);
+  const expertise = await listExpertiseByProfileId(row.profile_id);
+  const mapped = mapProfileRow(row);
+  mapped.expertise = expertise;
+  return mapped;
 }
 
 async function hasProfile(userId) {
@@ -122,6 +127,12 @@ async function patchMyPrivacy(userId, data, providedFields = []) {
   return getMyProfile(userId);
 }
 
+async function patchMyProfession(userId, data) {
+  const profileId = await getProfileIdOrThrow(userId);
+  await upsertProfession(profileId, data);
+  return getMyProfile(userId);
+}
+
 module.exports = {
   getMyProfile,
   hasProfile,
@@ -130,4 +141,5 @@ module.exports = {
   patchMyHealth,
   patchMyLocation,
   patchMyPrivacy,
+  patchMyProfession,
 };

--- a/backend/src/modules/profiles/validators.js
+++ b/backend/src/modules/profiles/validators.js
@@ -171,6 +171,47 @@ function validatePrivacyPatch(body) {
   return { ok: true, data };
 }
 
+function validateProfessionPatch(body) {
+  if (!isPlainObject(body)) {
+    return { ok: false, code: 'VALIDATION_ERROR', message: 'Payload must be an object' };
+  }
+
+  const data = pickAllowed(body, ['profession', 'expertiseArea']);
+
+  if (Object.keys(data).length === 0) {
+    return { ok: false, code: 'VALIDATION_ERROR', message: 'At least one profession field must be provided' };
+  }
+
+  if (data.profession !== undefined) {
+    if (typeof data.profession !== 'string' || data.profession.trim() === '') {
+      return { ok: false, code: 'VALIDATION_ERROR', message: 'profession must be a non-empty string' };
+    }
+
+    data.profession = data.profession.trim();
+
+    if (data.profession.length > 200) {
+      return { ok: false, code: 'VALIDATION_ERROR', message: 'profession must be at most 200 characters' };
+    }
+  }
+
+  if (data.expertiseArea !== undefined) {
+    if (data.expertiseArea !== null && typeof data.expertiseArea !== 'string') {
+      return { ok: false, code: 'VALIDATION_ERROR', message: 'expertiseArea must be a string or null' };
+    }
+
+    if (typeof data.expertiseArea === 'string') {
+      const trimmedArea = data.expertiseArea.trim();
+      data.expertiseArea = trimmedArea || null;
+
+      if (data.expertiseArea !== null && data.expertiseArea.length > 200) {
+        return { ok: false, code: 'VALIDATION_ERROR', message: 'expertiseArea must be at most 200 characters' };
+      }
+    }
+  }
+
+  return { ok: true, data };
+}
+
 module.exports = {
   readUserId,
   validateProfilePatch,
@@ -178,4 +219,5 @@ module.exports = {
   validateHealthPatch,
   validateLocationPatch,
   validatePrivacyPatch,
+  validateProfessionPatch,
 };


### PR DESCRIPTION
This PR introduces profession support in the Profiles module using a single-record approach for MVP.

What’s included

Added a protected endpoint: PATCH /api/profiles/me/profession
Added request validation for profession and expertiseArea fields
Implemented service and repository logic to create or update one expertise record
Extended profile response to include expertise data in GET /api/profiles/me
Updated profiles module scope metadata to include profession
Notes

This is intentionally scoped to single profession management.
Multi-expertise CRUD is out of scope for this PR.
profession is optional by current product decision.

Resolves #142 
