### PR TITLE
feat: standardize DB migrations under backend and add local/prod migration workflow

### DIFF
--- a/.github/workflows/db-prod-sync.yml
+++ b/.github/workflows/db-prod-sync.yml
@@ -57,18 +57,17 @@ jobs:
           echo "migration_changed=$MIGRATION_CHANGED" >> "$GITHUB_OUTPUT"
 
       - name: Install PostgreSQL client
-        if: steps.changes.outputs.init_sql_changed == 'true' || steps.changes.outputs.migration_changed == 'true'
+        if: steps.changes.outputs.init_sql_changed == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y postgresql-client
 
-      - name: Apply production DB updates
-        if: steps.changes.outputs.init_sql_changed == 'true' || steps.changes.outputs.migration_changed == 'true'
+      - name: Apply init.sql on production (guarded)
+        if: steps.changes.outputs.init_sql_changed == 'true'
         env:
           PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
           ALLOW_PROD_SCHEMA_RESET: ${{ secrets.ALLOW_PROD_SCHEMA_RESET }}
           INIT_SQL_CHANGED: ${{ steps.changes.outputs.init_sql_changed }}
-          MIGRATION_CHANGED: ${{ steps.changes.outputs.migration_changed }}
         shell: bash
         run: |
           set -euo pipefail
@@ -88,33 +87,23 @@ jobs:
             psql "$PROD_DATABASE_URL" -v ON_ERROR_STOP=1 -f infra/docker/postgres/init.sql
           fi
 
-          if [ "${MIGRATION_CHANGED}" = "true" ]; then
-            echo "Applying SQL migrations with schema_migrations tracking..."
+      - name: Setup Node
+        if: steps.changes.outputs.migration_changed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
 
-            psql "$PROD_DATABASE_URL" -v ON_ERROR_STOP=1 -c "CREATE TABLE IF NOT EXISTS schema_migrations (file_name TEXT PRIMARY KEY, applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP);"
+      - name: Install backend dependencies
+        if: steps.changes.outputs.migration_changed == 'true'
+        working-directory: backend
+        run: npm ci --omit=dev --no-audit --no-fund
 
-            apply_migration_dir() {
-              local migration_dir="$1"
-
-              if [ ! -d "$migration_dir" ]; then
-                return 0
-              fi
-
-              find "$migration_dir" -type f -name '*.sql' | sort | while IFS= read -r file; do
-                if [ -z "$file" ]; then
-                  continue
-                fi
-
-                if psql "$PROD_DATABASE_URL" -Atqc "SELECT 1 FROM schema_migrations WHERE file_name = '$file'" | grep -q '^1$'; then
-                  echo "Skipping already applied migration: $file"
-                  continue
-                fi
-
-                echo "Applying migration: $file"
-                psql "$PROD_DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file"
-                psql "$PROD_DATABASE_URL" -v ON_ERROR_STOP=1 -c "INSERT INTO schema_migrations (file_name) VALUES ('$file')"
-              done
-            }
-
-            apply_migration_dir "backend/migrations"
-          fi
+      - name: Apply production migrations with shared runner
+        if: steps.changes.outputs.migration_changed == 'true'
+        working-directory: backend
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          DB_SSL: 'true'
+        run: npm run migrate

