### PR TITLE
fix: connect frontend auth and profile flows to backend endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ test-results/
 # Runtime
 *.pid
 *.seed
+
+# Agent files
+.sisyphus
+mvp354/

--- a/web/src/app/(auth)/verify-email/page.tsx
+++ b/web/src/app/(auth)/verify-email/page.tsx
@@ -5,7 +5,7 @@ export default function VerifyEmailPage() {
     return (
         <AuthLayout
             title="Verify Email"
-            subtitle="Enter the 6-digit verification code sent to your email address."
+            subtitle="Use the verification link sent to your email, or resend it from this page."
         >
             <VerifyEmailForm />
         </AuthLayout>

--- a/web/src/components/feature/auth/CompleteProfileForm.tsx
+++ b/web/src/components/feature/auth/CompleteProfileForm.tsx
@@ -1,92 +1,108 @@
 "use client";
 
 import * as React from "react";
+import { useRouter } from "next/navigation";
 import { TextInput } from "@/components/ui/inputs/TextInput";
 import { SelectInput } from "@/components/ui/inputs/SelectInput";
 import { TextArea } from "@/components/ui/inputs/TextArea";
 import { ToggleSwitch } from "@/components/ui/selection/ToggleSwitch";
 import { ProfileInfoRow } from "../../ui/display/ProfileInfoRow";
 import { SaveActionBar } from "../../ui/display/SaveActionBar";
+import { HelperText } from "@/components/ui/display/HelperText";
 import { bloodTypeOptions } from "@/lib/bloodTypes";
+import { countryCodeOptions } from "@/lib/countryCodes";
+import { getAccessToken, SIGNUP_DRAFT_KEY } from "@/lib/auth";
+import {
+    buildAddress,
+    parseListField,
+    patchMyHealth,
+    patchMyLocation,
+    patchMyPhysical,
+    patchMyPrivacy,
+    patchMyProfile,
+    splitFullName,
+} from "@/lib/profile";
 
 type ProfileForm = {
-  gender: string;
-  height: string;
-  weight: string;
-  bloodType?: string;
-  birthDate: string;
-  medicalHistory: string;
-  country: string;
-  city: string;
-  district: string;
-  neighborhood: string;
-  extraAddress: string;
-  shareLocation: boolean;
+    fullName: string;
+    countryCode: string;
+    phone: string;
+    gender: string;
+    height: string;
+    weight: string;
+    bloodType: string;
+    birthDate: string;
+    medicalHistory: string;
+    country: string;
+    city: string;
+    district: string;
+    neighborhood: string;
+    extraAddress: string;
+    shareLocation: boolean;
 };
 
 type Neighborhood = {
-  label: string;
-  value: string;
+    label: string;
+    value: string;
 };
 
 type District = {
-  label: string;
-  neighborhoods: Neighborhood[];
+    label: string;
+    neighborhoods: Neighborhood[];
 };
 
 type City = {
-  label: string;
-  districts: Record<string, District>;
+    label: string;
+    districts: Record<string, District>;
 };
 
 type Country = {
-  label: string;
-  cities: Record<string, City>;
+    label: string;
+    cities: Record<string, City>;
 };
 
 type LocationData = Record<string, Country>;
 
 const locationData: LocationData = {
-  tr: {
-    label: "Turkey",
-    cities: {
-      istanbul: {
-        label: "Istanbul",
-        districts: {
-          kadikoy: {
-            label: "Kadıköy",
-            neighborhoods: [
-              { label: "Bostancı", value: "bostanci" },
-              { label: "Erenköy", value: "erenkoy" },
-            ],
-          },
-          besiktas: {
-            label: "Beşiktaş",
-            neighborhoods: [
-              { label: "Balmumcu", value: "balmumcu" },
-              { label: "Kuruçeşme", value: "kurucesme" },
-            ],
-          },
+    tr: {
+        label: "Turkey",
+        cities: {
+            istanbul: {
+                label: "Istanbul",
+                districts: {
+                    kadikoy: {
+                        label: "Kadıköy",
+                        neighborhoods: [
+                            { label: "Bostancı", value: "bostanci" },
+                            { label: "Erenköy", value: "erenkoy" },
+                        ],
+                    },
+                    besiktas: {
+                        label: "Beşiktaş",
+                        neighborhoods: [
+                            { label: "Balmumcu", value: "balmumcu" },
+                            { label: "Kuruçeşme", value: "kurucesme" },
+                        ],
+                    },
+                },
+            },
+            ankara: {
+                label: "Ankara",
+                districts: {
+                    cankaya: {
+                        label: "Çankaya",
+                        neighborhoods: [{ label: "Anıttepe", value: "anittepe" }],
+                    },
+                },
+            },
         },
-      },
-      ankara: {
-        label: "Ankara",
-        districts: {
-          cankaya: {
-            label: "Çankaya",
-            neighborhoods: [
-              { label: "Anıttepe", value: "anittepe" },
-            ],
-          },
-        },
-      },
     },
-  },
 };
 
-
-  export default function CompleteProfileForm() {
-    const [form, setForm] = React.useState<ProfileForm>({
+const initialForm: ProfileForm = {
+    fullName: "",
+    countryCode: "+90",
+    phone: "",
     gender: "",
     height: "",
     weight: "",
@@ -99,262 +115,376 @@ const locationData: LocationData = {
     neighborhood: "",
     extraAddress: "",
     shareLocation: false,
-  });
-
-  const [loading, setLoading] = React.useState(false);
-  const [error, setError] = React.useState("");
-
-
-  const countryData = locationData[form.country] ?? undefined;
-
-  const countryOptions = Object.entries(locationData).map(
-    ([key, val]) => ({
-      label: val.label,
-      value: key,
-    })
-  );
-
-  const cityOptions =
-  form.country && countryData
-    ? Object.entries(countryData.cities).map(([key, val]) => ({
-        label: val.label,
-        value: key,
-      }))
-    : [];
-
-  const districtOptions =
-  form.city && countryData?.cities?.[form.city]
-    ? Object.entries(
-        countryData.cities[form.city].districts
-      ).map(([key, val]) => ({
-        label: val.label,
-        value: key,
-      }))
-    : [];
-
-  const neighborhoodOptions =
-  form.city &&
-  form.district &&
-  countryData?.cities?.[form.city]?.districts?.[form.district]
-    ? countryData.cities[form.city].districts[form.district].neighborhoods
-    : [];
-
-
-  const handleSave = async () => {
-  setError("");
-
-  const isAddressIncomplete =
-    !form.country || !form.city || !form.district || !form.neighborhood;
-
-  if (!form.height || !form.weight || !form.birthDate || isAddressIncomplete) {
-    setError("Please fill in all required fields.");
-    return;
-  }
-
-  setLoading(true);
-  await new Promise((r) => setTimeout(r, 600));
-
-  const existingUser = localStorage.getItem("user");
-  const parsed = existingUser ? JSON.parse(existingUser) : {};
-  const finalData = { ...parsed, ...form };
-
-  // TODO: localStorage is used temporarily for demo purposes.
-  // Replace with a proper API call before production.
-  localStorage.setItem("user", JSON.stringify(finalData));
-
-  setLoading(false);
 };
 
-  return (
-    <div className="w-full max-w-md mx-auto flex flex-col gap-5">
+export default function CompleteProfileForm() {
+    const router = useRouter();
+    const [form, setForm] = React.useState<ProfileForm>(initialForm);
+    const [loading, setLoading] = React.useState(false);
+    const [error, setError] = React.useState("");
 
-        {/* HEIGHT & WEIGHT */}
-        <div className="grid grid-cols-2 gap-4">
-          <TextInput
-            id="height"
-            label="Height (cm)"
-            value={form.height}
-            onChange={(e) => {
-              const val = e.target.value;
-              if (/^\d{0,3}$/.test(val)) {
-                setForm({ ...form, height: val });
-              }
-            }}
-          />
+    React.useEffect(() => {
+        const savedDraft = sessionStorage.getItem(SIGNUP_DRAFT_KEY);
 
-          <TextInput
-            id="weight"
-            label="Weight (kg)"
-            value={form.weight}
-            onChange={(e) => {
-              const val = e.target.value;
-              if (/^\d{0,3}$/.test(val)) {
-                setForm({ ...form, weight: val });
-              }
-            }}
-          />
+        if (!savedDraft) {
+            return;
+        }
+
+        try {
+            const parsed = JSON.parse(savedDraft) as Partial<ProfileForm>;
+
+            setForm((currentForm) => ({
+                ...currentForm,
+                fullName: parsed.fullName || currentForm.fullName,
+                countryCode: parsed.countryCode || currentForm.countryCode,
+                phone: parsed.phone || currentForm.phone,
+            }));
+        } catch {
+            sessionStorage.removeItem(SIGNUP_DRAFT_KEY);
+        }
+    }, []);
+
+    const countryData = locationData[form.country] ?? undefined;
+
+    const countryOptions = Object.entries(locationData).map(([key, value]) => ({
+        label: value.label,
+        value: key,
+    }));
+
+    const cityOptions =
+        form.country && countryData
+            ? Object.entries(countryData.cities).map(([key, value]) => ({
+                label: value.label,
+                value: key,
+            }))
+            : [];
+
+    const districtOptions =
+        form.city && countryData?.cities[form.city]
+            ? Object.entries(countryData.cities[form.city].districts).map(
+                ([key, value]) => ({
+                    label: value.label,
+                    value: key,
+                })
+            )
+            : [];
+
+    const neighborhoodOptions =
+        form.city &&
+            form.district &&
+            countryData?.cities[form.city]?.districts[form.district]
+            ? countryData.cities[form.city].districts[form.district].neighborhoods
+            : [];
+
+    const handleSave = async () => {
+        setError("");
+
+        if (!form.fullName.trim()) {
+            setError("Please enter your full name.");
+            return;
+        }
+
+        const { firstName, lastName } = splitFullName(form.fullName);
+
+        if (!firstName || !lastName) {
+            setError("Please enter both first and last name.");
+            return;
+        }
+
+        if (!form.phone.trim()) {
+            setError("Please enter your phone number.");
+            return;
+        }
+
+        if (!form.birthDate) {
+            setError("Please enter your date of birth.");
+            return;
+        }
+
+        if (!form.bloodType) {
+            setError("Please select your blood type.");
+            return;
+        }
+
+        if (!form.height || !form.weight || !form.country || !form.city) {
+            setError("Please fill in all required fields.");
+            return;
+        }
+
+        const token = getAccessToken();
+
+        if (!token) {
+            setError("Your session has expired. Please log in again before completing your profile.");
+            return;
+        }
+
+        try {
+            setLoading(true);
+
+            await patchMyProfile(token, {
+                firstName,
+                lastName,
+                phoneNumber: `${form.countryCode}${form.phone.trim()}`,
+            });
+
+            await patchMyPhysical(token, {
+                gender: form.gender || null,
+                height: Number(form.height),
+                weight: Number(form.weight),
+            });
+
+            await patchMyHealth(token, {
+                medicalConditions: parseListField(form.medicalHistory),
+                bloodType: form.bloodType || null,
+            });
+
+            await patchMyLocation(token, {
+                country: countryData?.label || form.country,
+                city: countryData?.cities[form.city]?.label || form.city,
+                address:
+                    buildAddress({
+                        district: form.district,
+                        neighborhood: form.neighborhood,
+                        extraAddress: form.extraAddress,
+                    }) || null,
+            });
+
+            await patchMyPrivacy(token, {
+                locationSharingEnabled: form.shareLocation,
+            });
+
+            sessionStorage.removeItem(SIGNUP_DRAFT_KEY);
+            router.push("/profile");
+        } catch (err) {
+            const baseMessage =
+                err instanceof Error && err.message
+                    ? err.message
+                    : "Could not save your profile.";
+
+            setError(
+                `${baseMessage} Some sections may already be saved because the backend currently updates profile data in separate requests. Please review your profile and try again.`
+            );
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="mx-auto flex w-full max-w-md flex-col gap-5">
+            <TextInput
+                id="fullName"
+                label="Full Name"
+                value={form.fullName}
+                onChange={(e) =>
+                    setForm({
+                        ...form,
+                        fullName: e.target.value,
+                    })
+                }
+            />
+
+            <div className="grid grid-cols-[120px_1fr] gap-3">
+                <div className="w-[120px]">
+                    <SelectInput
+                        id="profile-country-code"
+                        label="Code"
+                        value={form.countryCode}
+                        onChange={(e) =>
+                            setForm({
+                                ...form,
+                                countryCode: e.target.value,
+                            })
+                        }
+                        options={countryCodeOptions}
+                        placeholder="Select"
+                    />
+                </div>
+
+                <TextInput
+                    id="phone"
+                    label="Phone Number"
+                    type="tel"
+                    inputMode="numeric"
+                    value={form.phone}
+                    onChange={(e) =>
+                        setForm({
+                            ...form,
+                            phone: e.target.value.replace(/\D/g, ""),
+                        })
+                    }
+                />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+                <TextInput
+                    id="height"
+                    label="Height (cm)"
+                    value={form.height}
+                    onChange={(e) => {
+                        const value = e.target.value;
+
+                        if (/^\d{0,3}$/.test(value)) {
+                            setForm({ ...form, height: value });
+                        }
+                    }}
+                />
+
+                <TextInput
+                    id="weight"
+                    label="Weight (kg)"
+                    value={form.weight}
+                    onChange={(e) => {
+                        const value = e.target.value;
+
+                        if (/^\d{0,3}$/.test(value)) {
+                            setForm({ ...form, weight: value });
+                        }
+                    }}
+                />
+            </div>
+
+            <ProfileInfoRow label="Gender">
+                <SelectInput
+                    id="gender"
+                    options={[
+                        { label: "Select Gender", value: "" },
+                        { label: "Male", value: "male" },
+                        { label: "Female", value: "female" },
+                        { label: "Other", value: "other" },
+                    ]}
+                    value={form.gender}
+                    onChange={(e) =>
+                        setForm({ ...form, gender: e.target.value })
+                    }
+                />
+            </ProfileInfoRow>
+
+            <ProfileInfoRow label="Date of Birth">
+                <TextInput
+                    id="birthDate"
+                    type="date"
+                    value={form.birthDate}
+                    onChange={(e) =>
+                        setForm({ ...form, birthDate: e.target.value })
+                    }
+                />
+                <HelperText>
+                    Date of birth is kept in the form for now, but the current backend
+                    profile API only stores age-related physical data.
+                </HelperText>
+            </ProfileInfoRow>
+
+            <ProfileInfoRow label="Blood Type">
+                <SelectInput
+                    id="bloodType"
+                    options={bloodTypeOptions}
+                    value={form.bloodType}
+                    onChange={(e) =>
+                        setForm({ ...form, bloodType: e.target.value })
+                    }
+                />
+            </ProfileInfoRow>
+
+            <ProfileInfoRow label="Medical History">
+                <TextArea
+                    id="medicalHistory"
+                    placeholder="Chronic diseases, allergies, or other important notes"
+                    value={form.medicalHistory}
+                    onChange={(e) =>
+                        setForm({ ...form, medicalHistory: e.target.value })
+                    }
+                />
+            </ProfileInfoRow>
+
+            <ProfileInfoRow label="Address">
+                <SelectInput
+                    id="country"
+                    options={[{ label: "Select Country", value: "" }, ...countryOptions]}
+                    value={form.country}
+                    onChange={(e) =>
+                        setForm({
+                            ...form,
+                            country: e.target.value,
+                            city: "",
+                            district: "",
+                            neighborhood: "",
+                        })
+                    }
+                />
+
+                <SelectInput
+                    id="city"
+                    options={[{ label: "Select City", value: "" }, ...cityOptions]}
+                    value={form.city}
+                    onChange={(e) =>
+                        setForm({
+                            ...form,
+                            city: e.target.value,
+                            district: "",
+                            neighborhood: "",
+                        })
+                    }
+                />
+
+                <SelectInput
+                    id="district"
+                    options={[{ label: "Select District", value: "" }, ...districtOptions]}
+                    value={form.district}
+                    onChange={(e) =>
+                        setForm({
+                            ...form,
+                            district: e.target.value,
+                            neighborhood: "",
+                        })
+                    }
+                />
+
+                <SelectInput
+                    id="neighborhood"
+                    options={[
+                        { label: "Select Neighborhood", value: "" },
+                        ...neighborhoodOptions,
+                    ]}
+                    value={form.neighborhood}
+                    onChange={(e) =>
+                        setForm({
+                            ...form,
+                            neighborhood: e.target.value,
+                        })
+                    }
+                />
+
+                <TextInput
+                    id="extraAddress"
+                    placeholder="Street, building, etc. (optional)"
+                    value={form.extraAddress}
+                    onChange={(e) =>
+                        setForm({
+                            ...form,
+                            extraAddress: e.target.value,
+                        })
+                    }
+                />
+                <HelperText>
+                    District and neighborhood are flattened into the backend address field
+                    until dedicated backend fields exist.
+                </HelperText>
+            </ProfileInfoRow>
+
+            <div className="flex items-center justify-between">
+                <span className="text-sm">Share Current Location</span>
+
+                <ToggleSwitch
+                    checked={form.shareLocation}
+                    onCheckedChange={(value) =>
+                        setForm({ ...form, shareLocation: value })
+                    }
+                />
+            </div>
+
+            {error ? <HelperText className="text-red-500">{error}</HelperText> : null}
+
+            <SaveActionBar onSave={handleSave} loading={loading} />
         </div>
-
-        {/* GENDER */}
-        <ProfileInfoRow label="Gender">
-          <SelectInput
-            id="gender"
-            options={[
-              { label: "Select Gender", value: "" },
-              { label: "Male", value: "male" },
-              { label: "Female", value: "female" },
-              { label: "Other", value: "other" },
-            ]}
-            value={form.gender}
-            onChange={(e) =>
-              setForm({ ...form, gender: e.target.value })
-            }
-          />
-        </ProfileInfoRow>
-
-        {/* DATE */}
-        <ProfileInfoRow label="Date of Birth">
-          <TextInput
-            id="birthDate"
-            type="date"
-            value={form.birthDate}
-            onChange={(e) =>
-              setForm({ ...form, birthDate: e.target.value })
-            }
-          />
-        </ProfileInfoRow>
-
-        {/* MEDICAL */}
-        <ProfileInfoRow label="Blood Type">
-  <SelectInput
-    id="bloodType"
-    options={bloodTypeOptions}
-    value={form.bloodType ?? ""}
-    onChange={(e) =>
-      setForm({ ...form, bloodType: e.target.value })
-    }
-  />
-</ProfileInfoRow>
-
-<ProfileInfoRow label="Medical History">
-  <TextArea
-    id="medicalHistory"
-    placeholder="Chronic diseases & allergies"
-    value={form.medicalHistory}
-    onChange={(e) =>
-      setForm({ ...form, medicalHistory: e.target.value })
-    }
-  />
-  <p className="text-xs text-gray-400">
-    You may need to verify this information later
-  </p>
-</ProfileInfoRow>
-
-        {/* ADDRESS */}
-        <ProfileInfoRow label="Address">
-          <SelectInput
-            id="country"
-            options={[
-              { label: "Select Country", value: "" },
-              ...countryOptions,
-            ]}
-            value={form.country}
-            onChange={(e) =>
-              setForm({
-                ...form,
-                country: e.target.value,
-                city: "",
-                district: "",
-                neighborhood: "",
-              })
-            }
-          />
-
-          <SelectInput
-            id="city"
-            options={[
-              { label: "Select City", value: "" },
-              ...(cityOptions || []),
-            ]}
-            value={form.city}
-            onChange={(e) =>
-              setForm({
-                ...form,
-                city: e.target.value,
-                district: "",
-                neighborhood: "",
-              })
-            }
-          />
-
-          <SelectInput
-            id="district"
-            options={[
-              { label: "Select District", value: "" },
-              ...(districtOptions || []),
-            ]}
-            value={form.district}
-            onChange={(e) =>
-              setForm({
-                ...form,
-                district: e.target.value,
-                neighborhood: "",
-              })
-            }
-          />
-
-          <SelectInput
-            id="neighborhood"
-            options={[
-              { label: "Select Neighborhood", value: "" },
-              ...(neighborhoodOptions || []),
-            ]}
-            value={form.neighborhood}
-            onChange={(e) =>
-              setForm({
-                ...form,
-                neighborhood: e.target.value,
-              })
-            }
-          />
-
-          <TextInput
-            id="extraAddress"
-            placeholder="Street, building, etc. (optional)"
-            value={form.extraAddress}
-            onChange={(e) =>
-              setForm({
-                ...form,
-                extraAddress: e.target.value,
-              })
-            }
-          />
-        </ProfileInfoRow>
-
-        {/* TOGGLE */}
-        <div className="flex items-center justify-between">
-          <span className="text-sm">
-            Share Current Location
-          </span>
-
-          <ToggleSwitch
-            checked={form.shareLocation ?? false}
-            onCheckedChange={(val) =>
-              setForm({ ...form, shareLocation: val })
-            }
-          />
-        </div>
-
-        {/* ERROR */}
-        {error && (
-          <p className="text-sm text-red-500">
-            {error}
-          </p>
-        )}
-
-        {/* SAVE */}
-        <SaveActionBar onSave={handleSave} loading={loading} />
-      </div>
-
-  );
+    );
 }

--- a/web/src/components/feature/auth/ForgotPasswordForm.tsx
+++ b/web/src/components/feature/auth/ForgotPasswordForm.tsx
@@ -10,6 +10,15 @@ import { Divider } from "@/components/ui/display/Divider";
 import { HelperText } from "@/components/ui/display/HelperText";
 import { isValidEmail } from "@/lib/validators/email";
 
+const FORGOT_PASSWORD_ENDPOINT = "/api/auth/forgot-password";
+
+type ForgotPasswordErrorResponse = {
+    detail?: string;
+    message?: string;
+    error?: string;
+    errors?: Record<string, string[] | string>;
+};
+
 export function ForgotPasswordForm() {
     const router = useRouter();
     const searchParams = useSearchParams();
@@ -26,25 +35,72 @@ export function ForgotPasswordForm() {
         e.preventDefault();
         setError("");
         setInfo("");
+        setSuccess(false);
 
-        if (!email.trim()) {
+        const trimmedEmail = email.trim();
+
+        if (!trimmedEmail) {
             setError("Please enter your email address.");
             return;
         }
 
-        if (!isValidEmail(email)) {
-    setError("Please enter a valid email address.");
-    return;
-}
+        if (!isValidEmail(trimmedEmail)) {
+            setError("Please enter a valid email address.");
+            return;
+        }
 
         try {
             setLoading(true);
 
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+            const response = await fetch(FORGOT_PASSWORD_ENDPOINT, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    email: trimmedEmail,
+                }),
+            });
+
+            if (!response.ok) {
+                let errorMessage =
+                    "We could not start the password reset flow. Please try again.";
+
+                try {
+                    const data =
+                        (await response.json()) as ForgotPasswordErrorResponse;
+
+                    if (typeof data.detail === "string" && data.detail.trim()) {
+                        errorMessage = data.detail;
+                    } else if (typeof data.message === "string" && data.message.trim()) {
+                        errorMessage = data.message;
+                    } else if (typeof data.error === "string" && data.error.trim()) {
+                        errorMessage = data.error;
+                    } else if (data.errors && typeof data.errors === "object") {
+                        const firstFieldError = Object.values(data.errors)[0];
+
+                        if (Array.isArray(firstFieldError) && firstFieldError[0]) {
+                            errorMessage = firstFieldError[0];
+                        } else if (
+                            typeof firstFieldError === "string" &&
+                            firstFieldError.trim()
+                        ) {
+                            errorMessage = firstFieldError;
+                        }
+                    }
+                } catch {
+                    // ignore JSON parse issues and keep fallback message
+                }
+
+                setError(errorMessage);
+                return;
+            }
 
             setSuccess(true);
         } catch {
-            setError("We could not start the password reset flow. Please try again.");
+            setError(
+                "We could not reach the server. Please check your connection and try again."
+            );
         } finally {
             setLoading(false);
         }
@@ -108,8 +164,6 @@ export function ForgotPasswordForm() {
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                 />
-
-               
 
                 {error ? (
                     <HelperText className="text-[#D84A4A]">{error}</HelperText>

--- a/web/src/components/feature/auth/LoginForm.tsx
+++ b/web/src/components/feature/auth/LoginForm.tsx
@@ -11,6 +11,9 @@ import { Divider } from "@/components/ui/display/Divider";
 import { HelperText } from "@/components/ui/display/HelperText";
 import { AuthFooterLinks } from "@/components/feature/auth/AuthFooterLinks";
 import { SocialAuthButtons } from "@/components/feature/auth/SocialAuthButtons";
+import { ApiError } from "@/lib/api";
+import { login, setAccessToken } from "@/lib/auth";
+import { fetchMyProfile } from "@/lib/profile";
 import { isValidEmail } from "@/lib/validators/email";
 
 export function LoginForm() {
@@ -42,11 +45,25 @@ export function LoginForm() {
         try {
             setLoading(true);
 
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+            const response = await login({ email, password });
 
+            try {
+                await fetchMyProfile(response.accessToken);
+                setAccessToken(response.accessToken, { rememberMe });
+                router.push("/profile");
+            } catch (profileError) {
+                if (profileError instanceof ApiError && profileError.status === 404) {
+                    setAccessToken(response.accessToken, { rememberMe });
+                    router.push("/complete-profile");
+                    return;
+                }
 
-        } catch {
-            setError("Login failed. Please try again.");
+                throw profileError;
+            }
+        } catch (err) {
+            setError(
+                err instanceof Error ? err.message : "Login failed. Please try again."
+            );
         } finally {
             setLoading(false);
         }

--- a/web/src/components/feature/auth/SignupForm.tsx
+++ b/web/src/components/feature/auth/SignupForm.tsx
@@ -14,9 +14,8 @@ import { HelperText } from "@/components/ui/display/HelperText";
 import { AuthFooterLinks } from "@/components/feature/auth/AuthFooterLinks";
 import { SocialAuthButtons } from "@/components/feature/auth/SocialAuthButtons";
 import { countryCodeOptions } from "@/lib/countryCodes";
+import { SIGNUP_DRAFT_KEY, signup } from "@/lib/auth";
 import { isValidEmail } from "@/lib/validators/email";
-
-const SIGNUP_DRAFT_KEY = "neph_signup_draft";
 
 export function SignupForm() {
     const router = useRouter();
@@ -117,37 +116,36 @@ export function SignupForm() {
         }
 
         try {
-        setLoading(true);
+            setLoading(true);
 
-        sessionStorage.setItem(
-            SIGNUP_DRAFT_KEY,
-            JSON.stringify({
-                fullName,
+            sessionStorage.setItem(
+                SIGNUP_DRAFT_KEY,
+                JSON.stringify({
+                    fullName,
+                    email,
+                    countryCode,
+                    phone,
+                    acceptedTerms,
+                })
+            );
+
+            await signup({
                 email,
-                countryCode,
-                phone,
+                password,
                 acceptedTerms,
-            })
-        );
-        localStorage.setItem(
-            "user",
-            JSON.stringify({
-                fullName,
-                email,
-                phone,
-            })
-        );
+            });
 
-        setInfo(
-            "Account created successfully. Redirecting to email verification..."
-        );
+            setInfo(
+                "Account created successfully. Check your email for the verification link."
+            );
 
-        redirectTimeoutRef.current = setTimeout(() => {
-            router.push(`/verify-email?email=${encodeURIComponent(email)}`);
-        }, 700);
-        
-        } catch {
-            setError("Signup failed. Please try again.");
+            redirectTimeoutRef.current = setTimeout(() => {
+                router.push(`/verify-email?email=${encodeURIComponent(email)}`);
+            }, 700);
+        } catch (err) {
+            setError(
+                err instanceof Error ? err.message : "Signup failed. Please try again."
+            );
         } finally {
             setLoading(false);
         }

--- a/web/src/components/feature/auth/VerifyEmailForm.tsx
+++ b/web/src/components/feature/auth/VerifyEmailForm.tsx
@@ -2,22 +2,20 @@
 
 import * as React from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { VerificationCodeInput } from "@/components/ui/inputs/VerificationCodeInput";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
 import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
 import { HelperText } from "@/components/ui/display/HelperText";
 import { Divider } from "@/components/ui/display/Divider";
 import { AuthFooterLinks } from "@/components/feature/auth/AuthFooterLinks";
-
-const SIGNUP_DRAFT_KEY = "neph_signup_draft";
+import { resendVerification, verifyEmail } from "@/lib/auth";
 
 export function VerifyEmailForm() {
     const router = useRouter();
     const searchParams = useSearchParams();
 
     const emailFromQuery = searchParams.get("email") || "";
+    const tokenFromQuery = searchParams.get("token") || "";
 
-    const [code, setCode] = React.useState("");
     const [loading, setLoading] = React.useState(false);
     const [resending, setResending] = React.useState(false);
     const [error, setError] = React.useState("");
@@ -29,20 +27,23 @@ export function VerifyEmailForm() {
         setError("");
         setInfo("");
 
-        if (code.trim().length !== 6) {
-            setError("Please enter the 6-digit verification code.");
+        if (!tokenFromQuery) {
+            setError(
+                "Email verification currently uses the link sent to your inbox."
+            );
             return;
         }
 
         try {
             setLoading(true);
 
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+            await verifyEmail(tokenFromQuery);
 
-            sessionStorage.removeItem(SIGNUP_DRAFT_KEY);
             setSuccess(true);
-        } catch {
-            setError("Verification failed. Please try again.");
+        } catch (err) {
+            setError(
+                err instanceof Error ? err.message : "Verification failed. Please try again."
+            );
         } finally {
             setLoading(false);
         }
@@ -55,11 +56,16 @@ export function VerifyEmailForm() {
         try {
             setResending(true);
 
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+            if (!emailFromQuery) {
+                setError("Email address is required to resend verification.");
+                return;
+            }
 
-            setInfo("A new verification code has been sent.");
-        } catch {
-            setError("Could not resend the code.");
+            const response = await resendVerification(emailFromQuery);
+
+            setInfo(response.message);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Could not resend the code.");
         } finally {
             setResending(false);
         }
@@ -74,13 +80,13 @@ export function VerifyEmailForm() {
                     </h3>
 
                     <p className="mt-2 text-sm text-[#737380]">
-                        Your account is now verified. You can continue to the login
-                        page.
+                        Your account is now verified. Log in to continue with profile
+                        setup.
                     </p>
 
                     <div className="mt-5">
-                        <PrimaryButton onClick={() => router.push("/complete-profile")}>
-                            Continue to Profile Setup
+                        <PrimaryButton onClick={() => router.push("/login")}>
+                            Continue to Log In
                         </PrimaryButton>
                     </div>
                 </div>
@@ -96,23 +102,21 @@ export function VerifyEmailForm() {
         <>
             <form className="flex flex-col gap-4" onSubmit={handleVerify}>
                 <div className="rounded-[14px] border border-[#E7E7EA] bg-[#FAFAFB] p-4">
-                    <p className="text-sm font-medium text-[#2B2B33]">
-                        Verification code
-                    </p>
-
                     <p className="mt-1 text-sm text-[#737380]">
-                        {emailFromQuery
-                            ? `We sent a verification code to ${emailFromQuery}.`
-                            : "Enter the code sent to your email address."}
+                        {tokenFromQuery
+                            ? "Your verification link is ready. Confirm your email below."
+                            : emailFromQuery
+                                ? `We sent a verification link to ${emailFromQuery}.`
+                                : "Open the verification link from your email, or resend it below."}
                     </p>
                 </div>
 
-                <div className="flex flex-col items-center gap-3">
-                    <VerificationCodeInput value={code} onChange={setCode} />
+                {!tokenFromQuery ? (
                     <HelperText className="text-center">
-                        The code should contain 6 digits.
+                        The current backend verifies email through a tokenized link, not a
+                        6-digit code.
                     </HelperText>
-                </div>
+                ) : null}
 
                 {error ? (
                     <HelperText className="text-center text-[#D84A4A]">
@@ -124,17 +128,21 @@ export function VerifyEmailForm() {
                     <HelperText className="text-center">{info}</HelperText>
                 ) : null}
 
-                <PrimaryButton type="submit" loading={loading}>
-                    Verify Email
-                </PrimaryButton>
+                {tokenFromQuery ? (
+                    <PrimaryButton type="submit" loading={loading}>
+                        Verify Email
+                    </PrimaryButton>
+                ) : null}
 
-                <SecondaryButton
-                    type="button"
-                    onClick={handleResend}
-                    disabled={resending}
-                >
-                    {resending ? "Sending..." : "Resend Code"}
-                </SecondaryButton>
+                {emailFromQuery ? (
+                    <SecondaryButton
+                        type="button"
+                        onClick={handleResend}
+                        disabled={resending}
+                    >
+                        {resending ? "Sending..." : "Resend Verification Email"}
+                    </SecondaryButton>
+                ) : null}
             </form>
 
             <Divider className="my-6" />

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { useRouter } from "next/navigation";
 import { Avatar } from "@/components/ui/media/Avatar";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { SectionHeader } from "@/components/ui/display/SectionHeader";
@@ -9,504 +10,724 @@ import { SelectInput } from "@/components/ui/inputs/SelectInput";
 import { TextArea } from "@/components/ui/inputs/TextArea";
 import { ToggleSwitch } from "@/components/ui/selection/ToggleSwitch";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { HelperText } from "@/components/ui/display/HelperText";
 import { bloodTypeOptions } from "@/lib/bloodTypes";
-
-// ─── Types ────────────────────────────────────────────────────────────────────
+import { clearAccessToken, fetchCurrentUser, getAccessToken } from "@/lib/auth";
+import { ApiError } from "@/lib/api";
+import {
+    BackendProfileResponse,
+    EditableProfileData,
+    buildAddress,
+    fetchMyProfile,
+    mapBackendProfileToEditableProfile,
+    parseListField,
+    patchMyHealth,
+    patchMyLocation,
+    patchMyPhysical,
+    patchMyPrivacy,
+} from "@/lib/profile";
 
 type Neighborhood = { label: string; value: string };
 type District = { label: string; neighborhoods: Neighborhood[] };
 type City = { label: string; districts: Record<string, District> };
 type Country = { label: string; cities: Record<string, City> };
 type LocationData = Record<string, Country>;
-
 type UploadedFile = { name: string; data: string };
+type UploadField = "chronicDiseasesFiles" | "allergiesFiles";
+type EmptyStateAction = "login" | "complete-profile" | null;
 
-type ProfileData = {
-  fullName?: string;
-  email?: string;
-  phone?: string;
-  height?: string;
-  weight?: string;
-  bloodType?: string;
-  gender?: string;
-  birthDate?: string;
-  medicalHistory?: string;
-  chronicDiseases?: string;
-  chronicDiseasesFiles?: UploadedFile[];
-  chronicDiseasesVerified?: boolean;
-  allergies?: string;
-  allergiesFiles?: UploadedFile[];
-  allergiesVerified?: boolean;
-  country?: string;
-  city?: string;
-  district?: string;
-  neighborhood?: string;
-  extraAddress?: string;
-  shareLocation?: boolean;
+type ProfileData = EditableProfileData & {
+    chronicDiseasesFiles: UploadedFile[];
+    chronicDiseasesVerified: boolean;
+    allergiesFiles: UploadedFile[];
+    allergiesVerified: boolean;
 };
-
-// Fix 4: explicit map instead of string replace — typo-proof
-const verifiedFieldMap = {
-  chronicDiseasesFiles: "chronicDiseasesVerified",
-  allergiesFiles: "allergiesVerified",
-} as const;
-
-// ─── Location Data ─────────────────────────────────────────────────────────────
 
 const locationData: LocationData = {
-  tr: {
-    label: "Turkey",
-    cities: {
-      istanbul: {
-        label: "Istanbul",
-        districts: {
-          kadikoy: {
-            label: "Kadıköy",
-            neighborhoods: [
-              { label: "Bostancı", value: "bostanci" },
-              { label: "Erenköy", value: "erenkoy" },
-            ],
-          },
-          besiktas: {
-            label: "Beşiktaş",
-            neighborhoods: [
-              { label: "Balmumcu", value: "balmumcu" },
-              { label: "Kuruçeşme", value: "kurucesme" },
-            ],
-          },
+    tr: {
+        label: "Turkey",
+        cities: {
+            istanbul: {
+                label: "Istanbul",
+                districts: {
+                    kadikoy: {
+                        label: "Kadıköy",
+                        neighborhoods: [
+                            { label: "Bostancı", value: "bostanci" },
+                            { label: "Erenköy", value: "erenkoy" },
+                        ],
+                    },
+                    besiktas: {
+                        label: "Beşiktaş",
+                        neighborhoods: [
+                            { label: "Balmumcu", value: "balmumcu" },
+                            { label: "Kuruçeşme", value: "kurucesme" },
+                        ],
+                    },
+                },
+            },
+            ankara: {
+                label: "Ankara",
+                districts: {
+                    cankaya: {
+                        label: "Çankaya",
+                        neighborhoods: [{ label: "Anıttepe", value: "anittepe" }],
+                    },
+                },
+            },
         },
-      },
-      ankara: {
-        label: "Ankara",
-        districts: {
-          cankaya: {
-            label: "Çankaya",
-            neighborhoods: [{ label: "Anıttepe", value: "anittepe" }],
-          },
-        },
-      },
     },
-  },
 };
 
-// ─── Component ─────────────────────────────────────────────────────────────────
+function findCountryKeyByLabel(label: string) {
+    return (
+        Object.entries(locationData).find(([, country]) => country.label === label)?.[0] ||
+        ""
+    );
+}
+
+function findCityKeyByLabel(countryKey: string, label: string) {
+    const country = locationData[countryKey];
+
+    if (!country) {
+        return "";
+    }
+
+    return (
+        Object.entries(country.cities).find(([, city]) => city.label === label)?.[0] ||
+        ""
+    );
+}
+
+function toProfileData(
+    backendProfile: BackendProfileResponse,
+    email: string
+): ProfileData {
+    const mapped = mapBackendProfileToEditableProfile(backendProfile, email);
+    const countryKey = findCountryKeyByLabel(mapped.country);
+    const cityKey = countryKey ? findCityKeyByLabel(countryKey, mapped.city) : "";
+
+    return {
+        ...mapped,
+        country: countryKey,
+        city: cityKey,
+        chronicDiseasesFiles: [],
+        chronicDiseasesVerified: false,
+        allergiesFiles: [],
+        allergiesVerified: false,
+    };
+}
 
 export default function ProfileView() {
-  const [profile, setProfile] = React.useState<ProfileData | null>(null);
-  const [uploading, setUploading] = React.useState<string | null>(null);
-  const [progress, setProgress] = React.useState<number>(0);
-  const [loading, setLoading] = React.useState(true);
+    const router = useRouter();
+    const [profile, setProfile] = React.useState<ProfileData | null>(null);
+    const [uploading, setUploading] = React.useState<string | null>(null);
+    const [progress] = React.useState<number>(100);
+    const [loading, setLoading] = React.useState(true);
+    const [saving, setSaving] = React.useState(false);
+    const [error, setError] = React.useState("");
+    const [info, setInfo] = React.useState("");
+    const [emptyStateAction, setEmptyStateAction] =
+        React.useState<EmptyStateAction>(null);
 
-  React.useEffect(() => {
-    const stored = localStorage.getItem("user");
-    setProfile(stored ? (JSON.parse(stored) as ProfileData) : null);
-    setLoading(false);
-  }, []);
+    React.useEffect(() => {
+        async function loadProfile() {
+            const token = getAccessToken();
 
-  // ── Guards ──────────────────────────────────────────────────────────────────
-
-  if (loading) {
-    return <p className="text-sm text-gray-500">Loading...</p>;
-  }
-
-  if (!profile) {
-    return <p className="text-sm text-gray-500">No profile data found</p>;
-  }
-
-  // ── Handlers ────────────────────────────────────────────────────────────────
-
-  const handleSave = () => {
-    // TODO: Replace localStorage with a proper API call before production.
-    const existing = JSON.parse(localStorage.getItem("user") || "{}") as ProfileData;
-    localStorage.setItem("user", JSON.stringify({ ...existing, ...profile }));
-  };
-
-  // Fix 4: use verifiedFieldMap instead of string replace
-  const handleFileUpload = (field: keyof typeof verifiedFieldMap, file: File) => {
-    setUploading(field);
-    setProgress(100);
-
-    // TODO: Replace with actual file upload to backend/storage service.
-    // Only storing file metadata here — base64 is intentionally NOT stored
-    // in localStorage to avoid hitting browser storage limits.
-    const verifiedField = verifiedFieldMap[field];
-
-    // Fix 2: functional updater for null safety
-    setProfile((prev) => {
-      if (!prev) return prev;
-      const existing = (prev[field] as UploadedFile[]) || [];
-      return {
-        ...prev,
-        [field]: [...existing, { name: file.name, data: "" }],
-        [verifiedField]: false,
-      };
-    });
-
-    setUploading(null);
-  };
-
-  const removeFile = (field: keyof typeof verifiedFieldMap, index: number) => {
-    setProfile((prev) => {
-      if (!prev) return prev;
-      const updated = [...((prev[field] as UploadedFile[]) || [])];
-      updated.splice(index, 1);
-      return { ...prev, [field]: updated };
-    });
-  };
-
-  // ── Location Options ────────────────────────────────────────────────────────
-
-  // Fix 1: runtime key guard + keyof cast
-  const countryData =
-    profile.country && profile.country in locationData
-      ? locationData[profile.country as keyof LocationData]
-      : undefined;
-
-  const countryOptions = Object.entries(locationData).map(([key, val]) => ({
-    label: val.label,
-    value: key,
-  }));
-
-  const cityOptions = countryData
-    ? Object.entries(countryData.cities).map(([key, val]) => ({
-        label: val.label,
-        value: key,
-      }))
-    : [];
-
-  const districtOptions =
-    profile.city && countryData?.cities?.[profile.city]
-      ? Object.entries(countryData.cities[profile.city].districts).map(([key, val]) => ({
-          label: val.label,
-          value: key,
-        }))
-      : [];
-
-  const neighborhoodOptions =
-    profile.city &&
-    profile.district &&
-    countryData?.cities?.[profile.city]?.districts?.[profile.district]
-      ? countryData.cities[profile.city].districts[profile.district].neighborhoods
-      : [];
-
-  // ── Render ──────────────────────────────────────────────────────────────────
-
-  return (
-    <div className="flex gap-10">
-
-      {/* LEFT */}
-      <div className="w-64 flex flex-col items-center gap-4">
-        <Avatar size="lg" />
-        <div className="text-center">
-          <h2 className="text-lg font-semibold">{profile.fullName || "User"}</h2>
-          <p className="text-sm text-gray-500">{profile.email || "No email"}</p>
-        </div>
-      </div>
-
-      {/* RIGHT */}
-      <div className="flex-1 flex flex-col gap-6">
-
-        {/* ACCOUNT */}
-        <SectionCard>
-          <SectionHeader title="Account Information" />
-          <p className="text-xs text-gray-400 mb-3">
-            Your contact details are used for account access and emergency communication.
-          </p>
-          <div className="flex flex-col gap-3 text-sm">
-            <div className="flex justify-between">
-              <span className="text-gray-500">Email</span>
-              <span>{profile.email || "-"}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-gray-500">Phone</span>
-              <span>{profile.phone || "-"}</span>
-            </div>
-          </div>
-        </SectionCard>
-
-        {/* PHYSICAL */}
-        <SectionCard>
-          <SectionHeader title="Physical Information" />
-          <p className="text-xs text-gray-400 mb-3">
-            This information helps responders assess your physical condition in emergencies.
-          </p>
-          <div className="grid grid-cols-2 gap-4">
-            <TextInput
-              id="height"
-              label="Height (cm)"
-              value={profile.height || ""}
-              onChange={(e) =>
-                setProfile((prev) => prev ? { ...prev, height: e.target.value } : prev)
-              }
-            />
-            <TextInput
-              id="weight"
-              label="Weight (kg)"
-              value={profile.weight || ""}
-              onChange={(e) =>
-                setProfile((prev) => prev ? { ...prev, weight: e.target.value } : prev)
-              }
-            />
-            <SelectInput
-              id="gender"
-              label="Gender"
-              value={profile.gender || ""}
-              onChange={(e) =>
-                setProfile((prev) => prev ? { ...prev, gender: e.target.value } : prev)
-              }
-              options={[
-                { label: "Select", value: "" },
-                { label: "Male", value: "male" },
-                { label: "Female", value: "female" },
-                { label: "Other", value: "other" },
-              ]}
-            />
-            <TextInput
-              id="birthDate"
-              label="Date of Birth"
-              type="date"
-              value={profile.birthDate || ""}
-              onChange={(e) =>
-                setProfile((prev) => prev ? { ...prev, birthDate: e.target.value } : prev)
-              }
-            />
-          </div>
-        </SectionCard>
-
-        {/* MEDICAL */}
-        <SectionCard>
-          <SectionHeader title="Medical Information" />
-          <p className="text-xs text-gray-400 mb-3">
-            In emergency situations, this information may help responders make faster and safer medical decisions.
-          </p>
-
-          <div className="flex flex-col gap-4">
-
-          <SelectInput
-          id="bloodType"
-          label="Blood Type"
-          value={profile.bloodType || ""}
-          options={bloodTypeOptions}
-          onChange={(e) =>
-            setProfile((prev) => prev ? { ...prev, bloodType: e.target.value } : prev)
-          }
-        />
-
-          <TextArea
-            id="medicalHistory"
-            label="Medical History"
-            value={profile.medicalHistory || ""}
-            onChange={(e) =>
-              setProfile((prev) => prev ? { ...prev, medicalHistory: e.target.value } : prev)
+            if (!token) {
+                setError("Please log in to view your profile.");
+                setEmptyStateAction("login");
+                setLoading(false);
+                return;
             }
-          />
 
-          {/* CHRONIC DISEASES */}
-          <div className="mt-4">
-            <div className="flex justify-between mb-1">
-              <span className="whitespace-nowrap">Chronic Diseases</span>
-              <div className="flex gap-2 text-xs items-center">
-                {/* Fix 5: removed flex layout classes from <p> */}
-                <p className="text-xs text-gray-400">
-                  If you declare a chronic condition, you must upload a supporting medical document.
-                </p>
-                <input
-                  type="file"
-                  id="chronic-upload"
-                  className="hidden"
-                  onChange={(e) =>
-                    e.target.files?.[0] &&
-                    handleFileUpload("chronicDiseasesFiles", e.target.files[0])
-                  }
-                />
-                <label htmlFor="chronic-upload" className="cursor-pointer text-blue-600">
-                  Upload
-                </label>
-              </div>
+            try {
+                const [user, backendProfile] = await Promise.all([
+                    fetchCurrentUser(token),
+                    fetchMyProfile(token),
+                ]);
+
+                setProfile(toProfileData(backendProfile, user.email));
+                setEmptyStateAction(null);
+            } catch (err) {
+                if (err instanceof ApiError && err.status === 401) {
+                    clearAccessToken();
+                    setError("Your session has expired. Please log in again.");
+                    setEmptyStateAction("login");
+                } else if (err instanceof ApiError && err.status === 404) {
+                    setProfile(null);
+                    setError("");
+                    setEmptyStateAction("complete-profile");
+                } else {
+                    setError(
+                        err instanceof Error
+                            ? err.message
+                            : "Could not load your profile."
+                    );
+                    setEmptyStateAction(null);
+                }
+            } finally {
+                setLoading(false);
+            }
+        }
+
+        void loadProfile();
+    }, []);
+
+    const handleSave = async () => {
+        if (!profile) {
+            return;
+        }
+
+        const token = getAccessToken();
+
+        if (!token) {
+            setError("Please log in to save your profile.");
+            router.push("/login");
+            return;
+        }
+
+        try {
+            setSaving(true);
+            setError("");
+            setInfo("");
+
+            await patchMyPhysical(token, {
+                gender: profile.gender || null,
+                height: profile.height ? Number(profile.height) : undefined,
+                weight: profile.weight ? Number(profile.weight) : undefined,
+            });
+
+            await patchMyHealth(token, {
+                medicalConditions: parseListField(profile.medicalHistory),
+                chronicDiseases: parseListField(profile.chronicDiseases),
+                allergies: parseListField(profile.allergies),
+                bloodType: profile.bloodType || null,
+            });
+
+            await patchMyLocation(token, {
+                country: locationData[profile.country]?.label || profile.country || null,
+                city:
+                    locationData[profile.country]?.cities[profile.city]?.label ||
+                    profile.city ||
+                    null,
+                address:
+                    buildAddress({
+                        district: profile.district,
+                        neighborhood: profile.neighborhood,
+                        extraAddress: profile.extraAddress,
+                    }) || null,
+            });
+
+            await patchMyPrivacy(token, {
+                locationSharingEnabled: profile.shareLocation,
+            });
+
+            const [user, backendProfile] = await Promise.all([
+                fetchCurrentUser(token),
+                fetchMyProfile(token),
+            ]);
+
+            setProfile((currentProfile) => {
+                const refreshedProfile = toProfileData(backendProfile, user.email);
+
+                return currentProfile
+                    ? {
+                        ...refreshedProfile,
+                        chronicDiseasesFiles: currentProfile.chronicDiseasesFiles,
+                        chronicDiseasesVerified:
+                            currentProfile.chronicDiseasesVerified,
+                        allergiesFiles: currentProfile.allergiesFiles,
+                        allergiesVerified: currentProfile.allergiesVerified,
+                    }
+                    : refreshedProfile;
+            });
+
+            setInfo("Profile updated successfully.");
+        } catch (err) {
+            const baseMessage =
+                err instanceof Error && err.message
+                    ? err.message
+                    : "Could not save your profile.";
+
+            setError(
+                `${baseMessage} Some sections may already be saved because the backend currently updates profile data in separate requests. Please review your profile and try again.`
+            );
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleFileUpload = (field: UploadField, file: File) => {
+        setUploading(field);
+
+        setProfile((prev) => {
+            if (!prev) {
+                return prev;
+            }
+
+            if (field === "chronicDiseasesFiles") {
+                return {
+                    ...prev,
+                    chronicDiseasesFiles: [
+                        ...prev.chronicDiseasesFiles,
+                        { name: file.name, data: "" },
+                    ],
+                    chronicDiseasesVerified: false,
+                };
+            }
+
+            return {
+                ...prev,
+                allergiesFiles: [...prev.allergiesFiles, { name: file.name, data: "" }],
+                allergiesVerified: false,
+            };
+        });
+
+        setUploading(null);
+        setInfo(
+            "Document uploads are not connected yet because the backend upload endpoint is not available."
+        );
+    };
+
+    const removeFile = (field: UploadField, index: number) => {
+        setProfile((prev) => {
+            if (!prev) {
+                return prev;
+            }
+
+            if (field === "chronicDiseasesFiles") {
+                const updated = [...prev.chronicDiseasesFiles];
+                updated.splice(index, 1);
+
+                return { ...prev, chronicDiseasesFiles: updated };
+            }
+
+            const updated = [...prev.allergiesFiles];
+            updated.splice(index, 1);
+
+            return { ...prev, allergiesFiles: updated };
+        });
+    };
+
+    if (loading) {
+        return <p className="text-sm text-gray-500">Loading...</p>;
+    }
+
+    if (!profile) {
+        return (
+            <div className="flex max-w-md flex-col gap-4">
+                <HelperText className="text-sm text-gray-500">
+                    {error || "No profile data found."}
+                </HelperText>
+
+                {emptyStateAction === "login" ? (
+                    <PrimaryButton onClick={() => router.push("/login")}>
+                        Log In
+                    </PrimaryButton>
+                ) : null}
+
+                {emptyStateAction === "complete-profile" ? (
+                    <PrimaryButton onClick={() => router.push("/complete-profile")}>
+                        Complete Profile
+                    </PrimaryButton>
+                ) : null}
+            </div>
+        );
+    }
+
+    const countryData = profile.country ? locationData[profile.country] : undefined;
+
+    const countryOptions = Object.entries(locationData).map(([key, value]) => ({
+        label: value.label,
+        value: key,
+    }));
+
+    const cityOptions = countryData
+        ? Object.entries(countryData.cities).map(([key, value]) => ({
+            label: value.label,
+            value: key,
+        }))
+        : [];
+
+    const districtOptions =
+        profile.city && countryData?.cities[profile.city]
+            ? Object.entries(countryData.cities[profile.city].districts).map(
+                ([key, value]) => ({
+                    label: value.label,
+                    value: key,
+                })
+            )
+            : [];
+
+    const neighborhoodOptions =
+        profile.city &&
+            profile.district &&
+            countryData?.cities[profile.city]?.districts[profile.district]
+            ? countryData.cities[profile.city].districts[profile.district].neighborhoods
+            : [];
+
+    return (
+        <div className="flex gap-10">
+            <div className="flex w-64 flex-col items-center gap-4">
+                <Avatar size="lg" />
+                <div className="text-center">
+                    <h2 className="text-lg font-semibold">{profile.fullName || "User"}</h2>
+                    <p className="text-sm text-gray-500">{profile.email || "No email"}</p>
+                </div>
             </div>
 
-            <TextInput
-              id="chronic"
-              value={profile.chronicDiseases || ""}
-              onChange={(e) =>
-                setProfile((prev) => prev ? { ...prev, chronicDiseases: e.target.value } : prev)
-              }
-            />
+            <div className="flex flex-1 flex-col gap-6">
+                <SectionCard>
+                    <SectionHeader title="Account Information" />
+                    <p className="mb-3 text-xs text-gray-400">
+                        Your contact details are used for account access and emergency
+                        communication.
+                    </p>
+                    <div className="flex flex-col gap-3 text-sm">
+                        <div className="flex justify-between">
+                            <span className="text-gray-500">Email</span>
+                            <span>{profile.email || "-"}</span>
+                        </div>
+                        <div className="flex justify-between">
+                            <span className="text-gray-500">Phone</span>
+                            <span>
+                                {[profile.countryCode, profile.phone]
+                                    .filter(Boolean)
+                                    .join(" ") || "-"}
+                            </span>
+                        </div>
+                    </div>
+                </SectionCard>
 
-            {uploading === "chronicDiseasesFiles" && (
-              <div className="mt-2 text-xs">Uploading... {progress}%</div>
-            )}
+                <SectionCard>
+                    <SectionHeader title="Physical Information" />
+                    <p className="mb-3 text-xs text-gray-400">
+                        This information helps responders assess your physical condition in
+                        emergencies.
+                    </p>
+                    <div className="grid grid-cols-2 gap-4">
+                        <TextInput
+                            id="height"
+                            label="Height (cm)"
+                            value={profile.height}
+                            onChange={(e) =>
+                                setProfile({ ...profile, height: e.target.value })
+                            }
+                        />
+                        <TextInput
+                            id="weight"
+                            label="Weight (kg)"
+                            value={profile.weight}
+                            onChange={(e) =>
+                                setProfile({ ...profile, weight: e.target.value })
+                            }
+                        />
+                        <SelectInput
+                            id="gender"
+                            label="Gender"
+                            value={profile.gender}
+                            onChange={(e) =>
+                                setProfile({ ...profile, gender: e.target.value })
+                            }
+                            options={[
+                                { label: "Select", value: "" },
+                                { label: "Male", value: "male" },
+                                { label: "Female", value: "female" },
+                                { label: "Other", value: "other" },
+                            ]}
+                        />
+                        <div>
+                            <TextInput
+                                id="birthDate"
+                                label="Date of Birth"
+                                type="date"
+                                value={profile.birthDate}
+                                onChange={(e) =>
+                                    setProfile({ ...profile, birthDate: e.target.value })
+                                }
+                            />
+                            <HelperText>
+                                Date of birth is not synced yet because the backend profile
+                                API currently stores age instead.
+                            </HelperText>
+                        </div>
+                    </div>
+                </SectionCard>
 
-            {profile.chronicDiseasesFiles?.map((file, index) => (
-              <div key={index} className="mt-2 flex justify-between text-xs text-gray-600">
-                <div className="flex flex-col">
-                  <span>📄 {file.name}</span>
-                  <span className="text-xs mt-1">
-                    {profile.chronicDiseasesVerified ? (
-                      <span className="text-green-600">Verified</span>
-                    ) : (
-                      <span className="text-red-500">Pending Verification</span>
-                    )}
-                  </span>
+                <SectionCard>
+                    <SectionHeader title="Medical Information" />
+                    <p className="mb-3 text-xs text-gray-400">
+                        In emergency situations, this information may help responders make
+                        faster and safer medical decisions.
+                    </p>
+
+                    <div className="flex flex-col gap-4">
+                        <SelectInput
+                            id="bloodType"
+                            label="Blood Type"
+                            value={profile.bloodType}
+                            options={bloodTypeOptions}
+                            onChange={(e) =>
+                                setProfile({ ...profile, bloodType: e.target.value })
+                            }
+                        />
+
+                        <TextArea
+                            id="medicalHistory"
+                            label="Medical History"
+                            value={profile.medicalHistory}
+                            onChange={(e) =>
+                                setProfile({ ...profile, medicalHistory: e.target.value })
+                            }
+                        />
+
+                        <div className="mt-4">
+                            <div className="mb-1 flex justify-between">
+                                <span className="whitespace-nowrap">Chronic Diseases</span>
+                                <div className="flex items-center gap-2 text-xs">
+                                    <p className="text-xs text-gray-400">
+                                        Upload is shown in the UI, but backend document storage is
+                                        not available yet.
+                                    </p>
+                                    <input
+                                        type="file"
+                                        id="chronic-upload"
+                                        className="hidden"
+                                        onChange={(e) =>
+                                            e.target.files?.[0] &&
+                                            handleFileUpload(
+                                                "chronicDiseasesFiles",
+                                                e.target.files[0]
+                                            )
+                                        }
+                                    />
+                                    <label
+                                        htmlFor="chronic-upload"
+                                        className="cursor-pointer text-blue-600"
+                                    >
+                                        Upload
+                                    </label>
+                                </div>
+                            </div>
+
+                            <TextInput
+                                id="chronic"
+                                value={profile.chronicDiseases}
+                                onChange={(e) =>
+                                    setProfile({
+                                        ...profile,
+                                        chronicDiseases: e.target.value,
+                                    })
+                                }
+                            />
+
+                            {uploading === "chronicDiseasesFiles" ? (
+                                <div className="mt-2 text-xs">Uploading... {progress}%</div>
+                            ) : null}
+
+                            {profile.chronicDiseasesFiles.map((file, index) => (
+                                <div
+                                    key={`${file.name}-${index}`}
+                                    className="mt-2 flex justify-between text-xs text-gray-600"
+                                >
+                                    <div className="flex flex-col">
+                                        <span>📄 {file.name}</span>
+                                        <span className="mt-1 text-xs text-red-500">
+                                            Pending Verification
+                                        </span>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        onClick={() =>
+                                            removeFile("chronicDiseasesFiles", index)
+                                        }
+                                        className="text-red-500"
+                                    >
+                                        Remove
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+
+                        <div className="mt-4">
+                            <div className="mb-1 flex justify-between">
+                                <span>Allergies</span>
+                                <div className="flex items-center gap-2 text-xs">
+                                    <p className="text-xs text-gray-400">
+                                        Verification is not connected yet because the backend upload
+                                        flow is still missing.
+                                    </p>
+                                    <input
+                                        type="file"
+                                        id="allergy-upload"
+                                        className="hidden"
+                                        onChange={(e) =>
+                                            e.target.files?.[0] &&
+                                            handleFileUpload(
+                                                "allergiesFiles",
+                                                e.target.files[0]
+                                            )
+                                        }
+                                    />
+                                    <label
+                                        htmlFor="allergy-upload"
+                                        className="cursor-pointer text-blue-600"
+                                    >
+                                        Upload
+                                    </label>
+                                </div>
+                            </div>
+
+                            <TextInput
+                                id="allergy"
+                                value={profile.allergies}
+                                onChange={(e) =>
+                                    setProfile({ ...profile, allergies: e.target.value })
+                                }
+                            />
+
+                            {uploading === "allergiesFiles" ? (
+                                <div className="mt-2 text-xs">Uploading... {progress}%</div>
+                            ) : null}
+
+                            {profile.allergiesFiles.map((file, index) => (
+                                <div
+                                    key={`${file.name}-${index}`}
+                                    className="mt-2 flex justify-between text-xs text-gray-600"
+                                >
+                                    <div className="flex flex-col">
+                                        <span>📄 {file.name}</span>
+                                        <span className="mt-1 text-xs text-red-500">
+                                            Pending Verification
+                                        </span>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        onClick={() => removeFile("allergiesFiles", index)}
+                                        className="text-red-500"
+                                    >
+                                        Remove
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                </SectionCard>
+
+                <SectionCard>
+                    <SectionHeader title="Location" />
+                    <p className="mb-3 text-xs text-gray-400">
+                        Your location may help emergency services reach you faster.
+                    </p>
+
+                    <div className="grid grid-cols-2 gap-4">
+                        <SelectInput
+                            id="country"
+                            label="Country"
+                            value={profile.country}
+                            options={[{ label: "Select Country", value: "" }, ...countryOptions]}
+                            onChange={(e) =>
+                                setProfile({
+                                    ...profile,
+                                    country: e.target.value,
+                                    city: "",
+                                    district: "",
+                                    neighborhood: "",
+                                })
+                            }
+                        />
+
+                        <SelectInput
+                            id="city"
+                            label="City"
+                            value={profile.city}
+                            disabled={!profile.country}
+                            options={[{ label: "Select City", value: "" }, ...cityOptions]}
+                            onChange={(e) =>
+                                setProfile({
+                                    ...profile,
+                                    city: e.target.value,
+                                    district: "",
+                                    neighborhood: "",
+                                })
+                            }
+                        />
+
+                        <SelectInput
+                            id="district"
+                            label="District"
+                            value={profile.district}
+                            disabled={!profile.city}
+                            options={[
+                                { label: "Select District", value: "" },
+                                ...districtOptions,
+                            ]}
+                            onChange={(e) =>
+                                setProfile({
+                                    ...profile,
+                                    district: e.target.value,
+                                    neighborhood: "",
+                                })
+                            }
+                        />
+
+                        <SelectInput
+                            id="neighborhood"
+                            label="Neighborhood"
+                            value={profile.neighborhood}
+                            disabled={!profile.district}
+                            options={[
+                                { label: "Select Neighborhood", value: "" },
+                                ...neighborhoodOptions,
+                            ]}
+                            onChange={(e) =>
+                                setProfile({
+                                    ...profile,
+                                    neighborhood: e.target.value,
+                                })
+                            }
+                        />
+
+                        <div className="col-span-2">
+                            <TextInput
+                                id="extraAddress"
+                                label="Extra Address"
+                                value={profile.extraAddress}
+                                onChange={(e) =>
+                                    setProfile({
+                                        ...profile,
+                                        extraAddress: e.target.value,
+                                    })
+                                }
+                            />
+                            <HelperText>
+                                District and neighborhood are flattened into a single backend
+                                address field for now.
+                            </HelperText>
+                        </div>
+                    </div>
+
+                    <div className="mt-4 flex items-center justify-between">
+                        <span className="text-sm">Share Current Location</span>
+                        <ToggleSwitch
+                            checked={profile.shareLocation}
+                            onCheckedChange={(value) =>
+                                setProfile({ ...profile, shareLocation: value })
+                            }
+                        />
+                    </div>
+                </SectionCard>
+
+                {error ? <HelperText className="text-red-500">{error}</HelperText> : null}
+                {info ? <HelperText>{info}</HelperText> : null}
+
+                <div className="flex justify-end">
+                    <PrimaryButton onClick={handleSave} loading={saving}>
+                        Save Changes
+                    </PrimaryButton>
                 </div>
-                <button
-                  onClick={() => removeFile("chronicDiseasesFiles", index)}
-                  className="text-red-500"
-                >
-                  Remove
-                </button>
-              </div>
-            ))}
-          </div>
-
-          {/* ALLERGIES */}
-          <div className="mt-4">
-            <div className="flex justify-between mb-1">
-              <span>Allergies</span>
-              <div className="flex gap-2 text-xs items-center">
-                {/* Fix 5: removed flex layout classes from <p> */}
-                <p className="text-xs text-gray-400">
-                  You may optionally add allergies. Verification is not required but recommended.
-                </p>
-                <input
-                  type="file"
-                  id="allergy-upload"
-                  className="hidden"
-                  onChange={(e) =>
-                    e.target.files?.[0] &&
-                    handleFileUpload("allergiesFiles", e.target.files[0])
-                  }
-                />
-                <label htmlFor="allergy-upload" className="cursor-pointer text-blue-600">
-                  Upload
-                </label>
-              </div>
             </div>
-
-            <TextInput
-              id="allergy"
-              value={profile.allergies || ""}
-              onChange={(e) =>
-                setProfile((prev) => prev ? { ...prev, allergies: e.target.value } : prev)
-              }
-            />
-
-            {uploading === "allergiesFiles" && (
-              <div className="mt-2 text-xs">Uploading... {progress}%</div>
-            )}
-
-            {profile.allergiesFiles?.map((file, index) => (
-              <div key={index} className="mt-2 flex justify-between text-xs text-gray-600">
-                <div className="flex flex-col">
-                  <span>📄 {file.name}</span>
-                  <span className="text-xs mt-1">
-                    {profile.allergiesVerified ? (
-                      <span className="text-green-600">Verified</span>
-                    ) : (
-                      <span className="text-red-500">Pending Verification</span>
-                    )}
-                  </span>
-                </div>
-                <button
-                  onClick={() => removeFile("allergiesFiles", index)}
-                  className="text-red-500"
-                >
-                  Remove
-                </button>
-              </div>
-            ))}
-          </div>
-          </div>
-        </SectionCard>
-
-        {/* LOCATION */}
-        <SectionCard>
-          <SectionHeader title="Location" />
-          <p className="text-xs text-gray-400 mb-3">
-            Your location may help emergency services reach you faster.
-          </p>
-
-          <div className="grid grid-cols-2 gap-4">
-            <SelectInput
-              id="country"
-              label="Country"
-              value={profile.country || ""}
-              options={[{ label: "Select Country", value: "" }, ...countryOptions]}
-              onChange={(e) =>
-                setProfile((prev) =>
-                  prev
-                    ? { ...prev, country: e.target.value, city: "", district: "", neighborhood: "" }
-                    : prev
-                )
-              }
-            />
-
-            {/* Fix 3: disabled until parent is selected */}
-            <SelectInput
-              id="city"
-              label="City"
-              value={profile.city || ""}
-              disabled={!profile.country}
-              options={[{ label: "Select City", value: "" }, ...cityOptions]}
-              onChange={(e) =>
-                setProfile((prev) =>
-                  prev
-                    ? { ...prev, city: e.target.value, district: "", neighborhood: "" }
-                    : prev
-                )
-              }
-            />
-            <SelectInput
-              id="district"
-              label="District"
-              value={profile.district || ""}
-              disabled={!profile.city}
-              options={[{ label: "Select District", value: "" }, ...districtOptions]}
-              onChange={(e) =>
-                setProfile((prev) =>
-                  prev ? { ...prev, district: e.target.value, neighborhood: "" } : prev
-                )
-              }
-            />
-            <SelectInput
-              id="neighborhood"
-              label="Neighborhood"
-              value={profile.neighborhood || ""}
-              disabled={!profile.district}
-              options={[{ label: "Select Neighborhood", value: "" }, ...neighborhoodOptions]}
-              onChange={(e) =>
-                setProfile((prev) =>
-                  prev ? { ...prev, neighborhood: e.target.value } : prev
-                )
-              }
-            />
-            <TextInput
-              id="extraAddress"
-              label="Extra Address"
-              value={profile.extraAddress || ""}
-              onChange={(e) =>
-                setProfile((prev) => prev ? { ...prev, extraAddress: e.target.value } : prev)
-              }
-            />
-          </div>
-
-          <div className="flex justify-between items-center mt-4">
-            <span className="text-sm">Share Current Location</span>
-            <ToggleSwitch
-              checked={profile.shareLocation || false}
-              onCheckedChange={(val) =>
-                setProfile((prev) => prev ? { ...prev, shareLocation: val } : prev)
-              }
-            />
-          </div>
-        </SectionCard>
-
-        {/* SAVE */}
-        <div className="flex justify-end">
-          <PrimaryButton onClick={handleSave}>Save Changes</PrimaryButton>
         </div>
-
-      </div>
-    </div>
-  );
+    );
 }

--- a/web/src/components/layout/TopNavbar.tsx
+++ b/web/src/components/layout/TopNavbar.tsx
@@ -1,5 +1,9 @@
+"use client";
+
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { PageContainer } from "@/components/layout/PageContainer";
+import { clearAccessToken } from "@/lib/auth";
 
 const navItems = [
     { label: "Profile", href: "/profile" },
@@ -8,6 +12,8 @@ const navItems = [
 ];
 
 export function TopNavbar() {
+    const router = useRouter();
+
     return (
         <header className="border-b border-gray-200 bg-white">
             <PageContainer className="flex h-16 items-center justify-between">
@@ -27,7 +33,16 @@ export function TopNavbar() {
                     ))}
                 </nav>
 
-                <button className="text-sm font-medium text-red-500">Logout</button>
+                <button
+                    type="button"
+                    className="text-sm font-medium text-red-500"
+                    onClick={() => {
+                        clearAccessToken();
+                        router.replace("/login");
+                    }}
+                >
+                    Logout
+                </button>
             </PageContainer>
         </header>
     );

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,170 @@
+export class ApiError extends Error {
+    code: string;
+    status: number;
+
+    constructor(message: string, options: { code?: string; status: number }) {
+        super(message);
+        this.name = "ApiError";
+        this.code = options.code || "UNKNOWN_ERROR";
+        this.status = options.status;
+
+        Object.setPrototypeOf(this, ApiError.prototype);
+    }
+}
+
+type ApiRequestOptions = Omit<RequestInit, "body"> & {
+    token?: string | null;
+    body?: BodyInit | Record<string, unknown> | unknown[] | null;
+};
+
+const API_BASE_URL =
+    process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, "") || "/api";
+
+function normalizePath(path: string) {
+    return path.startsWith("/") ? path : `/${path}`;
+}
+
+function buildHeaders(options: ApiRequestOptions): Headers {
+    const headers = new Headers(options.headers);
+
+    if (options.token) {
+        headers.set("Authorization", `Bearer ${options.token}`);
+    }
+
+    const body = options.body;
+
+    if (
+        body != null &&
+        !(body instanceof FormData) &&
+        !(body instanceof URLSearchParams) &&
+        typeof body !== "string" &&
+        !headers.has("Content-Type")
+    ) {
+        headers.set("Content-Type", "application/json");
+    }
+
+    return headers;
+}
+
+function buildBody(body: ApiRequestOptions["body"]): BodyInit | undefined {
+    if (body == null) {
+        return undefined;
+    }
+
+    if (
+        body instanceof FormData ||
+        body instanceof URLSearchParams ||
+        typeof body === "string"
+    ) {
+        return body;
+    }
+
+    return JSON.stringify(body);
+}
+
+function extractErrorCode(data: unknown) {
+    if (data && typeof data === "object" && "code" in data) {
+        const code = (data as { code?: unknown }).code;
+        if (typeof code === "string" && code.trim()) {
+            return code;
+        }
+    }
+
+    return undefined;
+}
+
+function extractErrorMessage(data: unknown, fallback = "Request failed") {
+    if (typeof data === "string" && data.trim()) {
+        return data;
+    }
+
+    if (!data || typeof data !== "object") {
+        return fallback;
+    }
+
+    const record = data as Record<string, unknown>;
+
+    const directMessageKeys = ["message", "detail", "error"];
+
+    for (const key of directMessageKeys) {
+        const value = record[key];
+        if (typeof value === "string" && value.trim()) {
+            return value;
+        }
+    }
+
+    if (record.errors && typeof record.errors === "object") {
+        for (const value of Object.values(record.errors as Record<string, unknown>)) {
+            if (Array.isArray(value) && typeof value[0] === "string" && value[0].trim()) {
+                return value[0];
+            }
+
+            if (typeof value === "string" && value.trim()) {
+                return value;
+            }
+        }
+    }
+
+    for (const [key, value] of Object.entries(record)) {
+        if (key === "code") {
+            continue;
+        }
+
+        if (Array.isArray(value) && typeof value[0] === "string" && value[0].trim()) {
+            return value[0];
+        }
+
+        if (typeof value === "string" && value.trim()) {
+            return value;
+        }
+    }
+
+    return fallback;
+}
+
+export async function apiRequest<T>(
+    path: string,
+    options: ApiRequestOptions = {}
+): Promise<T> {
+    let response: Response;
+
+    try {
+        response = await fetch(`${API_BASE_URL}${normalizePath(path)}`, {
+            ...options,
+            headers: buildHeaders(options),
+            body: buildBody(options.body),
+        });
+    } catch {
+        throw new ApiError(
+            "Could not reach the server. Please check your connection and try again.",
+            {
+                code: "NETWORK_ERROR",
+                status: 0,
+            }
+        );
+    }
+
+    if (response.status === 204) {
+        return undefined as T;
+    }
+
+    const text = await response.text();
+    let data: unknown = null;
+
+    if (text) {
+        try {
+            data = JSON.parse(text) as unknown;
+        } catch {
+            data = text;
+        }
+    }
+
+    if (!response.ok) {
+        throw new ApiError(extractErrorMessage(data), {
+            code: extractErrorCode(data),
+            status: response.status,
+        });
+    }
+
+    return data as T;
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,0 +1,128 @@
+import { apiRequest } from "@/lib/api";
+
+export const ACCESS_TOKEN_KEY = "neph_access_token";
+export const SIGNUP_DRAFT_KEY = "neph_signup_draft";
+
+export type AuthUser = {
+    userId: string;
+    email: string;
+    isEmailVerified: boolean;
+    acceptedTerms?: boolean;
+    createdAt?: string;
+    isAdmin?: boolean;
+    adminRole?: string | null;
+};
+
+type SignupResponse = {
+    message: string;
+    user: AuthUser;
+};
+
+type LoginResponse = {
+    message: string;
+    accessToken: string;
+    user: AuthUser;
+};
+
+type VerifyEmailResponse = {
+    message: string;
+    user: AuthUser;
+};
+
+type ResendVerificationResponse = {
+    message: string;
+};
+
+type CurrentUserResponse = AuthUser;
+
+type SetAccessTokenOptions = {
+    rememberMe?: boolean;
+};
+
+function isBrowser() {
+    return typeof window !== "undefined";
+}
+
+export function getAccessToken() {
+    if (!isBrowser()) {
+        return null;
+    }
+
+    return (
+        window.localStorage.getItem(ACCESS_TOKEN_KEY) ||
+        window.sessionStorage.getItem(ACCESS_TOKEN_KEY)
+    );
+}
+
+export function setAccessToken(
+    token: string,
+    options: SetAccessTokenOptions = {}
+) {
+    if (!isBrowser()) {
+        return;
+    }
+
+    const { rememberMe = true } = options;
+
+    window.localStorage.removeItem(ACCESS_TOKEN_KEY);
+    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+
+    if (rememberMe) {
+        window.localStorage.setItem(ACCESS_TOKEN_KEY, token);
+        return;
+    }
+
+    window.sessionStorage.setItem(ACCESS_TOKEN_KEY, token);
+}
+
+export function clearAccessToken() {
+    if (!isBrowser()) {
+        return;
+    }
+
+    window.localStorage.removeItem(ACCESS_TOKEN_KEY);
+    window.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+}
+
+export async function signup(payload: {
+    email: string;
+    password: string;
+    acceptedTerms: boolean;
+}) {
+    return apiRequest<SignupResponse>("/auth/signup", {
+        method: "POST",
+        body: {
+            ...payload,
+            email: payload.email.trim(),
+        },
+    });
+}
+
+export async function login(payload: { email: string; password: string }) {
+    return apiRequest<LoginResponse>("/auth/login", {
+        method: "POST",
+        body: {
+            ...payload,
+            email: payload.email.trim(),
+        },
+    });
+}
+
+export async function verifyEmail(token: string) {
+    const encodedToken = encodeURIComponent(token.trim());
+
+    return apiRequest<VerifyEmailResponse>(`/auth/verify-email?token=${encodedToken}`);
+}
+
+export async function resendVerification(email: string) {
+    return apiRequest<ResendVerificationResponse>("/auth/resend-verification", {
+        method: "POST",
+        body: { email: email.trim() },
+    });
+}
+
+export async function fetchCurrentUser(token: string) {
+    return apiRequest<CurrentUserResponse>("/auth/me", {
+        token: token.trim(),
+    });
+}

--- a/web/src/lib/profile.ts
+++ b/web/src/lib/profile.ts
@@ -1,0 +1,244 @@
+import { apiRequest } from "@/lib/api";
+import { countryCodeOptions } from "@/lib/countryCodes";
+
+export type BackendProfileResponse = {
+    profile: {
+        profileId: string;
+        userId: string;
+        firstName: string;
+        lastName: string;
+        phoneNumber: string | null;
+    };
+    privacySettings: {
+        profileVisibility: string;
+        healthInfoVisibility: string;
+        locationVisibility: string;
+        locationSharingEnabled: boolean;
+    };
+    healthInfo: {
+        medicalConditions: string[];
+        chronicDiseases: string[];
+        allergies: string[];
+        medications: string[];
+        bloodType: string | null;
+    };
+    physicalInfo: {
+        age: number | null;
+        gender: string | null;
+        height: number | null;
+        weight: number | null;
+    };
+    locationProfile: {
+        address: string | null;
+        city: string | null;
+        country: string | null;
+        latitude: number | null;
+        longitude: number | null;
+        lastUpdated: string | null;
+    };
+};
+
+export type EditableProfileData = {
+    fullName: string;
+    email: string;
+    phone: string;
+    countryCode: string;
+    height: string;
+    weight: string;
+    bloodType: string;
+    gender: string;
+    birthDate: string;
+    medicalHistory: string;
+    chronicDiseases: string;
+    allergies: string;
+    country: string;
+    city: string;
+    district: string;
+    neighborhood: string;
+    extraAddress: string;
+    shareLocation: boolean;
+};
+
+const availableCountryCodes = countryCodeOptions
+    .map((option) => option.value)
+    .filter((value): value is string => typeof value === "string" && value.startsWith("+"))
+    .sort((a, b) => b.length - a.length);
+
+function normalizePhoneParts(phoneNumber?: string | null) {
+    if (!phoneNumber) {
+        return {
+            countryCode: "",
+            phone: "",
+        };
+    }
+
+    const normalized = phoneNumber.trim().replace(/[\s()-]/g, "");
+
+    if (!normalized.startsWith("+")) {
+        return {
+            countryCode: "",
+            phone: normalized,
+        };
+    }
+
+    const matchedCountryCode = availableCountryCodes.find((code) =>
+        normalized.startsWith(code)
+    );
+
+    if (!matchedCountryCode) {
+        return {
+            countryCode: "",
+            phone: normalized,
+        };
+    }
+
+    return {
+        countryCode: matchedCountryCode,
+        phone: normalized.slice(matchedCountryCode.length),
+    };
+}
+
+export function joinFullName(firstName?: string | null, lastName?: string | null) {
+    return [firstName, lastName].filter(Boolean).join(" ").trim();
+}
+
+export function splitFullName(fullName: string) {
+    const normalized = fullName.trim().replace(/\s+/g, " ");
+
+    if (!normalized) {
+        return {
+            firstName: "",
+            lastName: "",
+        };
+    }
+
+    const parts = normalized.split(" ");
+    const firstName = parts.shift() || "";
+
+    return {
+        firstName,
+        lastName: parts.join(" "),
+    };
+}
+
+export function parseListField(value: string) {
+    return value
+        .split(/\n|,/)
+        .map((item) => item.trim())
+        .filter(Boolean);
+}
+
+export function serializeListField(values?: string[] | null) {
+    return (values || []).join(", ");
+}
+
+export function buildAddress(parts: {
+    district: string;
+    neighborhood: string;
+    extraAddress: string;
+}) {
+    return [parts.neighborhood, parts.district, parts.extraAddress]
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .join(", ");
+}
+
+export function mapBackendProfileToEditableProfile(
+    profile: BackendProfileResponse,
+    email: string
+): EditableProfileData {
+    const phoneParts = normalizePhoneParts(profile.profile.phoneNumber);
+
+    return {
+        fullName: joinFullName(profile.profile.firstName, profile.profile.lastName),
+        email,
+        phone: phoneParts.phone,
+        countryCode: phoneParts.countryCode,
+        height:
+            profile.physicalInfo.height !== null && profile.physicalInfo.height !== undefined
+                ? String(profile.physicalInfo.height)
+                : "",
+        weight:
+            profile.physicalInfo.weight !== null && profile.physicalInfo.weight !== undefined
+                ? String(profile.physicalInfo.weight)
+                : "",
+        bloodType: profile.healthInfo.bloodType || "",
+        gender: profile.physicalInfo.gender || "",
+        birthDate: "",
+        medicalHistory: serializeListField(profile.healthInfo.medicalConditions),
+        chronicDiseases: serializeListField(profile.healthInfo.chronicDiseases),
+        allergies: serializeListField(profile.healthInfo.allergies),
+        country: profile.locationProfile.country || "",
+        city: profile.locationProfile.city || "",
+        district: "",
+        neighborhood: "",
+        extraAddress: profile.locationProfile.address || "",
+        shareLocation: profile.privacySettings.locationSharingEnabled,
+    };
+}
+
+export async function fetchMyProfile(token: string) {
+    return apiRequest<BackendProfileResponse>("/profiles/me", {
+        token,
+    });
+}
+
+export async function patchMyProfile(
+    token: string,
+    payload: { firstName: string; lastName: string; phoneNumber: string | null }
+) {
+    return apiRequest<BackendProfileResponse>("/profiles/me", {
+        method: "PATCH",
+        token,
+        body: payload,
+    });
+}
+
+export async function patchMyPhysical(
+    token: string,
+    payload: { gender?: string | null; height?: number | null; weight?: number | null }
+) {
+    return apiRequest<BackendProfileResponse>("/profiles/me/physical", {
+        method: "PATCH",
+        token,
+        body: payload,
+    });
+}
+
+export async function patchMyHealth(
+    token: string,
+    payload: {
+        medicalConditions?: string[];
+        chronicDiseases?: string[];
+        allergies?: string[];
+        bloodType?: string | null;
+    }
+) {
+    return apiRequest<BackendProfileResponse>("/profiles/me/health", {
+        method: "PATCH",
+        token,
+        body: payload,
+    });
+}
+
+export async function patchMyLocation(
+    token: string,
+    payload: { address?: string | null; city?: string | null; country?: string | null }
+) {
+    return apiRequest<BackendProfileResponse>("/profiles/me/location", {
+        method: "PATCH",
+        token,
+        body: payload,
+    });
+}
+
+export async function patchMyPrivacy(
+    token: string,
+    payload: { locationSharingEnabled?: boolean }
+) {
+    return apiRequest<BackendProfileResponse>("/profiles/me/privacy", {
+        method: "PATCH",
+        token,
+        body: payload,
+    });
+}


### PR DESCRIPTION
## Summary

This PR connects the frontend auth and profile flows to real backend endpoints and removes remaining local demo-only behavior in these areas.

## What changed

* connected login, signup, verify email, resend verification, and current-user flows to backend APIs
* added token-based session handling and working logout behavior
* connected complete-profile and profile view/save flows to backend fetch/patch endpoints
* updated verify-email flow to use tokenized email links instead of a 6-digit code flow
* improved validation, empty states, and error handling across auth/profile forms
* added remember-me compatible token persistence behavior in the auth layer

## Notes

* profile updates still happen through multiple PATCH requests, so partial-save risk is communicated in the UI where relevant
* document upload UI remains placeholder-only until backend upload support is available

Can you please review? @erinc00

Closes #132 