### PR TITLE
feat: Add profile module unit and DB-backed integration tests with Jest setup improvements

### DIFF
--- a/backend/tests/integration/modules/profiles/profiles.integration.test.js
+++ b/backend/tests/integration/modules/profiles/profiles.integration.test.js
@@ -1,3 +1,233 @@
 'use strict';
 
-// Integration test scaffold for profiles module.
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+jest.mock('../../../../src/modules/auth/routes', () => ({
+	authRouter: require('express').Router(),
+}));
+
+jest.mock('../../../../src/modules/help-requests/routes', () => ({
+	helpRequestsRouter: require('express').Router(),
+}));
+
+jest.mock('../../../../src/modules/availability/routes', () => ({
+	availabilityRouter: require('express').Router(),
+}));
+
+const { query } = require('../../../../src/db/pool');
+const { createApp } = require('../../../../src/app');
+
+function buildAuthToken(userId) {
+	return jwt.sign(
+		{
+			userId,
+			email: 'user@example.com',
+			isAdmin: false,
+			adminRole: null,
+		},
+		process.env.JWT_SECRET || 'dev-secret-123',
+		{ expiresIn: '1h' },
+	);
+}
+
+async function seedActiveUser(userId, email = 'user@example.com') {
+	await query(
+		`
+			INSERT INTO users (
+				user_id,
+				email,
+				password_hash,
+				is_email_verified,
+				is_deleted,
+				accepted_terms
+			)
+			VALUES ($1, $2, 'hash', TRUE, FALSE, TRUE);
+		`,
+		[userId, email],
+	);
+}
+
+async function createBaseProfile(app, token) {
+	const response = await request(app)
+		.patch('/api/profiles/me')
+		.set('Authorization', `Bearer ${token}`)
+		.send({ firstName: 'Ada', lastName: 'Lovelace' });
+
+	expect(response.status).toBe(200);
+}
+
+beforeEach(async () => {
+	await query(`
+		TRUNCATE TABLE
+			messages,
+			assignments,
+			availability_records,
+			resources,
+			volunteers,
+			request_locations,
+			help_requests,
+			news_announcements,
+			reports,
+			expertise,
+			privacy_settings,
+			location_profiles,
+			health_info,
+			physical_info,
+			user_profiles,
+			admins,
+			users
+		RESTART IDENTITY CASCADE;
+	`);
+});
+
+describe('profiles integration', () => {
+	test('GET /api/profiles/me returns 401 without token', async () => {
+		const app = createApp();
+
+		const response = await request(app)
+			.get('/api/profiles/me');
+
+		expect(response.status).toBe(401);
+	});
+
+	test('PATCH /api/profiles/me creates profile', async () => {
+		const app = createApp();
+		const userId = 'user_profile_1';
+		await seedActiveUser(userId, 'profile1@example.com');
+		const token = buildAuthToken(userId);
+
+		const response = await request(app)
+			.patch('/api/profiles/me')
+			.set('Authorization', `Bearer ${token}`)
+			.send({ firstName: 'Ada', lastName: 'Lovelace' });
+
+		expect(response.status).toBe(200);
+		expect(response.body.profile.userId).toBe(userId);
+		expect(response.body.profile.firstName).toBe('Ada');
+	});
+
+	test('PATCH /api/profiles/me/physical returns 200 with valid payload', async () => {
+		const app = createApp();
+		const userId = 'user_phys_1';
+		await seedActiveUser(userId, 'phys1@example.com');
+		const token = buildAuthToken(userId);
+		await createBaseProfile(app, token);
+
+		const response = await request(app)
+			.patch('/api/profiles/me/physical')
+			.set('Authorization', `Bearer ${token}`)
+			.send({ age: 22 });
+
+		expect(response.status).toBe(200);
+		expect(response.body.physicalInfo.age).toBe(22);
+	});
+
+	test('PATCH /api/profiles/me/health returns 200 with valid payload', async () => {
+		const app = createApp();
+		const userId = 'user_health_1';
+		await seedActiveUser(userId, 'health1@example.com');
+		const token = buildAuthToken(userId);
+		await createBaseProfile(app, token);
+
+		const response = await request(app)
+			.patch('/api/profiles/me/health')
+			.set('Authorization', `Bearer ${token}`)
+			.send({ allergies: ['Peanut'] });
+
+		expect(response.status).toBe(200);
+		expect(response.body.healthInfo.allergies).toEqual(['Peanut']);
+	});
+
+	test('PATCH /api/profiles/me/location returns 400 for invalid coordinate payload', async () => {
+		const app = createApp();
+		const userId = 'user_loc_1';
+		await seedActiveUser(userId, 'loc1@example.com');
+		const token = buildAuthToken(userId);
+		await createBaseProfile(app, token);
+
+		const response = await request(app)
+			.patch('/api/profiles/me/location')
+			.set('Authorization', `Bearer ${token}`)
+			.send({ latitude: 41.0 });
+
+		expect(response.status).toBe(400);
+		expect(response.body.code).toBe('VALIDATION_ERROR');
+	});
+
+	test('PATCH /api/profiles/me/location returns 200 for valid payload', async () => {
+		const app = createApp();
+		const userId = 'user_loc_2';
+		await seedActiveUser(userId, 'loc2@example.com');
+		const token = buildAuthToken(userId);
+		await createBaseProfile(app, token);
+
+		const response = await request(app)
+			.patch('/api/profiles/me/location')
+			.set('Authorization', `Bearer ${token}`)
+			.send({ city: 'Istanbul' });
+
+		expect(response.status).toBe(200);
+		expect(response.body.locationProfile.city).toBe('Istanbul');
+	});
+
+	test('PATCH /api/profiles/me/privacy returns 200 with valid payload', async () => {
+		const app = createApp();
+		const userId = 'user_priv_1';
+		await seedActiveUser(userId, 'priv1@example.com');
+		const token = buildAuthToken(userId);
+		await createBaseProfile(app, token);
+
+		const response = await request(app)
+			.patch('/api/profiles/me/privacy')
+			.set('Authorization', `Bearer ${token}`)
+			.send({ profileVisibility: 'PUBLIC' });
+
+		expect(response.status).toBe(200);
+		expect(response.body.privacySettings.profileVisibility).toBe('PUBLIC');
+	});
+
+	test('PATCH /api/profiles/me/profession returns 401 without token', async () => {
+		const app = createApp();
+
+		const response = await request(app)
+			.patch('/api/profiles/me/profession')
+			.send({ profession: 'Doctor' });
+
+		expect(response.status).toBe(401);
+		expect(response.body.code).toBe('UNAUTHORIZED');
+	});
+
+	test('PATCH /api/profiles/me/profession returns 400 for invalid payload', async () => {
+		const app = createApp();
+		const userId = 'user_prof_1';
+		await seedActiveUser(userId, 'prof1@example.com');
+		const token = buildAuthToken(userId);
+		await createBaseProfile(app, token);
+
+		const response = await request(app)
+			.patch('/api/profiles/me/profession')
+			.set('Authorization', `Bearer ${token}`)
+			.send({});
+
+		expect(response.status).toBe(400);
+		expect(response.body.code).toBe('VALIDATION_ERROR');
+	});
+
+	test('PATCH /api/profiles/me/profession returns 200 and profile payload on success', async () => {
+		const app = createApp();
+		const userId = 'user_prof_2';
+		await seedActiveUser(userId, 'prof2@example.com');
+		const token = buildAuthToken(userId);
+		await createBaseProfile(app, token);
+
+		const response = await request(app)
+			.patch('/api/profiles/me/profession')
+			.set('Authorization', `Bearer ${token}`)
+			.send({ profession: 'Doctor' });
+
+		expect(response.status).toBe(200);
+		expect(response.body.profile.userId).toBe(userId);
+		expect(response.body.expertise[0].profession).toBe('Doctor');
+	});
+});