--- a/.github/workflows/db-prod-sync.yml
+++ b/.github/workflows/db-prod-sync.yml
@@ -1,0 +1,120 @@
+name: Sync Production DB Schema
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'infra/docker/postgres/init.sql'
+      - 'backend/migrations/**'
+      - '.github/workflows/db-prod-sync.yml'
+
+concurrency:
+  group: prod-db-sync
+  cancel-in-progress: false
+
+jobs:
+  sync-db:
+    name: Apply DB Changes on Production
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed files
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BEFORE_SHA="${{ github.event.before }}"
+          AFTER_SHA="${{ github.sha }}"
+
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE_SHA="${AFTER_SHA}~1"
+          fi
+
+          CHANGED_FILES="$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" || true)"
+
+          echo "Changed files:" 
+          echo "$CHANGED_FILES"
+
+          INIT_SQL_CHANGED=false
+          MIGRATION_CHANGED=false
+
+          if echo "$CHANGED_FILES" | grep -q '^infra/docker/postgres/init.sql$'; then
+            INIT_SQL_CHANGED=true
+          fi
+
+          if echo "$CHANGED_FILES" | grep -Eq '^backend/migrations/'; then
+            MIGRATION_CHANGED=true
+          fi
+
+          echo "init_sql_changed=$INIT_SQL_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "migration_changed=$MIGRATION_CHANGED" >> "$GITHUB_OUTPUT"
+
+      - name: Install PostgreSQL client
+        if: steps.changes.outputs.init_sql_changed == 'true' || steps.changes.outputs.migration_changed == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Apply production DB updates
+        if: steps.changes.outputs.init_sql_changed == 'true' || steps.changes.outputs.migration_changed == 'true'
+        env:
+          PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          ALLOW_PROD_SCHEMA_RESET: ${{ secrets.ALLOW_PROD_SCHEMA_RESET }}
+          INIT_SQL_CHANGED: ${{ steps.changes.outputs.init_sql_changed }}
+          MIGRATION_CHANGED: ${{ steps.changes.outputs.migration_changed }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PROD_DATABASE_URL:-}" ]; then
+            echo "PROD_DATABASE_URL secret is required."
+            exit 1
+          fi
+
+          if [ "${INIT_SQL_CHANGED}" = "true" ]; then
+            if [ "${ALLOW_PROD_SCHEMA_RESET:-false}" != "true" ]; then
+              echo "init.sql changed, but ALLOW_PROD_SCHEMA_RESET is not true. Refusing to run destructive reset on production."
+              exit 1
+            fi
+
+            echo "Applying infra/docker/postgres/init.sql to production DB..."
+            psql "$PROD_DATABASE_URL" -v ON_ERROR_STOP=1 -f infra/docker/postgres/init.sql
+          fi
+
+          if [ "${MIGRATION_CHANGED}" = "true" ]; then
+            echo "Applying SQL migrations with schema_migrations tracking..."
+
+            psql "$PROD_DATABASE_URL" -v ON_ERROR_STOP=1 -c "CREATE TABLE IF NOT EXISTS schema_migrations (file_name TEXT PRIMARY KEY, applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP);"
+
+            apply_migration_dir() {
+              local migration_dir="$1"
+
+              if [ ! -d "$migration_dir" ]; then
+                return 0
+              fi
+
+              find "$migration_dir" -type f -name '*.sql' | sort | while IFS= read -r file; do
+                if [ -z "$file" ]; then
+                  continue
+                fi
+
+                if psql "$PROD_DATABASE_URL" -Atqc "SELECT 1 FROM schema_migrations WHERE file_name = '$file'" | grep -q '^1$'; then
+                  echo "Skipping already applied migration: $file"
+                  continue
+                fi
+
+                echo "Applying migration: $file"
+                psql "$PROD_DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file"
+                psql "$PROD_DATABASE_URL" -v ON_ERROR_STOP=1 -c "INSERT INTO schema_migrations (file_name) VALUES ('$file')"
+              done
+            }
+
+            apply_migration_dir "backend/migrations"
+          fi

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Useful URLs:
 Notes:
 
 - PostgreSQL is initialized from `infra/docker/postgres/init.sql`
+- backend automatically applies SQL migrations from `backend/migrations/` on container start
 - the backend waits for PostgreSQL to become healthy before starting
 - the web container is configured to talk to the backend in the local Docker setup
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -53,8 +53,17 @@ From this folder:
 ```bash
 cp .env.example .env
 npm install
+npm run migrate
 npm run dev
 ```
