### PR TITLE
fix: keep helper assignments visible for guest help requests

### DIFF
--- a/backend/src/modules/auth/middleware.js
+++ b/backend/src/modules/auth/middleware.js
@@ -45,7 +45,33 @@ function requireAdmin(req, res, next) {
   return next();
 }
 
+function optionalAuth(req, _res, next) {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return next();
+  }
+
+  const token = authHeader.split(' ')[1];
+
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+
+    req.user = {
+      userId: decoded.userId,
+      email: decoded.email,
+      isAdmin: decoded.isAdmin,
+      adminRole: decoded.adminRole,
+    };
+  } catch (_error) {
+    // Token is invalid/expired — proceed as guest
+  }
+
+  return next();
+}
+
 module.exports = {
   requireAuth,
   requireAdmin,
+  optionalAuth,
 };

--- a/backend/src/modules/availability/repository.js
+++ b/backend/src/modules/availability/repository.js
@@ -128,13 +128,19 @@ async function updateRequestStatus(requestId, status) {
 async function getAssignmentByVolunteerId(volunteerId) {
   const sql = `
     SELECT a.*, hr.need_type, hr.description, hr.status as request_status,
+           hr.help_types, hr.other_help_text, hr.affected_people_count,
+           hr.risk_flags, hr.vulnerable_groups, hr.blood_type,
+           hr.contact_full_name, hr.contact_phone, hr.contact_alternative_phone,
            rl.latitude, rl.longitude,
+           rl.country AS request_country, rl.city AS request_city,
+           rl.district AS request_district, rl.neighborhood AS request_neighborhood,
+           rl.extra_address AS request_extra_address,
            u.email as requester_email,
            up.first_name as requester_first_name, up.last_name as requester_last_name
     FROM assignments a
     JOIN help_requests hr ON a.request_id = hr.request_id
     LEFT JOIN request_locations rl ON hr.request_id = rl.request_id
-    JOIN users u ON hr.user_id = u.user_id
+    LEFT JOIN users u ON hr.user_id = u.user_id
     LEFT JOIN user_profiles up ON u.user_id = up.user_id
     WHERE a.volunteer_id = $1 AND a.is_cancelled = FALSE AND hr.status != 'RESOLVED' AND hr.status != 'CANCELLED'
     LIMIT 1;

--- a/backend/src/modules/help-requests/controller.js
+++ b/backend/src/modules/help-requests/controller.js
@@ -23,9 +23,7 @@ function sendError(response, status, code, message, details) {
 async function createHelpRequest(request, response) {
   const userId = readUserId(request);
 
-  if (!userId) {
-    return sendError(response, 401, 'UNAUTHORIZED', 'Authentication required');
-  }
+  // userId may be null for guest submissions — that is allowed
 
   const { errors, warnings, value } = validateCreateHelpRequest(request.body || {});
 

--- a/backend/src/modules/help-requests/repository.js
+++ b/backend/src/modules/help-requests/repository.js
@@ -46,6 +46,19 @@ function mapContact(row) {
   };
 }
 
+function mapHelper(row) {
+  if (!row.helper_first_name && !row.helper_last_name && !row.helper_phone_number) {
+    return null;
+  }
+
+  return {
+    firstName: row.helper_first_name || null,
+    lastName: row.helper_last_name || null,
+    phone: row.helper_phone_number ? Number(row.helper_phone_number) : null,
+    expertise: row.helper_expertise_area || null,
+  };
+}
+
 function mapHelpRequest(row) {
   return {
     id: row.request_id,
@@ -66,6 +79,7 @@ function mapHelpRequest(row) {
     createdAt: row.created_at,
     resolvedAt: row.resolved_at,
     isSavedLocally: row.is_saved_locally,
+    helper: mapHelper(row),
   };
 }
 
@@ -100,9 +114,21 @@ function buildSelectQuery() {
       rl.longitude,
       rl.is_gps_location,
       rl.is_last_known,
-      rl.captured_at
+      rl.captured_at,
+      helper_profile.first_name AS helper_first_name,
+      helper_profile.last_name AS helper_last_name,
+      helper_profile.phone_number AS helper_phone_number,
+      helper_expertise.expertise_area AS helper_expertise_area
     FROM help_requests hr
     LEFT JOIN request_locations rl ON rl.request_id = hr.request_id
+    LEFT JOIN assignments asg
+      ON asg.request_id = hr.request_id
+      AND asg.is_cancelled = FALSE
+    LEFT JOIN volunteers vol ON vol.volunteer_id = asg.volunteer_id
+    LEFT JOIN users helper_user ON helper_user.user_id = vol.user_id
+    LEFT JOIN user_profiles helper_profile ON helper_profile.user_id = vol.user_id
+    LEFT JOIN expertise helper_expertise
+      ON helper_expertise.profile_id = helper_profile.profile_id
   `;
 }
 
@@ -156,7 +182,7 @@ async function createHelpRequest(input) {
       `,
       [
         requestId,
-        input.userId,
+        input.userId || null,
         input.helpTypes,
         input.otherHelpText,
         input.affectedPeopleCount,

--- a/backend/src/modules/help-requests/routes.js
+++ b/backend/src/modules/help-requests/routes.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { requireAuth } = require('../auth/middleware');
+const { requireAuth, optionalAuth } = require('../auth/middleware');
 const {
   createHelpRequest,
   listHelpRequests,
@@ -9,12 +9,13 @@ const {
 
 const helpRequestsRouter = express.Router();
 
-helpRequestsRouter.use(requireAuth);
+// Guest-accessible: optionalAuth sets req.user if token present, but doesn't block
+helpRequestsRouter.post('/', optionalAuth, createHelpRequest);
 
-helpRequestsRouter.post('/', createHelpRequest);
-helpRequestsRouter.get('/', listHelpRequests);
-helpRequestsRouter.get('/:requestId', getHelpRequest);
-helpRequestsRouter.patch('/:requestId/status', patchHelpRequestStatus);
+// These routes require authentication
+helpRequestsRouter.get('/', requireAuth, listHelpRequests);
+helpRequestsRouter.get('/:requestId', requireAuth, getHelpRequest);
+helpRequestsRouter.patch('/:requestId/status', requireAuth, patchHelpRequestStatus);
 
 module.exports = {
   helpRequestsRouter,

--- a/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
+++ b/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
@@ -5,12 +5,14 @@ const request = require('supertest');
 const jwt = require('jsonwebtoken');
 
 const { helpRequestsRouter } = require('../../../../src/modules/help-requests/routes');
+const { availabilityRouter } = require('../../../../src/modules/availability/routes');
 const { query } = require('../../../../src/db/pool');
 
 function createTestApp() {
 	const app = express();
 	app.use(express.json());
 	app.use('/api/help-requests', helpRequestsRouter);
+	app.use('/api/availability', availabilityRouter);
 	return app;
 }
 
@@ -95,14 +97,51 @@ beforeEach(async () => {
 });
 
 describe('help-requests integration', () => {
-	test('POST /api/help-requests returns 401 without token', async () => {
+	test('POST /api/help-requests creates request as guest without token', async () => {
 		const app = createTestApp();
 
 		const response = await request(app)
 			.post('/api/help-requests')
 			.send(buildCreatePayload());
 
-		expect(response.status).toBe(401);
+		expect(response.status).toBe(201);
+		expect(response.body.request.userId).toBeNull();
+		expect(response.body.request.helpTypes).toEqual(['first_aid', 'fire_brigade']);
+		expect(response.body.request.contact.fullName).toBe('Ayse Yilmaz');
+		expect(response.body.request.status).toBe('SYNCED');
+	});
+
+	test('guest-created request is visible in helper assignment endpoints', async () => {
+		const app = createTestApp();
+		const helperId = 'user_hr_guest_helper';
+		await seedActiveUser(helperId, 'guesthelper@example.com');
+		const helperToken = buildAuthToken(helperId);
+
+		const createRes = await request(app)
+			.post('/api/help-requests')
+			.send(buildCreatePayload());
+
+		expect(createRes.status).toBe(201);
+		expect(createRes.body.request.userId).toBeNull();
+
+		const toggleRes = await request(app)
+			.post('/api/availability/toggle')
+			.set('Authorization', `Bearer ${helperToken}`)
+			.send({ isAvailable: true });
+
+		expect(toggleRes.status).toBe(200);
+		expect(toggleRes.body.assignment).toBeTruthy();
+		expect(toggleRes.body.assignment.request_id).toBe(createRes.body.request.id);
+		expect(toggleRes.body.assignment.requester_email).toBeNull();
+
+		const assignmentRes = await request(app)
+			.get('/api/availability/my-assignment')
+			.set('Authorization', `Bearer ${helperToken}`);
+
+		expect(assignmentRes.status).toBe(200);
+		expect(assignmentRes.body.assignment).toBeTruthy();
+		expect(assignmentRes.body.assignment.request_id).toBe(createRes.body.request.id);
+		expect(assignmentRes.body.assignment.requester_email).toBeNull();
 	});
 
 	test('POST /api/help-requests creates request with the new payload shape', async () => {
@@ -465,5 +504,125 @@ describe('help-requests integration', () => {
 
 		expect(response.status).toBe(200);
 		expect(response.body.request.status).toBe('RESOLVED');
+	});
+
+	test('assigned helper sees full requester form details', async () => {
+		const app = createTestApp();
+		const requesterId = 'user_hr_form_1';
+		const helperId = 'user_hr_form_2';
+		await seedActiveUser(requesterId, 'form1@example.com');
+		await seedActiveUser(helperId, 'form2@example.com');
+		const requesterToken = buildAuthToken(requesterId);
+		const helperToken = buildAuthToken(helperId);
+
+		// Requester creates a rich help request
+		const createRes = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${requesterToken}`)
+			.send(buildCreatePayload());
+
+		expect(createRes.status).toBe(201);
+
+		// Helper toggles availability to get assigned
+		const toggleRes = await request(app)
+			.post('/api/availability/toggle')
+			.set('Authorization', `Bearer ${helperToken}`)
+			.send({ isAvailable: true });
+
+		expect(toggleRes.status).toBe(200);
+		expect(toggleRes.body.assignment).toBeTruthy();
+
+		// Helper fetches their assignment — should see full form data
+		const assignmentRes = await request(app)
+			.get('/api/availability/my-assignment')
+			.set('Authorization', `Bearer ${helperToken}`);
+
+		expect(assignmentRes.status).toBe(200);
+		const asg = assignmentRes.body.assignment;
+		expect(asg.help_types).toEqual(['first_aid', 'fire_brigade']);
+		expect(asg.affected_people_count).toBe(3);
+		expect(asg.risk_flags).toEqual(['fire', 'electric_hazard']);
+		expect(asg.vulnerable_groups).toEqual(['children', 'pregnant']);
+		expect(asg.contact_full_name).toBe('Ayse Yilmaz');
+		expect(asg.contact_phone).toBe('5052318546');
+		expect(asg.request_country).toBe('turkiye');
+		expect(asg.request_city).toBe('istanbul');
+		expect(asg.request_district).toBe('besiktas');
+		expect(asg.request_neighborhood).toBe('levazim');
+	});
+
+	test('requester sees assigned helper contact details', async () => {
+		const app = createTestApp();
+		const requesterId = 'user_hr_helper_1';
+		const helperId = 'user_hr_helper_2';
+		await seedActiveUser(requesterId, 'helper1@example.com');
+		await seedActiveUser(helperId, 'helper2@example.com');
+		const requesterToken = buildAuthToken(requesterId);
+		const helperToken = buildAuthToken(helperId);
+
+		// Create helper's profile with name, phone, and expertise
+		await query(
+			`INSERT INTO user_profiles (profile_id, user_id, first_name, last_name, phone_number)
+			 VALUES ('prf_helper_1', $1, 'Mehmet', 'Kaya', '5301234567')`,
+			[helperId],
+		);
+		await query(
+			`INSERT INTO expertise (expertise_id, profile_id, profession, expertise_area, is_verified)
+			 VALUES ('exp_helper_1', 'prf_helper_1', 'Doctor', 'First Aid', FALSE)`,
+		);
+
+		// Requester creates a help request
+		const createRes = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${requesterToken}`)
+			.send(buildCreatePayload());
+
+		expect(createRes.status).toBe(201);
+		const requestId = createRes.body.request.id;
+
+		// Initially, no helper assigned
+		expect(createRes.body.request.helper).toBeNull();
+
+		// Helper toggles availability → gets assigned
+		const toggleRes = await request(app)
+			.post('/api/availability/toggle')
+			.set('Authorization', `Bearer ${helperToken}`)
+			.send({ isAvailable: true });
+
+		expect(toggleRes.status).toBe(200);
+		expect(toggleRes.body.assignment).toBeTruthy();
+
+		// Requester fetches their request — should now see helper details
+		const getRes = await request(app)
+			.get(`/api/help-requests/${requestId}`)
+			.set('Authorization', `Bearer ${requesterToken}`);
+
+		expect(getRes.status).toBe(200);
+		expect(getRes.body.request.helper).toBeTruthy();
+		expect(getRes.body.request.helper.firstName).toBe('Mehmet');
+		expect(getRes.body.request.helper.lastName).toBe('Kaya');
+		expect(getRes.body.request.helper.phone).toBe(5301234567);
+		expect(getRes.body.request.helper.expertise).toBe('First Aid');
+	});
+
+	test('help request without assignment has null helper', async () => {
+		const app = createTestApp();
+		const requesterId = 'user_hr_nohelper';
+		await seedActiveUser(requesterId, 'nohelper@example.com');
+		const requesterToken = buildAuthToken(requesterId);
+
+		const createRes = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${requesterToken}`)
+			.send(buildCreatePayload());
+
+		const requestId = createRes.body.request.id;
+
+		const getRes = await request(app)
+			.get(`/api/help-requests/${requestId}`)
+			.set('Authorization', `Bearer ${requesterToken}`);
+
+		expect(getRes.status).toBe(200);
+		expect(getRes.body.request.helper).toBeNull();
 	});
 });

