### PR TITLE
[Feature] Implement android offline-first data layer and sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ test-results/
 # Agent files
 .sisyphus
 mvp354/
+.omx/

--- a/android/README.md
+++ b/android/README.md
@@ -37,6 +37,22 @@ Recommended approach:
 - `build.gradle` — project-level Gradle config
 - `gradlew` / `gradlew.bat` — Gradle wrapper
 
+
+## Offline-first mobile data layer
+
+The Android app now includes a Room + WorkManager offline-first layer for the emergency-critical mobile flows: help requests, helper availability, assigned requests, and the durable sync queue. Compose screens read these flows from local Room state first; writes are recorded locally and synchronized later by WorkManager when network constraints allow.
+
+Details, entities, conflict policy, and test commands are documented in:
+
+- `../docs/android-offline-first.md`
+
+Migration/config notes:
+
+- Room database name: `neph-offline.db`, schema version `1`
+- Existing availability SharedPreferences are migrated into Room on first app start
+- No prior Room schema existed, so no migration class is required for this milestone
+- Required dependencies are declared in `app/build.gradle` (`room-*`, `work-runtime-ktx`, KSP)
+
 ## Notes
 
 - The root quick-start focuses on the database, backend, and web MVP flow first.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,6 +3,7 @@ import java.util.Properties
 plugins {
     id 'com.android.application' version '9.1.0'
     id 'org.jetbrains.kotlin.plugin.compose' version '2.3.20'
+    id 'com.google.devtools.ksp' version '2.3.6'
 }
 
 def keystoreProperties = new Properties()
@@ -149,6 +150,13 @@ dependencies {
     implementation 'androidx.compose.material:material-icons-extended'
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.navigation:navigation-compose:2.9.7'
+    implementation 'androidx.room:room-runtime:2.8.4'
+    implementation 'androidx.room:room-ktx:2.8.4'
+    implementation 'androidx.work:work-runtime-ktx:2.11.2'
+    ksp 'androidx.room:room-compiler:2.8.4'
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.json:json:20240303'
 
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'

--- a/android/app/src/main/java/com/neph/MainActivity.kt
+++ b/android/app/src/main/java/com/neph/MainActivity.kt
@@ -6,6 +6,9 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.rememberNavController
+import com.neph.core.NephAppContext
+import com.neph.core.database.NephDatabaseProvider
+import com.neph.core.sync.OfflineSyncScheduler
 import com.neph.features.availability.data.AvailabilityRepository
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.profile.data.ProfileRepository
@@ -17,10 +20,14 @@ import com.neph.ui.theme.NephTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        NephAppContext.initialize(applicationContext)
+        NephDatabaseProvider.initialize(applicationContext)
         AuthSessionStore.initialize(applicationContext)
         AvailabilityRepository.initialize(applicationContext)
         ProfileRepository.initialize(applicationContext)
         RequestHelpRepository.initialize(applicationContext)
+        OfflineSyncScheduler.schedulePeriodicSync(applicationContext)
+        OfflineSyncScheduler.enqueueSync(applicationContext, reason = "app-start")
         setContent {
             NephApp()
         }

--- a/android/app/src/main/java/com/neph/MainActivity.kt
+++ b/android/app/src/main/java/com/neph/MainActivity.kt
@@ -40,10 +40,13 @@ fun NephApp() {
         val navController = rememberNavController()
         AppNavGraph(
             navController = navController,
-            startDestination = if (AuthSessionStore.getAccessToken().isNullOrBlank()) {
-                Routes.Welcome.route
-            } else {
-                Routes.Home.route
+            startDestination = when {
+                !AuthSessionStore.getAccessToken().isNullOrBlank() -> Routes.Home.route
+                AuthSessionStore.isGuestMode() && RequestHelpRepository.shouldOpenGuestRequestsOnStart() -> {
+                    Routes.MyHelpRequests.route
+                }
+                AuthSessionStore.isGuestMode() -> Routes.Home.route
+                else -> Routes.Welcome.route
             }
         )
     }

--- a/android/app/src/main/java/com/neph/core/NephAppContext.kt
+++ b/android/app/src/main/java/com/neph/core/NephAppContext.kt
@@ -1,0 +1,17 @@
+package com.neph.core
+
+import android.content.Context
+
+object NephAppContext {
+    private var appContext: Context? = null
+
+    fun initialize(context: Context) {
+        appContext = context.applicationContext
+    }
+
+    fun get(): Context = checkNotNull(appContext) {
+        "NephAppContext must be initialized before use."
+    }
+
+    fun getOrNull(): Context? = appContext
+}

--- a/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
+++ b/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
@@ -1,0 +1,49 @@
+package com.neph.core.database
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [
+        HelpRequestEntity::class,
+        AvailabilityEntity::class,
+        AssignedRequestEntity::class,
+        SyncOperationEntity::class,
+        SyncMetadataEntity::class
+    ],
+    version = 1,
+    exportSchema = false
+)
+abstract class NephDatabase : RoomDatabase() {
+    abstract fun helpRequestDao(): HelpRequestDao
+    abstract fun availabilityDao(): AvailabilityDao
+    abstract fun assignedRequestDao(): AssignedRequestDao
+    abstract fun syncOperationDao(): SyncOperationDao
+    abstract fun syncMetadataDao(): SyncMetadataDao
+}
+
+object NephDatabaseProvider {
+    @Volatile private var instance: NephDatabase? = null
+
+    fun initialize(context: Context) {
+        getInstance(context)
+    }
+
+    fun getInstance(context: Context): NephDatabase {
+        return instance ?: synchronized(this) {
+            instance ?: Room.databaseBuilder(
+                context.applicationContext,
+                NephDatabase::class.java,
+                "neph-offline.db"
+            ).build().also { instance = it }
+        }
+    }
+
+    fun requireInstance(): NephDatabase {
+        return checkNotNull(instance) {
+            "NephDatabaseProvider must be initialized before use."
+        }
+    }
+}

--- a/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
@@ -1,0 +1,156 @@
+package com.neph.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface HelpRequestDao {
+    @Query(
+        """
+        SELECT * FROM help_requests
+        WHERE ownerType = :ownerType AND isDeleted = 0
+        ORDER BY
+            CASE WHEN status NOT IN ('RESOLVED', 'CANCELLED') THEN 0 ELSE 1 END,
+            createdAtEpochMillis DESC
+        """
+    )
+    fun observeByOwner(ownerType: String): Flow<List<HelpRequestEntity>>
+
+    @Query(
+        """
+        SELECT * FROM help_requests
+        WHERE ownerType = :ownerType AND isDeleted = 0
+        ORDER BY
+            CASE WHEN status NOT IN ('RESOLVED', 'CANCELLED') THEN 0 ELSE 1 END,
+            createdAtEpochMillis DESC
+        """
+    )
+    suspend fun getByOwner(ownerType: String): List<HelpRequestEntity>
+
+    @Query("SELECT * FROM help_requests WHERE localId = :localId LIMIT 1")
+    suspend fun getByLocalId(localId: String): HelpRequestEntity?
+
+    @Query("SELECT * FROM help_requests WHERE remoteId = :remoteId OR localId = :remoteId LIMIT 1")
+    suspend fun getByRemoteId(remoteId: String): HelpRequestEntity?
+
+    @Query(
+        """
+        SELECT COUNT(*) FROM help_requests
+        WHERE ownerType = :ownerType
+          AND isDeleted = 0
+          AND status NOT IN ('RESOLVED', 'CANCELLED')
+          AND syncStatus != 'CONFLICTED'
+        """
+    )
+    suspend fun countActiveByOwner(ownerType: String): Int
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: HelpRequestEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(entities: List<HelpRequestEntity>)
+
+    @Query("DELETE FROM help_requests WHERE localId = :localId")
+    suspend fun deleteByLocalId(localId: String)
+}
+
+@Dao
+interface AvailabilityDao {
+    @Query("SELECT * FROM availability_state WHERE `key` = 'current' LIMIT 1")
+    fun observe(): Flow<AvailabilityEntity?>
+
+    @Query("SELECT * FROM availability_state WHERE `key` = 'current' LIMIT 1")
+    suspend fun get(): AvailabilityEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: AvailabilityEntity)
+}
+
+@Dao
+interface AssignedRequestDao {
+    @Query("SELECT * FROM assigned_requests WHERE locallyCancelled = 0 ORDER BY fetchedAtEpochMillis DESC LIMIT 1")
+    fun observeCurrent(): Flow<AssignedRequestEntity?>
+
+    @Query("SELECT * FROM assigned_requests ORDER BY fetchedAtEpochMillis DESC LIMIT 1")
+    suspend fun getCurrentIncludingPending(): AssignedRequestEntity?
+
+    @Query("SELECT * FROM assigned_requests WHERE assignmentId = :assignmentId LIMIT 1")
+    suspend fun getByAssignmentId(assignmentId: String): AssignedRequestEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: AssignedRequestEntity)
+
+    @Query("DELETE FROM assigned_requests WHERE syncStatus = 'SYNCED'")
+    suspend fun clearSyncedAssignments()
+
+    @Query("DELETE FROM assigned_requests")
+    suspend fun clearAll()
+}
+
+@Dao
+interface SyncOperationDao {
+    @Query(
+        """
+        SELECT * FROM sync_operations
+        WHERE status IN ('PENDING', 'FAILED', 'IN_PROGRESS')
+        ORDER BY createdAtEpochMillis ASC
+        """
+    )
+    suspend fun getPendingOperations(): List<SyncOperationEntity>
+
+    @Query(
+        """
+        SELECT * FROM sync_operations
+        WHERE entityType = :entityType
+          AND entityId = :entityId
+          AND operationType = :operationType
+          AND status IN ('PENDING', 'FAILED', 'IN_PROGRESS')
+        ORDER BY createdAtEpochMillis DESC
+        LIMIT 1
+        """
+    )
+    suspend fun getLatestPendingOperation(
+        entityType: String,
+        entityId: String,
+        operationType: String
+    ): SyncOperationEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(operation: SyncOperationEntity)
+
+    @Query(
+        """
+        UPDATE sync_operations
+        SET status = :status,
+            attemptCount = :attemptCount,
+            lastAttemptAtEpochMillis = :lastAttemptAtEpochMillis,
+            error = :error
+        WHERE operationId = :operationId
+        """
+    )
+    suspend fun updateStatus(
+        operationId: String,
+        status: String,
+        attemptCount: Int,
+        lastAttemptAtEpochMillis: Long?,
+        error: String?
+    )
+
+    @Query("DELETE FROM sync_operations WHERE operationId = :operationId")
+    suspend fun delete(operationId: String)
+
+    @Query("DELETE FROM sync_operations WHERE status = 'SYNCED'")
+    suspend fun deleteSynced()
+}
+
+@Dao
+interface SyncMetadataDao {
+    @Query("SELECT * FROM sync_metadata WHERE `key` = :key LIMIT 1")
+    suspend fun get(key: String): SyncMetadataEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: SyncMetadataEntity)
+}

--- a/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
@@ -139,6 +139,20 @@ interface SyncOperationDao {
         error: String?
     )
 
+    @Query(
+        """
+        UPDATE sync_operations
+        SET status = 'PENDING',
+            error = :error
+        WHERE status = 'IN_PROGRESS'
+          AND (lastAttemptAtEpochMillis IS NULL OR lastAttemptAtEpochMillis <= :staleBeforeEpochMillis)
+        """
+    )
+    suspend fun resetStaleInProgressOperations(
+        staleBeforeEpochMillis: Long,
+        error: String
+    ): Int
+
     @Query("DELETE FROM sync_operations WHERE operationId = :operationId")
     suspend fun delete(operationId: String)
 

