### PR TITLE
fix: Update DB and backend endpoints for help request form

### DIFF
--- a/backend/src/modules/help-requests/repository.js
+++ b/backend/src/modules/help-requests/repository.js
@@ -28,12 +28,21 @@ function mapLocation(row) {
   }
 
   return {
-    id: row.location_id,
-    latitude: row.latitude,
-    longitude: row.longitude,
-    isGpsLocation: row.is_gps_location,
-    isLastKnown: row.is_last_known,
-    capturedAt: row.captured_at,
+    country: row.country,
+    city: row.city,
+    district: row.district,
+    neighborhood: row.neighborhood,
+    extraAddress: row.extra_address || '',
+  };
+}
+
+function mapContact(row) {
+  return {
+    fullName: row.contact_full_name,
+    phone: Number(row.contact_phone),
+    alternativePhone: row.contact_alternative_phone == null
+      ? null
+      : Number(row.contact_alternative_phone),
   };
 }
 
@@ -41,14 +50,22 @@ function mapHelpRequest(row) {
   return {
     id: row.request_id,
     userId: row.user_id,
-    needType: row.need_type,
+    helpTypes: row.help_types || [],
+    otherHelpText: row.other_help_text || '',
+    affectedPeopleCount: row.affected_people_count,
+    riskFlags: row.risk_flags || [],
+    vulnerableGroups: row.vulnerable_groups || [],
     description: row.description,
+    bloodType: row.blood_type || '',
+    location: mapLocation(row),
+    contact: mapContact(row),
+    consentGiven: row.consent_given,
+    needType: row.need_type,
     status: mapStatus(row),
     internalStatus: row.status,
     createdAt: row.created_at,
     resolvedAt: row.resolved_at,
     isSavedLocally: row.is_saved_locally,
-    location: mapLocation(row),
   };
 }
 
