### PR TITLE
fix: Auto-assign when new help request created

### DIFF
--- a/backend/src/modules/availability/repository.js
+++ b/backend/src/modules/availability/repository.js
@@ -102,6 +102,32 @@ async function findMatchingRequestForVolunteer(volunteerId) {
   return result.rows[0] || null;
 }
 
+async function findMatchingVolunteerForRequest(requestId) {
+  const requestSql = `SELECT need_type FROM help_requests WHERE request_id = $1;`;
+  const rResult = await query(requestSql, [requestId]);
+  const request = rResult.rows[0];
+
+  if (!request) return null;
+
+  const sql = `
+    SELECT v.*
+    FROM volunteers v
+    WHERE v.is_available = TRUE
+      AND NOT EXISTS (
+        SELECT 1 FROM assignments a
+        JOIN help_requests hr ON a.request_id = hr.request_id
+        WHERE a.volunteer_id = v.volunteer_id
+          AND a.is_cancelled = FALSE
+          AND hr.status NOT IN ('RESOLVED', 'CANCELLED')
+      )
+      AND (v.need_types IS NULL OR v.need_types = '{}' OR $1 = ANY(v.need_types))
+    ORDER BY v.location_updated_at DESC NULLS LAST
+    LIMIT 1;
+  `;
+  const result = await query(sql, [request.need_type]);
+  return result.rows[0] || null;
+}
+
 async function createAssignment(volunteerId, requestId) {
   const assignmentId = makeId('asg');
   const sql = `
@@ -175,6 +201,7 @@ module.exports = {
   createAvailabilityRecord,
   findPendingRequests,
   findMatchingRequestForVolunteer,
+  findMatchingVolunteerForRequest,
   createAssignment,
   updateRequestStatus,
   getAssignmentByVolunteerId,

--- a/backend/src/modules/availability/service.js
+++ b/backend/src/modules/availability/service.js
@@ -9,6 +9,7 @@ const {
   getAssignmentByVolunteerId,
   getAssignmentById,
   cancelAssignment,
+  findMatchingVolunteerForRequest,
 } = require('./repository');
 
 async function setAvailability(userId, { isAvailable, latitude, longitude }) {
@@ -192,6 +193,16 @@ async function getAvailabilityStatus(userId) {
   };
 }
 
+async function tryToAssignRequest(requestId) {
+  const matchingVolunteer = await findMatchingVolunteerForRequest(requestId);
+  if (matchingVolunteer) {
+    await createAssignment(matchingVolunteer.volunteer_id, requestId);
+    await updateRequestStatus(requestId, 'ASSIGNED');
+    return true;
+  }
+  return false;
+}
+
 module.exports = {
   setAvailability,
   syncAvailability,
@@ -199,4 +210,5 @@ module.exports = {
   cancelMyAssignment,
   resolveMyAssignment,
   getAvailabilityStatus,
+  tryToAssignRequest,
 };

--- a/backend/src/modules/help-requests/service.js
+++ b/backend/src/modules/help-requests/service.js
@@ -11,6 +11,7 @@ const {
   markHelpRequestAsSyncedByRequestId,
   markHelpRequestAsResolvedByRequestId,
 } = require('./repository');
+const { tryToAssignRequest } = require('../availability/service');
 
 const JWT_SECRET = env.jwt.secret;
 const GUEST_HELP_REQUEST_SCOPE = 'help_request_guest_read';
@@ -18,10 +19,16 @@ const GUEST_HELP_REQUEST_TOKEN_TTL = '30d';
 
 async function createMyHelpRequest(userId, input) {
   try {
-    return await createHelpRequest({
+    const helpRequest = await createHelpRequest({
       ...input,
       userId,
     });
+
+    // Try to auto-assign a volunteer
+    await tryToAssignRequest(helpRequest.id);
+
+    // Return the request (it might have been updated to ASSIGNED status)
+    return await findHelpRequestById(helpRequest.id);
   } catch (error) {
     if (error.code === '23503') {
       const wrappedError = new Error('The provided user does not exist in the database yet.');

--- a/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
+++ b/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
@@ -794,4 +794,42 @@ describe('help-requests integration', () => {
 		expect(getRes.status).toBe(200);
 		expect(getRes.body.request.helper).toBeNull();
 	});
+
+	test('POST /api/help-requests auto-assigns to already available volunteer', async () => {
+		const app = createTestApp();
+		const helperId = 'user_auto_1';
+		const requesterId = 'user_auto_2';
+		await seedActiveUser(helperId, 'auto1@example.com');
+		await seedActiveUser(requesterId, 'auto2@example.com');
+		const helperToken = buildAuthToken(helperId);
+		const requesterToken = buildAuthToken(requesterId);
+
+		// 1. Volunteer becomes available FIRST
+		const toggleRes = await request(app)
+			.post('/api/availability/toggle')
+			.set('Authorization', `Bearer ${helperToken}`)
+			.send({ isAvailable: true });
+
+		expect(toggleRes.status).toBe(200);
+		expect(toggleRes.body.assignment).toBeNull(); // No requests yet
+
+		// 2. Requester creates a request
+		const createRes = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${requesterToken}`)
+			.send(buildCreatePayload({ needType: 'first_aid' }));
+
+		expect(createRes.status).toBe(201);
+		// It should be MATCHED (which corresponds to internal status ASSIGNED)
+		expect(createRes.body.request.status).toBe('MATCHED');
+
+		// 3. Verify helper has the assignment
+		const statusRes = await request(app)
+			.get('/api/availability/status')
+			.set('Authorization', `Bearer ${helperToken}`);
+
+		expect(statusRes.status).toBe(200);
+		expect(statusRes.body.assignment).toBeTruthy();
+		expect(statusRes.body.assignment.request_id).toBe(createRes.body.request.id);
+	});
 });