+
+Migration files are read from:
+
+- `migrations/`
+
+Team migration rules:
+
+- `migrations/README.md`
 
 ### 3. Verify backend health
 

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -1,0 +1,43 @@
+# Backend migrations
+
+This folder contains SQL migration files owned by backend domain changes.
+
+## Naming convention
+
+Use this format for every file:
+
+`YYYYMMDD_HHMMSS__short_description.sql`
+
+Examples:
+
+- `20260414_101500__add_users_last_login.sql`
+- `20260414_103000__create_help_request_index.sql`
+
+Rules:
+
+- use lowercase snake_case in descriptions
+- keep one migration concern per file
+- never edit an already committed migration file; create a new migration instead
+
+## Write migrations safely
+
+- prefer additive changes first (ADD COLUMN, CREATE INDEX)
+- for destructive changes (DROP, RENAME), split into multiple deploy-safe migrations when possible
+- include `IF EXISTS` / `IF NOT EXISTS` guards where applicable
+- wrap complex changes in transactions
+
+## Local run
+
+From `backend/`:
+
+```bash
+npm run migrate
+```
+
+Or run full stack from repository root:
+
+```bash
+docker compose up --build
+```
+
+Backend container runs migrations on startup using `scripts/apply-migrations.js`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,8 @@
   "main": "src/server.js",
   "scripts": {
     "dev": "node --watch src/server.js",
+    "migrate": "node scripts/apply-migrations.js",
+    "start:with-migrations": "npm run migrate && npm start",
     "start": "node src/server.js",
     "test": "jest --runInBand",
     "test:unit": "jest --selectProjects unit",

--- a/backend/scripts/apply-migrations.js
+++ b/backend/scripts/apply-migrations.js
@@ -3,6 +3,8 @@ const path = require('path');
 
 const { pool } = require('../src/db/pool');
 
+const MIGRATION_LOCK_KEY = 2026041501;
+
 function listSqlFilesRecursive(baseDir) {
   if (!fs.existsSync(baseDir)) {
     return [];
@@ -27,8 +29,8 @@ function listSqlFilesRecursive(baseDir) {
   return files;
 }
 
-async function ensureSchemaMigrationsTable() {
-  await pool.query(`
+async function ensureSchemaMigrationsTable(client) {
+  await client.query(`
     CREATE TABLE IF NOT EXISTS schema_migrations (
       file_name TEXT PRIMARY KEY,
       applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
@@ -36,18 +38,30 @@ async function ensureSchemaMigrationsTable() {
   `);
 }
 
-async function isAlreadyApplied(fileKey) {
-  const result = await pool.query('SELECT 1 FROM schema_migrations WHERE file_name = $1', [fileKey]);
-  return result.rowCount > 0;
-}
+async function applySingleMigrationAtomically(client, migration) {
+  const sql = fs.readFileSync(migration.filePath, 'utf8');
 
-async function markApplied(fileKey) {
-  await pool.query('INSERT INTO schema_migrations (file_name) VALUES ($1)', [fileKey]);
-}
+  await client.query('BEGIN');
 
-async function applyMigration(filePath) {
-  const sql = fs.readFileSync(filePath, 'utf8');
-  await pool.query(sql);
+  try {
+    const existing = await client.query('SELECT 1 FROM schema_migrations WHERE file_name = $1', [
+      migration.fileKey,
+    ]);
+
+    if (existing.rowCount > 0) {
+      await client.query('COMMIT');
+      console.log(`Skipping already applied migration: ${migration.fileKey}`);
+      return;
+    }
+
+    console.log(`Applying migration: ${migration.fileKey}`);
+    await client.query(sql);
+    await client.query('INSERT INTO schema_migrations (file_name) VALUES ($1)', [migration.fileKey]);
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  }
 }
 
 async function run() {
@@ -58,39 +72,44 @@ async function run() {
     },
   ];
 
-  await ensureSchemaMigrationsTable();
+  const client = await pool.connect();
 
-  const allMigrations = [];
+  try {
+    await client.query('SELECT pg_advisory_lock($1)', [MIGRATION_LOCK_KEY]);
+    await ensureSchemaMigrationsTable(client);
 
-  for (const source of migrationSources) {
-    const files = listSqlFilesRecursive(source.dir)
-      .sort((a, b) => a.localeCompare(b))
-      .map((filePath) => {
-        const relativeFile = path.relative(source.dir, filePath).split(path.sep).join('/');
-        const fileKey = `${source.keyPrefix}/${relativeFile}`;
+    const allMigrations = [];
 
-        return {
-          filePath,
-          fileKey,
-        };
-      });
+    for (const source of migrationSources) {
+      const files = listSqlFilesRecursive(source.dir)
+        .sort((a, b) => a.localeCompare(b))
+        .map((filePath) => {
+          const relativeFile = path.relative(source.dir, filePath).split(path.sep).join('/');
+          const fileKey = `${source.keyPrefix}/${relativeFile}`;
 
-    allMigrations.push(...files);
-  }
+          return {
+            filePath,
+            fileKey,
+          };
+        });
 
-  for (const migration of allMigrations) {
-    // Idempotency is managed by schema_migrations table.
-    if (await isAlreadyApplied(migration.fileKey)) {
-      console.log(`Skipping already applied migration: ${migration.fileKey}`);
-      continue;
+      allMigrations.push(...files);
     }
 
-    console.log(`Applying migration: ${migration.fileKey}`);
-    await applyMigration(migration.filePath);
-    await markApplied(migration.fileKey);
-  }
+    for (const migration of allMigrations) {
+      await applySingleMigrationAtomically(client, migration);
+    }
 
-  console.log('Migration step completed.');
+    console.log('Migration step completed.');
+  } finally {
+    try {
+      await client.query('SELECT pg_advisory_unlock($1)', [MIGRATION_LOCK_KEY]);
+    } catch (_error) {
+      // Best effort unlock.
+    }
+
+    client.release();
+  }
 }
 
 run()

--- a/backend/scripts/apply-migrations.js
+++ b/backend/scripts/apply-migrations.js
@@ -1,0 +1,103 @@
+const fs = require('fs');
+const path = require('path');
+
+const { pool } = require('../src/db/pool');
+
+function listSqlFilesRecursive(baseDir) {
+  if (!fs.existsSync(baseDir)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(baseDir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(baseDir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...listSqlFilesRecursive(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && fullPath.endsWith('.sql')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+async function ensureSchemaMigrationsTable() {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      file_name TEXT PRIMARY KEY,
+      applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+}
+
+async function isAlreadyApplied(fileKey) {
+  const result = await pool.query('SELECT 1 FROM schema_migrations WHERE file_name = $1', [fileKey]);
+  return result.rowCount > 0;
+}
+
+async function markApplied(fileKey) {
+  await pool.query('INSERT INTO schema_migrations (file_name) VALUES ($1)', [fileKey]);
+}
+
+async function applyMigration(filePath) {
+  const sql = fs.readFileSync(filePath, 'utf8');
+  await pool.query(sql);
+}
+
+async function run() {
+  const migrationSources = [
+    {
+      dir: path.resolve(__dirname, '../migrations'),
+      keyPrefix: 'backend/migrations',
+    },
+  ];
+
+  await ensureSchemaMigrationsTable();
+
+  const allMigrations = [];
+
+  for (const source of migrationSources) {
+    const files = listSqlFilesRecursive(source.dir)
+      .sort((a, b) => a.localeCompare(b))
+      .map((filePath) => {
+        const relativeFile = path.relative(source.dir, filePath).split(path.sep).join('/');
+        const fileKey = `${source.keyPrefix}/${relativeFile}`;
+
+        return {
+          filePath,
+          fileKey,
+        };
+      });
+
+    allMigrations.push(...files);
+  }
+
+  for (const migration of allMigrations) {
+    // Idempotency is managed by schema_migrations table.
+    if (await isAlreadyApplied(migration.fileKey)) {
+      console.log(`Skipping already applied migration: ${migration.fileKey}`);
+      continue;
+    }
+
+    console.log(`Applying migration: ${migration.fileKey}`);
+    await applyMigration(migration.filePath);
+    await markApplied(migration.fileKey);
+  }
+
+  console.log('Migration step completed.');
+}
+
+run()
+  .catch((error) => {
+    console.error('Migration step failed:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     build:
       context: ./backend
     restart: unless-stopped
+    command: ["sh", "-c", "npm run start:with-migrations"]
     depends_on:
       postgres:
         condition: service_healthy
@@ -45,6 +46,8 @@ services:
       SMTP_PASS: ${SMTP_PASS:-your_gmail_app_password}
       APP_URL: ${APP_URL:-http://localhost:3000}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3001}
+    volumes:
+      - ./backend/migrations:/app/migrations:ro
     ports:
       - "3000:3000"
     healthcheck:

--- a/infra/README.md
+++ b/infra/README.md
@@ -35,6 +35,25 @@ This Compose setup:
 - `dcompose/docker-compose-dev.yml` — local Postgres container setup
 - `docker/postgres/init.sql` — database schema bootstrap script
 
+## Production DB sync workflow
+
+Repository includes a GitHub Actions workflow at `.github/workflows/db-prod-sync.yml`.
+
+- trigger: push to `main`
+- path filter:
+  - `infra/docker/postgres/init.sql`
+  - `backend/migrations/**`
+- behavior:
+  - applies new SQL migration files once by tracking them in `schema_migrations`
+  - only applies `init.sql` to production when `ALLOW_PROD_SCHEMA_RESET=true` is set as a repository secret
+
+Required GitHub secrets:
+
+- `PROD_DATABASE_URL`
+- `ALLOW_PROD_SCHEMA_RESET` (`true` only when an intentional full reset is needed)
+
+This workflow connects to PostgreSQL directly from GitHub Actions runner, so SSH server credentials are not required.
+
 ## Notes
 
 - This folder is part of the local MVP quick-start because the backend depends on the Postgres container.


### PR DESCRIPTION
Unifies migration flow so local and production stay in sync.

Changes
Uses only backend/migrations for schema changes.
Adds idempotent migration runner (schema_migrations tracking).
Runs migrations on backend startup in Docker.
Adds production workflow to apply migrations on main.

Closes #259  