@@ -57,13 +74,28 @@ function buildSelectQuery() {
     SELECT
       hr.request_id,
       hr.user_id,
+      hr.help_types,
+      hr.other_help_text,
+      hr.affected_people_count,
+      hr.risk_flags,
+      hr.vulnerable_groups,
       hr.need_type,
       hr.description,
+      hr.blood_type,
+      hr.contact_full_name,
+      hr.contact_phone,
+      hr.contact_alternative_phone,
+      hr.consent_given,
       hr.status,
       hr.created_at,
       hr.resolved_at,
       hr.is_saved_locally,
       rl.location_id,
+      rl.country,
+      rl.city,
+      rl.district,
+      rl.neighborhood,
+      rl.extra_address,
       rl.latitude,
       rl.longitude,
       rl.is_gps_location,
@@ -87,22 +119,58 @@ async function createHelpRequest(input) {
         INSERT INTO help_requests (
           request_id,
           user_id,
+          help_types,
+          other_help_text,
+          affected_people_count,
+          risk_flags,
+          vulnerable_groups,
           need_type,
           description,
+          blood_type,
+          contact_full_name,
+          contact_phone,
+          contact_alternative_phone,
+          consent_given,
           is_saved_locally
         )
-        VALUES ($1, $2, $3, $4, $5)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
         RETURNING
           request_id,
           user_id,
+          help_types,
+          other_help_text,
+          affected_people_count,
+          risk_flags,
+          vulnerable_groups,
           need_type,
           description,
+          blood_type,
+          contact_full_name,
+          contact_phone,
+          contact_alternative_phone,
+          consent_given,
           status,
           created_at,
           resolved_at,
           is_saved_locally
       `,
-      [requestId, input.userId, input.needType, input.description, input.isSavedLocally],
+      [
+        requestId,
+        input.userId,
+        input.helpTypes,
+        input.otherHelpText,
+        input.affectedPeopleCount,
+        input.riskFlags,
+        input.vulnerableGroups,
+        input.needType,
+        input.description,
+        input.bloodType || null,
+        input.contact.fullName,
+        input.contact.phone,
+        input.contact.alternativePhone ?? null,
+        input.consentGiven,
+        input.isSavedLocally,
+      ],
     );
 
     let locationRow = null;
@@ -113,14 +181,24 @@ async function createHelpRequest(input) {
           INSERT INTO request_locations (
             location_id,
             request_id,
+            country,
+            city,
+            district,
+            neighborhood,
+            extra_address,
             latitude,
             longitude,
             is_gps_location,
             is_last_known
           )
-          VALUES ($1, $2, $3, $4, $5, $6)
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
           RETURNING
             location_id,
+            country,
+            city,
+            district,
+            neighborhood,
+            extra_address,
             latitude,
             longitude,
             is_gps_location,
@@ -130,10 +208,15 @@ async function createHelpRequest(input) {
         [
           crypto.randomUUID(),
           requestId,
-          input.location.latitude,
-          input.location.longitude,
-          input.location.isGpsLocation,
-          input.location.isLastKnown,
+          input.location.country,
+          input.location.city,
+          input.location.district,
+          input.location.neighborhood,
+          input.location.extraAddress || null,
+          null,
+          null,
+          false,
+          false,
         ],
       );
 

--- a/backend/src/modules/help-requests/validators.js
+++ b/backend/src/modules/help-requests/validators.js
@@ -20,11 +20,11 @@ function isBoolean(value) {
   return typeof value === 'boolean';
 }
 
-function isFiniteNumber(value) {
-  return typeof value === 'number' && Number.isFinite(value);
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function getNormalizedNeedType(value) {
+function normalizeOptionalString(value) {
   if (typeof value !== 'string') {
     return '';
   }
@@ -32,70 +32,208 @@ function getNormalizedNeedType(value) {
   return value.trim();
 }
 
+function validateStringArray(fieldName, value, errors, { required = false } = {}) {
+  if (value == null) {
+    if (required) {
+      errors.push(`\`${fieldName}\` is required.`);
+    }
+
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    errors.push(`\`${fieldName}\` must be an array of strings.`);
+    return [];
+  }
+
+  const normalized = [];
+
+  value.forEach((entry, index) => {
+    if (typeof entry !== 'string') {
+      errors.push(`\`${fieldName}[${index}]\` must be a string.`);
+      return;
+    }
+
+    const trimmed = entry.trim();
+
+    if (!trimmed) {
+      errors.push(`\`${fieldName}[${index}]\` must not be empty.`);
+      return;
+    }
+
+    if (trimmed.length > 100) {
+      errors.push(`\`${fieldName}[${index}]\` must be 100 characters or fewer.`);
+      return;
+    }
+
+    normalized.push(trimmed);
+  });
+
+  if (required && normalized.length === 0) {
+    errors.push(`\`${fieldName}\` must contain at least one item.`);
+  }
+
+  return normalized;
+}
+
+function validateRequiredString(fieldName, value, errors, { maxLength = 255 } = {}) {
+  const normalized = normalizeOptionalString(value);
+
+  if (!normalized) {
+    errors.push(`\`${fieldName}\` is required.`);
+    return '';
+  }
+
+  if (normalized.length > maxLength) {
+    errors.push(`\`${fieldName}\` must be ${maxLength} characters or fewer.`);
+  }
+
+  return normalized;
+}
+
+function validateOptionalString(fieldName, value, errors, { maxLength = 255 } = {}) {
+  if (value == null) {
+    return '';
+  }
+
+  if (typeof value !== 'string') {
+    errors.push(`\`${fieldName}\` must be a string.`);
+    return '';
+  }
+
+  const normalized = value.trim();
+
+  if (normalized.length > maxLength) {
+    errors.push(`\`${fieldName}\` must be ${maxLength} characters or fewer.`);
+  }
+
+  return normalized;
+}
+
+function isValidTurkishMobileNumber(value) {
+  return Number.isInteger(value) && value >= 5000000000 && value <= 5999999999;
+}
+
+function validateRequiredPhoneNumber(fieldName, value, errors) {
+  if (!isValidTurkishMobileNumber(value)) {
+    errors.push(`\`${fieldName}\` must be a 10-digit integer starting with 5.`);
+    return null;
+  }
+
+  return value;
+}
+
+function validateOptionalPhoneNumber(fieldName, value, errors) {
+  if (value == null) {
+    return null;
+  }
+
+  if (!isValidTurkishMobileNumber(value)) {
+    errors.push(`\`${fieldName}\` must be a 10-digit integer starting with 5.`);
+    return null;
+  }
+
+  return value;
+}
+
 function validateCreateHelpRequest(payload) {
   const errors = [];
   const warnings = [];
 
-  const requestedNeedType = getNormalizedNeedType(payload.needType);
-  const needType = requestedNeedType || 'general';
-
-  if (!requestedNeedType) {
-    warnings.push('Need type was not provided; defaulting to `general`.');
+  if (!isPlainObject(payload)) {
+    return {
+      errors: ['Payload must be an object.'],
+      warnings,
+      value: null,
+    };
   }
 
-  if (requestedNeedType.length > 200) {
-    errors.push('`needType` must be 200 characters or fewer.');
+  const helpTypes = validateStringArray('helpTypes', payload.helpTypes, errors, { required: true });
+  const otherHelpText = validateOptionalString('otherHelpText', payload.otherHelpText, errors, {
+    maxLength: 500,
+  });
+
+  let affectedPeopleCount = null;
+  if (!Number.isInteger(payload.affectedPeopleCount) || payload.affectedPeopleCount < 1) {
+    errors.push('`affectedPeopleCount` must be an integer greater than or equal to 1.');
+  } else {
+    affectedPeopleCount = payload.affectedPeopleCount;
   }
 
-  let description = null;
+  const riskFlags = validateStringArray('riskFlags', payload.riskFlags, errors);
+  const vulnerableGroups = validateStringArray('vulnerableGroups', payload.vulnerableGroups, errors);
+  const description = validateRequiredString('description', payload.description, errors, {
+    maxLength: 2000,
+  });
+  const bloodType = validateOptionalString('bloodType', payload.bloodType, errors, {
+    maxLength: 10,
+  });
 
-  if (typeof payload.description === 'string') {
-    const trimmedDescription = payload.description.trim();
-
-    if (trimmedDescription) {
-      description = trimmedDescription;
-    }
+  let consentGiven = false;
+  if (!isBoolean(payload.consentGiven)) {
+    errors.push('`consentGiven` must be a boolean.');
+  } else if (!payload.consentGiven) {
+    errors.push('`consentGiven` must be true.');
+  } else {
+    consentGiven = true;
   }
-
-  const isSavedLocally = isBoolean(payload.isSavedLocally)
-    ? payload.isSavedLocally
-    : false;
 
   let location = null;
-
-  if (payload.location == null) {
-    warnings.push('Location was not provided; the request was created without request coordinates.');
-  } else if (typeof payload.location !== 'object' || Array.isArray(payload.location)) {
-    errors.push('`location` must be an object when provided.');
+  if (!isPlainObject(payload.location)) {
+    errors.push('`location` is required and must be an object.');
   } else {
-    const { latitude, longitude, isGpsLocation, isLastKnown } = payload.location;
+    location = {
+      country: validateRequiredString('location.country', payload.location.country, errors, {
+        maxLength: 100,
+      }),
+      city: validateRequiredString('location.city', payload.location.city, errors, {
+        maxLength: 100,
+      }),
+      district: validateRequiredString('location.district', payload.location.district, errors, {
+        maxLength: 100,
+      }),
+      neighborhood: validateRequiredString('location.neighborhood', payload.location.neighborhood, errors, {
+        maxLength: 100,
+      }),
+      extraAddress: validateOptionalString('location.extraAddress', payload.location.extraAddress, errors, {
+        maxLength: 500,
+      }),
+    };
+  }
 
-    if (!isFiniteNumber(latitude) || latitude < -90 || latitude > 90) {
-      errors.push('`location.latitude` must be a number between -90 and 90.');
-    }
-
-    if (!isFiniteNumber(longitude) || longitude < -180 || longitude > 180) {
-      errors.push('`location.longitude` must be a number between -180 and 180.');
-    }
-
-    if (errors.length === 0) {
-      location = {
-        latitude,
-        longitude,
-        isGpsLocation: isBoolean(isGpsLocation) ? isGpsLocation : false,
-        isLastKnown: isBoolean(isLastKnown) ? isLastKnown : false,
-      };
-    }
+  let contact = null;
+  if (!isPlainObject(payload.contact)) {
+    errors.push('`contact` is required and must be an object.');
+  } else {
+    contact = {
+      fullName: validateRequiredString('contact.fullName', payload.contact.fullName, errors, {
+        maxLength: 200,
+      }),
+      phone: validateRequiredPhoneNumber('contact.phone', payload.contact.phone, errors),
+      alternativePhone: validateOptionalPhoneNumber(
+        'contact.alternativePhone',
+        payload.contact.alternativePhone,
+        errors,
+      ),
+    };
   }
 
   return {
     errors,
     warnings,
     value: {
-      needType,
+      helpTypes,
+      otherHelpText,
+      affectedPeopleCount,
+      riskFlags,
+      vulnerableGroups,
       description,
-      isSavedLocally,
+      bloodType,
       location,
+      contact,
+      consentGiven,
+      needType: helpTypes[0] || 'general',
+      isSavedLocally: false,
     },
   };
 }

--- a/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
+++ b/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
@@ -27,6 +27,32 @@ function buildAuthToken(userId) {
 	);
 }
 
+function buildCreatePayload(overrides = {}) {
+	return {
+		helpTypes: ['first_aid', 'fire_brigade'],
+		otherHelpText: '',
+		affectedPeopleCount: 3,
+		riskFlags: ['fire', 'electric_hazard'],
+		vulnerableGroups: ['children', 'pregnant'],
+		description: 'Apartment entrance blocked, one person bleeding.',
+		bloodType: 'A+',
+		location: {
+			country: 'turkiye',
+			city: 'istanbul',
+			district: 'besiktas',
+			neighborhood: 'levazim',
+			extraAddress: 'Bina B, 3. kat, arka giris',
+		},
+		contact: {
+			fullName: 'Ayse Yilmaz',
+			phone: 5052318546,
+			alternativePhone: 5321234567,
+		},
+		consentGiven: true,
+		...overrides,
+	};
+}
+
 async function seedActiveUser(userId, email = 'user@example.com') {
 	await query(
 		`
@@ -74,57 +100,77 @@ describe('help-requests integration', () => {
 
 		const response = await request(app)
 			.post('/api/help-requests')
-			.send({ needType: 'medical' });
+			.send(buildCreatePayload());
 
 		expect(response.status).toBe(401);
 	});
 
-	test('POST /api/help-requests creates request with default needType', async () => {
+	test('POST /api/help-requests creates request with the new payload shape', async () => {
 		const app = createTestApp();
 		const userId = 'user_hr_1';
 		await seedActiveUser(userId, 'hr1@example.com');
 		const token = buildAuthToken(userId);
 
+		const payload = buildCreatePayload();
 		const response = await request(app)
 			.post('/api/help-requests')
 			.set('Authorization', `Bearer ${token}`)
-			.send({});
+			.send(payload);
 
 		expect(response.status).toBe(201);
 		expect(response.body.request.userId).toBe(userId);
-		expect(response.body.request.needType).toBe('general');
+		expect(response.body.request.helpTypes).toEqual(payload.helpTypes);
+		expect(response.body.request.otherHelpText).toBe(payload.otherHelpText);
+		expect(response.body.request.affectedPeopleCount).toBe(payload.affectedPeopleCount);
+		expect(response.body.request.riskFlags).toEqual(payload.riskFlags);
+		expect(response.body.request.vulnerableGroups).toEqual(payload.vulnerableGroups);
+		expect(response.body.request.bloodType).toBe(payload.bloodType);
+		expect(response.body.request.location).toEqual(payload.location);
+		expect(response.body.request.contact).toEqual(payload.contact);
+		expect(response.body.request.consentGiven).toBe(true);
+		expect(response.body.request.needType).toBe('first_aid');
 		expect(response.body.request.status).toBe('SYNCED');
 		expect(response.body.request.isSavedLocally).toBe(false);
-		expect(response.body.warnings).toEqual(
-			expect.arrayContaining([expect.stringContaining('defaulting to')]),
-		);
+		expect(response.body.warnings).toEqual([]);
 	});
 
-	test('POST /api/help-requests creates request with location', async () => {
+	test('POST /api/help-requests trims optional string fields and preserves numeric phones', async () => {
 		const app = createTestApp();
 		const userId = 'user_hr_2';
 		await seedActiveUser(userId, 'hr2@example.com');
 		const token = buildAuthToken(userId);
 
+		const payload = buildCreatePayload({
+			otherHelpText: '  generator needed  ',
+			bloodType: '  A+  ',
+			location: {
+				country: 'turkiye',
+				city: 'istanbul',
+				district: 'besiktas',
+				neighborhood: 'levazim',
+				extraAddress: '  Need entry from the back  ',
+			},
+			contact: {
+				fullName: 'Ayse Yilmaz',
+				phone: 5052318546,
+				alternativePhone: 5321234567,
+			},
+		});
+
 		const response = await request(app)
 			.post('/api/help-requests')
 			.set('Authorization', `Bearer ${token}`)
-			.send({
-				needType: 'medical',
-				description: 'Need first aid',
-				location: { latitude: 41.0, longitude: 28.9, isGpsLocation: true },
-			});
+			.send(payload);
 
 		expect(response.status).toBe(201);
-		expect(response.body.request.needType).toBe('medical');
-		expect(response.body.request.description).toBe('Need first aid');
-		expect(response.body.request.location).toBeTruthy();
-		expect(response.body.request.location.latitude).toBe(41.0);
-		expect(response.body.request.location.longitude).toBe(28.9);
-		expect(response.body.request.location.isGpsLocation).toBe(true);
+		expect(response.body.request.otherHelpText).toBe('generator needed');
+		expect(response.body.request.bloodType).toBe('A+');
+		expect(response.body.request.location.extraAddress).toBe('Need entry from the back');
+		expect(response.body.request.contact.phone).toBe(5052318546);
+		expect(response.body.request.contact.alternativePhone).toBe(5321234567);
 	});
 
-	test('POST /api/help-requests creates locally saved request with PENDING_SYNC status', async () => {
+	test('POST /api/help-requests returns 400 for invalid payload', async () => {
 		const app = createTestApp();
 		const userId = 'user_hr_3';
 		await seedActiveUser(userId, 'hr3@example.com');
@@ -133,11 +179,32 @@ describe('help-requests integration', () => {
 		const response = await request(app)
 			.post('/api/help-requests')
 			.set('Authorization', `Bearer ${token}`)
-			.send({ needType: 'shelter', isSavedLocally: true });
+			.send(buildCreatePayload({ consentGiven: false }));
 
-		expect(response.status).toBe(201);
-		expect(response.body.request.isSavedLocally).toBe(true);
-		expect(response.body.request.status).toBe('PENDING_SYNC');
+		expect(response.status).toBe(400);
+		expect(response.body.code).toBe('VALIDATION_FAILED');
+	});
+
+	test('POST /api/help-requests returns 400 for invalid contact phone', async () => {
+		const app = createTestApp();
+		const userId = 'user_hr_3b';
+		await seedActiveUser(userId, 'hr3b@example.com');
+		const token = buildAuthToken(userId);
+
+		const response = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${token}`)
+			.send(buildCreatePayload({
+				contact: {
+					fullName: 'Ayse Yilmaz',
+					phone: 4052318546,
+					alternativePhone: 5321234567,
+				},
+			}));
+
+		expect(response.status).toBe(400);
+		expect(response.body.code).toBe('VALIDATION_FAILED');
+		expect(response.body.details).toContain('`contact.phone` must be a 10-digit integer starting with 5.');
 	});
 
 	test('POST /api/help-requests returns 400 for invalid location', async () => {
@@ -149,7 +216,15 @@ describe('help-requests integration', () => {
 		const response = await request(app)
 			.post('/api/help-requests')
 			.set('Authorization', `Bearer ${token}`)
-			.send({ location: { latitude: 999, longitude: 28 } });
+			.send(buildCreatePayload({
+				location: {
+					country: 'turkiye',
+					city: '',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: '',
+				},
+			}));
 
 		expect(response.status).toBe(400);
 		expect(response.body.code).toBe('VALIDATION_FAILED');
@@ -176,17 +251,17 @@ describe('help-requests integration', () => {
 		await request(app)
 			.post('/api/help-requests')
 			.set('Authorization', `Bearer ${token1}`)
-			.send({ needType: 'food' });
+			.send(buildCreatePayload({ helpTypes: ['food'] }));
 
 		await request(app)
 			.post('/api/help-requests')
 			.set('Authorization', `Bearer ${token1}`)
-			.send({ needType: 'water' });
+			.send(buildCreatePayload({ helpTypes: ['water'] }));
 
 		await request(app)
 			.post('/api/help-requests')
 			.set('Authorization', `Bearer ${token2}`)
-			.send({ needType: 'shelter' });
+			.send(buildCreatePayload({ helpTypes: ['shelter'] }));
 
 		const response1 = await request(app)
 			.get('/api/help-requests')
@@ -212,7 +287,7 @@ describe('help-requests integration', () => {
 		const createResponse = await request(app)
 			.post('/api/help-requests')
 			.set('Authorization', `Bearer ${token}`)
-			.send({ needType: 'medical', description: 'broken leg' });
+			.send(buildCreatePayload({ description: 'broken leg' }));
 
 		const requestId = createResponse.body.request.id;
 
@@ -223,6 +298,7 @@ describe('help-requests integration', () => {
 		expect(response.status).toBe(200);
 		expect(response.body.request.id).toBe(requestId);
 		expect(response.body.request.description).toBe('broken leg');
+		expect(response.body.request.helpTypes).toEqual(['first_aid', 'fire_brigade']);
 	});
 
 	test('GET /api/help-requests/:requestId returns 404 for nonexistent request', async () => {
@@ -250,7 +326,7 @@ describe('help-requests integration', () => {
 		const createResponse = await request(app)
 			.post('/api/help-requests')
 			.set('Authorization', `Bearer ${token1}`)
-			.send({ needType: 'food' });
+			.send(buildCreatePayload({ helpTypes: ['food'] }));
 
 		const requestId = createResponse.body.request.id;
 
@@ -270,10 +346,10 @@ describe('help-requests integration', () => {
 		const createResponse = await request(app)
 			.post('/api/help-requests')
 			.set('Authorization', `Bearer ${token}`)
-			.send({ needType: 'food', isSavedLocally: true });
+			.send(buildCreatePayload({ helpTypes: ['food'] }));
 
 		const requestId = createResponse.body.request.id;
-		expect(createResponse.body.request.status).toBe('PENDING_SYNC');
+		expect(createResponse.body.request.status).toBe('SYNCED');
 
 		const response = await request(app)
 			.patch(`/api/help-requests/${requestId}/status`)
@@ -294,7 +370,7 @@ describe('help-requests integration', () => {
 		const createResponse = await request(app)
 			.post('/api/help-requests')
 			.set('Authorization', `Bearer ${token}`)
-			.send({ needType: 'food' });
+			.send(buildCreatePayload({ helpTypes: ['food'] }));
 
 		const requestId = createResponse.body.request.id;
 
@@ -317,7 +393,7 @@ describe('help-requests integration', () => {
 		const createResponse = await request(app)
 			.post('/api/help-requests')
 			.set('Authorization', `Bearer ${token}`)
-			.send({ needType: 'food' });
+			.send(buildCreatePayload({ helpTypes: ['food'] }));
 
 		const requestId = createResponse.body.request.id;
 
@@ -373,7 +449,7 @@ describe('help-requests integration', () => {
 		const createResponse = await request(app)
 			.post('/api/help-requests')
 			.set('Authorization', `Bearer ${token}`)
-			.send({ needType: 'water' });
+			.send(buildCreatePayload({ helpTypes: ['water'] }));
 
 		const requestId = createResponse.body.request.id;
 

--- a/backend/tests/unit/modules/help-requests/controller.test.js
+++ b/backend/tests/unit/modules/help-requests/controller.test.js
@@ -44,7 +44,7 @@ describe('help-requests controller', () => {
 		test('returns 400 when validation fails', async () => {
 			validators.readUserId.mockReturnValueOnce('u1');
 			validators.validateCreateHelpRequest.mockReturnValueOnce({
-				errors: ['`needType` must be 200 characters or fewer.'],
+				errors: ['`helpTypes` must contain at least one item.'],
 				warnings: [],
 				value: {},
 			});
@@ -56,7 +56,7 @@ describe('help-requests controller', () => {
 			expect(response.json).toHaveBeenCalledWith({
 				code: 'VALIDATION_FAILED',
 				message: 'Validation failed',
-				details: ['`needType` must be 200 characters or fewer.'],
+				details: ['`helpTypes` must contain at least one item.'],
 			});
 		});
 
@@ -64,10 +64,33 @@ describe('help-requests controller', () => {
 			validators.readUserId.mockReturnValueOnce('u1');
 			validators.validateCreateHelpRequest.mockReturnValueOnce({
 				errors: [],
-				warnings: ['Need type was not provided; defaulting to `general`.'],
-				value: { needType: 'general', description: null, isSavedLocally: false, location: null },
+				warnings: [],
+				value: {
+					helpTypes: ['first_aid'],
+					otherHelpText: '',
+					affectedPeopleCount: 1,
+					riskFlags: [],
+					vulnerableGroups: [],
+					description: 'Need first aid',
+					bloodType: 'A+',
+					location: {
+						country: 'turkiye',
+						city: 'istanbul',
+						district: 'besiktas',
+						neighborhood: 'levazim',
+						extraAddress: '',
+					},
+					contact: {
+						fullName: 'Ayse Yilmaz',
+						phone: 5052318546,
+						alternativePhone: null,
+					},
+					consentGiven: true,
+					needType: 'first_aid',
+					isSavedLocally: false,
+				},
 			});
-			const created = { id: 'req_1', userId: 'u1', needType: 'general' };
+			const created = { id: 'req_1', userId: 'u1', helpTypes: ['first_aid'] };
 			service.createMyHelpRequest.mockResolvedValueOnce(created);
 			const response = buildResponse();
 
@@ -76,7 +99,7 @@ describe('help-requests controller', () => {
 			expect(response.status).toHaveBeenCalledWith(201);
 			expect(response.json).toHaveBeenCalledWith({
 				request: created,
-				warnings: ['Need type was not provided; defaulting to `general`.'],
+				warnings: [],
 			});
 		});
 
@@ -85,7 +108,7 @@ describe('help-requests controller', () => {
 			validators.validateCreateHelpRequest.mockReturnValueOnce({
 				errors: [],
 				warnings: [],
-				value: { needType: 'general' },
+				value: { helpTypes: ['first_aid'] },
 			});
 			const error = new Error('bad user');
 			error.code = 'INVALID_USER';
@@ -103,7 +126,7 @@ describe('help-requests controller', () => {
 			validators.validateCreateHelpRequest.mockReturnValueOnce({
 				errors: [],
 				warnings: [],
-				value: { needType: 'general' },
+				value: { helpTypes: ['first_aid'] },
 			});
 			service.createMyHelpRequest.mockRejectedValueOnce(new Error('boom'));
 			const response = buildResponse();

--- a/backend/tests/unit/modules/help-requests/service.test.js
+++ b/backend/tests/unit/modules/help-requests/service.test.js
@@ -19,15 +19,54 @@ const {
 describe('help-requests service', () => {
 	describe('createMyHelpRequest', () => {
 		test('delegates to repository with userId merged into input', async () => {
-			const input = { needType: 'medical', description: 'help' };
-			const expected = { id: 'req_1', userId: 'u1', needType: 'medical' };
+			const input = {
+				helpTypes: ['first_aid', 'fire_brigade'],
+				otherHelpText: '',
+				affectedPeopleCount: 3,
+				riskFlags: ['fire'],
+				vulnerableGroups: ['children'],
+				description: 'help',
+				bloodType: 'A+',
+				location: {
+					country: 'turkiye',
+					city: 'istanbul',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: 'Bina B',
+				},
+				contact: {
+					fullName: 'Ayse Yilmaz',
+					phone: 5052318546,
+					alternativePhone: 5321234567,
+				},
+				consentGiven: true,
+			};
+			const expected = { id: 'req_1', userId: 'u1', helpTypes: ['first_aid', 'fire_brigade'] };
 			repository.createHelpRequest.mockResolvedValueOnce(expected);
 
 			const result = await createMyHelpRequest('u1', input);
 
 			expect(repository.createHelpRequest).toHaveBeenCalledWith({
-				needType: 'medical',
+				helpTypes: ['first_aid', 'fire_brigade'],
+				otherHelpText: '',
+				affectedPeopleCount: 3,
+				riskFlags: ['fire'],
+				vulnerableGroups: ['children'],
 				description: 'help',
+				bloodType: 'A+',
+				location: {
+					country: 'turkiye',
+					city: 'istanbul',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: 'Bina B',
+				},
+				contact: {
+					fullName: 'Ayse Yilmaz',
+					phone: 5052318546,
+					alternativePhone: 5321234567,
+				},
+				consentGiven: true,
 				userId: 'u1',
 			});
 			expect(result).toEqual(expected);
@@ -38,7 +77,7 @@ describe('help-requests service', () => {
 			dbError.code = '23503';
 			repository.createHelpRequest.mockRejectedValueOnce(dbError);
 
-			await expect(createMyHelpRequest('bad_user', { needType: 'general' }))
+			await expect(createMyHelpRequest('bad_user', { helpTypes: ['general'] }))
 				.rejects
 				.toMatchObject({ code: 'INVALID_USER' });
 		});
@@ -47,7 +86,7 @@ describe('help-requests service', () => {
 			const dbError = new Error('connection lost');
 			repository.createHelpRequest.mockRejectedValueOnce(dbError);
 
-			await expect(createMyHelpRequest('u1', { needType: 'general' }))
+			await expect(createMyHelpRequest('u1', { helpTypes: ['general'] }))
 				.rejects
 				.toThrow('connection lost');
 		});

--- a/backend/tests/unit/modules/help-requests/validators.test.js
+++ b/backend/tests/unit/modules/help-requests/validators.test.js
@@ -68,143 +68,133 @@ describe('help-requests validators', () => {
 	});
 
 	describe('validateCreateHelpRequest', () => {
-		test('defaults needType to general when missing', () => {
-			const { errors, warnings, value } = validateCreateHelpRequest({});
+		function buildPayload() {
+			return {
+				helpTypes: ['first_aid', 'fire_brigade'],
+				otherHelpText: '',
+				affectedPeopleCount: 3,
+				riskFlags: ['fire', 'electric_hazard'],
+				vulnerableGroups: ['children', 'pregnant'],
+				description: 'Apartment entrance blocked, one person bleeding.',
+				bloodType: 'A+',
+				location: {
+					country: 'turkiye',
+					city: 'istanbul',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: 'Bina B, 3. kat, arka giris',
+				},
+				contact: {
+					fullName: 'Ayse Yilmaz',
+					phone: 5052318546,
+					alternativePhone: 5321234567,
+				},
+				consentGiven: true,
+			};
+		}
+
+		test('accepts the new help-request payload shape', () => {
+			const { errors, warnings, value } = validateCreateHelpRequest(buildPayload());
 
 			expect(errors).toHaveLength(0);
-			expect(value.needType).toBe('general');
-			expect(warnings).toContainEqual(expect.stringContaining('defaulting to'));
-		});
-
-		test('accepts provided needType', () => {
-			const { errors, value } = validateCreateHelpRequest({ needType: 'medical' });
-
-			expect(errors).toHaveLength(0);
-			expect(value.needType).toBe('medical');
-		});
-
-		test('trims needType', () => {
-			const { value } = validateCreateHelpRequest({ needType: '  fire  ' });
-
-			expect(value.needType).toBe('fire');
-		});
-
-		test('rejects needType longer than 200 characters', () => {
-			const { errors } = validateCreateHelpRequest({ needType: 'a'.repeat(201) });
-
-			expect(errors.length).toBeGreaterThan(0);
-			expect(errors[0]).toContain('200 characters');
-		});
-
-		test('trims and accepts description', () => {
-			const { value } = validateCreateHelpRequest({ description: '  help me  ' });
-
-			expect(value.description).toBe('help me');
-		});
-
-		test('sets description to null for empty string', () => {
-			const { value } = validateCreateHelpRequest({ description: '   ' });
-
-			expect(value.description).toBeNull();
-		});
-
-		test('sets description to null when not a string', () => {
-			const { value } = validateCreateHelpRequest({ description: 123 });
-
-			expect(value.description).toBeNull();
-		});
-
-		test('defaults isSavedLocally to false', () => {
-			const { value } = validateCreateHelpRequest({});
-
+			expect(warnings).toEqual([]);
+			expect(value.helpTypes).toEqual(['first_aid', 'fire_brigade']);
+			expect(value.needType).toBe('first_aid');
+			expect(value.affectedPeopleCount).toBe(3);
+			expect(value.location.city).toBe('istanbul');
+			expect(value.contact.fullName).toBe('Ayse Yilmaz');
+			expect(value.consentGiven).toBe(true);
 			expect(value.isSavedLocally).toBe(false);
 		});
 
-		test('accepts boolean isSavedLocally', () => {
-			const { value } = validateCreateHelpRequest({ isSavedLocally: true });
+		test('rejects missing required fields', () => {
+			const { errors } = validateCreateHelpRequest({});
 
-			expect(value.isSavedLocally).toBe(true);
+			expect(errors).toEqual(expect.arrayContaining([
+				expect.stringContaining('`helpTypes` is required'),
+				expect.stringContaining('`affectedPeopleCount`'),
+				expect.stringContaining('`description` is required'),
+				expect.stringContaining('`location` is required'),
+				expect.stringContaining('`contact` is required'),
+				expect.stringContaining('`consentGiven`'),
+			]));
 		});
 
-		test('defaults isSavedLocally to false for non-boolean', () => {
-			const { value } = validateCreateHelpRequest({ isSavedLocally: 'yes' });
+		test('rejects empty helpTypes', () => {
+			const payload = buildPayload();
+			payload.helpTypes = [];
 
-			expect(value.isSavedLocally).toBe(false);
+			const { errors } = validateCreateHelpRequest(payload);
+
+			expect(errors).toContain('`helpTypes` must contain at least one item.');
 		});
 
-		test('warns when location is not provided', () => {
-			const { warnings, value } = validateCreateHelpRequest({});
+		test('rejects non-array helpTypes', () => {
+			const payload = buildPayload();
+			payload.helpTypes = 'first_aid';
 
-			expect(value.location).toBeNull();
-			expect(warnings).toContainEqual(expect.stringContaining('Location was not provided'));
+			const { errors } = validateCreateHelpRequest(payload);
+
+			expect(errors).toContain('`helpTypes` must be an array of strings.');
 		});
 
-		test('rejects non-object location', () => {
-			const { errors } = validateCreateHelpRequest({ location: 'here' });
+		test('rejects non-positive affectedPeopleCount', () => {
+			const payload = buildPayload();
+			payload.affectedPeopleCount = 0;
 
-			expect(errors).toContainEqual(expect.stringContaining('must be an object'));
+			const { errors } = validateCreateHelpRequest(payload);
+
+			expect(errors).toContain('`affectedPeopleCount` must be an integer greater than or equal to 1.');
 		});
 
-		test('rejects array location', () => {
-			const { errors } = validateCreateHelpRequest({ location: [1, 2] });
+		test('trims optional strings while preserving numeric phones', () => {
+			const payload = buildPayload();
+			payload.otherHelpText = '  extra detail  ';
+			payload.bloodType = '  A+  ';
+			payload.location.extraAddress = '  back door  ';
 
-			expect(errors).toContainEqual(expect.stringContaining('must be an object'));
+			const { value } = validateCreateHelpRequest(payload);
+
+			expect(value.otherHelpText).toBe('extra detail');
+			expect(value.bloodType).toBe('A+');
+			expect(value.location.extraAddress).toBe('back door');
+			expect(value.contact.alternativePhone).toBe(5321234567);
 		});
 
-		test('rejects latitude out of range', () => {
-			const { errors } = validateCreateHelpRequest({
-				location: { latitude: 91, longitude: 28 },
-			});
+		test('rejects invalid location fields', () => {
+			const payload = buildPayload();
+			payload.location.city = '   ';
 
-			expect(errors).toContainEqual(expect.stringContaining('latitude'));
+			const { errors } = validateCreateHelpRequest(payload);
+
+			expect(errors).toContain('`location.city` is required.');
 		});
 
-		test('rejects longitude out of range', () => {
-			const { errors } = validateCreateHelpRequest({
-				location: { latitude: 41, longitude: 181 },
-			});
+		test('rejects invalid contact fields', () => {
+			const payload = buildPayload();
+			payload.contact.phone = 4052318546;
 
-			expect(errors).toContainEqual(expect.stringContaining('longitude'));
+			const { errors } = validateCreateHelpRequest(payload);
+
+			expect(errors).toContain('`contact.phone` must be a 10-digit integer starting with 5.');
 		});
 
-		test('rejects non-numeric latitude', () => {
-			const { errors } = validateCreateHelpRequest({
-				location: { latitude: 'north', longitude: 28 },
-			});
+		test('rejects invalid alternative phone fields', () => {
+			const payload = buildPayload();
+			payload.contact.alternativePhone = 532123456;
 
-			expect(errors).toContainEqual(expect.stringContaining('latitude'));
+			const { errors } = validateCreateHelpRequest(payload);
+
+			expect(errors).toContain('`contact.alternativePhone` must be a 10-digit integer starting with 5.');
 		});
 
-		test('accepts valid location with defaults for booleans', () => {
-			const { errors, value } = validateCreateHelpRequest({
-				location: { latitude: 41.0, longitude: 28.9 },
-			});
+		test('rejects consentGiven when false', () => {
+			const payload = buildPayload();
+			payload.consentGiven = false;
 
-			expect(errors).toHaveLength(0);
-			expect(value.location).toEqual({
-				latitude: 41.0,
-				longitude: 28.9,
-				isGpsLocation: false,
-				isLastKnown: false,
-			});
-		});
+			const { errors } = validateCreateHelpRequest(payload);
 
-		test('accepts location with explicit boolean flags', () => {
-			const { errors, value } = validateCreateHelpRequest({
-				location: { latitude: 41.0, longitude: 28.9, isGpsLocation: true, isLastKnown: true },
-			});
-
-			expect(errors).toHaveLength(0);
-			expect(value.location.isGpsLocation).toBe(true);
-			expect(value.location.isLastKnown).toBe(true);
-		});
-
-		test('sets location to null when coordinate errors exist', () => {
-			const { value } = validateCreateHelpRequest({
-				location: { latitude: 999, longitude: 28 },
-			});
-
-			expect(value.location).toBeNull();
+			expect(errors).toContain('`consentGiven` must be true.');
 		});
 	});
 

--- a/infra/docker/postgres/init.sql
+++ b/infra/docker/postgres/init.sql
@@ -208,8 +208,18 @@ CREATE TABLE news_announcements (
 CREATE TABLE help_requests (
     request_id             VARCHAR(64) PRIMARY KEY,
     user_id                VARCHAR(64) NOT NULL,
+    help_types             TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    other_help_text        TEXT NOT NULL DEFAULT '',
+    affected_people_count  INTEGER NOT NULL DEFAULT 1,
+    risk_flags             TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    vulnerable_groups      TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
     need_type              VARCHAR(200) NOT NULL,
     description            TEXT,
+    blood_type             VARCHAR(10),
+    contact_full_name      VARCHAR(200) NOT NULL,
+    contact_phone          BIGINT NOT NULL,
+    contact_alternative_phone BIGINT,
+    consent_given          BOOLEAN NOT NULL DEFAULT FALSE,
     status                 request_status NOT NULL DEFAULT 'PENDING',
     created_at             TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     resolved_at            TIMESTAMP,
@@ -224,14 +234,31 @@ CREATE TABLE help_requests (
         CHECK (
             resolved_at IS NULL
             OR resolved_at >= created_at
+        ),
+
+    CONSTRAINT chk_help_request_affected_people_count
+        CHECK (affected_people_count >= 1),
+
+    CONSTRAINT chk_help_request_contact_phone
+        CHECK (contact_phone BETWEEN 5000000000 AND 5999999999),
+
+    CONSTRAINT chk_help_request_contact_alternative_phone
+        CHECK (
+            contact_alternative_phone IS NULL
+            OR contact_alternative_phone BETWEEN 5000000000 AND 5999999999
         )
 );
 
 CREATE TABLE request_locations (
     location_id            VARCHAR(64) PRIMARY KEY,
     request_id             VARCHAR(64) NOT NULL UNIQUE,
-    latitude               DOUBLE PRECISION NOT NULL,
-    longitude              DOUBLE PRECISION NOT NULL,
+    country                VARCHAR(100) NOT NULL,
+    city                   VARCHAR(100) NOT NULL,
+    district               VARCHAR(100) NOT NULL,
+    neighborhood           VARCHAR(100) NOT NULL,
+    extra_address          VARCHAR(500),
+    latitude               DOUBLE PRECISION,
+    longitude              DOUBLE PRECISION,
     is_gps_location        BOOLEAN NOT NULL DEFAULT FALSE,
     is_last_known          BOOLEAN NOT NULL DEFAULT FALSE,
     captured_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -241,11 +268,17 @@ CREATE TABLE request_locations (
         REFERENCES help_requests(request_id)
         ON DELETE CASCADE,
 
-    CONSTRAINT chk_request_location_latitude
-        CHECK (latitude BETWEEN -90 AND 90),
-
-    CONSTRAINT chk_request_location_longitude
-        CHECK (longitude BETWEEN -180 AND 180)
+    CONSTRAINT chk_request_location_coordinates
+        CHECK (
+            (latitude IS NULL AND longitude IS NULL)
+            OR
+            (
+                latitude IS NOT NULL
+                AND longitude IS NOT NULL
+                AND latitude BETWEEN -90 AND 90
+                AND longitude BETWEEN -180 AND 180
+            )
+        )
 );
 
 


### PR DESCRIPTION
Fixes #184 

With the changes to be applied, the backend should provide the necessary endpoints for the simple help request form below:

**Noting that the formatting for the phone number is different than the format the frontend team suggested.**

```
{
  "helpTypes": ["first_aid", "fire_brigade"],
  "otherHelpText": "",
  "affectedPeopleCount": 3,
  "riskFlags": ["fire", "electric_hazard"],
  "vulnerableGroups": ["children", "pregnant"],
  "description": "Apartment entrance blocked, one person bleeding.",
  "bloodType": "A+",
  "location": {
    "country": "turkiye",
    "city": "istanbul",
    "district": "besiktas",
    "neighborhood": "levazim",
    "extraAddress": "Bina B, 3. kat, arka giris"
  },
  "contact": {
    "fullName": "Ayse Yilmaz",
    "phone": "5053217788",
    "alternativePhone": "5053217788"
  },
  "consentGiven": true
}
```