--- a/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
@@ -95,7 +95,7 @@ interface SyncOperationDao {
     @Query(
         """
         SELECT * FROM sync_operations
-        WHERE status IN ('PENDING', 'FAILED', 'IN_PROGRESS')
+        WHERE status IN ('PENDING', 'FAILED')
         ORDER BY createdAtEpochMillis ASC
         """
     )

--- a/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
@@ -1,0 +1,123 @@
+package com.neph.core.database
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.neph.core.sync.SyncOperationStatus
+import com.neph.core.sync.SyncStatus
+import java.util.UUID
+
+@Entity(
+    tableName = "help_requests",
+    indices = [
+        Index(value = ["ownerType"]),
+        Index(value = ["remoteId"]),
+        Index(value = ["syncStatus"])
+    ]
+)
+data class HelpRequestEntity(
+    @PrimaryKey val localId: String,
+    val remoteId: String?,
+    val ownerType: String,
+    val guestAccessToken: String?,
+    val helpTypesJson: String,
+    val otherHelpText: String,
+    val affectedPeopleCount: Int,
+    val riskFlagsJson: String,
+    val vulnerableGroupsJson: String,
+    val description: String,
+    val bloodType: String,
+    val country: String,
+    val city: String,
+    val district: String,
+    val neighborhood: String,
+    val extraAddress: String,
+    val contactFullName: String,
+    val contactPhone: String,
+    val contactAlternativePhone: String?,
+    val status: String,
+    val helperFirstName: String?,
+    val helperLastName: String?,
+    val helperPhone: String?,
+    val helperProfession: String?,
+    val helperExpertise: String?,
+    val syncStatus: String = SyncStatus.SYNCED,
+    val pendingError: String? = null,
+    val createdAtEpochMillis: Long,
+    val updatedAtEpochMillis: Long,
+    val lastSyncedAtEpochMillis: Long? = null,
+    val serverCreatedAt: String? = null,
+    val isDeleted: Boolean = false
+)
+
+@Entity(tableName = "availability_state")
+data class AvailabilityEntity(
+    @PrimaryKey val key: String = CURRENT_KEY,
+    val isAvailable: Boolean,
+    val assignmentId: String?,
+    val syncStatus: String = SyncStatus.SYNCED,
+    val pendingError: String? = null,
+    val updatedAtEpochMillis: Long,
+    val lastSyncedAtEpochMillis: Long? = null
+) {
+    companion object {
+        const val CURRENT_KEY = "current"
+    }
+}
+
+@Entity(
+    tableName = "assigned_requests",
+    indices = [Index(value = ["requestId"]), Index(value = ["syncStatus"])]
+)
+data class AssignedRequestEntity(
+    @PrimaryKey val assignmentId: String,
+    val requestId: String,
+    val helpType: String,
+    val helpTypesJson: String,
+    val otherHelpText: String?,
+    val description: String,
+    val affectedPeopleCount: Int?,
+    val riskFlagsJson: String,
+    val vulnerableGroupsJson: String,
+    val bloodType: String?,
+    val locationLabel: String,
+    val status: String,
+    val requesterName: String?,
+    val requesterEmail: String?,
+    val contactFullName: String?,
+    val contactPhone: String?,
+    val contactAlternativePhone: String?,
+    val assignedAt: String?,
+    val syncStatus: String = SyncStatus.SYNCED,
+    val pendingError: String? = null,
+    val fetchedAtEpochMillis: Long,
+    val lastSyncedAtEpochMillis: Long? = null,
+    val locallyCancelled: Boolean = false
+)
+
+@Entity(
+    tableName = "sync_operations",
+    indices = [
+        Index(value = ["status", "createdAtEpochMillis"]),
+        Index(value = ["entityType", "entityId"])
+    ]
+)
+data class SyncOperationEntity(
+    @PrimaryKey val operationId: String = UUID.randomUUID().toString(),
+    val entityType: String,
+    val entityId: String,
+    val operationType: String,
+    val payloadJson: String,
+    val createdAtEpochMillis: Long,
+    val attemptCount: Int = 0,
+    val lastAttemptAtEpochMillis: Long? = null,
+    val status: String = SyncOperationStatus.PENDING,
+    val error: String? = null
+)
+
+@Entity(tableName = "sync_metadata")
+data class SyncMetadataEntity(
+    @PrimaryKey val key: String,
+    val value: String,
+    val updatedAtEpochMillis: Long
+)

--- a/android/app/src/main/java/com/neph/core/sync/OfflineSyncCoordinator.kt
+++ b/android/app/src/main/java/com/neph/core/sync/OfflineSyncCoordinator.kt
@@ -1,0 +1,275 @@
+package com.neph.core.sync
+
+import android.content.Context
+import android.util.Log
+import com.neph.core.database.NephDatabaseProvider
+import com.neph.core.database.SyncOperationEntity
+import com.neph.core.network.ApiException
+import com.neph.features.assignedrequest.data.AssignedRequestRepository
+import com.neph.features.auth.data.AuthSessionStore
+import com.neph.features.availability.data.AvailabilityRepository
+import com.neph.features.requesthelp.data.RequestHelpRepository
+
+object OfflineSyncCoordinator {
+    private const val Tag = "NephOfflineSync"
+
+    suspend fun sync(context: Context): Boolean {
+        val appContext = context.applicationContext
+        NephDatabaseProvider.initialize(appContext)
+        AuthSessionStore.initialize(appContext)
+        AvailabilityRepository.initialize(appContext)
+        RequestHelpRepository.initialize(appContext)
+
+        val database = NephDatabaseProvider.requireInstance()
+        val token = AuthSessionStore.getAccessToken()
+        val pendingOperations = database.syncOperationDao().getPendingOperations()
+        Log.i(Tag, "Starting sync. Pending operations=${pendingOperations.size}")
+
+        var retryNeeded = false
+        val availabilityOperations = pendingOperations.filter {
+            it.operationType == SyncOperationType.SET_AVAILABILITY
+        }
+        val otherOperations = pendingOperations.filterNot {
+            it.operationType == SyncOperationType.SET_AVAILABILITY
+        }
+
+        for (operation in otherOperations.sortedBy { it.createdAtEpochMillis }) {
+            retryNeeded = processOperation(operation, token) || retryNeeded
+        }
+
+        if (availabilityOperations.isNotEmpty()) {
+            retryNeeded = processAvailabilityOperations(availabilityOperations, token) || retryNeeded
+        }
+
+        if (!retryNeeded) {
+            retryNeeded = pullLatestRemoteState(token) || retryNeeded
+        }
+
+        database.syncOperationDao().deleteSynced()
+        Log.i(Tag, "Sync finished. retryNeeded=$retryNeeded")
+        return retryNeeded
+    }
+
+    private suspend fun processOperation(operation: SyncOperationEntity, token: String?): Boolean {
+        val database = NephDatabaseProvider.requireInstance()
+        if (operationRequiresAuthentication(operation) && token.isNullOrBlank()) {
+            database.syncOperationDao().updateStatus(
+                operationId = operation.operationId,
+                status = SyncOperationStatus.PENDING,
+                attemptCount = operation.attemptCount,
+                lastAttemptAtEpochMillis = operation.lastAttemptAtEpochMillis,
+                error = "Login required before this offline change can sync."
+            )
+            return false
+        }
+
+        val attempt = operation.attemptCount + 1
+        database.syncOperationDao().updateStatus(
+            operationId = operation.operationId,
+            status = SyncOperationStatus.IN_PROGRESS,
+            attemptCount = attempt,
+            lastAttemptAtEpochMillis = System.currentTimeMillis(),
+            error = null
+        )
+
+        return try {
+            when (operation.operationType) {
+                SyncOperationType.CREATE_HELP_REQUEST -> RequestHelpRepository.pushCreateOperation(operation, token)
+                SyncOperationType.UPDATE_HELP_REQUEST_STATUS -> RequestHelpRepository.pushStatusOperation(operation, token)
+                SyncOperationType.CANCEL_ASSIGNMENT -> AssignedRequestRepository.pushCancelOperation(operation, token)
+            }
+            false
+        } catch (error: ApiException) {
+            if (error.status == 401 && operationRequiresAuthentication(operation)) {
+                handleUnauthorizedOperation(operation, error.message)
+            } else {
+                handleOperationFailure(operation, attempt, error.message, error.status)
+            }
+        } catch (error: Exception) {
+            handleOperationFailure(operation, attempt, error.message, status = 0)
+        }
+    }
+
+    private suspend fun processAvailabilityOperations(
+        operations: List<SyncOperationEntity>,
+        token: String?
+    ): Boolean {
+        val database = NephDatabaseProvider.requireInstance()
+        if (token.isNullOrBlank()) {
+            operations.forEach { operation ->
+                database.syncOperationDao().updateStatus(
+                    operationId = operation.operationId,
+                    status = SyncOperationStatus.PENDING,
+                    attemptCount = operation.attemptCount,
+                    lastAttemptAtEpochMillis = operation.lastAttemptAtEpochMillis,
+                    error = "Login required before availability can sync."
+                )
+            }
+            return false
+        }
+
+        val now = System.currentTimeMillis()
+        val attempts = operations.associateWith { it.attemptCount + 1 }
+        operations.forEach { operation ->
+            database.syncOperationDao().updateStatus(
+                operationId = operation.operationId,
+                status = SyncOperationStatus.IN_PROGRESS,
+                attemptCount = attempts.getValue(operation),
+                lastAttemptAtEpochMillis = now,
+                error = null
+            )
+        }
+
+        return try {
+            AvailabilityRepository.pushAvailabilityOperations(operations, token)
+            false
+        } catch (error: ApiException) {
+            if (error.status == 401) {
+                AuthSessionStore.clearAccessToken()
+                operations.forEach { operation ->
+                    database.syncOperationDao().updateStatus(
+                        operationId = operation.operationId,
+                        status = SyncOperationStatus.PENDING,
+                        attemptCount = attempts.getValue(operation),
+                        lastAttemptAtEpochMillis = now,
+                        error = "Session expired. Log in again to sync availability."
+                    )
+                }
+                AvailabilityRepository.markSyncDeferred("Session expired. Log in again to sync availability.")
+                return false
+            }
+
+            val maxAttempt = attempts.values.maxOrNull() ?: 1
+            val retry = SyncConflictPolicy.shouldRetryHttpStatus(error.status, maxAttempt)
+            operations.forEach { operation ->
+                database.syncOperationDao().updateStatus(
+                    operationId = operation.operationId,
+                    status = if (retry) SyncOperationStatus.PENDING else SyncOperationStatus.FAILED,
+                    attemptCount = attempts.getValue(operation),
+                    lastAttemptAtEpochMillis = now,
+                    error = error.message
+                )
+            }
+            if (!retry) AvailabilityRepository.markSyncFailed(error.message)
+            retry
+        } catch (error: Exception) {
+            val maxAttempt = attempts.values.maxOrNull() ?: 1
+            val retry = SyncConflictPolicy.shouldRetryHttpStatus(0, maxAttempt)
+            operations.forEach { operation ->
+                database.syncOperationDao().updateStatus(
+                    operationId = operation.operationId,
+                    status = if (retry) SyncOperationStatus.PENDING else SyncOperationStatus.FAILED,
+                    attemptCount = attempts.getValue(operation),
+                    lastAttemptAtEpochMillis = now,
+                    error = error.message
+                )
+            }
+            if (!retry) AvailabilityRepository.markSyncFailed(error.message)
+            retry
+        }
+    }
+
+
+    private suspend fun operationRequiresAuthentication(operation: SyncOperationEntity): Boolean {
+        if (operation.entityType == SyncEntityType.AVAILABILITY || operation.entityType == SyncEntityType.ASSIGNED_REQUEST) {
+            return true
+        }
+
+        if (operation.entityType != SyncEntityType.HELP_REQUEST) {
+            return false
+        }
+
+        val entity = NephDatabaseProvider.requireInstance().helpRequestDao().getByLocalId(operation.entityId)
+            ?: return false
+        return entity.ownerType == LocalOwnerType.AUTHENTICATED
+    }
+
+    private suspend fun pullLatestRemoteState(token: String?): Boolean {
+        return try {
+            if (!token.isNullOrBlank()) {
+                RequestHelpRepository.refreshAuthenticatedHelpRequests(token)
+                AvailabilityRepository.refreshAssignmentState(token)
+                AssignedRequestRepository.fetchCurrentAssignment(token)
+            }
+            RequestHelpRepository.refreshGuestHelpRequests()
+            false
+        } catch (error: ApiException) {
+            if (error.status == 401) {
+                AuthSessionStore.clearAccessToken()
+                false
+            } else {
+                SyncConflictPolicy.shouldRetryHttpStatus(error.status, attemptCount = 1)
+            }
+        } catch (_: Exception) {
+            true
+        }
+    }
+
+
+    private suspend fun handleUnauthorizedOperation(
+        operation: SyncOperationEntity,
+        message: String?
+    ): Boolean {
+        val database = NephDatabaseProvider.requireInstance()
+        AuthSessionStore.clearAccessToken()
+        val displayMessage = message?.takeIf { it.isNotBlank() }
+            ?: "Session expired. Log in again to sync this offline change."
+        database.syncOperationDao().updateStatus(
+            operationId = operation.operationId,
+            status = SyncOperationStatus.PENDING,
+            attemptCount = operation.attemptCount,
+            lastAttemptAtEpochMillis = System.currentTimeMillis(),
+            error = displayMessage
+        )
+
+        when (operation.entityType) {
+            SyncEntityType.HELP_REQUEST -> {
+                database.helpRequestDao().getByLocalId(operation.entityId)?.let { entity ->
+                    database.helpRequestDao().upsert(
+                        entity.copy(
+                            pendingError = displayMessage,
+                            updatedAtEpochMillis = System.currentTimeMillis()
+                        )
+                    )
+                }
+            }
+            SyncEntityType.AVAILABILITY -> AvailabilityRepository.markSyncDeferred(displayMessage)
+        }
+        return false
+    }
+
+    private suspend fun handleOperationFailure(
+        operation: SyncOperationEntity,
+        attempt: Int,
+        message: String?,
+        status: Int
+    ): Boolean {
+        val database = NephDatabaseProvider.requireInstance()
+        val retry = SyncConflictPolicy.shouldRetryHttpStatus(status, attempt)
+        database.syncOperationDao().updateStatus(
+            operationId = operation.operationId,
+            status = if (retry) SyncOperationStatus.PENDING else SyncOperationStatus.FAILED,
+            attemptCount = attempt,
+            lastAttemptAtEpochMillis = System.currentTimeMillis(),
+            error = message
+        )
+
+        if (!retry) {
+            when (operation.entityType) {
+                SyncEntityType.HELP_REQUEST -> {
+                    database.helpRequestDao().getByLocalId(operation.entityId)?.let { entity ->
+                        database.helpRequestDao().upsert(
+                            entity.copy(
+                                syncStatus = if (status == 409) SyncStatus.CONFLICTED else SyncStatus.FAILED,
+                                pendingError = message,
+                                updatedAtEpochMillis = System.currentTimeMillis()
+                            )
+                        )
+                    }
+                }
+                SyncEntityType.ASSIGNED_REQUEST -> AssignedRequestRepository.markCancelFailed(operation.entityId, message)
+            }
+        }
+        return retry
+    }
+}

--- a/android/app/src/main/java/com/neph/core/sync/OfflineSyncCoordinator.kt
+++ b/android/app/src/main/java/com/neph/core/sync/OfflineSyncCoordinator.kt
@@ -21,6 +21,7 @@ object OfflineSyncCoordinator {
         RequestHelpRepository.initialize(appContext)
 
         val database = NephDatabaseProvider.requireInstance()
+        recoverStaleInProgressOperations()
         val pendingOperations = database.syncOperationDao().getPendingOperations()
         Log.i(Tag, "Starting sync. Pending operations=${pendingOperations.size}")
 
@@ -51,6 +52,17 @@ object OfflineSyncCoordinator {
         database.syncOperationDao().deleteSynced()
         Log.i(Tag, "Sync finished. retryNeeded=$retryNeeded")
         return retryNeeded
+    }
+
+    private suspend fun recoverStaleInProgressOperations(now: Long = System.currentTimeMillis()) {
+        val recoveredCount = NephDatabaseProvider.requireInstance().syncOperationDao()
+            .resetStaleInProgressOperations(
+                staleBeforeEpochMillis = SyncOperationRecoveryPolicy.staleInProgressCutoff(now),
+                error = "Previous sync attempt was interrupted; retrying this offline change."
+            )
+        if (recoveredCount > 0) {
+            Log.i(Tag, "Recovered stale IN_PROGRESS operations=$recoveredCount")
+        }
     }
 
     private suspend fun processOperation(operation: SyncOperationEntity, token: String?): Boolean {

--- a/android/app/src/main/java/com/neph/core/sync/OfflineSyncCoordinator.kt
+++ b/android/app/src/main/java/com/neph/core/sync/OfflineSyncCoordinator.kt
@@ -21,11 +21,11 @@ object OfflineSyncCoordinator {
         RequestHelpRepository.initialize(appContext)
 
         val database = NephDatabaseProvider.requireInstance()
-        val token = AuthSessionStore.getAccessToken()
         val pendingOperations = database.syncOperationDao().getPendingOperations()
         Log.i(Tag, "Starting sync. Pending operations=${pendingOperations.size}")
 
         var retryNeeded = false
+        var token = AuthSessionStore.getAccessToken()
         val availabilityOperations = pendingOperations.filter {
             it.operationType == SyncOperationType.SET_AVAILABILITY
         }
@@ -35,13 +35,16 @@ object OfflineSyncCoordinator {
 
         for (operation in otherOperations.sortedBy { it.createdAtEpochMillis }) {
             retryNeeded = processOperation(operation, token) || retryNeeded
+            token = AuthSessionStore.getAccessToken()
         }
 
         if (availabilityOperations.isNotEmpty()) {
+            token = AuthSessionStore.getAccessToken()
             retryNeeded = processAvailabilityOperations(availabilityOperations, token) || retryNeeded
         }
 
         if (!retryNeeded) {
+            token = AuthSessionStore.getAccessToken()
             retryNeeded = pullLatestRemoteState(token) || retryNeeded
         }
 
@@ -60,6 +63,10 @@ object OfflineSyncCoordinator {
                 lastAttemptAtEpochMillis = operation.lastAttemptAtEpochMillis,
                 error = "Login required before this offline change can sync."
             )
+            return false
+        }
+
+        if (deferOperationUntilDependenciesSync(operation)) {
             return false
         }
 
@@ -88,6 +95,28 @@ object OfflineSyncCoordinator {
         } catch (error: Exception) {
             handleOperationFailure(operation, attempt, error.message, status = 0)
         }
+    }
+
+    private suspend fun deferOperationUntilDependenciesSync(operation: SyncOperationEntity): Boolean {
+        if (operation.operationType != SyncOperationType.UPDATE_HELP_REQUEST_STATUS) {
+            return false
+        }
+
+        val database = NephDatabaseProvider.requireInstance()
+        val entity = database.helpRequestDao().getByLocalId(operation.entityId) ?: return false
+        val remoteId = RequestHelpRepository.resolveRemoteRequestIdForSync(entity)
+        if (!remoteId.isNullOrBlank()) {
+            return false
+        }
+
+        database.syncOperationDao().updateStatus(
+            operationId = operation.operationId,
+            status = SyncOperationStatus.PENDING,
+            attemptCount = operation.attemptCount,
+            lastAttemptAtEpochMillis = operation.lastAttemptAtEpochMillis,
+            error = RequestHelpRepository.DeferredStatusSyncMessage
+        )
+        return true
     }
 
     private suspend fun processAvailabilityOperations(

--- a/android/app/src/main/java/com/neph/core/sync/OfflineSyncScheduler.kt
+++ b/android/app/src/main/java/com/neph/core/sync/OfflineSyncScheduler.kt
@@ -1,0 +1,58 @@
+package com.neph.core.sync
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import java.util.concurrent.TimeUnit
+
+object OfflineSyncScheduler {
+    private const val OneTimeSyncName = "neph-offline-sync"
+    private const val PeriodicSyncName = "neph-periodic-offline-sync"
+    const val SyncTag = "neph-sync"
+
+    fun enqueueSync(context: Context, reason: String, replaceExisting: Boolean = false) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        val request = OneTimeWorkRequestBuilder<OfflineSyncWorker>()
+            .setConstraints(constraints)
+            .setInitialDelay(10, TimeUnit.SECONDS)
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+            .setInputData(workDataOf("reason" to reason))
+            .addTag(SyncTag)
+            .build()
+
+        WorkManager.getInstance(context.applicationContext).enqueueUniqueWork(
+            OneTimeSyncName,
+            if (replaceExisting) ExistingWorkPolicy.REPLACE else ExistingWorkPolicy.KEEP,
+            request
+        )
+    }
+
+    fun schedulePeriodicSync(context: Context) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .setRequiresBatteryNotLow(true)
+            .build()
+
+        val request = PeriodicWorkRequestBuilder<OfflineSyncWorker>(30, TimeUnit.MINUTES)
+            .setConstraints(constraints)
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+            .addTag(SyncTag)
+            .build()
+
+        WorkManager.getInstance(context.applicationContext).enqueueUniquePeriodicWork(
+            PeriodicSyncName,
+            ExistingPeriodicWorkPolicy.KEEP,
+            request
+        )
+    }
+}

--- a/android/app/src/main/java/com/neph/core/sync/OfflineSyncWorker.kt
+++ b/android/app/src/main/java/com/neph/core/sync/OfflineSyncWorker.kt
@@ -1,0 +1,21 @@
+package com.neph.core.sync
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+
+class OfflineSyncWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        return try {
+            val retryNeeded = OfflineSyncCoordinator.sync(applicationContext)
+            if (retryNeeded) Result.retry() else Result.success()
+        } catch (error: Exception) {
+            Log.w("NephOfflineSync", "Sync worker failed; scheduling retry.", error)
+            Result.retry()
+        }
+    }
+}

--- a/android/app/src/main/java/com/neph/core/sync/SyncConflictPolicy.kt
+++ b/android/app/src/main/java/com/neph/core/sync/SyncConflictPolicy.kt
@@ -1,0 +1,57 @@
+package com.neph.core.sync
+
+data class ConflictDecision(
+    val shouldApplyRemote: Boolean,
+    val nextSyncStatus: String,
+    val reason: String? = null
+)
+
+object SyncConflictPolicy {
+    private val pendingStatuses = setOf(
+        SyncStatus.PENDING_CREATE,
+        SyncStatus.PENDING_UPDATE,
+        SyncStatus.PENDING_DELETE,
+        SyncStatus.FAILED
+    )
+
+    fun decideHelpRequestRemoteMerge(
+        localSyncStatus: String,
+        localStatus: String,
+        remoteStatus: String
+    ): ConflictDecision {
+        if (localSyncStatus == SyncStatus.SYNCED) {
+            return ConflictDecision(shouldApplyRemote = true, nextSyncStatus = SyncStatus.SYNCED)
+        }
+
+        if (localSyncStatus == SyncStatus.PENDING_CREATE) {
+            return ConflictDecision(shouldApplyRemote = false, nextSyncStatus = localSyncStatus)
+        }
+
+        if (localSyncStatus in pendingStatuses && statusesEquivalent(localStatus, remoteStatus)) {
+            return ConflictDecision(shouldApplyRemote = true, nextSyncStatus = SyncStatus.SYNCED)
+        }
+
+        if (localSyncStatus in pendingStatuses && isTerminal(remoteStatus) && !statusesEquivalent(localStatus, remoteStatus)) {
+            return ConflictDecision(
+                shouldApplyRemote = false,
+                nextSyncStatus = SyncStatus.CONFLICTED,
+                reason = "Remote request is already ${remoteStatus.lowercase()} while local change is ${localStatus.lowercase()}."
+            )
+        }
+
+        return ConflictDecision(shouldApplyRemote = false, nextSyncStatus = localSyncStatus)
+    }
+
+    fun shouldRetryHttpStatus(status: Int, attemptCount: Int): Boolean {
+        if (attemptCount >= 5) return false
+        return status == 0 || status == 408 || status == 429 || status >= 500
+    }
+
+    fun isTerminal(status: String): Boolean {
+        return status.uppercase() in setOf("RESOLVED", "CANCELLED")
+    }
+
+    fun statusesEquivalent(first: String, second: String): Boolean {
+        return first.trim().uppercase() == second.trim().uppercase()
+    }
+}

--- a/android/app/src/main/java/com/neph/core/sync/SyncConstants.kt
+++ b/android/app/src/main/java/com/neph/core/sync/SyncConstants.kt
@@ -1,0 +1,35 @@
+package com.neph.core.sync
+
+object SyncStatus {
+    const val SYNCED = "SYNCED"
+    const val PENDING_CREATE = "PENDING_CREATE"
+    const val PENDING_UPDATE = "PENDING_UPDATE"
+    const val PENDING_DELETE = "PENDING_DELETE"
+    const val FAILED = "FAILED"
+    const val CONFLICTED = "CONFLICTED"
+}
+
+object SyncOperationStatus {
+    const val PENDING = "PENDING"
+    const val IN_PROGRESS = "IN_PROGRESS"
+    const val SYNCED = "SYNCED"
+    const val FAILED = "FAILED"
+}
+
+object SyncEntityType {
+    const val HELP_REQUEST = "HELP_REQUEST"
+    const val AVAILABILITY = "AVAILABILITY"
+    const val ASSIGNED_REQUEST = "ASSIGNED_REQUEST"
+}
+
+object SyncOperationType {
+    const val CREATE_HELP_REQUEST = "CREATE_HELP_REQUEST"
+    const val UPDATE_HELP_REQUEST_STATUS = "UPDATE_HELP_REQUEST_STATUS"
+    const val SET_AVAILABILITY = "SET_AVAILABILITY"
+    const val CANCEL_ASSIGNMENT = "CANCEL_ASSIGNMENT"
+}
+
+object LocalOwnerType {
+    const val AUTHENTICATED = "AUTHENTICATED"
+    const val GUEST = "GUEST"
+}

--- a/android/app/src/main/java/com/neph/core/sync/SyncOperationRecoveryPolicy.kt
+++ b/android/app/src/main/java/com/neph/core/sync/SyncOperationRecoveryPolicy.kt
@@ -1,0 +1,24 @@
+package com.neph.core.sync
+
+import java.util.concurrent.TimeUnit
+
+object SyncOperationRecoveryPolicy {
+    val InProgressRecoveryTimeoutMillis: Long = TimeUnit.MINUTES.toMillis(15)
+
+    fun staleInProgressCutoff(nowEpochMillis: Long): Long {
+        return nowEpochMillis - InProgressRecoveryTimeoutMillis
+    }
+
+    fun isStaleInProgress(
+        status: String,
+        lastAttemptAtEpochMillis: Long?,
+        nowEpochMillis: Long
+    ): Boolean {
+        if (status != SyncOperationStatus.IN_PROGRESS) {
+            return false
+        }
+
+        return lastAttemptAtEpochMillis == null ||
+            lastAttemptAtEpochMillis <= staleInProgressCutoff(nowEpochMillis)
+    }
+}

--- a/android/app/src/main/java/com/neph/features/assignedrequest/data/AssignedRequestRepository.kt
+++ b/android/app/src/main/java/com/neph/features/assignedrequest/data/AssignedRequestRepository.kt
@@ -1,7 +1,18 @@
 package com.neph.features.assignedrequest.data
 
