### PR TITLE
fix: help-request auth middleware wiring

### DIFF
--- a/backend/src/modules/help-requests/routes.js
+++ b/backend/src/modules/help-requests/routes.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { requireAuth } = require('../auth/middleware');
 const {
   createHelpRequest,
   listHelpRequests,
@@ -7,6 +8,8 @@ const {
 } = require('./controller');
 
 const helpRequestsRouter = express.Router();
+
+helpRequestsRouter.use(requireAuth);
 
 helpRequestsRouter.post('/', createHelpRequest);
 helpRequestsRouter.get('/', listHelpRequests);

--- a/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
+++ b/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
@@ -4,14 +4,13 @@ const express = require('express');
 const request = require('supertest');
 const jwt = require('jsonwebtoken');
 
-const { requireAuth } = require('../../../../src/modules/auth/middleware');
 const { helpRequestsRouter } = require('../../../../src/modules/help-requests/routes');
 const { query } = require('../../../../src/db/pool');
 
 function createTestApp() {
 	const app = express();
 	app.use(express.json());
-	app.use('/api/help-requests', requireAuth, helpRequestsRouter);
+	app.use('/api/help-requests', helpRequestsRouter);
 	return app;
 }
 


### PR DESCRIPTION
Apply requireAuth directly to help-request routes so production matches the rest of the backend and the test setup no longer masks the missing auth guard.