--- a/backend/tests/unit/modules/help-requests/controller.test.js
+++ b/backend/tests/unit/modules/help-requests/controller.test.js
@@ -31,14 +31,38 @@ function buildResponse() {
 
 describe('help-requests controller', () => {
 	describe('createHelpRequest', () => {
-		test('returns 401 when user is missing', async () => {
+		test('proceeds to validation even when user is not authenticated (guest)', async () => {
 			validators.readUserId.mockReturnValueOnce(null);
+			validators.validateCreateHelpRequest.mockReturnValueOnce({
+				errors: ['`helpTypes` must contain at least one item.'],
+				warnings: [],
+				value: {},
+			});
 			const response = buildResponse();
 
 			await createHelpRequest({ body: {} }, response);
 
-			expect(response.status).toHaveBeenCalledWith(401);
-			expect(response.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'UNAUTHORIZED' }));
+			// Should NOT return 401; should proceed to validation
+			expect(response.status).toHaveBeenCalledWith(400);
+			expect(response.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'VALIDATION_FAILED' }));
+		});
+
+		test('returns 201 for guest submission (null userId)', async () => {
+			validators.readUserId.mockReturnValueOnce(null);
+			validators.validateCreateHelpRequest.mockReturnValueOnce({
+				errors: [],
+				warnings: [],
+				value: { helpTypes: ['first_aid'] },
+			});
+			const created = { id: 'req_1', userId: null, helpTypes: ['first_aid'] };
+			service.createMyHelpRequest.mockResolvedValueOnce(created);
+			const response = buildResponse();
+
+			await createHelpRequest({ body: {} }, response);
+
+			expect(service.createMyHelpRequest).toHaveBeenCalledWith(null, { helpTypes: ['first_aid'] });
+			expect(response.status).toHaveBeenCalledWith(201);
+			expect(response.json).toHaveBeenCalledWith({ request: created, warnings: [] });
 		});
 
 		test('returns 400 when validation fails', async () => {

--- a/infra/docker/postgres/init.sql
+++ b/infra/docker/postgres/init.sql
@@ -207,7 +207,7 @@ CREATE TABLE news_announcements (
 
 CREATE TABLE help_requests (
     request_id             VARCHAR(64) PRIMARY KEY,
-    user_id                VARCHAR(64) NOT NULL,
+    user_id                VARCHAR(64),
     help_types             TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
     other_help_text        TEXT NOT NULL DEFAULT '',
     affected_people_count  INTEGER NOT NULL DEFAULT 1,
@@ -228,7 +228,7 @@ CREATE TABLE help_requests (
     CONSTRAINT fk_help_request_user
         FOREIGN KEY (user_id)
         REFERENCES users(user_id)
-        ON DELETE RESTRICT,
+        ON DELETE SET NULL,
 
     CONSTRAINT chk_help_request_resolved_at
         CHECK (


### PR DESCRIPTION
Fixes #199 

- Guest submission: 
Added optionalAuth middleware, moved to per-route auth, made user_id nullable in DB
- Helper sees form:
Enriched `getAssignmentByVolunteerId` SQL to return all form fields (helpTypes, contact, location, riskFlags, etc.)
- Requester sees helper:
Added JOINs to assignments → volunteers → user_profiles → expertise, new helper object in response with firstName, lastName, phone, expertise