--- a/backend/tests/unit/modules/availability/service.test.js
+++ b/backend/tests/unit/modules/availability/service.test.js
@@ -5,6 +5,7 @@ const {
   cancelMyAssignment,
   resolveMyAssignment,
   getAvailabilityStatus,
+  tryToAssignRequest,
 } = require('../../../../src/modules/availability/service');
 const repository = require('../../../../src/modules/availability/repository');
 
@@ -169,6 +170,30 @@ describe('Availability Service', () => {
       expect(result.isAvailable).toBe(true);
       expect(result.volunteer.is_available).toBe(true);
       expect(result.assignment).toEqual(assignment);
+    });
+  });
+
+  describe('tryToAssignRequest', () => {
+    it('should assign a volunteer if a match is found', async () => {
+      repository.findMatchingVolunteerForRequest.mockResolvedValue(volunteer);
+      repository.createAssignment.mockResolvedValue(assignment);
+
+      const result = await tryToAssignRequest('req_123');
+
+      expect(repository.findMatchingVolunteerForRequest).toHaveBeenCalledWith('req_123');
+      expect(repository.createAssignment).toHaveBeenCalledWith('vol_123', 'req_123');
+      expect(repository.updateRequestStatus).toHaveBeenCalledWith('req_123', 'ASSIGNED');
+      expect(result).toBe(true);
+    });
+
+    it('should return false if no matching volunteer is found', async () => {
+      repository.findMatchingVolunteerForRequest.mockResolvedValue(null);
+
+      const result = await tryToAssignRequest('req_123');
+
+      expect(repository.findMatchingVolunteerForRequest).toHaveBeenCalledWith('req_123');
+      expect(repository.createAssignment).not.toHaveBeenCalled();
+      expect(result).toBe(false);
     });
   });
 });

--- a/backend/tests/unit/modules/help-requests/service.test.js
+++ b/backend/tests/unit/modules/help-requests/service.test.js
@@ -14,6 +14,12 @@ jest.mock('../../../../src/modules/help-requests/repository', () => ({
 }));
 
 const repository = require('../../../../src/modules/help-requests/repository');
+const availabilityService = require('../../../../src/modules/availability/service');
+
+jest.mock('../../../../src/modules/availability/service', () => ({
+	tryToAssignRequest: jest.fn(),
+}));
+
 const {
 	createMyHelpRequest,
 	listMyHelpRequests,
@@ -51,6 +57,8 @@ describe('help-requests service', () => {
 			};
 			const expected = { id: 'req_1', userId: 'u1', helpTypes: ['first_aid', 'fire_brigade'] };
 			repository.createHelpRequest.mockResolvedValueOnce(expected);
+			repository.findHelpRequestById.mockResolvedValueOnce(expected);
+			availabilityService.tryToAssignRequest.mockResolvedValueOnce(false);
 
 			const result = await createMyHelpRequest('u1', input);
 
@@ -77,6 +85,8 @@ describe('help-requests service', () => {
 				consentGiven: true,
 				userId: 'u1',
 			});
+			expect(availabilityService.tryToAssignRequest).toHaveBeenCalledWith('req_1');
+			expect(repository.findHelpRequestById).toHaveBeenCalledWith('req_1');
 			expect(result).toEqual(expected);
 		});
 


### PR DESCRIPTION
Related to [#225](https://github.com/bounswe/bounswe2026group6/issues/225)

Changes:
   - backend/src/modules/availability/repository.js: Added findMatchingVolunteerForRequest to find an
     available volunteer who doesn't have an active assignment and matches the request's need type.
   - backend/src/modules/availability/service.js: Added and exported tryToAssignRequest to encapsulate the
     assignment logic (creating an assignment record and updating the request status to ASSIGNED).
   - backend/src/modules/help-requests/service.js: Updated createMyHelpRequest to call tryToAssignRequest
     immediately after a request is successfully created. It now returns the updated request (which will
     have MATCHED status if a volunteer was found).
   - Tests:
     - Added a new integration test case in
       backend/tests/integration/modules/help-requests/help-requests.integration.test.js to verify that a
       new request is auto-assigned to an already available volunteer.
     - Updated unit tests in both availability and help-requests modules to reflect the new functionality
       and ensure correct mocking.