--- a/backend/tests/setup/README.md
+++ b/backend/tests/setup/README.md
@@ -1,4 +1,57 @@
 # Test Setup
 
-This folder is reserved for test runner setup files.
-Scaffold only: no setup implementation yet.
+This folder contains Jest setup files used by backend tests.
+
+## Prerequisites
+
+1. Docker Desktop must be running.
+2. PostgreSQL test container must be up before running integration tests.
+3. Backend dependencies must be installed.
+
+## Start Test Database (Docker)
+
+From repository root:
+
+```powershell
+docker compose -f infra/dcompose/docker-compose-dev.yml up -d postgres
+```
+
+Check container status:
+
+```powershell
+docker compose -f infra/dcompose/docker-compose-dev.yml ps
+```
+
+Stop container when you are done:
+
+```powershell
+docker compose -f infra/dcompose/docker-compose-dev.yml down
+```
+
+## Run Tests
+
+From `backend` folder:
+
+```powershell
+npm install
+npm run test:unit
+npm run test:integration
+```
+
+Run both unit and integration tests together:
+
+```powershell
+npm run test -- tests/unit/modules/profiles tests/integration/modules/profiles/profiles.integration.test.js
+```
+
+If PowerShell blocks npm script execution, use:
+
+```powershell
+npm.cmd run test:integration
+```
+
+## Notes
+
+- Integration tests use a dedicated test database (`POSTGRES_DB` from test environment settings).
+- `global-setup.js` prepares database/schema before integration tests.
+- `global-teardown.js` closes DB pool after test run.