+import com.neph.core.NephAppContext
+import com.neph.core.database.AssignedRequestEntity
+import com.neph.core.database.NephDatabaseProvider
+import com.neph.core.database.SyncOperationEntity
 import com.neph.core.network.ApiException
 import com.neph.core.network.JsonHttpClient
+import com.neph.core.sync.OfflineSyncScheduler
+import com.neph.core.sync.SyncEntityType
+import com.neph.core.sync.SyncOperationType
+import com.neph.core.sync.SyncStatus
+import com.neph.features.requesthelp.data.jsonArrayToStringList
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -26,25 +37,47 @@ data class AssignedRequestUiModel(
     val contactFullName: String?,
     val contactPhone: String?,
     val contactAlternativePhone: String?,
-    val assignedAt: String?
-)
+    val assignedAt: String?,
+    val syncStatus: String = SyncStatus.SYNCED,
+    val pendingError: String? = null
+) {
+    val isPendingSync: Boolean
+        get() = syncStatus == SyncStatus.PENDING_UPDATE || syncStatus == SyncStatus.PENDING_DELETE
+
+    val isFailedSync: Boolean
+        get() = syncStatus == SyncStatus.FAILED || syncStatus == SyncStatus.CONFLICTED
+}
 
 object AssignedRequestRepository {
+    private val database get() = NephDatabaseProvider.requireInstance()
+
+    fun observeCurrentAssignment(): Flow<AssignedRequestUiModel?> {
+        return database.assignedRequestDao().observeCurrent().map { it?.toUiModel() }
+    }
+
     suspend fun fetchAssignedRequests(token: String): List<AssignedRequestUiModel> {
         return fetchCurrentAssignment(token)?.let(::listOf) ?: emptyList()
     }
 
     suspend fun fetchCurrentAssignment(token: String): AssignedRequestUiModel? {
-        try {
+        return try {
             val response = JsonHttpClient.request(
                 path = "/availability/my-assignment",
                 token = token
             )
 
-            val assignment = response.optJSONObject("assignment") ?: return null
-            return mapAssignment(assignment)
+            val assignment = response.optJSONObject("assignment")
+            if (assignment == null) {
+                database.assignedRequestDao().clearSyncedAssignments()
+                return null
+            }
+            val entity = mapAssignmentEntity(assignment, syncStatus = SyncStatus.SYNCED)
+            database.assignedRequestDao().clearSyncedAssignments()
+            database.assignedRequestDao().upsert(entity)
+            entity.toUiModel()
         } catch (error: ApiException) {
             if (error.status == 404) {
+                database.assignedRequestDao().clearSyncedAssignments()
                 return null
             }
             throw error
@@ -52,16 +85,55 @@ object AssignedRequestRepository {
     }
 
     suspend fun cancelAssignment(token: String, assignmentId: String): AssignedRequestUiModel? {
-        val response = JsonHttpClient.request(
+        val current = database.assignedRequestDao().getByAssignmentId(assignmentId)
+            ?: return null
+        val now = System.currentTimeMillis()
+        val pending = current.copy(
+            syncStatus = SyncStatus.PENDING_DELETE,
+            pendingError = null,
+            locallyCancelled = false,
+            fetchedAtEpochMillis = now
+        )
+        database.assignedRequestDao().upsert(pending)
+        database.syncOperationDao().upsert(
+            SyncOperationEntity(
+                entityType = SyncEntityType.ASSIGNED_REQUEST,
+                entityId = assignmentId,
+                operationType = SyncOperationType.CANCEL_ASSIGNMENT,
+                payloadJson = JSONObject().put("assignmentId", assignmentId).toString(),
+                createdAtEpochMillis = now
+            )
+        )
+        OfflineSyncScheduler.enqueueSync(NephAppContext.get(), reason = "assignment-cancelled")
+        return pending.toUiModel()
+    }
+
+    internal suspend fun pushCancelOperation(operation: SyncOperationEntity, token: String?) {
+        if (token.isNullOrBlank()) return
+        val assignmentId = JSONObject(operation.payloadJson).optString("assignmentId")
+            .ifBlank { operation.entityId }
+        JsonHttpClient.request(
             path = "/availability/assignments/$assignmentId/cancel",
             method = "POST",
             token = token
         )
-
-        return response.optJSONObject("newAssignment")?.let(::mapAssignment)
+        database.syncOperationDao().delete(operation.operationId)
+        database.assignedRequestDao().clearAll()
+        fetchCurrentAssignment(token)
     }
 
-    private fun mapAssignment(assignment: JSONObject): AssignedRequestUiModel {
+    internal suspend fun markCancelFailed(assignmentId: String, message: String?) {
+        val current = database.assignedRequestDao().getByAssignmentId(assignmentId) ?: return
+        database.assignedRequestDao().upsert(
+            current.copy(
+                syncStatus = SyncStatus.FAILED,
+                pendingError = message,
+                fetchedAtEpochMillis = System.currentTimeMillis()
+            )
+        )
+    }
+
+    private fun mapAssignmentEntity(assignment: JSONObject, syncStatus: String): AssignedRequestEntity {
         val description = assignment.optString("description").trim()
         val firstName = assignment.optString("requester_first_name").trim()
         val lastName = assignment.optString("requester_last_name").trim()
@@ -69,32 +141,71 @@ object AssignedRequestRepository {
             .filter { it.isNotBlank() }
             .joinToString(" ")
             .takeIf { it.isNotBlank() }
-        val helpTypes = assignment.optJSONArray("help_types").toStringList().map(::formatValue)
+        val helpTypes = assignment.optJSONArray("help_types").toStringList()
         val status = assignment.optString("request_status").ifBlank { "ASSIGNED" }
+        val now = System.currentTimeMillis()
 
-        return AssignedRequestUiModel(
+        return AssignedRequestEntity(
             assignmentId = assignment.optString("assignment_id"),
             requestId = assignment.optString("request_id"),
             helpType = formatValue(assignment.optString("need_type")),
-            helpTypes = helpTypes,
-            helpTypeSummary = buildHelpTypeSummary(helpTypes, assignment.optString("need_type")),
+            helpTypesJson = JSONArray(helpTypes).toString(),
             otherHelpText = assignment.optString("other_help_text").trim().takeIf { it.isNotBlank() },
             description = description,
-            shortDescription = buildShortDescription(description),
             affectedPeopleCount = assignment.opt("affected_people_count")?.toString()?.toIntOrNull(),
-            riskFlags = assignment.optJSONArray("risk_flags").toStringList().map(::formatValue),
-            vulnerableGroups = assignment.optJSONArray("vulnerable_groups").toStringList().map(::formatValue),
+            riskFlagsJson = JSONArray(assignment.optJSONArray("risk_flags").toStringList()).toString(),
+            vulnerableGroupsJson = JSONArray(assignment.optJSONArray("vulnerable_groups").toStringList()).toString(),
             bloodType = assignment.optString("blood_type").trim().takeIf { it.isNotBlank() },
             locationLabel = buildLocationLabel(assignment),
             status = status,
-            statusLabel = formatStatus(status),
             requesterName = requesterName,
             requesterEmail = assignment.optString("requester_email").takeIf { it.isNotBlank() },
             contactFullName = assignment.optString("contact_full_name").trim().takeIf { it.isNotBlank() },
             contactPhone = assignment.opt("contact_phone")?.toString()?.takeIf { it.isNotBlank() },
             contactAlternativePhone = assignment.opt("contact_alternative_phone")?.toString()
                 ?.takeIf { it.isNotBlank() },
-            assignedAt = assignment.optString("assigned_at").takeIf { it.isNotBlank() }?.let(::formatTimestamp)
+            assignedAt = assignment.optString("assigned_at").takeIf { it.isNotBlank() }?.let(::formatTimestamp),
+            syncStatus = syncStatus,
+            pendingError = null,
+            fetchedAtEpochMillis = now,
+            lastSyncedAtEpochMillis = now,
+            locallyCancelled = false
+        )
+    }
+
+    private fun AssignedRequestEntity.toUiModel(): AssignedRequestUiModel {
+        val formattedHelpTypes = helpTypesJson.jsonArrayToStringList().map(::formatValue)
+        val statusLabel = when (syncStatus) {
+            SyncStatus.PENDING_DELETE -> "Release waiting to sync"
+            SyncStatus.FAILED -> "Sync failed"
+            SyncStatus.CONFLICTED -> "Needs review"
+            else -> formatStatus(status)
+        }
+
+        return AssignedRequestUiModel(
+            assignmentId = assignmentId,
+            requestId = requestId,
+            helpType = helpType,
+            helpTypes = formattedHelpTypes,
+            helpTypeSummary = buildHelpTypeSummary(formattedHelpTypes, helpType),
+            otherHelpText = otherHelpText,
+            description = description,
+            shortDescription = buildShortDescription(description),
+            affectedPeopleCount = affectedPeopleCount,
+            riskFlags = riskFlagsJson.jsonArrayToStringList().map(::formatValue),
+            vulnerableGroups = vulnerableGroupsJson.jsonArrayToStringList().map(::formatValue),
+            bloodType = bloodType,
+            locationLabel = locationLabel,
+            status = status,
+            statusLabel = statusLabel,
+            requesterName = requesterName,
+            requesterEmail = requesterEmail,
+            contactFullName = contactFullName,
+            contactPhone = contactPhone,
+            contactAlternativePhone = contactAlternativePhone,
+            assignedAt = assignedAt,
+            syncStatus = syncStatus,
+            pendingError = pendingError
         )
     }
 

--- a/android/app/src/main/java/com/neph/features/assignedrequest/presentation/AssignedRequestScreen.kt
+++ b/android/app/src/main/java/com/neph/features/assignedrequest/presentation/AssignedRequestScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -23,12 +24,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.verticalScroll
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import com.neph.core.network.ApiException
+import com.neph.core.sync.OfflineSyncScheduler
 import com.neph.features.assignedrequest.data.AssignedRequestRepository
 import com.neph.features.assignedrequest.data.AssignedRequestUiModel
-import com.neph.features.auth.data.AuthRepository
 import com.neph.features.auth.data.AuthSessionStore
-import com.neph.features.availability.data.AvailabilityRepository
 import com.neph.navigation.Routes
 import com.neph.ui.components.buttons.SecondaryButton
 import com.neph.ui.components.display.HelperText
@@ -37,7 +36,6 @@ import com.neph.ui.components.display.SectionHeader
 import com.neph.ui.layout.AppDrawerScaffold
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
-import kotlinx.coroutines.CancellationException
 
 @Composable
 fun AssignedRequestScreen(
@@ -52,18 +50,13 @@ fun AssignedRequestScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
     val token = AuthSessionStore.getAccessToken().orEmpty()
 
+    val currentRequest by AssignedRequestRepository.observeCurrentAssignment()
+        .collectAsState(initial = null)
     var loading by remember { mutableStateOf(true) }
     var error by remember { mutableStateOf("") }
     var infoMessage by remember { mutableStateOf("") }
-    var currentRequest by remember { mutableStateOf<AssignedRequestUiModel?>(null) }
     var refreshVersion by remember { mutableStateOf(0) }
     var cancelling by remember { mutableStateOf(false) }
-
-    fun startLoading() {
-        loading = true
-        error = ""
-        infoMessage = ""
-    }
 
     DisposableEffect(lifecycleOwner, token) {
         val observer = LifecycleEventObserver { _, event ->
@@ -85,31 +78,10 @@ fun AssignedRequestScreen(
             return@LaunchedEffect
         }
 
-        startLoading()
-
-        try {
-            currentRequest = AssignedRequestRepository.fetchCurrentAssignment(token)
-            AvailabilityRepository.refreshAssignmentState(token)
-        } catch (cancellationException: CancellationException) {
-            throw cancellationException
-        } catch (errorResponse: ApiException) {
-            when (errorResponse.status) {
-                401 -> {
-                    AuthRepository.logout()
-                    onNavigateToLogin()
-                    return@LaunchedEffect
-                }
-                else -> {
-                    error = errorResponse.message.ifBlank {
-                        "Could not load your assigned request."
-                    }
-                }
-            }
-        } catch (_: Exception) {
-            error = "Something went wrong while loading your assigned request."
-        } finally {
-            loading = false
-        }
+        error = ""
+        infoMessage = ""
+        OfflineSyncScheduler.enqueueSync(context, reason = "assigned-request-open", replaceExisting = true)
+        loading = false
     }
 
     suspend fun runCancelAction(assignmentId: String) {
@@ -121,30 +93,9 @@ fun AssignedRequestScreen(
                 token = token,
                 assignmentId = assignmentId
             )
-
-            val refreshedAssignment = AssignedRequestRepository.fetchCurrentAssignment(token)
-            currentRequest = refreshedAssignment
-            AvailabilityRepository.setAvailabilityStateForUi(
-                AvailabilityRepository.getAvailabilityState().copy(
-                    assignmentId = refreshedAssignment?.assignmentId
-                )
-            )
-            infoMessage = if (refreshedAssignment == null) {
-                "Assignment released successfully."
-            } else {
-                "Assignment updated successfully."
-            }
-        } catch (cancellationException: CancellationException) {
-            throw cancellationException
-        } catch (errorResponse: ApiException) {
-            if (errorResponse.status == 401) {
-                AuthRepository.logout()
-                onNavigateToLogin()
-            } else {
-                error = errorResponse.message.ifBlank { "Could not update this assignment." }
-            }
+            infoMessage = "Assignment release saved locally and queued for sync."
         } catch (_: Exception) {
-            error = "Something went wrong while updating this assignment."
+            error = "Could not save the assignment update locally."
         }
     }
 
@@ -228,6 +179,14 @@ fun AssignedRequestScreen(
                                 style = MaterialTheme.typography.labelMedium,
                                 color = MaterialTheme.colorScheme.primary
                             )
+
+                            if (request.isPendingSync) {
+                                HelperText(text = "Saved locally. Assignment changes will sync when connected.")
+                            }
+
+                            if (request.isFailedSync) {
+                                HelperText(text = request.pendingError ?: "Sync failed. Retry when connected.")
+                            }
 
                             request.assignedAt?.let {
                                 Text(

--- a/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
+++ b/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
@@ -1,6 +1,8 @@
 package com.neph.features.auth.data
 
+import com.neph.core.NephAppContext
 import com.neph.core.network.ApiException
+import com.neph.core.sync.OfflineSyncScheduler
 import com.neph.core.network.JsonHttpClient
 import com.neph.features.profile.data.ProfileData
 import com.neph.features.profile.data.ProfileRepository
@@ -86,6 +88,7 @@ object AuthRepository {
         return try {
             ProfileRepository.fetchAndCacheRemoteProfile()
             AuthSessionStore.clearPendingVerificationEmail()
+            NephAppContext.getOrNull()?.let { OfflineSyncScheduler.enqueueSync(it, reason = "login") }
             LoginDestination.PROFILE
         } catch (cancellationException: CancellationException) {
             throw cancellationException
@@ -93,6 +96,7 @@ object AuthRepository {
             when (error.status) {
                 404 -> {
                     AuthSessionStore.clearPendingVerificationEmail()
+                    NephAppContext.getOrNull()?.let { OfflineSyncScheduler.enqueueSync(it, reason = "login-without-profile") }
                     LoginDestination.COMPLETE_PROFILE
                 }
                 401 -> {
@@ -120,6 +124,7 @@ object AuthRepository {
         val accessToken = response.optString("accessToken")
         if (accessToken.isNotBlank()) {
             AuthSessionStore.saveAccessToken(accessToken, rememberMe = true)
+            NephAppContext.getOrNull()?.let { OfflineSyncScheduler.enqueueSync(it, reason = "email-verified") }
         }
 
         AuthSessionStore.clearPendingVerificationEmail()

--- a/android/app/src/main/java/com/neph/features/auth/data/AuthSessionStore.kt
+++ b/android/app/src/main/java/com/neph/features/auth/data/AuthSessionStore.kt
@@ -2,6 +2,8 @@ package com.neph.features.auth.data
 
 import android.content.Context
 import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 object AuthSessionStore {
     private const val PrefsName = "neph_auth"
@@ -9,14 +11,18 @@ object AuthSessionStore {
     private const val PendingVerificationEmailKey = "pending_verification_email"
 
     private lateinit var prefs: SharedPreferences
+    private val accessTokenState = MutableStateFlow<String?>(null)
     private var sessionToken: String? = null
 
     fun initialize(context: Context) {
         if (!::prefs.isInitialized) {
             prefs = context.applicationContext.getSharedPreferences(PrefsName, Context.MODE_PRIVATE)
             sessionToken = prefs.getString(AccessTokenKey, null)
+            accessTokenState.value = sessionToken
         }
     }
+
+    val accessTokenFlow: StateFlow<String?> = accessTokenState
 
     fun getAccessToken(): String? {
         ensureInitialized()
@@ -26,6 +32,7 @@ object AuthSessionStore {
     fun saveAccessToken(token: String, rememberMe: Boolean) {
         ensureInitialized()
         sessionToken = token
+        accessTokenState.value = token
         prefs.edit().apply {
             if (rememberMe) {
                 putString(AccessTokenKey, token)
@@ -38,6 +45,7 @@ object AuthSessionStore {
     fun clearAccessToken() {
         ensureInitialized()
         sessionToken = null
+        accessTokenState.value = null
         prefs.edit().remove(AccessTokenKey).apply()
     }
 

--- a/android/app/src/main/java/com/neph/features/auth/data/AuthSessionStore.kt
+++ b/android/app/src/main/java/com/neph/features/auth/data/AuthSessionStore.kt
@@ -9,6 +9,7 @@ object AuthSessionStore {
     private const val PrefsName = "neph_auth"
     private const val AccessTokenKey = "access_token"
     private const val PendingVerificationEmailKey = "pending_verification_email"
+    private const val GuestModeKey = "guest_mode"
 
     private lateinit var prefs: SharedPreferences
     private val accessTokenState = MutableStateFlow<String?>(null)
@@ -34,6 +35,7 @@ object AuthSessionStore {
         sessionToken = token
         accessTokenState.value = token
         prefs.edit().apply {
+            putBoolean(GuestModeKey, false)
             if (rememberMe) {
                 putString(AccessTokenKey, token)
             } else {
@@ -47,6 +49,16 @@ object AuthSessionStore {
         sessionToken = null
         accessTokenState.value = null
         prefs.edit().remove(AccessTokenKey).apply()
+    }
+
+    fun setGuestMode(enabled: Boolean) {
+        ensureInitialized()
+        prefs.edit().putBoolean(GuestModeKey, enabled).apply()
+    }
+
+    fun isGuestMode(): Boolean {
+        ensureInitialized()
+        return prefs.getBoolean(GuestModeKey, false)
     }
 
     fun setPendingVerificationEmail(email: String?) {

--- a/android/app/src/main/java/com/neph/features/availability/data/AvailabilityRepository.kt
+++ b/android/app/src/main/java/com/neph/features/availability/data/AvailabilityRepository.kt
@@ -2,13 +2,37 @@ package com.neph.features.availability.data
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.neph.core.NephAppContext
+import com.neph.core.database.AvailabilityEntity
+import com.neph.core.database.NephDatabaseProvider
+import com.neph.core.database.SyncOperationEntity
 import com.neph.core.network.JsonHttpClient
+import com.neph.core.sync.OfflineSyncScheduler
+import com.neph.core.sync.SyncEntityType
+import com.neph.core.sync.SyncOperationType
+import com.neph.core.sync.SyncStatus
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import org.json.JSONArray
 import org.json.JSONObject
 
 data class AvailabilityState(
     val isAvailable: Boolean = false,
-    val assignmentId: String? = null
-)
+    val assignmentId: String? = null,
+    val syncStatus: String = SyncStatus.SYNCED,
+    val pendingError: String? = null,
+    val lastSyncedAtEpochMillis: Long? = null
+) {
+    val isPendingSync: Boolean
+        get() = syncStatus == SyncStatus.PENDING_UPDATE
+
+    val isFailedSync: Boolean
+        get() = syncStatus == SyncStatus.FAILED || syncStatus == SyncStatus.CONFLICTED
+}
 
 object AvailabilityAccessPolicy {
     // Logged-in users only.
@@ -26,14 +50,44 @@ object AvailabilityRepository {
 
     private lateinit var prefs: SharedPreferences
     private var cachedState = AvailabilityState()
+    private val repositoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val database get() = NephDatabaseProvider.requireInstance()
 
     fun initialize(context: Context) {
         if (!::prefs.isInitialized) {
-            prefs = context.applicationContext.getSharedPreferences(PrefsName, Context.MODE_PRIVATE)
+            val appContext = context.applicationContext
+            NephAppContext.initialize(appContext)
+            NephDatabaseProvider.initialize(appContext)
+            prefs = appContext.getSharedPreferences(PrefsName, Context.MODE_PRIVATE)
             cachedState = AvailabilityState(
                 isAvailable = prefs.getBoolean(AvailabilityKey, false),
                 assignmentId = prefs.getString(AssignmentIdKey, null)
             )
+            repositoryScope.launch {
+                val current = database.availabilityDao().get()
+                if (current != null) {
+                    cachedState = current.toState()
+                } else {
+                    val migrated = AvailabilityEntity(
+                        isAvailable = cachedState.isAvailable,
+                        assignmentId = cachedState.assignmentId,
+                        updatedAtEpochMillis = System.currentTimeMillis(),
+                        lastSyncedAtEpochMillis = null
+                    )
+                    database.availabilityDao().upsert(migrated)
+                    cachedState = migrated.toState()
+                }
+            }
+        }
+    }
+
+    fun observeAvailabilityState(): Flow<AvailabilityState> {
+        ensureInitialized()
+        return database.availabilityDao().observe().map { entity ->
+            val next = entity?.toState() ?: cachedState
+            cachedState = next
+            next
         }
     }
 
@@ -42,9 +96,9 @@ object AvailabilityRepository {
         return cachedState
     }
 
-    fun setAvailabilityStateForUi(state: AvailabilityState) {
+    suspend fun setAvailabilityStateForUi(state: AvailabilityState) {
         ensureInitialized()
-        saveAvailabilityState(state)
+        saveAvailabilityState(state.toEntity(syncStatus = state.syncStatus))
     }
 
     suspend fun refreshAssignmentState(token: String): AvailabilityState {
@@ -58,10 +112,13 @@ object AvailabilityRepository {
         val assignment = response.optJSONObject("assignment")
         val nextState = AvailabilityState(
             isAvailable = response.optBoolean("isAvailable", false),
-            assignmentId = assignment?.optString("assignment_id")?.takeIf { it.isNotBlank() }
+            assignmentId = assignment?.optString("assignment_id")?.takeIf { it.isNotBlank() },
+            syncStatus = SyncStatus.SYNCED,
+            pendingError = null,
+            lastSyncedAtEpochMillis = System.currentTimeMillis()
         )
 
-        saveAvailabilityState(nextState)
+        saveAvailabilityState(nextState.toEntity(syncStatus = SyncStatus.SYNCED))
         return nextState
     }
 
@@ -70,36 +127,146 @@ object AvailabilityRepository {
         token: String?
     ): AvailabilityState {
         ensureInitialized()
+        val now = System.currentTimeMillis()
+        val nextState = AvailabilityState(
+            isAvailable = isAvailable,
+            assignmentId = cachedState.assignmentId,
+            syncStatus = SyncStatus.PENDING_UPDATE,
+            pendingError = null,
+            lastSyncedAtEpochMillis = cachedState.lastSyncedAtEpochMillis
+        )
+
+        saveAvailabilityState(nextState.toEntity(syncStatus = SyncStatus.PENDING_UPDATE, now = now))
+        database.syncOperationDao().upsert(
+            SyncOperationEntity(
+                entityType = SyncEntityType.AVAILABILITY,
+                entityId = AvailabilityEntity.CURRENT_KEY,
+                operationType = SyncOperationType.SET_AVAILABILITY,
+                payloadJson = JSONObject()
+                    .put("isAvailable", isAvailable)
+                    .put("timestamp", now)
+                    .toString(),
+                createdAtEpochMillis = now
+            )
+        )
+        OfflineSyncScheduler.enqueueSync(NephAppContext.get(), reason = "availability-updated")
+        return nextState
+    }
+
+    internal suspend fun pushAvailabilityOperations(
+        operations: List<SyncOperationEntity>,
+        token: String?
+    ) {
+        if (operations.isEmpty() || token.isNullOrBlank()) return
+
+        val records = JSONArray().apply {
+            operations.sortedBy { it.createdAtEpochMillis }.forEach { operation ->
+                val payload = JSONObject(operation.payloadJson)
+                put(
+                    JSONObject()
+                        .put("isAvailable", payload.optBoolean("isAvailable"))
+                        .put("timestamp", payload.optLong("timestamp").toIsoLikeString())
+                )
+            }
+        }
 
         val response = JsonHttpClient.request(
-            path = "/availability/toggle",
+            path = "/availability/sync",
             method = "POST",
-            token = token?.takeIf { it.isNotBlank() },
-            body = JSONObject().put("isAvailable", isAvailable)
+            token = token,
+            body = JSONObject().put("records", records)
         )
 
         val volunteer = response.optJSONObject("volunteer")
         val assignment = response.optJSONObject("assignment")
-
-        val nextState = AvailabilityState(
-            isAvailable = volunteer?.optBoolean("is_available") ?: isAvailable,
-            assignmentId = assignment?.optString("assignment_id")?.takeIf { it.isNotBlank() }
+        val now = System.currentTimeMillis()
+        saveAvailabilityState(
+            AvailabilityEntity(
+                isAvailable = volunteer?.optBoolean("is_available") ?: cachedState.isAvailable,
+                assignmentId = assignment?.optString("assignment_id")?.takeIf { it.isNotBlank() },
+                syncStatus = SyncStatus.SYNCED,
+                pendingError = null,
+                updatedAtEpochMillis = now,
+                lastSyncedAtEpochMillis = now
+            )
         )
 
-        saveAvailabilityState(nextState)
-        return nextState
+        operations.forEach { database.syncOperationDao().delete(it.operationId) }
     }
 
-    private fun saveAvailabilityState(state: AvailabilityState) {
-        cachedState = state
+
+    internal suspend fun markSyncDeferred(message: String?) {
+        val now = System.currentTimeMillis()
+        saveAvailabilityState(
+            (database.availabilityDao().get() ?: AvailabilityEntity(
+                isAvailable = cachedState.isAvailable,
+                assignmentId = cachedState.assignmentId,
+                updatedAtEpochMillis = now
+            )).copy(
+                syncStatus = SyncStatus.PENDING_UPDATE,
+                pendingError = message,
+                updatedAtEpochMillis = now
+            )
+        )
+    }
+
+    internal suspend fun markSyncFailed(message: String?) {
+        val now = System.currentTimeMillis()
+        saveAvailabilityState(
+            (database.availabilityDao().get() ?: AvailabilityEntity(
+                isAvailable = false,
+                assignmentId = null,
+                updatedAtEpochMillis = now
+            )).copy(
+                syncStatus = SyncStatus.FAILED,
+                pendingError = message,
+                updatedAtEpochMillis = now
+            )
+        )
+    }
+
+    private suspend fun saveAvailabilityState(entity: AvailabilityEntity) {
+        cachedState = entity.toState()
+        database.availabilityDao().upsert(entity)
         prefs.edit().apply {
-            putBoolean(AvailabilityKey, state.isAvailable)
-            if (state.assignmentId.isNullOrBlank()) {
+            putBoolean(AvailabilityKey, entity.isAvailable)
+            if (entity.assignmentId.isNullOrBlank()) {
                 remove(AssignmentIdKey)
             } else {
-                putString(AssignmentIdKey, state.assignmentId)
+                putString(AssignmentIdKey, entity.assignmentId)
             }
         }.apply()
+    }
+
+    private fun AvailabilityState.toEntity(
+        syncStatus: String,
+        now: Long = System.currentTimeMillis()
+    ): AvailabilityEntity {
+        return AvailabilityEntity(
+            isAvailable = isAvailable,
+            assignmentId = assignmentId,
+            syncStatus = syncStatus,
+            pendingError = pendingError,
+            updatedAtEpochMillis = now,
+            lastSyncedAtEpochMillis = lastSyncedAtEpochMillis
+        )
+    }
+
+    private fun AvailabilityEntity.toState(): AvailabilityState {
+        return AvailabilityState(
+            isAvailable = isAvailable,
+            assignmentId = assignmentId,
+            syncStatus = syncStatus,
+            pendingError = pendingError,
+            lastSyncedAtEpochMillis = lastSyncedAtEpochMillis
+        )
+    }
+
+    private fun Long.toIsoLikeString(): String {
+        // Backend only requires a parsable timestamp and sorts by Date(timestamp).
+        val formatter = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.US)
+        formatter.timeZone = java.util.TimeZone.getTimeZone("UTC")
+        return formatter.format(java.util.Date(this))
     }
 
     private fun ensureInitialized() {

--- a/android/app/src/main/java/com/neph/features/availability/presentation/AvailableToHelpCard.kt
+++ b/android/app/src/main/java/com/neph/features/availability/presentation/AvailableToHelpCard.kt
@@ -15,6 +15,7 @@ fun AvailableToHelpCard(
     loading: Boolean,
     errorMessage: String,
     infoMessage: String,
+    syncMessage: String = "",
     onAvailabilityChange: (Boolean) -> Unit
 ) {
     val spacing = LocalNephSpacing.current
@@ -48,6 +49,10 @@ fun AvailableToHelpCard(
 
             if (infoMessage.isNotBlank()) {
                 HelperText(text = infoMessage)
+            }
+
+            if (syncMessage.isNotBlank()) {
+                HelperText(text = syncMessage)
             }
         }
     }

--- a/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
+++ b/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
@@ -6,9 +6,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -17,7 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.neph.core.network.ApiException
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.availability.data.AvailabilityAccessPolicy
 import com.neph.features.availability.data.AvailabilityRepository
@@ -48,26 +47,13 @@ fun HomeScreen(
     val scope = rememberCoroutineScope()
     val sessionToken = AuthSessionStore.getAccessToken()
 
-    var availabilityState by remember {
-        mutableStateOf(AvailabilityRepository.getAvailabilityState())
-    }
+    val availabilityState by AvailabilityRepository.observeAvailabilityState()
+        .collectAsState(initial = AvailabilityRepository.getAvailabilityState())
     var availabilityLoading by remember { mutableStateOf(false) }
     var availabilityError by remember { mutableStateOf("") }
     var availabilityInfo by remember { mutableStateOf("") }
     var requestHelpLoading by remember { mutableStateOf(false) }
     var requestHelpError by remember { mutableStateOf("") }
-
-    LaunchedEffect(isAuthenticated, sessionToken) {
-        if (!isAuthenticated || sessionToken.isNullOrBlank()) {
-            return@LaunchedEffect
-        }
-
-        try {
-            availabilityState = AvailabilityRepository.refreshAssignmentState(sessionToken)
-        } catch (_: Exception) {
-            // Keep the cached state if the refresh attempt fails.
-        }
-    }
 
     fun handleAvailabilityChange(nextValue: Boolean) {
         availabilityError = ""
@@ -81,44 +67,23 @@ fun HomeScreen(
             return
         }
 
-        val previousState = availabilityState
-        availabilityState = previousState.copy(isAvailable = nextValue)
         availabilityLoading = true
 
         scope.launch {
             try {
-                availabilityState = AvailabilityRepository.setAvailability(
+                val recordedState = AvailabilityRepository.setAvailability(
                     isAvailable = nextValue,
                     token = sessionToken
                 )
-                availabilityInfo = if (availabilityState.isAvailable) {
-                    if (availabilityState.assignmentId != null) {
-                        onOpenAssignedRequest()
-                        "You are now available to help. A request has been assigned to you."
-                    } else {
-                        "You are now available to help."
-                    }
+                availabilityInfo = if (recordedState.isAvailable) {
+                    "Availability saved locally and will sync when connected."
                 } else {
-                    "You are no longer available."
+                    "Unavailable status saved locally and will sync when connected."
                 }
             } catch (cancellationException: CancellationException) {
-                availabilityState = previousState
                 throw cancellationException
-            } catch (error: ApiException) {
-                availabilityState = previousState
-                availabilityError = when {
-                    error.status == 401 && !sessionToken.isNullOrBlank() && AvailabilityAccessPolicy.shouldRedirectToLogin() -> {
-                        onNavigateToLogin()
-                        "Your session expired. Please log in again."
-                    }
-                    error.status == 401 -> {
-                        "The backend currently requires login to update availability."
-                    }
-                    else -> error.message.ifBlank { "Could not update your availability." }
-                }
             } catch (_: Exception) {
-                availabilityState = previousState
-                availabilityError = "Something went wrong while updating your availability."
+                availabilityError = "Could not save your availability locally. Please try again."
             } finally {
                 availabilityLoading = false
             }
@@ -178,8 +143,13 @@ fun HomeScreen(
                 AvailableToHelpCard(
                     isAvailable = availabilityState.isAvailable,
                     loading = availabilityLoading,
-                    errorMessage = availabilityError,
+                    errorMessage = availabilityError.ifBlank { availabilityState.pendingError.orEmpty() },
                     infoMessage = availabilityInfo,
+                    syncMessage = when {
+                        availabilityState.isPendingSync -> "Pending sync — your latest availability is saved on this device."
+                        availabilityState.isFailedSync -> "Sync failed — use Retry from a connected network."
+                        else -> ""
+                    },
                     onAvailabilityChange = ::handleAvailabilityChange
                 )
             }

--- a/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
+++ b/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.neph.core.network.ApiException
+import com.neph.features.auth.data.AuthRepository
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.availability.data.AvailabilityAccessPolicy
 import com.neph.features.availability.data.AvailabilityRepository
@@ -108,6 +110,14 @@ fun HomeScreen(
                     onOpenMyHelpRequests()
                 } else {
                     onRequestHelp()
+                }
+            } catch (error: ApiException) {
+                if (error.status == 401) {
+                    AuthRepository.logout()
+                    requestHelpError = "Your session expired. Please log in again before requesting help."
+                    onNavigateToLogin()
+                } else {
+                    requestHelpError = "We could not verify your current help request status. Please try again."
                 }
             } catch (_: Exception) {
                 requestHelpError = "We could not verify your current help request status. Please try again."

--- a/android/app/src/main/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepository.kt
+++ b/android/app/src/main/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepository.kt
@@ -1,7 +1,20 @@
 package com.neph.features.myhelprequests.data
 
+import com.neph.core.NephAppContext
+import com.neph.core.database.HelpRequestEntity
+import com.neph.core.database.NephDatabaseProvider
+import com.neph.core.database.SyncOperationEntity
 import com.neph.core.network.JsonHttpClient
+import com.neph.core.sync.LocalOwnerType
+import com.neph.core.sync.OfflineSyncScheduler
+import com.neph.core.sync.SyncEntityType
+import com.neph.core.sync.SyncOperationType
+import com.neph.core.sync.SyncStatus
 import com.neph.features.requesthelp.data.RequestHelpRepository
+import com.neph.features.requesthelp.data.jsonArrayToStringList
+import com.neph.features.requesthelp.data.toHelpRequestEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -25,191 +38,254 @@ data class MyHelpRequestUiModel(
     val helperProfession: String?,
     val helperExpertise: String?,
     val helperFullName: String?,
-    val createdAt: String?
-)
+    val createdAt: String?,
+    val syncStatus: String = SyncStatus.SYNCED,
+    val pendingError: String? = null,
+    val lastSyncedAt: String? = null
+) {
+    val isPendingSync: Boolean
+        get() = syncStatus == SyncStatus.PENDING_CREATE || syncStatus == SyncStatus.PENDING_UPDATE
+
+    val isFailedSync: Boolean
+        get() = syncStatus == SyncStatus.FAILED || syncStatus == SyncStatus.CONFLICTED
+}
 
 object MyHelpRequestsRepository {
+    private val database get() = NephDatabaseProvider.requireInstance()
+
+    fun observeHelpRequests(isAuthenticated: Boolean): Flow<List<MyHelpRequestUiModel>> {
+        val ownerType = if (isAuthenticated) LocalOwnerType.AUTHENTICATED else LocalOwnerType.GUEST
+        return database.helpRequestDao()
+            .observeByOwner(ownerType)
+            .map { entities -> entities.distinctBy { it.remoteId ?: it.localId }.map { it.toUiModel() } }
+    }
+
     suspend fun fetchMyHelpRequests(token: String): List<MyHelpRequestUiModel> {
-        val response = JsonHttpClient.request(
-            path = "/help-requests",
-            token = token
-        )
-
-        val requests = response.optJSONArray("requests") ?: return emptyList()
-        val mappedRequests = buildList {
-            for (index in 0 until requests.length()) {
-                val request = requests.optJSONObject(index) ?: continue
-                add(mapRequest(request))
-            }
-        }
-
-        return mappedRequests.distinctBy { it.id }
+        RequestHelpRepository.refreshAuthenticatedHelpRequests(token)
+        return database.helpRequestDao()
+            .getByOwner(LocalOwnerType.AUTHENTICATED)
+            .map { it.toUiModel() }
+            .distinctBy { it.id }
     }
 
     suspend fun fetchGuestHelpRequests(): List<MyHelpRequestUiModel> {
-        val trackedRequests = RequestHelpRepository.getGuestTrackedRequests()
-        return buildList {
-            for (trackedRequest in trackedRequests) {
-                val request = RequestHelpRepository.fetchGuestHelpRequest(trackedRequest) ?: continue
-                add(
-                    mapRequest(
-                        request = request,
-                        guestAccessToken = trackedRequest.guestAccessToken
-                    )
-                )
-            }
-        }.distinctBy { it.id }
+        RequestHelpRepository.refreshGuestHelpRequests()
+        return database.helpRequestDao()
+            .getByOwner(LocalOwnerType.GUEST)
+            .map { it.toUiModel() }
+            .distinctBy { it.id }
     }
 
     suspend fun markRequestAsResolved(token: String, requestId: String): MyHelpRequestUiModel? {
-        val response = JsonHttpClient.request(
-            path = "/help-requests/$requestId/status",
-            method = "PATCH",
-            token = token,
-            body = JSONObject().put("status", "RESOLVED")
+        return markLocalRequestStatus(
+            requestId = requestId,
+            ownerType = LocalOwnerType.AUTHENTICATED,
+            nextStatus = "RESOLVED"
         )
-
-        return response.optJSONObject("request")?.let(::mapRequest)
     }
 
     suspend fun markGuestRequestAsResolved(
         requestId: String,
         guestAccessToken: String
     ): MyHelpRequestUiModel? {
-        val response = JsonHttpClient.request(
-            path = "/help-requests/$requestId/status?guestAccessToken=$guestAccessToken",
-            method = "PATCH",
-            body = JSONObject().put("status", "RESOLVED")
+        return markLocalRequestStatus(
+            requestId = requestId,
+            ownerType = LocalOwnerType.GUEST,
+            nextStatus = "RESOLVED",
+            guestAccessToken = guestAccessToken
         )
-
-        return response.optJSONObject("request")?.let {
-            mapRequest(
-                request = it,
-                guestAccessToken = guestAccessToken
-            )
-        }
     }
 
-    private fun mapRequest(
+    internal suspend fun upsertRemoteHelpRequest(
+        ownerType: String,
+        request: JSONObject,
+        guestAccessToken: String?
+    ) {
+        val remoteId = request.optString("id").takeIf { it.isNotBlank() } ?: return
+        val existing = database.helpRequestDao().getByRemoteId(remoteId)
+        database.helpRequestDao().upsert(
+            request.toHelpRequestEntity(
+                ownerType = ownerType,
+                existing = existing,
+                guestAccessToken = guestAccessToken ?: existing?.guestAccessToken,
+                now = System.currentTimeMillis()
+            )
+        )
+    }
+
+    private suspend fun markLocalRequestStatus(
+        requestId: String,
+        ownerType: String,
+        nextStatus: String,
+        guestAccessToken: String? = null
+    ): MyHelpRequestUiModel? {
+        val now = System.currentTimeMillis()
+        val entity = database.helpRequestDao().getByLocalId(requestId)
+            ?: database.helpRequestDao().getByRemoteId(requestId)
+            ?: return null
+
+        val nextEntity = entity.copy(
+            status = nextStatus,
+            guestAccessToken = guestAccessToken ?: entity.guestAccessToken,
+            syncStatus = if (entity.syncStatus == SyncStatus.PENDING_CREATE) {
+                SyncStatus.PENDING_CREATE
+            } else {
+                SyncStatus.PENDING_UPDATE
+            },
+            pendingError = null,
+            updatedAtEpochMillis = now
+        )
+        database.helpRequestDao().upsert(nextEntity)
+        database.syncOperationDao().upsert(
+            SyncOperationEntity(
+                entityType = SyncEntityType.HELP_REQUEST,
+                entityId = entity.localId,
+                operationType = SyncOperationType.UPDATE_HELP_REQUEST_STATUS,
+                payloadJson = JSONObject().put("status", nextStatus).toString(),
+                createdAtEpochMillis = now
+            )
+        )
+        OfflineSyncScheduler.enqueueSync(NephAppContext.get(), reason = "help-request-status")
+        return nextEntity.toUiModel().takeIf { nextEntity.ownerType == ownerType }
+    }
+
+    internal fun mapRequest(
         request: JSONObject,
         guestAccessToken: String? = null
     ): MyHelpRequestUiModel {
-        val description = request.optString("description").trim()
-        val helpTypes = request.optJSONArray("helpTypes").toStringList().map(::formatHelpType)
-        val status = request.optString("status").ifBlank { "Unknown" }
-        val contact = request.optJSONObject("contact")
-        val helper = request.optJSONObject("helper")
-        val helperFirstName = helper?.optString("firstName")?.trim()?.takeIf { it.isNotBlank() }
-        val helperLastName = helper?.optString("lastName")?.trim()?.takeIf { it.isNotBlank() }
-        val helperPhone = helper?.opt("phone")?.toString()?.takeIf { it.isNotBlank() }
-        val helperProfession = helper?.optString("profession")?.trim()?.takeIf { it.isNotBlank() }
-        val helperExpertise = helper?.optString("expertise")?.trim()?.takeIf { it.isNotBlank() }
-
-        return MyHelpRequestUiModel(
-            id = request.optString("id"),
+        return request.toHelpRequestEntity(
+            ownerType = if (guestAccessToken == null) LocalOwnerType.AUTHENTICATED else LocalOwnerType.GUEST,
+            existing = null,
             guestAccessToken = guestAccessToken,
-            helpTypes = helpTypes,
-            helpTypeSummary = buildHelpTypeSummary(helpTypes),
-            description = description,
-            shortDescription = buildShortDescription(description),
-            locationLabel = buildLocationLabel(request.optJSONObject("location")),
-            status = status,
-            statusLabel = formatStatus(status),
-            isActive = status != "RESOLVED" && status != "CANCELLED",
-            contactName = contact?.optString("fullName")?.trim()?.takeIf { it.isNotBlank() },
-            contactPhone = contact?.opt("phone")?.toString()?.takeIf { it.isNotBlank() },
-            alternativePhone = contact?.opt("alternativePhone")?.toString()?.takeIf { it.isNotBlank() },
-            helperFirstName = helperFirstName,
-            helperLastName = helperLastName,
-            helperPhone = helperPhone,
-            helperProfession = helperProfession,
-            helperExpertise = helperExpertise,
-            helperFullName = listOfNotNull(helperFirstName, helperLastName)
-                .joinToString(" ")
-                .trim()
-                .takeIf { it.isNotBlank() },
-            createdAt = request.optString("createdAt").takeIf { it.isNotBlank() }?.let(::formatTimestamp)
-        )
+            now = System.currentTimeMillis()
+        ).toUiModel()
     }
+}
 
-    private fun buildHelpTypeSummary(helpTypes: List<String>): String {
-        if (helpTypes.isEmpty()) {
-            return "General Support"
-        }
-
-        return if (helpTypes.size == 1) {
-            helpTypes.first()
-        } else {
-            "${helpTypes.first()} +${helpTypes.size - 1}"
-        }
+internal fun HelpRequestEntity.toUiModel(): MyHelpRequestUiModel {
+    val helpTypes = helpTypesJson.jsonArrayToStringList().map(::formatHelpType)
+    val riskStatusLabel = when (syncStatus) {
+        SyncStatus.PENDING_CREATE -> "Saved offline, waiting to sync"
+        SyncStatus.PENDING_UPDATE -> "Update waiting to sync"
+        SyncStatus.FAILED -> "Sync failed"
+        SyncStatus.CONFLICTED -> "Needs review"
+        else -> formatStatus(status)
     }
+    val displayId = remoteId ?: localId
+    val created = serverCreatedAt?.let(::formatTimestamp)
+        ?: formatEpochMillis(createdAtEpochMillis)
 
-    private fun formatHelpType(value: String): String {
-        return value
+    return MyHelpRequestUiModel(
+        id = displayId,
+        guestAccessToken = guestAccessToken,
+        helpTypes = helpTypes,
+        helpTypeSummary = buildHelpTypeSummary(helpTypes),
+        description = description,
+        shortDescription = buildShortDescription(description),
+        locationLabel = buildLocationLabel(country, city, district, neighborhood, extraAddress),
+        status = status,
+        statusLabel = riskStatusLabel,
+        isActive = status != "RESOLVED" && status != "CANCELLED",
+        contactName = contactFullName.takeIf { it.isNotBlank() },
+        contactPhone = contactPhone.takeIf { it.isNotBlank() },
+        alternativePhone = contactAlternativePhone,
+        helperFirstName = helperFirstName,
+        helperLastName = helperLastName,
+        helperPhone = helperPhone,
+        helperProfession = helperProfession,
+        helperExpertise = helperExpertise,
+        helperFullName = listOfNotNull(helperFirstName, helperLastName)
+            .joinToString(" ")
             .trim()
-            .split('_')
-            .filter { it.isNotBlank() }
-            .joinToString(" ") { part ->
-                part.lowercase().replaceFirstChar { it.uppercase() }
-            }
-            .ifBlank { "General Support" }
+            .takeIf { it.isNotBlank() },
+        createdAt = created,
+        syncStatus = syncStatus,
+        pendingError = pendingError,
+        lastSyncedAt = lastSyncedAtEpochMillis?.let(::formatEpochMillis)
+    )
+}
+
+private fun buildHelpTypeSummary(helpTypes: List<String>): String {
+    if (helpTypes.isEmpty()) {
+        return "General Support"
     }
 
-    private fun buildLocationLabel(location: JSONObject?): String {
-        if (location == null) {
-            return "Location unavailable"
+    return if (helpTypes.size == 1) {
+        helpTypes.first()
+    } else {
+        "${helpTypes.first()} +${helpTypes.size - 1}"
+    }
+}
+
+private fun formatHelpType(value: String): String {
+    return value
+        .trim()
+        .split('_')
+        .filter { it.isNotBlank() }
+        .joinToString(" ") { part ->
+            part.lowercase().replaceFirstChar { it.uppercase() }
         }
+        .ifBlank { "General Support" }
+}
 
-        val parts = listOf(
-            location.optString("country").trim(),
-            location.optString("city").trim(),
-            location.optString("district").trim(),
-            location.optString("neighborhood").trim(),
-            location.optString("extraAddress").trim()
-        ).filter { it.isNotBlank() }
+private fun buildLocationLabel(
+    country: String,
+    city: String,
+    district: String,
+    neighborhood: String,
+    extraAddress: String
+): String {
+    val parts = listOf(country, city, district, neighborhood, extraAddress)
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
 
-        return parts.joinToString(" / ").ifBlank { "Location unavailable" }
+    return parts.joinToString(" / ").ifBlank { "Location unavailable" }
+}
+
+private fun formatStatus(status: String): String {
+    return when (status.trim().uppercase()) {
+        "SYNCED" -> "Awaiting match"
+        "MATCHED" -> "Responder assigned"
+        "RESOLVED" -> "Resolved"
+        "CANCELLED" -> "Cancelled"
+        "PENDING_SYNC" -> "Pending sync"
+        else -> "Status unavailable"
+    }
+}
+
+private fun buildShortDescription(description: String): String {
+    val normalized = description.replace('\n', ' ').replace(Regex("\\s+"), " ").trim()
+    if (normalized.isBlank()) return "No description provided."
+    return if (normalized.length > 160) {
+        normalized.take(157).trimEnd() + "..."
+    } else {
+        normalized
+    }
+}
+
+private fun formatTimestamp(raw: String): String {
+    return raw
+        .replace('T', ' ')
+        .substringBefore('.')
+        .substringBefore('Z')
+}
+
+private fun formatEpochMillis(raw: Long): String {
+    val formatter = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", java.util.Locale.US)
+    return formatter.format(java.util.Date(raw))
+}
+
+@Suppress("unused")
+private fun JSONArray?.toStringList(): List<String> {
+    if (this == null) {
+        return emptyList()
     }
 
-    private fun formatStatus(status: String): String {
-        return when (status.trim().uppercase()) {
-            "SYNCED" -> "Awaiting match"
-            "MATCHED" -> "Responder assigned"
-            "RESOLVED" -> "Resolved"
-            "CANCELLED" -> "Cancelled"
-            "PENDING_SYNC" -> "Pending sync"
-            else -> "Status unavailable"
-        }
-    }
-
-    private fun buildShortDescription(description: String): String {
-        val normalized = description.replace('\n', ' ').replace(Regex("\\s+"), " ").trim()
-        if (normalized.isBlank()) return "No description provided."
-        return if (normalized.length > 160) {
-            normalized.take(157).trimEnd() + "..."
-        } else {
-            normalized
-        }
-    }
-
-    private fun formatTimestamp(raw: String): String {
-        return raw
-            .replace('T', ' ')
-            .substringBefore('.')
-            .substringBefore('Z')
-    }
-
-    private fun JSONArray?.toStringList(): List<String> {
-        if (this == null) {
-            return emptyList()
-        }
-
-        return buildList {
-            for (index in 0 until length()) {
-                val value = optString(index).trim()
-                if (value.isNotBlank()) {
-                    add(value)
-                }
+    return buildList {
+        for (index in 0 until length()) {
+            val value = optString(index).trim()
+            if (value.isNotBlank()) {
+                add(value)
             }
         }
     }

--- a/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,8 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.text.style.TextAlign
-import com.neph.core.network.ApiException
-import com.neph.features.auth.data.AuthRepository
+import com.neph.core.sync.OfflineSyncScheduler
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.myhelprequests.data.MyHelpRequestUiModel
 import com.neph.features.myhelprequests.data.MyHelpRequestsRepository
@@ -45,7 +45,6 @@ import com.neph.ui.components.display.SectionHeader
 import com.neph.ui.layout.AppDrawerScaffold
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import androidx.compose.runtime.rememberCoroutineScope
 
@@ -60,11 +59,10 @@ fun MyHelpRequestsScreen(
     val spacing = LocalNephSpacing.current
     val token = AuthSessionStore.getAccessToken().orEmpty()
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
 
-    var loading by remember { mutableStateOf(true) }
-    var error by remember { mutableStateOf("") }
-    var requests by remember { mutableStateOf<List<MyHelpRequestUiModel>>(emptyList()) }
-    var refreshVersion by remember { mutableStateOf(0) }
+    val requests by MyHelpRequestsRepository.observeHelpRequests(isAuthenticated)
+        .collectAsState(initial = emptyList())
     var actionInProgressRequestId by remember { mutableStateOf<String?>(null) }
     var actionMessage by remember { mutableStateOf("") }
 
@@ -83,56 +81,11 @@ fun MyHelpRequestsScreen(
         profileLabel = if (isAuthenticated) "Profile" else "Login / Create Account",
         contentFillMaxSize = true
     ) {
-        LaunchedEffect(isAuthenticated, token, refreshVersion) {
-            loading = true
-            error = ""
-
-            try {
-                requests = if (!isAuthenticated || token.isBlank()) {
-                    MyHelpRequestsRepository.fetchGuestHelpRequests()
-                } else {
-                    MyHelpRequestsRepository.fetchMyHelpRequests(token)
-                }
-            } catch (cancellationException: CancellationException) {
-                throw cancellationException
-            } catch (errorResponse: ApiException) {
-                if (errorResponse.status == 401 && isAuthenticated) {
-                    AuthRepository.logout()
-                    requests = emptyList()
-                    error = "Your session expired. Please log in again to view your help requests."
-                } else {
-                    error = errorResponse.message.ifBlank { "Could not load your help requests." }
-                }
-            } catch (_: Exception) {
-                error = "Something went wrong while loading your help requests."
-            } finally {
-                loading = false
-            }
+        LaunchedEffect(isAuthenticated, token) {
+            OfflineSyncScheduler.enqueueSync(context, reason = "my-help-requests-open", replaceExisting = true)
         }
 
         when {
-            loading -> {
-                LoadingStateView()
-            }
-
-            error.isNotBlank() -> {
-                Column(verticalArrangement = Arrangement.spacedBy(spacing.lg)) {
-                    SectionCard {
-                        SectionHeader(
-                            title = "My Help Requests",
-                            subtitle = "We could not load your request history."
-                        )
-
-                        HelperText(text = error)
-
-                        SecondaryButton(
-                            text = "Retry",
-                            onClick = { refreshVersion += 1 }
-                        )
-                    }
-                }
-            }
-
             requests.isEmpty() -> {
                 EmptyStateView(
                     onRequestHelp = { onNavigateToRoute(Routes.RequestHelp.route) }
@@ -182,33 +135,13 @@ fun MyHelpRequestsScreen(
                                         actionInProgressRequestId = activeRequest.id
                                         scope.launch {
                                             try {
-                                                val updatedRequest = MyHelpRequestsRepository.markRequestAsResolved(
+                                                MyHelpRequestsRepository.markRequestAsResolved(
                                                     token = token,
                                                     requestId = activeRequest.id
                                                 )
-                                                requests = buildList {
-                                                    for (request in requests) {
-                                                        if (request.id == activeRequest.id && updatedRequest != null) {
-                                                            add(updatedRequest)
-                                                        } else {
-                                                            add(request)
-                                                        }
-                                                    }
-                                                }
-                                                actionMessage = "Your help request was marked as resolved."
-                                            } catch (cancellationException: CancellationException) {
-                                                throw cancellationException
-                                            } catch (errorResponse: ApiException) {
-                                                if (errorResponse.status == 401) {
-                                                    AuthRepository.logout()
-                                                    error = "Your session expired. Please log in again to manage your request."
-                                                } else {
-                                                    actionMessage = errorResponse.message.ifBlank {
-                                                        "Could not update your help request."
-                                                    }
-                                                }
+                                                actionMessage = "Request marked resolved locally and queued for sync."
                                             } catch (_: Exception) {
-                                                actionMessage = "Something went wrong while updating your help request."
+                                                actionMessage = "Could not save the status change locally."
                                             } finally {
                                                 actionInProgressRequestId = null
                                             }
@@ -220,28 +153,13 @@ fun MyHelpRequestsScreen(
                                         actionInProgressRequestId = activeRequest.id
                                         scope.launch {
                                             try {
-                                                val updatedRequest = MyHelpRequestsRepository.markGuestRequestAsResolved(
+                                                MyHelpRequestsRepository.markGuestRequestAsResolved(
                                                     requestId = activeRequest.id,
                                                     guestAccessToken = activeRequest.guestAccessToken
                                                 )
-                                                requests = buildList {
-                                                    for (request in requests) {
-                                                        if (request.id == activeRequest.id && updatedRequest != null) {
-                                                            add(updatedRequest)
-                                                        } else {
-                                                            add(request)
-                                                        }
-                                                    }
-                                                }
-                                                actionMessage = "Your help request was marked as resolved."
-                                            } catch (cancellationException: CancellationException) {
-                                                throw cancellationException
-                                            } catch (errorResponse: ApiException) {
-                                                actionMessage = errorResponse.message.ifBlank {
-                                                    "Could not update your help request."
-                                                }
+                                                actionMessage = "Request marked resolved locally and queued for sync."
                                             } catch (_: Exception) {
-                                                actionMessage = "Something went wrong while updating your help request."
+                                                actionMessage = "Could not save the status change locally."
                                             } finally {
                                                 actionInProgressRequestId = null
                                             }
@@ -395,6 +313,28 @@ private fun MyHelpRequestCard(
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.primary
             )
+
+            if (request.isPendingSync) {
+                HelperText(text = "Saved locally. NEPH will sync this change when the network is available.")
+            }
+
+            if (request.isFailedSync) {
+                HelperText(text = request.pendingError ?: "Sync failed. Retry when connected.")
+                SecondaryButton(
+                    text = "Retry Sync",
+                    onClick = {
+                        OfflineSyncScheduler.enqueueSync(context, reason = "manual-help-request-retry", replaceExisting = true)
+                    }
+                )
+            }
+
+            request.lastSyncedAt?.let {
+                Text(
+                    text = "Last synced: $it",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
 
             if (
                 request.helperFullName != null ||

--- a/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
@@ -32,7 +32,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.text.style.TextAlign
+import com.neph.core.network.ApiException
 import com.neph.core.sync.OfflineSyncScheduler
+import com.neph.features.auth.data.AuthRepository
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.myhelprequests.data.MyHelpRequestUiModel
 import com.neph.features.myhelprequests.data.MyHelpRequestsRepository
@@ -45,6 +47,7 @@ import com.neph.ui.components.display.SectionHeader
 import com.neph.ui.layout.AppDrawerScaffold
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import androidx.compose.runtime.rememberCoroutineScope
 
@@ -65,6 +68,7 @@ fun MyHelpRequestsScreen(
         .collectAsState(initial = emptyList())
     var actionInProgressRequestId by remember { mutableStateOf<String?>(null) }
     var actionMessage by remember { mutableStateOf("") }
+    var initialRefreshInProgress by remember(isAuthenticated, token) { mutableStateOf(true) }
 
     AppDrawerScaffold(
         title = "My Help Requests",
@@ -82,10 +86,33 @@ fun MyHelpRequestsScreen(
         contentFillMaxSize = true
     ) {
         LaunchedEffect(isAuthenticated, token) {
+            initialRefreshInProgress = true
             OfflineSyncScheduler.enqueueSync(context, reason = "my-help-requests-open", replaceExisting = true)
+            try {
+                if (isAuthenticated && token.isNotBlank()) {
+                    MyHelpRequestsRepository.fetchMyHelpRequests(token)
+                } else {
+                    MyHelpRequestsRepository.fetchGuestHelpRequests()
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (error: ApiException) {
+                if (error.status == 401 && isAuthenticated) {
+                    AuthRepository.logout()
+                    onNavigateToRoute(Routes.Login.route)
+                }
+            } catch (_: Exception) {
+                // Keep showing the best local snapshot if the initial refresh fails.
+            } finally {
+                initialRefreshInProgress = false
+            }
         }
 
         when {
+            initialRefreshInProgress && requests.isEmpty() -> {
+                LoadingStateView()
+            }
+
             requests.isEmpty() -> {
                 EmptyStateView(
                     onRequestHelp = { onNavigateToRoute(Routes.RequestHelp.route) }

--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
@@ -2,10 +2,25 @@ package com.neph.features.requesthelp.data
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.neph.core.NephAppContext
+import com.neph.core.database.HelpRequestEntity
+import com.neph.core.database.NephDatabaseProvider
+import com.neph.core.database.SyncOperationEntity
+import com.neph.core.network.ApiException
 import com.neph.core.network.JsonHttpClient
+import com.neph.core.sync.LocalOwnerType
+import com.neph.core.sync.OfflineSyncScheduler
+import com.neph.core.sync.SyncConflictPolicy
+import com.neph.core.sync.SyncEntityType
+import com.neph.core.sync.SyncOperationStatus
+import com.neph.core.sync.SyncOperationType
+import com.neph.core.sync.SyncStatus
 import org.json.JSONArray
 import org.json.JSONObject
 import java.net.URLEncoder
+import java.util.UUID
+
+private const val PendingHelpRequestStatus = "PENDING_SYNC"
 
 data class RequestHelpLocationSubmission(
     val country: String,
@@ -36,7 +51,8 @@ data class RequestHelpSubmission(
 
 data class CreateHelpRequestResult(
     val requestId: String,
-    val guestAccessToken: String? = null
+    val guestAccessToken: String? = null,
+    val recordedLocally: Boolean = true
 )
 
 data class GuestTrackedHelpRequest(
@@ -50,88 +66,50 @@ object RequestHelpRepository {
 
     private lateinit var prefs: SharedPreferences
 
+    private val database get() = NephDatabaseProvider.requireInstance()
+
     fun initialize(context: Context) {
         if (!::prefs.isInitialized) {
-            prefs = context.applicationContext.getSharedPreferences(PrefsName, Context.MODE_PRIVATE)
+            val appContext = context.applicationContext
+            NephAppContext.initialize(appContext)
+            NephDatabaseProvider.initialize(appContext)
+            prefs = appContext.getSharedPreferences(PrefsName, Context.MODE_PRIVATE)
         }
     }
 
     suspend fun hasActiveHelpRequest(token: String): Boolean {
-        val response = JsonHttpClient.request(
-            path = "/help-requests",
-            token = token
-        )
-
-        val requests = response.optJSONArray("requests") ?: return false
-        for (index in 0 until requests.length()) {
-            val request = requests.optJSONObject(index) ?: continue
-            val status = request.optString("status").trim().uppercase()
-            if (status != "RESOLVED" && status != "CANCELLED") {
-                return true
-            }
-        }
-
-        return false
+        ensureInitialized()
+        return database.helpRequestDao().countActiveByOwner(ownerTypeForToken(token)) > 0
     }
 
     suspend fun createHelpRequest(
         token: String?,
         submission: RequestHelpSubmission
     ): CreateHelpRequestResult {
-        val response = JsonHttpClient.request(
-            path = "/help-requests",
-            method = "POST",
-            token = token,
-            body = JSONObject().apply {
-                put("helpTypes", JSONArray(submission.helpTypes))
-                put("otherHelpText", submission.otherHelpText)
-                put("affectedPeopleCount", submission.affectedPeopleCount)
-                put("description", submission.description)
-                put("riskFlags", JSONArray(submission.riskFlags))
-                put("vulnerableGroups", JSONArray(submission.vulnerableGroups))
-                put("bloodType", submission.bloodType)
-                put(
-                    "location",
-                    JSONObject().apply {
-                        put("country", submission.location.country)
-                        put("city", submission.location.city)
-                        put("district", submission.location.district)
-                        put("neighborhood", submission.location.neighborhood)
-                        put("extraAddress", submission.location.extraAddress)
-                    }
-                )
-                put(
-                    "contact",
-                    JSONObject().apply {
-                        put("fullName", submission.contact.fullName)
-                        put("phone", submission.contact.phone)
-                        submission.contact.alternativePhone?.let {
-                            put("alternativePhone", it)
-                        }
-                    }
-                )
-                put("consentGiven", submission.consentGiven)
-            }
+        ensureInitialized()
+        val now = System.currentTimeMillis()
+        val localId = "local_${UUID.randomUUID()}"
+        val ownerType = ownerTypeForToken(token)
+        val entity = submission.toEntity(
+            localId = localId,
+            ownerType = ownerType,
+            now = now,
+            syncStatus = SyncStatus.PENDING_CREATE
         )
 
-        val requestId = response.optJSONObject("request")?.optString("id")
-            ?.takeIf { it.isNotBlank() }
-            ?: ""
-        val guestAccessToken = response.optString("guestAccessToken").takeIf { it.isNotBlank() }
-
-        if (token.isNullOrBlank() && requestId.isNotBlank() && guestAccessToken != null) {
-            saveGuestTrackedRequest(
-                GuestTrackedHelpRequest(
-                    requestId = requestId,
-                    guestAccessToken = guestAccessToken
-                )
+        database.helpRequestDao().upsert(entity)
+        database.syncOperationDao().upsert(
+            SyncOperationEntity(
+                entityType = SyncEntityType.HELP_REQUEST,
+                entityId = localId,
+                operationType = SyncOperationType.CREATE_HELP_REQUEST,
+                payloadJson = submission.toJson().toString(),
+                createdAtEpochMillis = now
             )
-        }
-
-        return CreateHelpRequestResult(
-            requestId = requestId,
-            guestAccessToken = guestAccessToken
         )
+        OfflineSyncScheduler.enqueueSync(NephAppContext.get(), reason = "help-request-created")
+
+        return CreateHelpRequestResult(requestId = localId, recordedLocally = true)
     }
 
     fun getGuestTrackedRequests(): List<GuestTrackedHelpRequest> {
@@ -168,6 +146,155 @@ object RequestHelpRepository {
         return response.optJSONObject("request")
     }
 
+    internal suspend fun pushCreateOperation(operation: SyncOperationEntity, token: String?) {
+        val entity = database.helpRequestDao().getByLocalId(operation.entityId) ?: run {
+            database.syncOperationDao().delete(operation.operationId)
+            return
+        }
+
+        val response = JsonHttpClient.request(
+            path = "/help-requests",
+            method = "POST",
+            token = token.takeIf { entity.ownerType == LocalOwnerType.AUTHENTICATED && !it.isNullOrBlank() },
+            body = JSONObject(operation.payloadJson)
+        )
+
+        val remoteRequest = response.optJSONObject("request")
+            ?: throw ApiException("Server did not return the created help request.", 200, "INVALID_RESPONSE")
+        val guestAccessToken = response.optString("guestAccessToken").takeIf { it.isNotBlank() }
+        val remoteId = remoteRequest.optString("id").takeIf { it.isNotBlank() }
+            ?: throw ApiException("Server did not return a help request id.", 200, "INVALID_RESPONSE")
+
+        val synced = remoteRequest.toHelpRequestEntity(
+            ownerType = entity.ownerType,
+            existing = entity,
+            guestAccessToken = guestAccessToken ?: entity.guestAccessToken,
+            now = System.currentTimeMillis()
+        ).copy(
+            localId = entity.localId,
+            remoteId = remoteId,
+            syncStatus = SyncStatus.SYNCED,
+            pendingError = null,
+            lastSyncedAtEpochMillis = System.currentTimeMillis()
+        )
+
+        database.helpRequestDao().upsert(synced)
+        if (synced.ownerType == LocalOwnerType.GUEST && guestAccessToken != null) {
+            saveGuestTrackedRequest(
+                GuestTrackedHelpRequest(
+                    requestId = remoteId,
+                    guestAccessToken = guestAccessToken
+                )
+            )
+        }
+        database.syncOperationDao().delete(operation.operationId)
+    }
+
+    internal suspend fun pushStatusOperation(operation: SyncOperationEntity, token: String?) {
+        val entity = database.helpRequestDao().getByLocalId(operation.entityId) ?: run {
+            database.syncOperationDao().delete(operation.operationId)
+            return
+        }
+        val remoteId = entity.remoteId ?: entity.localId.takeUnless { it.startsWith("local_") }
+        if (remoteId.isNullOrBlank()) {
+            // Creation has not reached the server yet. Leave the status operation queued behind it.
+            return
+        }
+
+        val nextStatus = JSONObject(operation.payloadJson).optString("status").ifBlank { entity.status }
+        val guestAccessToken = entity.guestAccessToken
+        val encodedGuestToken = guestAccessToken?.let { URLEncoder.encode(it, Charsets.UTF_8.name()) }
+        val path = if (entity.ownerType == LocalOwnerType.GUEST && encodedGuestToken != null) {
+            "/help-requests/$remoteId/status?guestAccessToken=$encodedGuestToken"
+        } else {
+            "/help-requests/$remoteId/status"
+        }
+
+        val response = JsonHttpClient.request(
+            path = path,
+            method = "PATCH",
+            token = token.takeIf { entity.ownerType == LocalOwnerType.AUTHENTICATED && !it.isNullOrBlank() },
+            body = JSONObject().put("status", nextStatus)
+        )
+
+        val remoteRequest = response.optJSONObject("request")
+            ?: throw ApiException("Server did not return the updated help request.", 200, "INVALID_RESPONSE")
+        upsertRemoteHelpRequest(
+            ownerType = entity.ownerType,
+            request = remoteRequest,
+            guestAccessToken = entity.guestAccessToken
+        )
+        database.syncOperationDao().delete(operation.operationId)
+    }
+
+    internal suspend fun refreshAuthenticatedHelpRequests(token: String) {
+        if (token.isBlank()) return
+        val response = JsonHttpClient.request(
+            path = "/help-requests",
+            token = token
+        )
+
+        val requests = response.optJSONArray("requests") ?: JSONArray()
+        for (index in 0 until requests.length()) {
+            val request = requests.optJSONObject(index) ?: continue
+            upsertRemoteHelpRequest(LocalOwnerType.AUTHENTICATED, request, guestAccessToken = null)
+        }
+    }
+
+    internal suspend fun refreshGuestHelpRequests() {
+        for (trackedRequest in getGuestTrackedRequests()) {
+            val request = fetchGuestHelpRequest(trackedRequest) ?: continue
+            upsertRemoteHelpRequest(
+                ownerType = LocalOwnerType.GUEST,
+                request = request,
+                guestAccessToken = trackedRequest.guestAccessToken
+            )
+        }
+    }
+
+    internal suspend fun upsertRemoteHelpRequest(
+        ownerType: String,
+        request: JSONObject,
+        guestAccessToken: String?
+    ) {
+        val remoteId = request.optString("id").takeIf { it.isNotBlank() } ?: return
+        val existing = database.helpRequestDao().getByRemoteId(remoteId)
+        val now = System.currentTimeMillis()
+
+        if (existing != null) {
+            val decision = SyncConflictPolicy.decideHelpRequestRemoteMerge(
+                localSyncStatus = existing.syncStatus,
+                localStatus = existing.status,
+                remoteStatus = request.optString("status").ifBlank { existing.status }
+            )
+
+            if (!decision.shouldApplyRemote) {
+                if (decision.nextSyncStatus == SyncStatus.CONFLICTED) {
+                    database.helpRequestDao().upsert(
+                        existing.copy(
+                            syncStatus = SyncStatus.CONFLICTED,
+                            pendingError = decision.reason,
+                            updatedAtEpochMillis = now
+                        )
+                    )
+                }
+                return
+            }
+        }
+
+        val mapped = request.toHelpRequestEntity(
+            ownerType = ownerType,
+            existing = existing,
+            guestAccessToken = guestAccessToken ?: existing?.guestAccessToken,
+            now = now
+        )
+        database.helpRequestDao().upsert(mapped)
+    }
+
+    internal fun ownerTypeForToken(token: String?): String {
+        return if (token.isNullOrBlank()) LocalOwnerType.GUEST else LocalOwnerType.AUTHENTICATED
+    }
+
     private fun saveGuestTrackedRequest(trackedRequest: GuestTrackedHelpRequest) {
         ensureInitialized()
 
@@ -193,6 +320,138 @@ object RequestHelpRepository {
     private fun ensureInitialized() {
         check(::prefs.isInitialized) {
             "RequestHelpRepository must be initialized before use."
+        }
+    }
+}
+
+internal fun RequestHelpSubmission.toJson(): JSONObject {
+    return JSONObject().apply {
+        put("helpTypes", JSONArray(helpTypes))
+        put("otherHelpText", otherHelpText)
+        put("affectedPeopleCount", affectedPeopleCount)
+        put("description", description)
+        put("riskFlags", JSONArray(riskFlags))
+        put("vulnerableGroups", JSONArray(vulnerableGroups))
+        put("bloodType", bloodType)
+        put(
+            "location",
+            JSONObject().apply {
+                put("country", location.country)
+                put("city", location.city)
+                put("district", location.district)
+                put("neighborhood", location.neighborhood)
+                put("extraAddress", location.extraAddress)
+            }
+        )
+        put(
+            "contact",
+            JSONObject().apply {
+                put("fullName", contact.fullName)
+                put("phone", contact.phone)
+                contact.alternativePhone?.let { put("alternativePhone", it) }
+            }
+        )
+        put("consentGiven", consentGiven)
+    }
+}
+
+internal fun RequestHelpSubmission.toEntity(
+    localId: String,
+    ownerType: String,
+    now: Long,
+    syncStatus: String
+): HelpRequestEntity {
+    return HelpRequestEntity(
+        localId = localId,
+        remoteId = null,
+        ownerType = ownerType,
+        guestAccessToken = null,
+        helpTypesJson = JSONArray(helpTypes).toString(),
+        otherHelpText = otherHelpText,
+        affectedPeopleCount = affectedPeopleCount,
+        riskFlagsJson = JSONArray(riskFlags).toString(),
+        vulnerableGroupsJson = JSONArray(vulnerableGroups).toString(),
+        description = description,
+        bloodType = bloodType,
+        country = location.country,
+        city = location.city,
+        district = location.district,
+        neighborhood = location.neighborhood,
+        extraAddress = location.extraAddress,
+        contactFullName = contact.fullName,
+        contactPhone = contact.phone.toString(),
+        contactAlternativePhone = contact.alternativePhone?.toString(),
+        status = PendingHelpRequestStatus,
+        helperFirstName = null,
+        helperLastName = null,
+        helperPhone = null,
+        helperProfession = null,
+        helperExpertise = null,
+        syncStatus = syncStatus,
+        pendingError = null,
+        createdAtEpochMillis = now,
+        updatedAtEpochMillis = now,
+        lastSyncedAtEpochMillis = null,
+        serverCreatedAt = null,
+        isDeleted = false
+    )
+}
+
+internal fun JSONObject.toHelpRequestEntity(
+    ownerType: String,
+    existing: HelpRequestEntity?,
+    guestAccessToken: String?,
+    now: Long
+): HelpRequestEntity {
+    val remoteId = optString("id").takeIf { it.isNotBlank() }
+    val location = optJSONObject("location") ?: JSONObject()
+    val contact = optJSONObject("contact") ?: JSONObject()
+    val helper = optJSONObject("helper")
+
+    return HelpRequestEntity(
+        localId = existing?.localId ?: remoteId ?: "remote_${UUID.randomUUID()}",
+        remoteId = remoteId,
+        ownerType = ownerType,
+        guestAccessToken = guestAccessToken,
+        helpTypesJson = optJSONArray("helpTypes").orEmptyJsonArrayString(),
+        otherHelpText = optString("otherHelpText"),
+        affectedPeopleCount = optInt("affectedPeopleCount", 1),
+        riskFlagsJson = optJSONArray("riskFlags").orEmptyJsonArrayString(),
+        vulnerableGroupsJson = optJSONArray("vulnerableGroups").orEmptyJsonArrayString(),
+        description = optString("description"),
+        bloodType = optString("bloodType"),
+        country = location.optString("country"),
+        city = location.optString("city"),
+        district = location.optString("district"),
+        neighborhood = location.optString("neighborhood"),
+        extraAddress = location.optString("extraAddress"),
+        contactFullName = contact.optString("fullName"),
+        contactPhone = contact.opt("phone")?.toString().orEmpty(),
+        contactAlternativePhone = contact.opt("alternativePhone")?.toString()?.takeIf { it.isNotBlank() && it != "null" },
+        status = optString("status").ifBlank { existing?.status ?: "SYNCED" },
+        helperFirstName = helper?.optString("firstName")?.takeIf { it.isNotBlank() },
+        helperLastName = helper?.optString("lastName")?.takeIf { it.isNotBlank() },
+        helperPhone = helper?.opt("phone")?.toString()?.takeIf { it.isNotBlank() && it != "null" },
+        helperProfession = helper?.optString("profession")?.takeIf { it.isNotBlank() },
+        helperExpertise = helper?.optString("expertise")?.takeIf { it.isNotBlank() },
+        syncStatus = SyncStatus.SYNCED,
+        pendingError = null,
+        createdAtEpochMillis = existing?.createdAtEpochMillis ?: now,
+        updatedAtEpochMillis = now,
+        lastSyncedAtEpochMillis = now,
+        serverCreatedAt = optString("createdAt").takeIf { it.isNotBlank() } ?: existing?.serverCreatedAt,
+        isDeleted = false
+    )
+}
+
+internal fun JSONArray?.orEmptyJsonArrayString(): String = (this ?: JSONArray()).toString()
+
+internal fun String.jsonArrayToStringList(): List<String> {
+    val json = runCatching { JSONArray(this) }.getOrNull() ?: return emptyList()
+    return buildList {
+        for (index in 0 until json.length()) {
+            val value = json.optString(index).trim()
+            if (value.isNotBlank()) add(value)
         }
     }
 }

--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
@@ -63,6 +63,7 @@ data class GuestTrackedHelpRequest(
 object RequestHelpRepository {
     private const val PrefsName = "neph_guest_help_requests"
     private const val GuestRequestsKey = "guest_requests"
+    private const val GuestHasLocalRequestsKey = "guest_has_local_requests"
 
     private lateinit var prefs: SharedPreferences
 
@@ -107,6 +108,9 @@ object RequestHelpRepository {
                 createdAtEpochMillis = now
             )
         )
+        if (ownerType == LocalOwnerType.GUEST) {
+            prefs.edit().putBoolean(GuestHasLocalRequestsKey, true).apply()
+        }
         OfflineSyncScheduler.enqueueSync(NephAppContext.get(), reason = "help-request-created")
 
         return CreateHelpRequestResult(requestId = localId, recordedLocally = true)
@@ -133,6 +137,11 @@ object RequestHelpRepository {
                 }
             }
         }
+    }
+
+    fun shouldOpenGuestRequestsOnStart(): Boolean {
+        ensureInitialized()
+        return prefs.getBoolean(GuestHasLocalRequestsKey, false) || getGuestTrackedRequests().isNotEmpty()
     }
 
     suspend fun fetchGuestHelpRequest(

--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
@@ -64,6 +64,8 @@ object RequestHelpRepository {
     private const val PrefsName = "neph_guest_help_requests"
     private const val GuestRequestsKey = "guest_requests"
     private const val GuestHasLocalRequestsKey = "guest_has_local_requests"
+    internal const val DeferredStatusSyncMessage =
+        "Waiting for the help request creation to sync before sending the status update."
 
     private lateinit var prefs: SharedPreferences
 
@@ -80,6 +82,19 @@ object RequestHelpRepository {
 
     suspend fun hasActiveHelpRequest(token: String): Boolean {
         ensureInitialized()
+
+        if (token.isNotBlank()) {
+            try {
+                refreshAuthenticatedHelpRequests(token)
+            } catch (error: ApiException) {
+                if (error.status == 401) {
+                    throw error
+                }
+            } catch (_: Exception) {
+                // Fall back to the last local snapshot when the network is unavailable.
+            }
+        }
+
         return database.helpRequestDao().countActiveByOwner(ownerTypeForToken(token)) > 0
     }
 
@@ -204,9 +219,15 @@ object RequestHelpRepository {
             database.syncOperationDao().delete(operation.operationId)
             return
         }
-        val remoteId = entity.remoteId ?: entity.localId.takeUnless { it.startsWith("local_") }
+        val remoteId = resolveRemoteRequestIdForSync(entity)
         if (remoteId.isNullOrBlank()) {
-            // Creation has not reached the server yet. Leave the status operation queued behind it.
+            database.syncOperationDao().updateStatus(
+                operationId = operation.operationId,
+                status = SyncOperationStatus.PENDING,
+                attemptCount = operation.attemptCount,
+                lastAttemptAtEpochMillis = operation.lastAttemptAtEpochMillis,
+                error = DeferredStatusSyncMessage
+            )
             return
         }
 
@@ -302,6 +323,10 @@ object RequestHelpRepository {
 
     internal fun ownerTypeForToken(token: String?): String {
         return if (token.isNullOrBlank()) LocalOwnerType.GUEST else LocalOwnerType.AUTHENTICATED
+    }
+
+    internal fun resolveRemoteRequestIdForSync(entity: HelpRequestEntity): String? {
+        return entity.remoteId ?: entity.localId.takeUnless { it.startsWith("local_") }
     }
 
     private fun saveGuestTrackedRequest(trackedRequest: GuestTrackedHelpRequest) {

--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -307,13 +307,13 @@ fun RequestHelpScreen(
             return@LaunchedEffect
         }
 
-        val hasActiveRequest = RequestHelpRepository.hasActiveHelpRequest(sessionToken)
-        if (hasActiveRequest) {
-            onNavigateToMyHelpRequests()
-            return@LaunchedEffect
-        }
-
         try {
+            val hasActiveRequest = RequestHelpRepository.hasActiveHelpRequest(sessionToken)
+            if (hasActiveRequest) {
+                onNavigateToMyHelpRequests()
+                return@LaunchedEffect
+            }
+
             val profile = ProfileRepository.fetchAndCacheRemoteProfile()
             formState = buildPrefilledForm(profile)
             infoMessage = ""
@@ -363,6 +363,14 @@ fun RequestHelpScreen(
                 )
                 infoMessage = "Help request saved on this device and queued for sync."
                 onNavigateToMyHelpRequests()
+            } catch (error: ApiException) {
+                if (error.status == 401) {
+                    AuthRepository.logout()
+                    errorMessage = "Your session expired. Please log in again before sending a help request."
+                    onNavigateToLogin()
+                } else {
+                    errorMessage = "Could not save your help request locally. Please try again."
+                }
             } catch (_: Exception) {
                 errorMessage = "Could not save your help request locally. Please try again."
             } finally {

--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -307,40 +307,27 @@ fun RequestHelpScreen(
             return@LaunchedEffect
         }
 
-        try {
-            val hasActiveRequest = RequestHelpRepository.hasActiveHelpRequest(sessionToken)
-            if (hasActiveRequest) {
-                onNavigateToMyHelpRequests()
-                return@LaunchedEffect
-            }
-        } catch (cancellationException: CancellationException) {
-            throw cancellationException
-        } catch (error: ApiException) {
-            if (error.status == 401) {
-                AuthRepository.logout()
-                errorMessage = "Your session expired. Please log in again before sending a help request."
-            } else {
-                errorMessage = "We could not verify your current help request status. Please try again."
-            }
-            return@LaunchedEffect
-        } catch (_: Exception) {
-            errorMessage = "We could not verify your current help request status. Please try again."
+        val hasActiveRequest = RequestHelpRepository.hasActiveHelpRequest(sessionToken)
+        if (hasActiveRequest) {
+            onNavigateToMyHelpRequests()
             return@LaunchedEffect
         }
 
         try {
             val profile = ProfileRepository.fetchAndCacheRemoteProfile()
             formState = buildPrefilledForm(profile)
+            infoMessage = ""
         } catch (cancellationException: CancellationException) {
             throw cancellationException
         } catch (error: ApiException) {
             if (error.status == 401) {
                 AuthRepository.logout()
                 errorMessage = "Your session expired. Please log in again before sending a help request."
-            } else {
-                formState = buildPrefilledForm(ProfileRepository.getProfile())
-                infoMessage = "Could not refresh profile details. Using saved information where available."
+                onNavigateToLogin()
+                return@LaunchedEffect
             }
+            formState = buildPrefilledForm(ProfileRepository.getProfile())
+            infoMessage = "Could not refresh profile details. Using saved information where available."
         } catch (_: Exception) {
             formState = buildPrefilledForm(ProfileRepository.getProfile())
             infoMessage = "Could not refresh profile details. Using saved information where available."
@@ -374,21 +361,10 @@ fun RequestHelpScreen(
                     token = sessionToken,
                     submission = buildSubmission(formState)
                 )
-                infoMessage = "Help request sent successfully."
-                onNavigateBack()
-            } catch (cancellationException: CancellationException) {
-                throw cancellationException
-            } catch (error: ApiException) {
-                if (error.status == 401) {
-                    AuthRepository.logout()
-                    errorMessage = "Your session expired. Please log in again to send your request."
-                    onNavigateToLogin()
-                    return@launch
-                } else {
-                    errorMessage = error.message.ifBlank { "Could not send your help request." }
-                }
+                infoMessage = "Help request saved on this device and queued for sync."
+                onNavigateToMyHelpRequests()
             } catch (_: Exception) {
-                errorMessage = "Something went wrong while sending your help request."
+                errorMessage = "Could not save your help request locally. Please try again."
             } finally {
                 loading = false
             }

--- a/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
@@ -2,6 +2,8 @@ package com.neph.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.navigation.NavType
 import androidx.navigation.NavHostController
 import androidx.navigation.navArgument
@@ -39,8 +41,9 @@ fun AppNavGraph(
     startDestination: String = Routes.Welcome.route
 ) {
     val verifyEmailRouteWithToken = "${Routes.VerifyEmail.route}?token={token}"
+    val accessToken by AuthSessionStore.accessTokenFlow.collectAsState()
 
-    fun isAuthenticated(): Boolean = AuthSessionStore.getAccessToken().isNullOrBlank().not()
+    fun isAuthenticated(): Boolean = accessToken.isNullOrBlank().not()
 
     fun navigateToLogin() {
         navController.navigate(Routes.Login.route) {

--- a/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
@@ -378,6 +378,7 @@ fun AppNavGraph(
                     navController.navigate(Routes.Signup.route)
                 },
                 onContinueAsGuest = {
+                    AuthSessionStore.setGuestMode(true)
                     navController.navigate(Routes.Home.route) {
                         popUpTo(Routes.Welcome.route) { inclusive = true }
                         launchSingleTop = true
@@ -412,6 +413,7 @@ fun AppNavGraph(
                     navController.navigate(Routes.ForgotPassword.route)
                 },
                 onContinueAsGuest = {
+                    AuthSessionStore.setGuestMode(true)
                     navController.navigate(Routes.Home.route) {
                         popUpTo(Routes.Welcome.route) { inclusive = true }
                         launchSingleTop = true

--- a/android/app/src/main/java/com/neph/ui/layout/AppDrawerScaffold.kt
+++ b/android/app/src/main/java/com/neph/ui/layout/AppDrawerScaffold.kt
@@ -44,13 +44,17 @@ import com.neph.navigation.Routes
 import com.neph.ui.theme.LocalNephSpacing
 import kotlinx.coroutines.launch
 
+internal fun sanitizeDrawerItems(drawerItems: List<Routes?>): List<Routes> {
+    return drawerItems.filterNotNull()
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppDrawerScaffold(
     title: String,
     currentRoute: String,
     onNavigateToRoute: (String) -> Unit,
-    drawerItems: List<Routes> = Routes.drawerItems,
+    drawerItems: List<Routes?> = Routes.drawerItems,
     modifier: Modifier = Modifier,
     onOpenSettings: (() -> Unit)? = null,
     onProfileClick: (() -> Unit)? = null,
@@ -65,6 +69,7 @@ fun AppDrawerScaffold(
     val spacing = LocalNephSpacing.current
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val scope = rememberCoroutineScope()
+    val safeDrawerItems = sanitizeDrawerItems(drawerItems)
 
     ModalNavigationDrawer(
         drawerState = drawerState,
@@ -82,7 +87,7 @@ fun AppDrawerScaffold(
 
                     Spacer(modifier = Modifier.height(spacing.lg))
 
-                    drawerItems.forEach { item ->
+                    safeDrawerItems.forEach { item ->
                         NavigationDrawerItem(
                             label = {
                                 Text(text = item.drawerLabel.orEmpty())

--- a/android/app/src/test/java/com/neph/core/sync/SyncConflictPolicyTest.kt
+++ b/android/app/src/test/java/com/neph/core/sync/SyncConflictPolicyTest.kt
@@ -1,0 +1,53 @@
+package com.neph.core.sync
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SyncConflictPolicyTest {
+    @Test
+    fun syncedLocalRowsAcceptRemoteState() {
+        val decision = SyncConflictPolicy.decideHelpRequestRemoteMerge(
+            localSyncStatus = SyncStatus.SYNCED,
+            localStatus = "SYNCED",
+            remoteStatus = "MATCHED"
+        )
+
+        assertTrue(decision.shouldApplyRemote)
+        assertEquals(SyncStatus.SYNCED, decision.nextSyncStatus)
+    }
+
+    @Test
+    fun pendingCreateDoesNotGetOverwrittenByRemoteRefresh() {
+        val decision = SyncConflictPolicy.decideHelpRequestRemoteMerge(
+            localSyncStatus = SyncStatus.PENDING_CREATE,
+            localStatus = "PENDING_SYNC",
+            remoteStatus = "SYNCED"
+        )
+
+        assertFalse(decision.shouldApplyRemote)
+        assertEquals(SyncStatus.PENDING_CREATE, decision.nextSyncStatus)
+    }
+
+    @Test
+    fun terminalRemoteMismatchBecomesExplicitConflict() {
+        val decision = SyncConflictPolicy.decideHelpRequestRemoteMerge(
+            localSyncStatus = SyncStatus.PENDING_UPDATE,
+            localStatus = "RESOLVED",
+            remoteStatus = "CANCELLED"
+        )
+
+        assertFalse(decision.shouldApplyRemote)
+        assertEquals(SyncStatus.CONFLICTED, decision.nextSyncStatus)
+        assertTrue(decision.reason.orEmpty().contains("cancelled"))
+    }
+
+    @Test
+    fun retryPolicyRetriesTransientErrorsOnlyWithinAttemptBudget() {
+        assertTrue(SyncConflictPolicy.shouldRetryHttpStatus(status = 0, attemptCount = 1))
+        assertTrue(SyncConflictPolicy.shouldRetryHttpStatus(status = 503, attemptCount = 2))
+        assertFalse(SyncConflictPolicy.shouldRetryHttpStatus(status = 409, attemptCount = 1))
+        assertFalse(SyncConflictPolicy.shouldRetryHttpStatus(status = 503, attemptCount = 5))
+    }
+}

--- a/android/app/src/test/java/com/neph/core/sync/SyncOperationRecoveryPolicyTest.kt
+++ b/android/app/src/test/java/com/neph/core/sync/SyncOperationRecoveryPolicyTest.kt
@@ -1,0 +1,57 @@
+package com.neph.core.sync
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SyncOperationRecoveryPolicyTest {
+    @Test
+    fun inProgressOperationAtOrBeyondRecoveryTimeoutIsStale() {
+        val now = 1_000_000L
+        val cutoff = SyncOperationRecoveryPolicy.staleInProgressCutoff(now)
+
+        assertTrue(
+            SyncOperationRecoveryPolicy.isStaleInProgress(
+                status = SyncOperationStatus.IN_PROGRESS,
+                lastAttemptAtEpochMillis = cutoff,
+                nowEpochMillis = now
+            )
+        )
+    }
+
+    @Test
+    fun recentInProgressOperationIsNotStale() {
+        val now = 1_000_000L
+        val recentAttempt = SyncOperationRecoveryPolicy.staleInProgressCutoff(now) + 1
+
+        assertFalse(
+            SyncOperationRecoveryPolicy.isStaleInProgress(
+                status = SyncOperationStatus.IN_PROGRESS,
+                lastAttemptAtEpochMillis = recentAttempt,
+                nowEpochMillis = now
+            )
+        )
+    }
+
+    @Test
+    fun inProgressOperationWithoutAttemptTimestampIsStale() {
+        assertTrue(
+            SyncOperationRecoveryPolicy.isStaleInProgress(
+                status = SyncOperationStatus.IN_PROGRESS,
+                lastAttemptAtEpochMillis = null,
+                nowEpochMillis = 1_000_000L
+            )
+        )
+    }
+
+    @Test
+    fun pendingOperationIsNotRecoveredByInProgressPolicy() {
+        assertFalse(
+            SyncOperationRecoveryPolicy.isStaleInProgress(
+                status = SyncOperationStatus.PENDING,
+                lastAttemptAtEpochMillis = null,
+                nowEpochMillis = 1_000_000L
+            )
+        )
+    }
+}

--- a/android/app/src/test/java/com/neph/features/requesthelp/data/RequestHelpOfflineMappingTest.kt
+++ b/android/app/src/test/java/com/neph/features/requesthelp/data/RequestHelpOfflineMappingTest.kt
@@ -1,0 +1,66 @@
+package com.neph.features.requesthelp.data
+
+import com.neph.core.sync.LocalOwnerType
+import com.neph.core.sync.SyncStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RequestHelpOfflineMappingTest {
+    @Test
+    fun submissionCreatesPendingLocalEntityForOfflineWrite() {
+        val submission = sampleSubmission()
+        val entity = submission.toEntity(
+            localId = "local-test",
+            ownerType = LocalOwnerType.GUEST,
+            now = 1234L,
+            syncStatus = SyncStatus.PENDING_CREATE
+        )
+
+        assertEquals("local-test", entity.localId)
+        assertEquals(LocalOwnerType.GUEST, entity.ownerType)
+        assertEquals(SyncStatus.PENDING_CREATE, entity.syncStatus)
+        assertEquals("PENDING_SYNC", entity.status)
+        assertEquals("Need water and medication", entity.description)
+        assertEquals(listOf("food_water", "first_aid"), entity.helpTypesJson.jsonArrayToStringList())
+        assertFalse(entity.isDeleted)
+    }
+
+    @Test
+    fun submissionJsonMatchesBackendContractForCreate() {
+        val json = sampleSubmission().toJson()
+
+        assertEquals(2, json.getJSONArray("helpTypes").length())
+        assertEquals("food_water", json.getJSONArray("helpTypes").getString(0))
+        assertEquals(3, json.getInt("affectedPeopleCount"))
+        assertEquals("Kadikoy", json.getJSONObject("location").getString("district"))
+        assertEquals(5551234567L, json.getJSONObject("contact").getLong("phone"))
+        assertTrue(json.getBoolean("consentGiven"))
+    }
+
+    private fun sampleSubmission(): RequestHelpSubmission {
+        return RequestHelpSubmission(
+            helpTypes = listOf("food_water", "first_aid"),
+            otherHelpText = "",
+            affectedPeopleCount = 3,
+            description = "Need water and medication",
+            riskFlags = listOf("Flooding"),
+            vulnerableGroups = listOf("Elderly"),
+            bloodType = "A+",
+            location = RequestHelpLocationSubmission(
+                country = "Turkey",
+                city = "Istanbul",
+                district = "Kadikoy",
+                neighborhood = "Moda",
+                extraAddress = "Near park"
+            ),
+            contact = RequestHelpContactSubmission(
+                fullName = "Ayse Yilmaz",
+                phone = 5551234567L,
+                alternativePhone = null
+            ),
+            consentGiven = true
+        )
+    }
+}

--- a/android/app/src/test/java/com/neph/ui/layout/AppDrawerScaffoldTest.kt
+++ b/android/app/src/test/java/com/neph/ui/layout/AppDrawerScaffoldTest.kt
@@ -1,0 +1,49 @@
+package com.neph.ui.layout
+
+import com.neph.navigation.Routes
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppDrawerScaffoldTest {
+    @Test
+    fun sanitizeDrawerItemsRemovesNullEntriesAndPreservesOrder() {
+        val sanitized = sanitizeDrawerItems(
+            listOf(
+                Routes.Home,
+                null,
+                Routes.News,
+                null,
+                Routes.MyHelpRequests
+            )
+        )
+
+        assertEquals(
+            listOf(
+                Routes.Home,
+                Routes.News,
+                Routes.MyHelpRequests
+            ),
+            sanitized
+        )
+    }
+
+    @Test
+    fun sanitizeDrawerItemsKeepsExistingDrawerListUnchanged() {
+        val sanitized = sanitizeDrawerItems(
+            listOf(
+                Routes.Home,
+                Routes.News,
+                Routes.MyHelpRequests
+            )
+        )
+
+        assertEquals(
+            listOf(
+                Routes.Home.route,
+                Routes.News.route,
+                Routes.MyHelpRequests.route
+            ),
+            sanitized.map { it.route }
+        )
+    }
+}

--- a/docs/android-offline-first-verification.md
+++ b/docs/android-offline-first-verification.md
@@ -1,0 +1,409 @@
+# Android offline-first verification guide
+
+Use this guide to manually prove the NEPH Android app's offline-first behavior against a local backend. The recommended setup is Docker Compose for backend + PostgreSQL, Android Studio for the emulator, and SQL or authenticated `curl` for server-side verification.
+
+This guide is intentionally local-first:
+
+- do **not** use production web or a production admin page
+- do **not** depend on any web admin UI
+- prefer the Android emulator with `http://10.0.2.2:3000/api`
+- verify backend sync with local PostgreSQL queries or authenticated `curl`
+
+## 1. Local backend setup
+
+From the repository root, start the local stack:
+
+```bash
+docker compose up --build
+```
+
+Expected URLs:
+
+- host machine backend API base: `http://localhost:3000/api`
+- Android emulator backend API base: `http://10.0.2.2:3000/api`
+
+To identify the PostgreSQL container:
+
+```bash
+docker ps
+```
+
+If you need to confirm the database name or user, inspect:
+
+- `docker-compose.yml`
+- `backend/.env.example`
+
+Current local defaults are:
+
+- database service: `postgres`
+- database name: `neph_db`
+- database user: `neph_user`
+- database password: `neph_pass`
+
+## 2. Android emulator setup
+
+1. Open `android/` in Android Studio.
+2. Let Gradle sync finish.
+3. Start an Android emulator.
+4. Run the debug app.
+
+The debug API base URL is configured in `android/app/build.gradle` and currently uses:
+
+```text
+http://10.0.2.2:3000/api
+```
+
+`10.0.2.2` is an Android emulator alias for the host machine's localhost. It does not work on a physical phone.
+
+In the current repo state, the debug API base URL is hardcoded in `android/app/build.gradle`. If the app is unexpectedly calling the wrong backend during verification, update that debug `API_BASE_URL` value and reinstall the debug app before testing again.
+
+The debug package name is:
+
+```text
+com.neph
+```
+
+## 3. Offline help request verification
+
+This flow proves that a help request can be created offline, survives restart, and syncs after reconnect.
+
+1. Start the backend with Docker Compose.
+2. Run the Android debug app on the emulator.
+3. Continue as guest or log in.
+4. Turn emulator network off.
+
+Preferred commands:
+
+```bash
+adb shell svc wifi disable
+adb shell svc data disable
+```
+
+If you need airplane mode instead, this sometimes works on emulators and some devices, but it is less reliable across Android versions and OEM builds:
+
+```bash
+adb shell settings put global airplane_mode_on 1
+adb shell am broadcast -a android.intent.action.AIRPLANE_MODE --ez state true
+```
+
+5. In the app, open **Request Help** and submit a help request.
+6. Expected Android result:
+   - the request is accepted locally
+   - a generic fatal network error is **not** shown
+   - the app shows local/offline persistence rather than dropping the request
+7. Open **My Help Requests**.
+8. Expected Android result:
+   - the request is still visible while offline
+   - its status should be consistent with the offline-first UI, for example pending/local messaging such as `Saved locally. NEPH will sync this change when the network is available.`
+9. Force-stop the app:
+
+```bash
+adb shell am force-stop com.neph
+```
+
+10. Reopen the app while still offline.
+11. Expected Android result:
+    - the pending request is still visible after restart
+12. Turn network back on:
+
+```bash
+adb shell svc wifi enable
+adb shell svc data enable
+```
+
+If you enabled airplane mode, reverse those settings:
+
+```bash
+adb shell settings put global airplane_mode_on 0
+adb shell am broadcast -a android.intent.action.AIRPLANE_MODE --ez state false
+```
+
+13. Wait for WorkManager sync, or open **My Help Requests** again to trigger sync-related refresh.
+14. Expected Android result:
+    - the pending request eventually leaves the local-only pending state
+    - the request appears on the backend when verified with SQL or `curl`
+
+## 4. Offline availability verification
+
+This flow proves that helper availability can be toggled offline, survives restart, and syncs after reconnect.
+
+Prerequisite for auth-required verification:
+
+- availability routes require authentication
+- login requires an existing user whose email is already verified
+- the authenticated availability flow should use a user with a completed profile, otherwise login can route to profile completion before returning to home
+- enable **Remember me** during login if you want the authenticated session to survive `adb shell am force-stop com.neph`
+- if you create a local user but do not have working SMTP in your local setup, mark the user verified directly in PostgreSQL before logging in:
+
+```sql
+UPDATE users
+SET is_email_verified = TRUE
+WHERE email = '<EMAIL>';
+```
+
+If the user does not already have a profile row, create or complete it before starting the offline availability flow. The app only shows the **Available to Help** card after a successful authenticated path back to `home`.
+
+1. Start the backend.
+2. Run the Android debug app on the emulator.
+3. Launch the app and go through the real authenticated path:
+   - `welcome`
+   - `login`
+   - tap **Continue with Email**
+   - enter email and password
+   - check **Remember me**
+   - log in until you land on `home`
+4. Confirm the **Available to Help** card is visible on the home screen.
+5. Turn emulator network off:
+
+```bash
+adb shell svc wifi disable
+adb shell svc data disable
+```
+
+6. Toggle **Available to Help** on or off while offline.
+7. Expected Android result:
+   - the toggle change is accepted offline
+   - the latest availability state remains visible locally
+   - the app shows local-save feedback such as `Availability saved locally and will sync when connected.` or `Unavailable status saved locally and will sync when connected.`
+   - the app may show pending-sync messaging such as `Pending sync — your latest availability is saved on this device.`
+8. Force-stop the app:
+
+```bash
+adb shell am force-stop com.neph
+```
+
+9. Reopen the app while still offline.
+10. Expected Android result:
+    - the availability state is preserved locally after restart
+    - the app returns to authenticated `home` instead of dropping back to `welcome`, which is why **Remember me** is required for this particular restart check
+11. Turn network back on:
+
+```bash
+adb shell svc wifi enable
+adb shell svc data enable
+```
+
+12. Wait for WorkManager sync after reconnect, then return to the home screen to confirm the synced state.
+13. Verify the backend state with SQL or authenticated `curl`.
+
+Troubleshooting for the authenticated availability flow:
+
+- If you land on **Complete Profile** instead of `home`, finish the profile once before starting the offline availability scenario.
+- If login says the email is not verified, update `users.is_email_verified = TRUE` and try again.
+- If the **Available to Help** card is missing, you are not on an authenticated `home` state.
+- If force-stop returns you to `welcome`, rerun the flow with **Remember me** enabled.
+- If reconnect does not sync an authenticated availability change, log in again before concluding the queue is broken. Auth-required sync work can remain pending after a session-expiry path.
+
+## 5. SQL verification
+
+Use local PostgreSQL queries instead of any admin page.
+
+First, identify the Postgres container:
+
+```bash
+docker ps
+```
+
+Then open `psql` inside the container, replacing `<POSTGRES_CONTAINER>` if needed:
+
+```bash
+docker exec -it <POSTGRES_CONTAINER> psql -U neph_user -d neph_db
+```
+
+If your local env overrides the defaults, use the values from `docker-compose.yml` or your local `.env`.
+
+### Help requests
+
+```sql
+SELECT request_id, user_id, description, status, created_at
+FROM help_requests
+ORDER BY created_at DESC
+LIMIT 10;
+```
+
+### Volunteer availability
+
+```sql
+SELECT volunteer_id, user_id, is_available, location_updated_at
+FROM volunteers
+ORDER BY location_updated_at DESC NULLS LAST
+LIMIT 10;
+```
+
+```sql
+SELECT availability_id, volunteer_id, is_available, stored_locally, synced_at
+FROM availability_records
+ORDER BY synced_at DESC
+LIMIT 20;
+```
+
+What to look for:
+
+- the offline-created help request eventually appears in `help_requests`
+- the volunteer's latest availability state appears in `volunteers`
+- availability sync writes appear in `availability_records`
+
+## 6. Authenticated `curl` verification
+
+Use `curl` when you want API-level confirmation instead of direct SQL.
+
+### Login
+
+```bash
+curl -s -X POST http://localhost:3000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "your@email.com",
+    "password": "yourpassword"
+  }' | jq
+```
+
+Notes:
+
+- the user must already exist
+- the user's email must already be verified, or login will fail
+- if local SMTP is not configured, you can verify a local test user directly in PostgreSQL:
+
+```sql
+UPDATE users
+SET is_email_verified = TRUE
+WHERE email = '<EMAIL>';
+```
+
+The response includes `accessToken`.
+
+### List help requests
+
+```bash
+curl -s http://localhost:3000/api/help-requests \
+  -H "Authorization: Bearer <ACCESS_TOKEN>" | jq
+```
+
+### Check availability status
+
+```bash
+curl -s http://localhost:3000/api/availability/status \
+  -H "Authorization: Bearer <ACCESS_TOKEN>" | jq
+```
+
+### Optional guest verification for a guest-created help request
+
+`POST /api/help-requests` is guest-accessible. Guest create responses include a `guestAccessToken`, and guest reads can use `x-help-request-access-token`.
+
+```bash
+curl -s http://localhost:3000/api/help-requests/<REQUEST_ID> \
+  -H "x-help-request-access-token: <GUEST_ACCESS_TOKEN>" | jq
+```
+
+## 7. Local Room database inspection
+
+The Android debug app uses the Room database:
+
+```text
+neph-offline.db
+```
+
+Optional commands for inspecting the local app database from a debuggable build:
+
+```bash
+adb shell run-as com.neph ls databases
+adb exec-out run-as com.neph cat databases/neph-offline.db > neph-offline.db
+sqlite3 neph-offline.db
+```
+
+Example SQLite queries:
+
+```sql
+.tables
+SELECT localId, remoteId, status, syncStatus, description FROM help_requests;
+SELECT * FROM availability_state;
+SELECT operationId, entityType, entityId, operationType, status, attemptCount, error FROM sync_operations;
+SELECT assignmentId, requestId, syncStatus, pendingError FROM assigned_requests;
+```
+
+For availability-focused verification, these local tables are the most useful checkpoints:
+
+- `availability_state` confirms the current local on/off state and sync status
+- `sync_operations` confirms that the offline toggle was queued before reconnect
+
+Notes:
+
+- prefer Android Studio Database Inspector when convenient
+- `run-as` works for debuggable builds and may not work the same way on every device
+
+## 8. Physical phone APK notes
+
+`10.0.2.2` only works on the Android emulator.
+
+For a physical phone, use one of these options instead:
+
+- your laptop LAN IP
+- `adb reverse`
+- a staging or production backend, only if you are intentionally doing integration testing there
+
+Get your laptop LAN IP on macOS:
+
+```bash
+ipconfig getifaddr en0
+```
+
+In the current repo state, the debug API base URL is hardcoded in `android/app/build.gradle`.
+
+For a physical phone test build, temporarily edit the debug `API_BASE_URL` in `android/app/build.gradle` to one of these values, then rebuild:
+
+- `http://<LAPTOP_IP>:3000/api` for LAN testing
+- `http://127.0.0.1:3000/api` when using `adb reverse`
+
+Install the APK:
+
+```bash
+adb install -r app/build/outputs/apk/debug/app-debug.apk
+```
+
+Example reverse port forwarding:
+
+```bash
+adb reverse tcp:3000 tcp:3000
+```
+
+Rebuild after changing the debug API base URL:
+
+```bash
+./gradlew :app:assembleDebug
+```
+
+Warnings:
+
+- `adb reverse` is per connected device and disappears after disconnect
+- `http://127.0.0.1:3000/api` with `adb reverse` is for a physical device path, while `http://10.0.2.2:3000/api` remains emulator-only
+- restore the debug `API_BASE_URL` in `android/app/build.gradle` after a physical-device test build so emulator verification keeps using the intended backend
+- do not use production unless you intentionally want production integration testing
+- this verification guide is designed for local Docker + emulator first
+
+## 9. Final acceptance checklist
+
+- [ ] Help request accepted offline
+- [ ] Request visible as pending
+- [ ] Request survives force-stop/reopen
+- [ ] Request appears in backend after reconnect
+- [ ] Availability toggle accepted offline
+- [ ] Availability persists after restart
+- [ ] Availability appears in backend after reconnect
+- [ ] No production web/admin required
+- [ ] Backend state confirmed with local SQL or authenticated `curl`
+
+## 10. Verification after doc changes
+
+Run:
+
+```bash
+git diff --check
+```
+
+If no Android code changed, no Gradle build is required.
+
+If Android code changes are made in the future, run:
+
+```bash
+cd android && ./gradlew :app:compileDebugKotlin
+```

--- a/docs/android-offline-first.md
+++ b/docs/android-offline-first.md
@@ -9,7 +9,7 @@ The Android client now treats local persistence as the canonical read source for
 | Help requests | `help_requests` Room table | Create request, mark request resolved | Local writes are queued as `sync_operations`. Creates keep a client `local_*` id until the server id arrives. Status conflicts with terminal server state become `CONFLICTED` instead of silently overwriting local intent. |
 | Helper availability | `availability_state` Room table | Toggle available/unavailable | Toggles are recorded locally and batched through `/availability/sync`. Latest local intent remains visible until sync succeeds. |
 | Assigned request | `assigned_requests` Room table | Release/cancel assignment | Release is queued as durable WorkManager-backed work. The assigned request remains visible with pending/failed sync state until backend reconciliation. |
-| Sync queue | `sync_operations` Room table | All queued mutations | Operations are replayed oldest-first. `IN_PROGRESS` operations are treated as recoverable after app/process interruption. |
+| Sync queue | `sync_operations` Room table | All queued mutations | Operations are replayed oldest-first. Stale `IN_PROGRESS` operations are reset to `PENDING` at sync start after a 15-minute recovery timeout so interrupted workers do not strand queued writes. |
 
 ## Runtime flow
 
@@ -17,7 +17,7 @@ The Android client now treats local persistence as the canonical read source for
 2. Screens observe Room-backed `Flow`s, so cached content renders immediately.
 3. User actions write to Room first with `PENDING_CREATE`, `PENDING_UPDATE`, or `PENDING_DELETE` metadata.
 4. `OfflineSyncScheduler` enqueues unique WorkManager work with connected-network constraints and exponential backoff.
-5. `OfflineSyncWorker` drains the queue, pushes pending writes, then pulls fresh help requests, availability, assigned request state, and guest-tracked requests.
+5. `OfflineSyncWorker` first recovers stale `IN_PROGRESS` rows older than 15 minutes back to `PENDING`, then drains the queue, pushes pending writes, and pulls fresh help requests, availability, assigned request state, and guest-tracked requests.
 6. Sync failures keep cached data visible and surface `FAILED`/`CONFLICTED` state in the UI with retry affordances where critical.
 7. Auth expiry (`401`) clears the local access token through an observable session store, keeps auth-required queued operations pending, and lets protected routes redirect back to login instead of silently failing.
 
@@ -42,6 +42,7 @@ New unit tests cover:
 - local help request entity creation and backend JSON payload mapping
 - conflict policy for remote terminal-state mismatches
 - retry policy for transient vs non-retryable sync failures
+- stale `IN_PROGRESS` recovery policy for interrupted sync attempts
 
 Run from `android/`:
 

--- a/docs/android-offline-first.md
+++ b/docs/android-offline-first.md
@@ -1,0 +1,56 @@
+# Android offline-first architecture
+
+The Android client now treats local persistence as the canonical read source for NEPH's emergency-critical mobile flows. Network calls synchronize Room state with the backend; Compose screens render cached Room data and queue writes locally before WorkManager pushes them.
+
+## Implemented data ownership
+
+| Domain | Local source of truth | Offline writes | Sync/conflict policy |
+| --- | --- | --- | --- |
+| Help requests | `help_requests` Room table | Create request, mark request resolved | Local writes are queued as `sync_operations`. Creates keep a client `local_*` id until the server id arrives. Status conflicts with terminal server state become `CONFLICTED` instead of silently overwriting local intent. |
+| Helper availability | `availability_state` Room table | Toggle available/unavailable | Toggles are recorded locally and batched through `/availability/sync`. Latest local intent remains visible until sync succeeds. |
+| Assigned request | `assigned_requests` Room table | Release/cancel assignment | Release is queued as durable WorkManager-backed work. The assigned request remains visible with pending/failed sync state until backend reconciliation. |
+| Sync queue | `sync_operations` Room table | All queued mutations | Operations are replayed oldest-first. `IN_PROGRESS` operations are treated as recoverable after app/process interruption. |
+
+## Runtime flow
+
+1. `MainActivity` initializes `NephDatabaseProvider`, repositories, and WorkManager sync without blocking startup on Room reads.
+2. Screens observe Room-backed `Flow`s, so cached content renders immediately.
+3. User actions write to Room first with `PENDING_CREATE`, `PENDING_UPDATE`, or `PENDING_DELETE` metadata.
+4. `OfflineSyncScheduler` enqueues unique WorkManager work with connected-network constraints and exponential backoff.
+5. `OfflineSyncWorker` drains the queue, pushes pending writes, then pulls fresh help requests, availability, assigned request state, and guest-tracked requests.
+6. Sync failures keep cached data visible and surface `FAILED`/`CONFLICTED` state in the UI with retry affordances where critical.
+7. Auth expiry (`401`) clears the local access token through an observable session store, keeps auth-required queued operations pending, and lets protected routes redirect back to login instead of silently failing.
+
+## Battery and disaster-use choices
+
+- One-time sync work is unique and delayed briefly to batch reconnect/toggle bursts.
+- Periodic sync runs every 30 minutes only when connected and battery is not low.
+- Critical writes do not block on network availability.
+- Cached data is not cleared when refresh fails.
+
+## Database and migration notes
+
+- New Room database: `neph-offline.db`, schema version `1`.
+- Existing SharedPreferences availability state is migrated into Room on first initialization.
+- There was no prior Room schema, so no Room migration class is required for this change.
+- New Gradle dependencies: Room runtime/ktx/compiler via KSP, WorkManager runtime-ktx, and unit-test dependencies.
+
+## Tests
+
+New unit tests cover:
+
+- local help request entity creation and backend JSON payload mapping
+- conflict policy for remote terminal-state mismatches
+- retry policy for transient vs non-retryable sync failures
+
+Run from `android/`:
+
+```bash
+./gradlew :app:testDebugUnitTest
+./gradlew :app:compileDebugKotlin
+```
+
+## Known limitations
+
+- Profile editing still uses the existing SharedPreferences-backed profile repository and online save path. The disaster-critical help request, availability, and assignment flows are Room/WorkManager offline-first.
+- There is no advanced conflict-resolution UI yet; conflicted records are preserved locally and labelled for review rather than discarded.


### PR DESCRIPTION
## Summary

  Implements Android offline-first support for emergency-critical mobile flows.

  The Android app now uses Room as the local source of truth for help requests, helper availability, assigned
  requests, and queued sync operations. User actions are written locally first and synchronized later through
  WorkManager with network constraints, periodic sync, retry/backoff behavior, and explicit pending/failed/
  conflicted UI states.

  ## What changed

  - Added Room database schema for offline-critical data
  - Added sync operation queue and conflict/retry policy
  - Added WorkManager scheduler/worker/coordinator for durable background sync
  - Refactored help request, availability, and assigned-request repositories to local-first writes
  - Updated Compose screens to observe local state and show pending/failed/conflicted sync states
  - Preserved auth-expiry recovery by clearing expired sessions and keeping auth-required queued writes
  pending
  - Migrated existing availability SharedPreferences state into Room asynchronously
  - Added offline-first documentation and focused unit tests

  ## Verification

I verified the Android offline-first flow against a local backend, and the result is mixed: **help requests are fully proven end-to-end**, while **availability is only partially proven because the authenticated restart step crashes the app**.

- **What passed**
  - Help request offline create worked: the app showed `Status: Saved offline, waiting to sync` and `Saved locally. NEPH will sync this change when the network is available.`
  - While offline, PostgreSQL had **no** row for that request.
  - After force-stop/reopen offline, the same pending request was still visible.
  - After reconnect, PostgreSQL got the new row and the UI changed to `Status: Awaiting match` with `Last synced: ...`.

- **What passed for availability**
  - Logged-in home screen showed the `Available to Help` card.
  - Offline toggle worked locally: the UI showed `Currently available`, `Availability saved locally and will sync when connected.`, and `Pending sync — your latest availability is saved on this device.`

- **What failed**
  - The authenticated offline restart step is blocked by a real app bug.
  - On force-stop + relaunch with remembered login, `com.neph` crashes with:
    - `java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String com.neph.navigation.Routes.getRoute()' on a null object reference`
    - stack rooted at `AppDrawerScaffold.kt:90`, reached from `HomeScreen.kt:120` / `AppNavGraph.kt:107`