--- a/backend/tests/setup/global-setup.js
+++ b/backend/tests/setup/global-setup.js
@@ -1,5 +1,75 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
+const { Client } = require('pg');
+
+function quoteIdentifier(identifier) {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier)) {
+    throw new Error(
+      `Invalid test database name "${identifier}". Use letters, numbers and underscores only.`
+    );
+  }
+
+  return `"${identifier}"`;
+}
+
+function getDbConfig() {
+  const host = process.env.TEST_POSTGRES_HOST || process.env.POSTGRES_HOST || 'localhost';
+  const port = Number(process.env.TEST_POSTGRES_PORT || process.env.POSTGRES_PORT || 5432);
+  const user = process.env.TEST_POSTGRES_USER || process.env.POSTGRES_USER || 'neph_user';
+  const password = process.env.TEST_POSTGRES_PASSWORD || process.env.POSTGRES_PASSWORD || 'neph_pass';
+  const database = process.env.TEST_POSTGRES_DB || process.env.POSTGRES_DB || 'neph_test_db';
+
+  process.env.NODE_ENV = 'test';
+  process.env.POSTGRES_HOST = host;
+  process.env.POSTGRES_PORT = String(port);
+  process.env.POSTGRES_USER = user;
+  process.env.POSTGRES_PASSWORD = password;
+  process.env.POSTGRES_DB = database;
+
+  return { host, port, user, password, database };
+}
+
 module.exports = async function globalSetup() {
-  // Reserved for future DB/container bootstrapping.
+  const db = getDbConfig();
+
+  const adminClient = new Client({
+    host: db.host,
+    port: db.port,
+    user: db.user,
+    password: db.password,
+    database: 'postgres',
+  });
+
+  await adminClient.connect();
+
+  try {
+    const dbExists = await adminClient.query('SELECT 1 FROM pg_database WHERE datname = $1;', [db.database]);
+
+    if (dbExists.rowCount === 0) {
+      await adminClient.query(`CREATE DATABASE ${quoteIdentifier(db.database)};`);
+    }
+  } finally {
+    await adminClient.end();
+  }
+
+  const initSqlPath = path.resolve(__dirname, '../../../infra/docker/postgres/init.sql');
+  const initSql = fs.readFileSync(initSqlPath, 'utf-8');
+
+  const testClient = new Client({
+    host: db.host,
+    port: db.port,
+    user: db.user,
+    password: db.password,
+    database: db.database,
+  });
+
+  await testClient.connect();
+
+  try {
+    await testClient.query(initSql);
+  } finally {
+    await testClient.end();
+  }
 };

--- a/backend/tests/setup/global-teardown.js
+++ b/backend/tests/setup/global-teardown.js
@@ -1,5 +1,10 @@
 'use strict';
 
 module.exports = async function globalTeardown() {
-  // Reserved for future DB/container cleanup.
+  try {
+    const { pool } = require('../../src/db/pool');
+    await pool.end();
+  } catch (_error) {
+    // Pool may not be initialized in some test runs.
+  }
 };

--- a/backend/tests/setup/integration.setup.js
+++ b/backend/tests/setup/integration.setup.js
@@ -1,6 +1,22 @@
 'use strict';
 
-// Shared integration-test setup hook.
-beforeEach(() => {
-  // Intentionally empty scaffold.
+function useTestEnv(name, fallback) {
+  const testName = `TEST_${name}`;
+  process.env[name] = process.env[testName] || process.env[name] || fallback;
+}
+
+process.env.NODE_ENV = 'test';
+useTestEnv('POSTGRES_HOST', 'localhost');
+useTestEnv('POSTGRES_PORT', '5432');
+useTestEnv('POSTGRES_DB', 'neph_test_db');
+useTestEnv('POSTGRES_USER', 'neph_user');
+useTestEnv('POSTGRES_PASSWORD', 'neph_pass');
+
+afterAll(async () => {
+  try {
+    const { pool } = require('../../src/db/pool');
+    await pool.end();
+  } catch (_error) {
+    // Pool may not be initialized in isolated runs.
+  }
 });

--- a/backend/tests/unit/modules/profiles/controller.test.js
+++ b/backend/tests/unit/modules/profiles/controller.test.js
@@ -1,3 +1,184 @@
 'use strict';
 
-// Unit test scaffold for profiles controller error mapping.
+jest.mock('../../../../src/modules/profiles/service', () => ({
+	getMyProfile: jest.fn(),
+	hasProfile: jest.fn(),
+	patchMyProfile: jest.fn(),
+	patchMyPhysical: jest.fn(),
+	patchMyHealth: jest.fn(),
+	patchMyLocation: jest.fn(),
+	patchMyPrivacy: jest.fn(),
+	patchMyProfession: jest.fn(),
+}));
+
+jest.mock('../../../../src/modules/profiles/validators', () => ({
+	readUserId: jest.fn(),
+	validateProfilePatch: jest.fn(),
+	validatePhysicalPatch: jest.fn(),
+	validateHealthPatch: jest.fn(),
+	validateLocationPatch: jest.fn(),
+	validatePrivacyPatch: jest.fn(),
+	validateProfessionPatch: jest.fn(),
+}));
+
+const service = require('../../../../src/modules/profiles/service');
+const validators = require('../../../../src/modules/profiles/validators');
+const {
+	getMe,
+	patchMe,
+	patchPhysical,
+	patchHealth,
+	patchLocation,
+	patchPrivacy,
+	patchProfession,
+} = require('../../../../src/modules/profiles/controller');
+
+function buildResponse() {
+	const response = {};
+	response.status = jest.fn().mockReturnValue(response);
+	response.json = jest.fn().mockReturnValue(response);
+	return response;
+}
+
+describe('profiles controller', () => {
+	test('getMe returns 404 when profile does not exist', async () => {
+		validators.readUserId.mockReturnValueOnce('u1');
+		service.getMyProfile.mockResolvedValueOnce(null);
+		const response = buildResponse();
+
+		await getMe({}, response);
+
+		expect(response.status).toHaveBeenCalledWith(404);
+		expect(response.json).toHaveBeenCalledWith({ code: 'NOT_FOUND', message: 'Profile not found' });
+	});
+
+	test('patchMe returns 200 when payload is valid', async () => {
+		validators.readUserId.mockReturnValueOnce('u1');
+		service.hasProfile.mockResolvedValueOnce(true);
+		validators.validateProfilePatch.mockReturnValueOnce({ ok: true, data: { firstName: 'Ada' } });
+		service.patchMyProfile.mockResolvedValueOnce({ profile: { userId: 'u1' } });
+		const response = buildResponse();
+
+		await patchMe({ body: { firstName: 'Ada' } }, response);
+
+		expect(service.patchMyProfile).toHaveBeenCalledWith('u1', { firstName: 'Ada' });
+		expect(response.status).toHaveBeenCalledWith(200);
+	});
+
+	test('patchMe returns 400 for invalid payload', async () => {
+		validators.readUserId.mockReturnValueOnce('u1');
+		service.hasProfile.mockResolvedValueOnce(false);
+		validators.validateProfilePatch.mockReturnValueOnce({
+			ok: false,
+			code: 'VALIDATION_ERROR',
+			message: 'firstName and lastName are required to create profile',
+		});
+		const response = buildResponse();
+
+		await patchMe({ body: {} }, response);
+
+		expect(response.status).toHaveBeenCalledWith(400);
+	});
+
+	test('patchPhysical returns 200 on success', async () => {
+		validators.readUserId.mockReturnValueOnce('u1');
+		validators.validatePhysicalPatch.mockReturnValueOnce({ ok: true, data: { age: 20 } });
+		service.patchMyPhysical.mockResolvedValueOnce({ profile: { userId: 'u1' } });
+		const response = buildResponse();
+
+		await patchPhysical({ body: { age: 20 } }, response);
+
+		expect(service.patchMyPhysical).toHaveBeenCalledWith('u1', { age: 20 }, ['age']);
+		expect(response.status).toHaveBeenCalledWith(200);
+	});
+
+	test('patchHealth returns 200 on success', async () => {
+		validators.readUserId.mockReturnValueOnce('u1');
+		validators.validateHealthPatch.mockReturnValueOnce({ ok: true, data: { allergies: ['Peanut'] } });
+		service.patchMyHealth.mockResolvedValueOnce({ profile: { userId: 'u1' } });
+		const response = buildResponse();
+
+		await patchHealth({ body: { allergies: ['Peanut'] } }, response);
+
+		expect(service.patchMyHealth).toHaveBeenCalledWith('u1', { allergies: ['Peanut'] }, ['allergies']);
+		expect(response.status).toHaveBeenCalledWith(200);
+	});
+
+	test('patchLocation returns 400 for invalid location payload', async () => {
+		validators.readUserId.mockReturnValueOnce('u1');
+		validators.validateLocationPatch.mockReturnValueOnce({
+			ok: false,
+			code: 'VALIDATION_ERROR',
+			message: 'latitude and longitude must be provided together',
+		});
+		const response = buildResponse();
+
+		await patchLocation({ body: { latitude: 41 } }, response);
+
+		expect(response.status).toHaveBeenCalledWith(400);
+	});
+
+	test('patchPrivacy returns 200 on success', async () => {
+		validators.readUserId.mockReturnValueOnce('u1');
+		validators.validatePrivacyPatch.mockReturnValueOnce({ ok: true, data: { locationSharingEnabled: true } });
+		service.patchMyPrivacy.mockResolvedValueOnce({ profile: { userId: 'u1' } });
+		const response = buildResponse();
+
+		await patchPrivacy({ body: { locationSharingEnabled: true } }, response);
+
+		expect(service.patchMyPrivacy).toHaveBeenCalledWith('u1', { locationSharingEnabled: true }, ['locationSharingEnabled']);
+		expect(response.status).toHaveBeenCalledWith(200);
+	});
+
+	test('patchProfession returns 401 when user is missing', async () => {
+		validators.readUserId.mockReturnValueOnce(null);
+		const response = buildResponse();
+
+		await patchProfession({}, response);
+
+		expect(response.status).toHaveBeenCalledWith(401);
+		expect(response.json).toHaveBeenCalledWith({ code: 'UNAUTHORIZED', message: 'Authentication required' });
+	});
+
+	test('patchProfession returns 400 for validation error', async () => {
+		validators.readUserId.mockReturnValueOnce('u1');
+		validators.validateProfessionPatch.mockReturnValueOnce({
+			ok: false,
+			code: 'VALIDATION_ERROR',
+			message: 'profession must be a non-empty string',
+		});
+		const response = buildResponse();
+
+		await patchProfession({ body: {} }, response);
+
+		expect(response.status).toHaveBeenCalledWith(400);
+		expect(response.json).toHaveBeenCalledWith({ code: 'VALIDATION_ERROR', message: 'profession must be a non-empty string' });
+	});
+
+	test('patchProfession returns 200 with profile response on success', async () => {
+		validators.readUserId.mockReturnValueOnce('u1');
+		validators.validateProfessionPatch.mockReturnValueOnce({ ok: true, data: { profession: 'Doctor' } });
+		service.patchMyProfession.mockResolvedValueOnce({ profile: { userId: 'u1' }, expertise: [] });
+		const response = buildResponse();
+
+		await patchProfession({ body: { profession: 'Doctor' } }, response);
+
+		expect(service.patchMyProfession).toHaveBeenCalledWith('u1', { profession: 'Doctor' });
+		expect(response.status).toHaveBeenCalledWith(200);
+	});
+
+	test('patchProfession maps PROFILE_NOT_FOUND to 404', async () => {
+		validators.readUserId.mockReturnValueOnce('u1');
+		validators.validateProfessionPatch.mockReturnValueOnce({ ok: true, data: { profession: 'Doctor' } });
+		service.patchMyProfession.mockRejectedValueOnce(new Error('PROFILE_NOT_FOUND'));
+		const response = buildResponse();
+
+		await patchProfession({ body: { profession: 'Doctor' } }, response);
+
+		expect(response.status).toHaveBeenCalledWith(404);
+		expect(response.json).toHaveBeenCalledWith({
+			code: 'NOT_FOUND',
+			message: 'Profile not found. Create base profile first via PATCH /api/profiles/me',
+		});
+	});
+});

--- a/backend/tests/unit/modules/profiles/service.test.js
+++ b/backend/tests/unit/modules/profiles/service.test.js
@@ -1,3 +1,173 @@
 'use strict';
 
-// Unit test scaffold for profiles service.
+jest.mock('../../../../src/modules/profiles/repository', () => ({
+	findActiveUserById: jest.fn(),
+	findProfileByUserId: jest.fn(),
+	createProfileByUserId: jest.fn(),
+	updateProfileByUserId: jest.fn(),
+	upsertPhysicalInfo: jest.fn(),
+	upsertHealthInfo: jest.fn(),
+	upsertLocationProfile: jest.fn(),
+	upsertPrivacySettings: jest.fn(),
+	upsertProfession: jest.fn(),
+	findProfileBundleByUserId: jest.fn(),
+	listExpertiseByProfileId: jest.fn(),
+}));
+
+const repository = require('../../../../src/modules/profiles/repository');
+const {
+	getMyProfile,
+	patchMyProfile,
+	patchMyPhysical,
+	patchMyHealth,
+	patchMyLocation,
+	patchMyPrivacy,
+	patchMyProfession,
+} = require('../../../../src/modules/profiles/service');
+
+function makeBundleRow(overrides = {}) {
+	return {
+		profile_id: 'prf_1',
+		user_id: 'u1',
+		first_name: 'Ada',
+		last_name: 'Lovelace',
+		phone_number: null,
+		profile_visibility: null,
+		health_info_visibility: null,
+		location_visibility: null,
+		location_sharing_enabled: null,
+		medical_conditions: null,
+		chronic_diseases: null,
+		allergies: null,
+		medications: null,
+		blood_type: null,
+		age: null,
+		gender: null,
+		height: null,
+		weight: null,
+		address: null,
+		city: null,
+		country: null,
+		latitude: null,
+		longitude: null,
+		last_updated: null,
+		...overrides,
+	};
+}
+
+describe('profiles service', () => {
+	test('getMyProfile returns null when bundle does not exist', async () => {
+		repository.findProfileBundleByUserId.mockResolvedValueOnce(null);
+
+		const result = await getMyProfile('u1');
+
+		expect(result).toBeNull();
+		expect(repository.listExpertiseByProfileId).not.toHaveBeenCalled();
+	});
+
+	test('getMyProfile includes expertise list', async () => {
+		repository.findProfileBundleByUserId.mockResolvedValueOnce(makeBundleRow());
+		repository.listExpertiseByProfileId.mockResolvedValueOnce([
+			{ expertiseId: 'exp_1', profession: 'Doctor', expertiseArea: 'ER', isVerified: false },
+		]);
+
+		const result = await getMyProfile('u1');
+
+		expect(result.profile.userId).toBe('u1');
+		expect(result.expertise).toHaveLength(1);
+		expect(result.expertise[0].profession).toBe('Doctor');
+	});
+
+	test('patchMyProfile creates profile when missing', async () => {
+		repository.findActiveUserById.mockResolvedValueOnce({ user_id: 'u1' });
+		repository.findProfileByUserId.mockResolvedValueOnce(null);
+		repository.createProfileByUserId.mockResolvedValueOnce({ profile_id: 'prf_1' });
+		repository.findProfileBundleByUserId.mockResolvedValueOnce(makeBundleRow());
+		repository.listExpertiseByProfileId.mockResolvedValueOnce([]);
+
+		await patchMyProfile('u1', { firstName: 'Ada', lastName: 'Lovelace' });
+
+		expect(repository.createProfileByUserId).toHaveBeenCalledWith('u1', { firstName: 'Ada', lastName: 'Lovelace' });
+		expect(repository.updateProfileByUserId).not.toHaveBeenCalled();
+	});
+
+	test('patchMyProfile updates profile when existing', async () => {
+		repository.findActiveUserById.mockResolvedValueOnce({ user_id: 'u1' });
+		repository.findProfileByUserId.mockResolvedValueOnce({ profile_id: 'prf_1' });
+		repository.updateProfileByUserId.mockResolvedValueOnce({ profile_id: 'prf_1' });
+		repository.findProfileBundleByUserId.mockResolvedValueOnce(makeBundleRow());
+		repository.listExpertiseByProfileId.mockResolvedValueOnce([]);
+
+		await patchMyProfile('u1', { phoneNumber: '555' });
+
+		expect(repository.updateProfileByUserId).toHaveBeenCalledWith('u1', { phoneNumber: '555' });
+	});
+
+	test('patchMyPhysical delegates to repository with provided fields', async () => {
+		repository.findActiveUserById.mockResolvedValueOnce({ user_id: 'u1' });
+		repository.findProfileByUserId.mockResolvedValueOnce({ profile_id: 'prf_1' });
+		repository.findProfileBundleByUserId.mockResolvedValueOnce(makeBundleRow());
+		repository.listExpertiseByProfileId.mockResolvedValueOnce([]);
+
+		await patchMyPhysical('u1', { age: 21 }, ['age']);
+
+		expect(repository.upsertPhysicalInfo).toHaveBeenCalledWith('prf_1', { age: 21 }, ['age']);
+	});
+
+	test('patchMyHealth delegates to repository with provided fields', async () => {
+		repository.findActiveUserById.mockResolvedValueOnce({ user_id: 'u1' });
+		repository.findProfileByUserId.mockResolvedValueOnce({ profile_id: 'prf_1' });
+		repository.findProfileBundleByUserId.mockResolvedValueOnce(makeBundleRow());
+		repository.listExpertiseByProfileId.mockResolvedValueOnce([]);
+
+		await patchMyHealth('u1', { allergies: ['Peanut'] }, ['allergies']);
+
+		expect(repository.upsertHealthInfo).toHaveBeenCalledWith('prf_1', { allergies: ['Peanut'] }, ['allergies']);
+	});
+
+	test('patchMyLocation delegates to repository with provided fields', async () => {
+		repository.findActiveUserById.mockResolvedValueOnce({ user_id: 'u1' });
+		repository.findProfileByUserId.mockResolvedValueOnce({ profile_id: 'prf_1' });
+		repository.findProfileBundleByUserId.mockResolvedValueOnce(makeBundleRow());
+		repository.listExpertiseByProfileId.mockResolvedValueOnce([]);
+
+		await patchMyLocation('u1', { city: 'Istanbul' }, ['city']);
+
+		expect(repository.upsertLocationProfile).toHaveBeenCalledWith('prf_1', { city: 'Istanbul' }, ['city']);
+	});
+
+	test('patchMyPrivacy delegates to repository with provided fields', async () => {
+		repository.findActiveUserById.mockResolvedValueOnce({ user_id: 'u1' });
+		repository.findProfileByUserId.mockResolvedValueOnce({ profile_id: 'prf_1' });
+		repository.findProfileBundleByUserId.mockResolvedValueOnce(makeBundleRow());
+		repository.listExpertiseByProfileId.mockResolvedValueOnce([]);
+
+		await patchMyPrivacy('u1', { locationSharingEnabled: true }, ['locationSharingEnabled']);
+
+		expect(repository.upsertPrivacySettings).toHaveBeenCalledWith('prf_1', { locationSharingEnabled: true }, ['locationSharingEnabled']);
+	});
+
+	test('patchMyProfession throws PROFILE_NOT_FOUND when base profile is missing', async () => {
+		repository.findActiveUserById.mockResolvedValueOnce({ user_id: 'u1' });
+		repository.findProfileByUserId.mockResolvedValueOnce(null);
+
+		await expect(patchMyProfession('u1', { profession: 'Doctor' }))
+			.rejects
+			.toThrow('PROFILE_NOT_FOUND');
+	});
+
+	test('patchMyProfession updates expertise and returns refreshed profile', async () => {
+		repository.findActiveUserById.mockResolvedValue({ user_id: 'u1' });
+		repository.findProfileByUserId.mockResolvedValueOnce({ profile_id: 'prf_1' });
+		repository.upsertProfession.mockResolvedValueOnce();
+		repository.findProfileBundleByUserId.mockResolvedValueOnce(makeBundleRow());
+		repository.listExpertiseByProfileId.mockResolvedValueOnce([
+			{ expertiseId: 'exp_1', profession: 'Nurse', expertiseArea: null, isVerified: false },
+		]);
+
+		const result = await patchMyProfession('u1', { profession: 'Nurse' });
+
+		expect(repository.upsertProfession).toHaveBeenCalledWith('prf_1', { profession: 'Nurse' });
+		expect(result.expertise[0].profession).toBe('Nurse');
+	});
+});

--- a/backend/tests/unit/modules/profiles/validators.test.js
+++ b/backend/tests/unit/modules/profiles/validators.test.js
@@ -1,3 +1,120 @@
 'use strict';
 
-// Unit test scaffold for profiles validators.
+const {
+	validateProfilePatch,
+	validatePhysicalPatch,
+	validateHealthPatch,
+	validateLocationPatch,
+	validatePrivacyPatch,
+	validateProfessionPatch,
+} = require('../../../../src/modules/profiles/validators');
+
+describe('profiles validators', () => {
+	describe('validateProfilePatch', () => {
+		test('accepts valid profile patch', () => {
+			const result = validateProfilePatch({ firstName: 'Ada', lastName: 'Lovelace' }, { requireNames: true });
+
+			expect(result.ok).toBe(true);
+			expect(result.data).toEqual({ firstName: 'Ada', lastName: 'Lovelace' });
+		});
+
+		test('requires firstName and lastName when creating profile', () => {
+			const result = validateProfilePatch({ firstName: 'Ada' }, { requireNames: true });
+
+			expect(result.ok).toBe(false);
+			expect(result.message).toContain('firstName and lastName are required');
+		});
+	});
+
+	describe('validatePhysicalPatch', () => {
+		test('accepts valid physical payload', () => {
+			const result = validatePhysicalPatch({ age: 28, height: 171, weight: 66 });
+
+			expect(result.ok).toBe(true);
+		});
+
+		test('rejects negative age', () => {
+			const result = validatePhysicalPatch({ age: -1 });
+
+			expect(result.ok).toBe(false);
+			expect(result.message).toBe('age must be a number >= 0');
+		});
+	});
+
+	describe('validateHealthPatch', () => {
+		test('accepts valid health payload', () => {
+			const result = validateHealthPatch({ allergies: ['Peanut'], bloodType: 'A+' });
+
+			expect(result.ok).toBe(true);
+		});
+
+		test('rejects non-string items in list fields', () => {
+			const result = validateHealthPatch({ medications: ['MedA', 12] });
+
+			expect(result.ok).toBe(false);
+			expect(result.message).toBe('medications must be an array of strings');
+		});
+	});
+
+	describe('validateLocationPatch', () => {
+		test('rejects payload without latitude/longitude pair', () => {
+			const result = validateLocationPatch({ latitude: 41.01 });
+
+			expect(result.ok).toBe(false);
+			expect(result.message).toBe('latitude and longitude must be provided together');
+		});
+
+		test('accepts partial string-only location update', () => {
+			const result = validateLocationPatch({ city: 'Istanbul' });
+
+			expect(result.ok).toBe(true);
+			expect(result.data).toEqual({ city: 'Istanbul' });
+		});
+
+		test('accepts full coordinates in valid ranges', () => {
+			const result = validateLocationPatch({ latitude: 41.0082, longitude: 28.9784 });
+
+			expect(result.ok).toBe(true);
+			expect(result.data).toEqual({ latitude: 41.0082, longitude: 28.9784 });
+		});
+	});
+
+	describe('validatePrivacyPatch', () => {
+		test('accepts valid privacy payload', () => {
+			const result = validatePrivacyPatch({ profileVisibility: 'PUBLIC', locationSharingEnabled: true });
+
+			expect(result.ok).toBe(true);
+		});
+
+		test('rejects invalid visibility value', () => {
+			const result = validatePrivacyPatch({ profileVisibility: 'FRIENDS_ONLY' });
+
+			expect(result.ok).toBe(false);
+			expect(result.message).toContain('must be one of PUBLIC, EMERGENCY_ONLY, PRIVATE');
+		});
+	});
+
+	describe('validateProfessionPatch', () => {
+		test('rejects empty payload', () => {
+			const result = validateProfessionPatch({});
+
+			expect(result.ok).toBe(false);
+			expect(result.message).toContain('At least one profession field');
+		});
+
+		test('trims profession and accepts optional expertiseArea', () => {
+			const result = validateProfessionPatch({ profession: '  Doctor  ', expertiseArea: ' ER ' });
+
+			expect(result.ok).toBe(true);
+			expect(result.data).toEqual({ profession: 'Doctor', expertiseArea: 'ER' });
+		});
+
+		test('rejects profession longer than 200 characters', () => {
+			const longProfession = 'a'.repeat(201);
+			const result = validateProfessionPatch({ profession: longProfession });
+
+			expect(result.ok).toBe(false);
+			expect(result.message).toBe('profession must be at most 200 characters');
+		});
+	});
+});


### PR DESCRIPTION
This PR adds profile module test coverage and improves test setup reliability.

Changes:

Added unit tests for profile validators, service, and controller.
Added DB-backed integration tests for all profile endpoints (profile, physical, health, location, privacy, profession).
Improved Jest integration setup with test DB initialization and pool teardown.
Updated setup documentation for running tests with Docker/PostgreSQL locally.
Result:

Better regression protection for profile flows.
More realistic integration testing with PostgreSQL.
Cleaner and more consistent local test execution.

Closes #152