### PR TITLE
 Add shared location infrastructure and hybrid location validation safeguards

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -81,6 +81,39 @@ The backend exposes these top-level paths:
 - `GET /api/profiles`
 - `GET /api/help-requests`
 - `GET /api/availability`
+- `GET /api/location`
+
+Location module endpoints:
+
+- `GET /api/location/tree?countryCode=TR`
+- `GET /api/location/search?q=<text>&countryCode=TR&limit=10`
+- `GET /api/location/reverse?lat=<number>&lon=<number>`
+
+Location payload compatibility:
+
+- Existing payloads for `PATCH /api/profiles/me/location` and `POST /api/help-requests` remain valid.
+- Hybrid payloads are also supported (administrative + coordinate fields together).
+
+Hybrid location payload example:
+
+```json
+{
+  "location": {
+    "country": "turkiye",
+    "city": "istanbul",
+    "district": "besiktas",
+    "neighborhood": "levazim",
+    "extraAddress": "Bina B",
+    "displayAddress": "Levazim, Besiktas, Bina B",
+    "coordinate": {
+      "latitude": 41.043,
+      "longitude": 29.009,
+      "source": "MANUAL_MAP_PIN",
+      "capturedAt": "2026-04-18T11:20:00.000Z"
+    }
+  }
+}
+```
 
 ## Environment notes
 
@@ -94,6 +127,13 @@ Important notes:
 
 - when backend runs on host and Postgres runs via Docker on the host machine, use `POSTGRES_HOST=localhost`
 - if backend later runs in the same Docker network as Postgres, use `POSTGRES_HOST=postgres`
+
+Location provider and cache env vars:
+
+- `NOMINATIM_BASE_URL` (default: `https://nominatim.openstreetmap.org`)
+- `LOCATION_HTTP_TIMEOUT_MS` (default: `4500`)
+- `LOCATION_CACHE_TTL_MS` (default: `300000`)
+- `LOCATION_CACHE_MAX_ENTRIES` (default: `500`)
 
 ## Shared API conventions
 

--- a/backend/src/modules/help-requests/repository.js
+++ b/backend/src/modules/help-requests/repository.js
@@ -27,13 +27,27 @@ function mapLocation(row) {
     return null;
   }
 
-  return {
+  const location = {
     country: row.country,
     city: row.city,
     district: row.district,
     neighborhood: row.neighborhood,
     extraAddress: row.extra_address || '',
   };
+
+  if (row.latitude != null && row.longitude != null) {
+    location.latitude = row.latitude;
+    location.longitude = row.longitude;
+    location.coordinate = {
+      latitude: row.latitude,
+      longitude: row.longitude,
+      accuracyMeters: null,
+      source: row.is_gps_location ? 'GPS' : null,
+      capturedAt: row.captured_at,
+    };
+  }
+
+  return location;
 }
 
 function mapContact(row) {
@@ -209,6 +223,15 @@ async function createHelpRequest(input) {
     let locationRow = null;
 
     if (input.location) {
+      const coordinate = input.location.coordinate || null;
+      const latitude = input.location.latitude ?? coordinate?.latitude ?? null;
+      const longitude = input.location.longitude ?? coordinate?.longitude ?? null;
+      const isGpsLocation = Boolean(
+        coordinate
+        && typeof coordinate.source === 'string'
+        && coordinate.source.toUpperCase().includes('GPS'),
+      );
+
       const locationResult = await client.query(
         `
           INSERT INTO request_locations (
@@ -245,10 +268,10 @@ async function createHelpRequest(input) {
           input.location.city,
           input.location.district,
           input.location.neighborhood,
-          input.location.extraAddress || null,
-          null,
-          null,
-          false,
+          input.location.displayAddress || input.location.extraAddress || null,
+          latitude,
+          longitude,
+          isGpsLocation,
           false,
         ],
       );

--- a/backend/src/modules/help-requests/validators.js
+++ b/backend/src/modules/help-requests/validators.js
@@ -262,6 +262,28 @@ function validateCreateHelpRequest(payload) {
       errors.push('`location.latitude` and `location.longitude` must be provided together.');
     }
 
+    if (
+      coordinate
+      && Object.prototype.hasOwnProperty.call(payload.location, 'latitude')
+      && Object.prototype.hasOwnProperty.call(payload.location.coordinate, 'latitude')
+      && payload.location.latitude !== null
+      && payload.location.coordinate.latitude !== null
+      && payload.location.latitude !== payload.location.coordinate.latitude
+    ) {
+      errors.push('`location.latitude` conflicts with `location.coordinate.latitude`.');
+    }
+
+    if (
+      coordinate
+      && Object.prototype.hasOwnProperty.call(payload.location, 'longitude')
+      && Object.prototype.hasOwnProperty.call(payload.location.coordinate, 'longitude')
+      && payload.location.longitude !== null
+      && payload.location.coordinate.longitude !== null
+      && payload.location.longitude !== payload.location.coordinate.longitude
+    ) {
+      errors.push('`location.longitude` conflicts with `location.coordinate.longitude`.');
+    }
+
     location = {
       country: validateRequiredString('location.country', payload.location.country, errors, {
         maxLength: 100,

--- a/backend/src/modules/help-requests/validators.js
+++ b/backend/src/modules/help-requests/validators.js
@@ -136,6 +136,55 @@ function validateOptionalPhoneNumber(fieldName, value, errors) {
   return value;
 }
 
+function validateCoordinateObject(fieldName, value, errors) {
+  if (value == null) {
+    return null;
+  }
+
+  if (!isPlainObject(value)) {
+    errors.push(`\`${fieldName}\` must be an object.`);
+    return null;
+  }
+
+  const latitudeProvided = Object.prototype.hasOwnProperty.call(value, 'latitude');
+  const longitudeProvided = Object.prototype.hasOwnProperty.call(value, 'longitude');
+
+  if (latitudeProvided !== longitudeProvided) {
+    errors.push(`\`${fieldName}.latitude\` and \`${fieldName}.longitude\` must be provided together.`);
+  }
+
+  const latitude = value.latitude;
+  const longitude = value.longitude;
+
+  if (latitudeProvided && latitude !== null && (typeof latitude !== 'number' || latitude < -90 || latitude > 90)) {
+    errors.push(`\`${fieldName}.latitude\` must be a number between -90 and 90.`);
+  }
+
+  if (longitudeProvided && longitude !== null && (typeof longitude !== 'number' || longitude < -180 || longitude > 180)) {
+    errors.push(`\`${fieldName}.longitude\` must be a number between -180 and 180.`);
+  }
+
+  let accuracyMeters = null;
+  if (Object.prototype.hasOwnProperty.call(value, 'accuracyMeters')) {
+    if (value.accuracyMeters !== null && (typeof value.accuracyMeters !== 'number' || value.accuracyMeters < 0)) {
+      errors.push(`\`${fieldName}.accuracyMeters\` must be a number greater than or equal to 0.`);
+    } else {
+      accuracyMeters = value.accuracyMeters;
+    }
+  }
+
+  const source = validateOptionalString(`${fieldName}.source`, value.source, errors, { maxLength: 40 });
+  const capturedAt = validateOptionalString(`${fieldName}.capturedAt`, value.capturedAt, errors, { maxLength: 80 });
+
+  return {
+    latitude: latitudeProvided ? latitude : null,
+    longitude: longitudeProvided ? longitude : null,
+    accuracyMeters,
+    source,
+    capturedAt,
+  };
+}
+
 function validateCreateHelpRequest(payload) {
   const errors = [];
   const warnings = [];
@@ -182,6 +231,37 @@ function validateCreateHelpRequest(payload) {
   if (!isPlainObject(payload.location)) {
     errors.push('`location` is required and must be an object.');
   } else {
+    const coordinate = validateCoordinateObject('location.coordinate', payload.location.coordinate, errors);
+
+    let latitude = null;
+    let longitude = null;
+
+    if (Object.prototype.hasOwnProperty.call(payload.location, 'latitude')) {
+      if (
+        payload.location.latitude !== null
+        && (typeof payload.location.latitude !== 'number' || payload.location.latitude < -90 || payload.location.latitude > 90)
+      ) {
+        errors.push('`location.latitude` must be a number between -90 and 90.');
+      } else {
+        latitude = payload.location.latitude;
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(payload.location, 'longitude')) {
+      if (
+        payload.location.longitude !== null
+        && (typeof payload.location.longitude !== 'number' || payload.location.longitude < -180 || payload.location.longitude > 180)
+      ) {
+        errors.push('`location.longitude` must be a number between -180 and 180.');
+      } else {
+        longitude = payload.location.longitude;
+      }
+    }
+
+    if ((latitude === null) !== (longitude === null)) {
+      errors.push('`location.latitude` and `location.longitude` must be provided together.');
+    }
+
     location = {
       country: validateRequiredString('location.country', payload.location.country, errors, {
         maxLength: 100,
@@ -198,6 +278,15 @@ function validateCreateHelpRequest(payload) {
       extraAddress: validateOptionalString('location.extraAddress', payload.location.extraAddress, errors, {
         maxLength: 500,
       }),
+      displayAddress: validateOptionalString('location.displayAddress', payload.location.displayAddress, errors, {
+        maxLength: 500,
+      }),
+      placeId: validateOptionalString('location.placeId', payload.location.placeId, errors, {
+        maxLength: 100,
+      }),
+      latitude,
+      longitude,
+      coordinate,
     };
   }
 

--- a/backend/src/modules/location/controller.js
+++ b/backend/src/modules/location/controller.js
@@ -1,0 +1,92 @@
+const {
+  getLocationTree,
+  searchLocations,
+  reverseGeocode,
+} = require('./service');
+const {
+  validateTreeQuery,
+  validateSearchQuery,
+  validateReverseQuery,
+} = require('./validators');
+
+function sendError(response, status, code, message) {
+  return response.status(status).json({ code, message });
+}
+
+function mapServiceError(response, error) {
+  if (error.code === 'GEOCODER_TIMEOUT') {
+    return sendError(response, 504, 'GEOCODER_TIMEOUT', 'Location provider timed out');
+  }
+
+  if (error.code === 'LOCATION_NOT_FOUND') {
+    return sendError(response, 404, 'LOCATION_NOT_FOUND', 'No location found for coordinates');
+  }
+
+  if (error.code === 'GEOCODER_UNAVAILABLE') {
+    return sendError(response, 503, 'GEOCODER_UNAVAILABLE', 'Location provider is unavailable');
+  }
+
+  console.error('location.controller failed', error);
+  return sendError(response, 500, 'INTERNAL_ERROR', 'Unexpected server error');
+}
+
+async function handleGetLocationTree(request, response) {
+  const validation = validateTreeQuery(request.query || {});
+  if (!validation.ok) {
+    return sendError(response, 400, validation.code, validation.message);
+  }
+
+  try {
+    const tree = await getLocationTree(validation.value.countryCode);
+
+    if (!tree) {
+      return sendError(response, 404, 'NOT_FOUND', 'No location tree found for countryCode');
+    }
+
+    return response.status(200).json({
+      countryCode: validation.value.countryCode,
+      tree,
+    });
+  } catch (error) {
+    return mapServiceError(response, error);
+  }
+}
+
+async function handleSearchLocation(request, response) {
+  const validation = validateSearchQuery(request.query || {});
+  if (!validation.ok) {
+    return sendError(response, 400, validation.code, validation.message);
+  }
+
+  try {
+    const items = await searchLocations(validation.value);
+    return response.status(200).json({ items });
+  } catch (error) {
+    return mapServiceError(response, error);
+  }
+}
+
+async function handleReverseLocation(request, response) {
+  const validation = validateReverseQuery(request.query || {});
+  if (!validation.ok) {
+    return sendError(response, 400, validation.code, validation.message);
+  }
+
+  try {
+    const item = await reverseGeocode(validation.value);
+
+    if (!item) {
+      return sendError(response, 404, 'LOCATION_NOT_FOUND', 'No location found for coordinates');
+    }
+
+    return response.status(200).json({ item });
+  } catch (error) {
+    return mapServiceError(response, error);
+  }
+}
+
+module.exports = {
+  handleGetLocationTree,
+  handleSearchLocation,
+  handleReverseLocation,
+};

--- a/backend/src/modules/location/routes.js
+++ b/backend/src/modules/location/routes.js
@@ -1,0 +1,17 @@
+const express = require('express');
+
+const {
+  handleGetLocationTree,
+  handleSearchLocation,
+  handleReverseLocation,
+} = require('./controller');
+
+const locationRouter = express.Router();
+
+locationRouter.get('/tree', handleGetLocationTree);
+locationRouter.get('/search', handleSearchLocation);
+locationRouter.get('/reverse', handleReverseLocation);
+
+module.exports = {
+  locationRouter,
+};

--- a/backend/src/modules/location/service.js
+++ b/backend/src/modules/location/service.js
@@ -1,0 +1,242 @@
+const DEFAULT_NOMINATIM_BASE_URL = 'https://nominatim.openstreetmap.org';
+const DEFAULT_TIMEOUT_MS = 4500;
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_CACHE_MAX_ENTRIES = 500;
+
+// Process-local cache for geocoder reads.
+// Purpose: cut repeated provider calls for identical short-term queries.
+// Scope: current Node.js process only (reset on restart, not shared across replicas).
+const locationCache = new Map();
+
+const staticLocationTree = {
+  TR: {
+    label: 'Turkey',
+    cities: {
+      istanbul: {
+        label: 'Istanbul',
+        districts: {
+          kadikoy: {
+            label: 'Kadikoy',
+            neighborhoods: [
+              { label: 'Bostanci', value: 'bostanci' },
+              { label: 'Erenkoy', value: 'erenkoy' },
+            ],
+          },
+          besiktas: {
+            label: 'Besiktas',
+            neighborhoods: [
+              { label: 'Balmumcu', value: 'balmumcu' },
+              { label: 'Kurucesme', value: 'kurucesme' },
+            ],
+          },
+        },
+      },
+      ankara: {
+        label: 'Ankara',
+        districts: {
+          cankaya: {
+            label: 'Cankaya',
+            neighborhoods: [
+              { label: 'Anittepe', value: 'anittepe' },
+            ],
+          },
+        },
+      },
+    },
+  },
+};
+
+function getNominatimBaseUrl() {
+  return process.env.NOMINATIM_BASE_URL || DEFAULT_NOMINATIM_BASE_URL;
+}
+
+function readPositiveNumberEnv(value, fallback, { integer = false } = {}) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return integer ? Math.floor(parsed) : parsed;
+}
+
+function getTimeoutMs() {
+  return readPositiveNumberEnv(process.env.LOCATION_HTTP_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
+}
+
+function getCacheTtlMs() {
+  return readPositiveNumberEnv(process.env.LOCATION_CACHE_TTL_MS, DEFAULT_CACHE_TTL_MS);
+}
+
+function getCacheMaxEntries() {
+  return readPositiveNumberEnv(process.env.LOCATION_CACHE_MAX_ENTRIES, DEFAULT_CACHE_MAX_ENTRIES, { integer: true });
+}
+
+function makeCacheKey(scope, value) {
+  return `${scope}:${value}`;
+}
+
+function readFromCache(cacheKey) {
+  const entry = locationCache.get(cacheKey);
+  if (!entry) {
+    return null;
+  }
+
+  if (entry.expiresAt <= Date.now()) {
+    locationCache.delete(cacheKey);
+    return null;
+  }
+
+  return entry.value;
+}
+
+function pruneCache() {
+  // 1) remove expired entries first, 2) enforce entry-count cap.
+  const now = Date.now();
+  for (const [key, entry] of locationCache.entries()) {
+    if (entry.expiresAt <= now) {
+      locationCache.delete(key);
+    }
+  }
+
+  const maxEntries = getCacheMaxEntries();
+  while (locationCache.size > maxEntries) {
+    const oldestKey = locationCache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    locationCache.delete(oldestKey);
+  }
+}
+
+function writeToCache(cacheKey, value) {
+  const expiresAt = Date.now() + getCacheTtlMs();
+  locationCache.set(cacheKey, { value, expiresAt });
+  pruneCache();
+}
+
+function mapNominatimItem(item) {
+  const address = item.address || {};
+
+  return {
+    placeId: String(item.place_id || ''),
+    displayName: item.display_name || '',
+    latitude: Number(item.lat),
+    longitude: Number(item.lon),
+    administrative: {
+      countryCode: (address.country_code || '').toUpperCase(),
+      country: address.country || '',
+      city: address.city || address.town || address.village || '',
+      district: address.county || address.state_district || address.municipality || '',
+      neighborhood: address.neighbourhood || address.suburb || '',
+      extraAddress: [address.road, address.house_number].filter(Boolean).join(' ').trim(),
+      postalCode: address.postcode || '',
+    },
+  };
+}
+
+async function fetchJsonFromNominatim(path, params) {
+  const url = new URL(path, getNominatimBaseUrl());
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.set(key, String(value));
+  });
+  url.searchParams.set('format', 'jsonv2');
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), getTimeoutMs());
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'neph-backend/0.1 location-module',
+        Accept: 'application/json',
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const error = new Error('GEOCODER_UNAVAILABLE');
+      error.code = 'GEOCODER_UNAVAILABLE';
+      throw error;
+    }
+
+    return await response.json();
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      const timeoutError = new Error('GEOCODER_TIMEOUT');
+      timeoutError.code = 'GEOCODER_TIMEOUT';
+      throw timeoutError;
+    }
+
+    if (error.code) {
+      throw error;
+    }
+
+    const wrapped = new Error('GEOCODER_UNAVAILABLE');
+    wrapped.code = 'GEOCODER_UNAVAILABLE';
+    throw wrapped;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function getLocationTree(countryCode) {
+  return staticLocationTree[countryCode] || null;
+}
+
+async function searchLocations({ q, countryCode, limit }) {
+  const cacheKey = makeCacheKey('search', `${countryCode.toUpperCase()}|${q.trim().toLowerCase()}|${limit}`);
+  const cached = readFromCache(cacheKey);
+  if (cached !== null) {
+    return cached;
+  }
+
+  const items = await fetchJsonFromNominatim('/search', {
+    q,
+    countrycodes: countryCode.toLowerCase(),
+    limit,
+    addressdetails: 1,
+  });
+
+  if (!Array.isArray(items)) {
+    return [];
+  }
+
+  const mapped = items.map(mapNominatimItem);
+  writeToCache(cacheKey, mapped);
+  return mapped;
+}
+
+async function reverseGeocode({ lat, lon }) {
+  const cacheKey = makeCacheKey('reverse', `${lat.toFixed(6)}|${lon.toFixed(6)}`);
+  const cached = readFromCache(cacheKey);
+  if (cached !== null) {
+    return cached;
+  }
+
+  const item = await fetchJsonFromNominatim('/reverse', {
+    lat,
+    lon,
+    addressdetails: 1,
+  });
+
+  if (!item || typeof item !== 'object') {
+    return null;
+  }
+
+  const mapped = mapNominatimItem(item);
+  writeToCache(cacheKey, mapped);
+  return mapped;
+}
+
+function __resetLocationCache() {
+  // Test helper: keep deterministic assertions by clearing process-local cache.
+  // Do not call this from runtime request handlers.
+  locationCache.clear();
+}
+
+module.exports = {
+  getLocationTree,
+  searchLocations,
+  reverseGeocode,
+  __resetLocationCache,
+};

--- a/backend/src/modules/location/validators.js
+++ b/backend/src/modules/location/validators.js
@@ -1,0 +1,122 @@
+function parseLimit(value, fallback, max) {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return Math.min(parsed, max);
+}
+
+const MAX_SEARCH_QUERY_LENGTH = 120;
+
+function readString(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+}
+
+function validateTreeQuery(query) {
+  const countryCode = readString(query.countryCode || 'TR').toUpperCase();
+
+  if (!/^[A-Z]{2}$/.test(countryCode)) {
+    return {
+      ok: false,
+      code: 'VALIDATION_ERROR',
+      message: 'countryCode must be a 2-letter ISO code',
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      countryCode,
+    },
+  };
+}
+
+function validateSearchQuery(query) {
+  const q = readString(query.q);
+  if (q.length < 2) {
+    return {
+      ok: false,
+      code: 'VALIDATION_ERROR',
+      message: 'q must be at least 2 characters long',
+    };
+  }
+
+  if (q.length > MAX_SEARCH_QUERY_LENGTH) {
+    return {
+      ok: false,
+      code: 'VALIDATION_ERROR',
+      message: `q must be at most ${MAX_SEARCH_QUERY_LENGTH} characters long`,
+    };
+  }
+
+  const countryCode = readString(query.countryCode || 'TR').toUpperCase();
+  if (!/^[A-Z]{2}$/.test(countryCode)) {
+    return {
+      ok: false,
+      code: 'VALIDATION_ERROR',
+      message: 'countryCode must be a 2-letter ISO code',
+    };
+  }
+
+  const limit = parseLimit(query.limit, 10, 20);
+  if (limit === null) {
+    return {
+      ok: false,
+      code: 'VALIDATION_ERROR',
+      message: 'limit must be a positive integer',
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      q,
+      countryCode,
+      limit,
+    },
+  };
+}
+
+function validateReverseQuery(query) {
+  const lat = Number(query.lat);
+  const lon = Number(query.lon);
+
+  if (!Number.isFinite(lat) || lat < -90 || lat > 90) {
+    return {
+      ok: false,
+      code: 'VALIDATION_ERROR',
+      message: 'lat must be a number between -90 and 90',
+    };
+  }
+
+  if (!Number.isFinite(lon) || lon < -180 || lon > 180) {
+    return {
+      ok: false,
+      code: 'VALIDATION_ERROR',
+      message: 'lon must be a number between -180 and 180',
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      lat,
+      lon,
+    },
+  };
+}
+
+module.exports = {
+  validateTreeQuery,
+  validateSearchQuery,
+  validateReverseQuery,
+};

--- a/backend/src/modules/profiles/repository.js
+++ b/backend/src/modules/profiles/repository.js
@@ -30,6 +30,10 @@ function isPlainObject(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+function hasOwn(object, key) {
+  return isPlainObject(object) && Object.prototype.hasOwnProperty.call(object, key);
+}
+
 function buildAddressFromAdministrative(administrative) {
   if (!isPlainObject(administrative)) {
     return null;
@@ -271,11 +275,18 @@ async function upsertHealthInfo(profileId, data, providedFields = []) {
 
 async function upsertLocationProfile(profileId, data, providedFields = []) {
   const provided = new Set(providedFields);
-  const hasAddress = provided.has('address') || provided.has('displayAddress') || provided.has('administrative');
-  const hasCity = provided.has('city') || provided.has('administrative');
-  const hasCountry = provided.has('country') || provided.has('administrative');
-  const hasLatitude = provided.has('latitude') || provided.has('coordinate');
-  const hasLongitude = provided.has('longitude') || provided.has('coordinate');
+  const administrative = isPlainObject(data.administrative) ? data.administrative : null;
+  const coordinate = isPlainObject(data.coordinate) ? data.coordinate : null;
+  const hasAddress =
+    provided.has('address')
+    || provided.has('displayAddress')
+    || hasOwn(administrative, 'neighborhood')
+    || hasOwn(administrative, 'district')
+    || hasOwn(administrative, 'extraAddress');
+  const hasCity = provided.has('city') || hasOwn(administrative, 'city');
+  const hasCountry = provided.has('country') || hasOwn(administrative, 'country');
+  const hasLatitude = provided.has('latitude') || hasOwn(coordinate, 'latitude');
+  const hasLongitude = provided.has('longitude') || hasOwn(coordinate, 'longitude');
   const normalizedLocation = normalizeLocationInput(data);
 
   const sql = `

--- a/backend/src/modules/profiles/repository.js
+++ b/backend/src/modules/profiles/repository.js
@@ -26,6 +26,45 @@ function serializeExpertiseAreas(expertiseAreas) {
   return JSON.stringify(expertiseAreas || []);
 }
 
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function buildAddressFromAdministrative(administrative) {
+  if (!isPlainObject(administrative)) {
+    return null;
+  }
+
+  const parts = [administrative.neighborhood, administrative.district, administrative.extraAddress]
+    .filter((item) => typeof item === 'string' && item.trim() !== '')
+    .map((item) => item.trim());
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return parts.join(', ');
+}
+
+function normalizeLocationInput(data) {
+  const administrative = isPlainObject(data.administrative) ? data.administrative : null;
+  const coordinate = isPlainObject(data.coordinate) ? data.coordinate : null;
+
+  const address = data.displayAddress ?? data.address ?? buildAddressFromAdministrative(administrative);
+  const city = data.city ?? administrative?.city ?? null;
+  const country = data.country ?? administrative?.country ?? null;
+  const latitude = data.latitude ?? coordinate?.latitude ?? null;
+  const longitude = data.longitude ?? coordinate?.longitude ?? null;
+
+  return {
+    address,
+    city,
+    country,
+    latitude,
+    longitude,
+  };
+}
+
 async function findActiveUserById(userId) {
   const sql = `
     SELECT user_id
@@ -232,11 +271,12 @@ async function upsertHealthInfo(profileId, data, providedFields = []) {
 
 async function upsertLocationProfile(profileId, data, providedFields = []) {
   const provided = new Set(providedFields);
-  const hasAddress = provided.has('address');
-  const hasCity = provided.has('city');
-  const hasCountry = provided.has('country');
-  const hasLatitude = provided.has('latitude');
-  const hasLongitude = provided.has('longitude');
+  const hasAddress = provided.has('address') || provided.has('displayAddress') || provided.has('administrative');
+  const hasCity = provided.has('city') || provided.has('administrative');
+  const hasCountry = provided.has('country') || provided.has('administrative');
+  const hasLatitude = provided.has('latitude') || provided.has('coordinate');
+  const hasLongitude = provided.has('longitude') || provided.has('coordinate');
+  const normalizedLocation = normalizeLocationInput(data);
 
   const sql = `
     INSERT INTO location_profiles (
@@ -263,11 +303,11 @@ async function upsertLocationProfile(profileId, data, providedFields = []) {
   const values = [
     makeId('loc'),
     profileId,
-    data.address ?? null,
-    data.city ?? null,
-    data.country ?? null,
-    data.latitude ?? null,
-    data.longitude ?? null,
+    normalizedLocation.address,
+    normalizedLocation.city,
+    normalizedLocation.country,
+    normalizedLocation.latitude,
+    normalizedLocation.longitude,
     hasAddress,
     hasCity,
     hasCountry,

--- a/backend/src/modules/profiles/service.js
+++ b/backend/src/modules/profiles/service.js
@@ -43,10 +43,30 @@ function mapProfileRow(row) {
     },
     locationProfile: {
       address: row.address,
+      displayAddress: row.address,
       city: row.city,
       country: row.country,
       latitude: row.latitude,
       longitude: row.longitude,
+      administrative: {
+        countryCode: null,
+        country: row.country,
+        city: row.city,
+        district: null,
+        neighborhood: null,
+        extraAddress: row.address,
+        postalCode: null,
+      },
+      coordinate: row.latitude === null || row.longitude === null
+        ? null
+        : {
+            latitude: row.latitude,
+            longitude: row.longitude,
+            accuracyMeters: null,
+            source: null,
+            capturedAt: row.last_updated,
+          },
+      placeId: null,
       lastUpdated: row.last_updated,
     },
   };

--- a/backend/src/modules/profiles/validators.js
+++ b/backend/src/modules/profiles/validators.js
@@ -188,6 +188,26 @@ function validateLocationPatch(body) {
     ) {
       return { ok: false, code: 'VALIDATION_ERROR', message: 'coordinate.capturedAt must be a string or null' };
     }
+
+    if (
+      Object.prototype.hasOwnProperty.call(data, 'latitude')
+      && Object.prototype.hasOwnProperty.call(data.coordinate, 'latitude')
+      && data.latitude !== null
+      && data.coordinate.latitude !== null
+      && data.latitude !== data.coordinate.latitude
+    ) {
+      return { ok: false, code: 'VALIDATION_ERROR', message: 'latitude conflicts with coordinate.latitude' };
+    }
+
+    if (
+      Object.prototype.hasOwnProperty.call(data, 'longitude')
+      && Object.prototype.hasOwnProperty.call(data.coordinate, 'longitude')
+      && data.longitude !== null
+      && data.coordinate.longitude !== null
+      && data.longitude !== data.coordinate.longitude
+    ) {
+      return { ok: false, code: 'VALIDATION_ERROR', message: 'longitude conflicts with coordinate.longitude' };
+    }
   }
 
   const latitudeProvided = Object.prototype.hasOwnProperty.call(data, 'latitude');

--- a/backend/src/modules/profiles/validators.js
+++ b/backend/src/modules/profiles/validators.js
@@ -117,10 +117,77 @@ function validateLocationPatch(body) {
     return { ok: false, code: 'VALIDATION_ERROR', message: 'Payload must be an object' };
   }
 
-  const data = pickAllowed(body, ['address', 'city', 'country', 'latitude', 'longitude']);
+  const data = pickAllowed(body, [
+    'address',
+    'city',
+    'country',
+    'latitude',
+    'longitude',
+    'displayAddress',
+    'placeId',
+    'administrative',
+    'coordinate',
+  ]);
 
   if (Object.keys(data).length === 0) {
     return { ok: false, code: 'VALIDATION_ERROR', message: 'At least one location field must be provided' };
+  }
+
+  if (data.administrative !== undefined && !isPlainObject(data.administrative)) {
+    return { ok: false, code: 'VALIDATION_ERROR', message: 'administrative must be an object' };
+  }
+
+  if (data.coordinate !== undefined && !isPlainObject(data.coordinate)) {
+    return { ok: false, code: 'VALIDATION_ERROR', message: 'coordinate must be an object' };
+  }
+
+  if (isPlainObject(data.coordinate)) {
+    const coordinateHasLatitude = Object.prototype.hasOwnProperty.call(data.coordinate, 'latitude');
+    const coordinateHasLongitude = Object.prototype.hasOwnProperty.call(data.coordinate, 'longitude');
+
+    if (coordinateHasLatitude !== coordinateHasLongitude) {
+      return { ok: false, code: 'VALIDATION_ERROR', message: 'coordinate.latitude and coordinate.longitude must be provided together' };
+    }
+
+    if (
+      coordinateHasLatitude
+      && data.coordinate.latitude !== null
+      && (typeof data.coordinate.latitude !== 'number' || data.coordinate.latitude < -90 || data.coordinate.latitude > 90)
+    ) {
+      return { ok: false, code: 'VALIDATION_ERROR', message: 'coordinate.latitude must be between -90 and 90' };
+    }
+
+    if (
+      coordinateHasLongitude
+      && data.coordinate.longitude !== null
+      && (typeof data.coordinate.longitude !== 'number' || data.coordinate.longitude < -180 || data.coordinate.longitude > 180)
+    ) {
+      return { ok: false, code: 'VALIDATION_ERROR', message: 'coordinate.longitude must be between -180 and 180' };
+    }
+
+    if (
+      Object.prototype.hasOwnProperty.call(data.coordinate, 'accuracyMeters')
+      && data.coordinate.accuracyMeters !== null
+      && (typeof data.coordinate.accuracyMeters !== 'number' || data.coordinate.accuracyMeters < 0)
+    ) {
+      return { ok: false, code: 'VALIDATION_ERROR', message: 'coordinate.accuracyMeters must be a number >= 0' };
+    }
+
+    if (
+      Object.prototype.hasOwnProperty.call(data.coordinate, 'source')
+      && data.coordinate.source !== null
+      && typeof data.coordinate.source !== 'string'
+    ) {
+      return { ok: false, code: 'VALIDATION_ERROR', message: 'coordinate.source must be a string or null' };
+    }
+
+    if (
+      Object.prototype.hasOwnProperty.call(data.coordinate, 'capturedAt')
+      && data.coordinate.capturedAt !== null
+      && typeof data.coordinate.capturedAt !== 'string'
+    ) {
+      return { ok: false, code: 'VALIDATION_ERROR', message: 'coordinate.capturedAt must be a string or null' };
+    }
   }
 
   const latitudeProvided = Object.prototype.hasOwnProperty.call(data, 'latitude');
@@ -138,9 +205,21 @@ function validateLocationPatch(body) {
     return { ok: false, code: 'VALIDATION_ERROR', message: 'longitude must be between -180 and 180' };
   }
 
-  for (const field of ['address', 'city', 'country']) {
+  for (const field of ['address', 'city', 'country', 'displayAddress', 'placeId']) {
     if (data[field] !== undefined && data[field] !== null && typeof data[field] !== 'string') {
       return { ok: false, code: 'VALIDATION_ERROR', message: `${field} must be a string or null` };
+    }
+  }
+
+  if (isPlainObject(data.administrative)) {
+    for (const field of ['countryCode', 'country', 'city', 'district', 'neighborhood', 'extraAddress', 'postalCode']) {
+      if (
+        Object.prototype.hasOwnProperty.call(data.administrative, field)
+        && data.administrative[field] !== null
+        && typeof data.administrative[field] !== 'string'
+      ) {
+        return { ok: false, code: 'VALIDATION_ERROR', message: `administrative.${field} must be a string or null` };
+      }
     }
   }
 

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -4,13 +4,14 @@ const { authRouter } = require('../modules/auth/routes');
 const { profilesRouter } = require('../modules/profiles/routes');
 const { helpRequestsRouter } = require('../modules/help-requests/routes');
 const { availabilityRouter } = require('../modules/availability/routes');
+const { locationRouter } = require('../modules/location/routes');
 
 const apiRouter = express.Router();
 
 apiRouter.get('/', (_request, response) => {
   response.status(200).json({
     name: 'Neighborhood Emergency Preparedness Hub API',
-    modules: ['auth', 'profiles', 'help-requests', 'availability'],
+    modules: ['auth', 'profiles', 'help-requests', 'availability', 'location'],
   });
 });
 
@@ -18,6 +19,7 @@ apiRouter.use('/auth', authRouter);
 apiRouter.use('/profiles', profilesRouter);
 apiRouter.use('/help-requests', helpRequestsRouter);
 apiRouter.use('/availability', availabilityRouter);
+apiRouter.use('/location', locationRouter);
 
 module.exports = {
   apiRouter,

--- a/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
+++ b/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
@@ -166,6 +166,9 @@ describe('help-requests integration', () => {
 		expect(response.body.request.vulnerableGroups).toEqual(payload.vulnerableGroups);
 		expect(response.body.request.bloodType).toBe(payload.bloodType);
 		expect(response.body.request.location).toEqual(payload.location);
+		expect(response.body.request.location).not.toHaveProperty('coordinate');
+		expect(response.body.request.location).not.toHaveProperty('latitude');
+		expect(response.body.request.location).not.toHaveProperty('longitude');
 		expect(response.body.request.contact).toEqual(payload.contact);
 		expect(response.body.request.consentGiven).toBe(true);
 		expect(response.body.request.needType).toBe('first_aid');
@@ -208,6 +211,50 @@ describe('help-requests integration', () => {
 		expect(response.body.request.location.extraAddress).toBe('Need entry from the back');
 		expect(response.body.request.contact.phone).toBe(5052318546);
 		expect(response.body.request.contact.alternativePhone).toBe(5321234567);
+	});
+
+	test('POST /api/help-requests accepts hybrid location payload with coordinate object', async () => {
+		const app = createTestApp();
+		const userId = 'user_hr_hybrid_1';
+		await seedActiveUser(userId, 'hrhybrid1@example.com');
+		const token = buildAuthToken(userId);
+
+		const payload = buildCreatePayload({
+			location: {
+				country: 'turkiye',
+				city: 'istanbul',
+				district: 'besiktas',
+				neighborhood: 'levazim',
+				extraAddress: 'Bina B',
+				displayAddress: 'Levazim, Besiktas, Bina B',
+				coordinate: {
+					latitude: 41.043,
+					longitude: 29.009,
+					source: 'MANUAL_MAP_PIN',
+					capturedAt: '2026-04-18T11:20:00.000Z',
+				},
+			},
+		});
+
+		const response = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${token}`)
+			.send(payload);
+
+		expect(response.status).toBe(201);
+		expect(response.body.request.location.country).toBe('turkiye');
+		expect(response.body.request.location.city).toBe('istanbul');
+		expect(response.body.request.location.latitude).toBeCloseTo(41.043, 6);
+		expect(response.body.request.location.longitude).toBeCloseTo(29.009, 6);
+		expect(response.body.request.location.coordinate).toBeTruthy();
+		expect(response.body.request.location).toHaveProperty('coordinate');
+		expect(response.body.request.location).toHaveProperty('latitude');
+		expect(response.body.request.location).toHaveProperty('longitude');
+		expect(response.body.request.location.coordinate.latitude).toBeCloseTo(41.043, 6);
+		expect(response.body.request.location.coordinate.longitude).toBeCloseTo(29.009, 6);
+		expect(response.body.request.location.coordinate.source).toBeNull();
+		expect(response.body.request.location.coordinate.capturedAt).toEqual(expect.any(String));
+		expect(response.body.request.location.extraAddress).toBe('Levazim, Besiktas, Bina B');
 	});
 
 	test('POST /api/help-requests returns 400 for invalid payload', async () => {

--- a/backend/tests/integration/modules/location/location.integration.test.js
+++ b/backend/tests/integration/modules/location/location.integration.test.js
@@ -1,0 +1,217 @@
+'use strict';
+
+const request = require('supertest');
+
+jest.mock('../../../../src/modules/auth/routes', () => ({
+  authRouter: require('express').Router(),
+}));
+
+jest.mock('../../../../src/modules/profiles/routes', () => ({
+  profilesRouter: require('express').Router(),
+}));
+
+jest.mock('../../../../src/modules/help-requests/routes', () => ({
+  helpRequestsRouter: require('express').Router(),
+}));
+
+jest.mock('../../../../src/modules/availability/routes', () => ({
+  availabilityRouter: require('express').Router(),
+}));
+
+const { createApp } = require('../../../../src/app');
+const locationService = require('../../../../src/modules/location/service');
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  locationService.__resetLocationCache();
+  global.fetch = jest.fn();
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+describe('location integration', () => {
+  test('GET /api/location/tree returns tree for TR', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .get('/api/location/tree?countryCode=TR');
+
+    expect(response.status).toBe(200);
+    expect(response.body.countryCode).toBe('TR');
+    expect(response.body.tree).toBeTruthy();
+    expect(response.body.tree.cities).toBeTruthy();
+  });
+
+  test('GET /api/location/tree returns 404 for unknown countryCode', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .get('/api/location/tree?countryCode=DE');
+
+    expect(response.status).toBe(404);
+    expect(response.body.code).toBe('NOT_FOUND');
+  });
+
+  test('GET /api/location/search validates q', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .get('/api/location/search?q=a&countryCode=TR');
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('GET /api/location/search rejects overly long q', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .get(`/api/location/search?q=${'a'.repeat(121)}&countryCode=TR`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+    expect(response.body.message).toContain('at most 120 characters');
+  });
+
+  test('GET /api/location/reverse validates coordinates', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .get('/api/location/reverse?lat=120&lon=20');
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('GET /api/location/search returns mapped results', async () => {
+    const app = createApp();
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ([
+        {
+          place_id: 12345,
+          display_name: 'Kadikoy, Istanbul, Turkey',
+          lat: '40.9909',
+          lon: '29.0303',
+          address: {
+            country_code: 'tr',
+            country: 'Turkey',
+            city: 'Istanbul',
+            county: 'Kadikoy',
+            neighbourhood: 'Moda',
+            postcode: '34710',
+          },
+        },
+      ]),
+    });
+
+    const response = await request(app)
+      .get('/api/location/search?q=Kadikoy&countryCode=TR&limit=5');
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(1);
+    expect(response.body.items[0].placeId).toBe('12345');
+    expect(response.body.items[0].latitude).toBeCloseTo(40.9909, 6);
+    expect(response.body.items[0].longitude).toBeCloseTo(29.0303, 6);
+    expect(response.body.items[0].administrative.city).toBe('Istanbul');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('GET /api/location/reverse returns mapped item', async () => {
+    const app = createApp();
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        place_id: 67890,
+        display_name: 'Besiktas, Istanbul, Turkey',
+        lat: '41.0430',
+        lon: '29.0090',
+        address: {
+          country_code: 'tr',
+          country: 'Turkey',
+          city: 'Istanbul',
+          county: 'Besiktas',
+          suburb: 'Levent',
+          road: 'Buyukdere Cd.',
+          postcode: '34330',
+        },
+      }),
+    });
+
+    const response = await request(app)
+      .get('/api/location/reverse?lat=41.043&lon=29.009');
+
+    expect(response.status).toBe(200);
+    expect(response.body.item.placeId).toBe('67890');
+    expect(response.body.item.administrative.district).toBe('Besiktas');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('GET /api/location/search uses in-memory cache for identical queries', async () => {
+    const app = createApp();
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ([
+        {
+          place_id: 33333,
+          display_name: 'Cankaya, Ankara, Turkey',
+          lat: '39.9208',
+          lon: '32.8541',
+          address: {
+            country_code: 'tr',
+            country: 'Turkey',
+            city: 'Ankara',
+            county: 'Cankaya',
+          },
+        },
+      ]),
+    });
+
+    const firstResponse = await request(app)
+      .get('/api/location/search?q=Cankaya&countryCode=TR&limit=5');
+
+    const secondResponse = await request(app)
+      .get('/api/location/search?q=Cankaya&countryCode=TR&limit=5');
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(secondResponse.body.items[0].placeId).toBe('33333');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('GET /api/location/search returns 503 when provider is unavailable', async () => {
+    const app = createApp();
+
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    });
+
+    const response = await request(app)
+      .get('/api/location/search?q=Besiktas&countryCode=TR&limit=5');
+
+    expect(response.status).toBe(503);
+    expect(response.body.code).toBe('GEOCODER_UNAVAILABLE');
+  });
+
+  test('GET /api/location/reverse returns 504 on provider timeout', async () => {
+    const app = createApp();
+
+    const timeoutError = new Error('timeout');
+    timeoutError.name = 'AbortError';
+    global.fetch.mockRejectedValueOnce(timeoutError);
+
+    const response = await request(app)
+      .get('/api/location/reverse?lat=41.043&lon=29.009');
+
+    expect(response.status).toBe(504);
+    expect(response.body.code).toBe('GEOCODER_TIMEOUT');
+  });
+});

--- a/backend/tests/integration/modules/profiles/profiles.integration.test.js
+++ b/backend/tests/integration/modules/profiles/profiles.integration.test.js
@@ -171,6 +171,45 @@ describe('profiles integration', () => {
 		expect(response.body.locationProfile.city).toBe('Istanbul');
 	});
 
+	test('PATCH /api/profiles/me/location accepts hybrid payload with administrative and coordinate', async () => {
+		const app = createApp();
+		const userId = 'user_loc_hybrid_1';
+		await seedActiveUser(userId, 'lochybrid1@example.com');
+		const token = buildAuthToken(userId);
+		await createBaseProfile(app, token);
+
+		const response = await request(app)
+			.patch('/api/profiles/me/location')
+			.set('Authorization', `Bearer ${token}`)
+			.send({
+				displayAddress: 'Levazim, Besiktas, Istanbul',
+				administrative: {
+					countryCode: 'TR',
+					country: 'Turkey',
+					city: 'Istanbul',
+					district: 'Besiktas',
+					neighborhood: 'Levazim',
+					extraAddress: 'Bina B',
+					postalCode: '34340',
+				},
+				coordinate: {
+					latitude: 41.043,
+					longitude: 29.009,
+					source: 'MANUAL_MAP_PIN',
+					capturedAt: '2026-04-18T11:20:00.000Z',
+				},
+			});
+
+		expect(response.status).toBe(200);
+		expect(response.body.locationProfile.country).toBe('Turkey');
+		expect(response.body.locationProfile.city).toBe('Istanbul');
+		expect(response.body.locationProfile.latitude).toBeCloseTo(41.043, 6);
+		expect(response.body.locationProfile.longitude).toBeCloseTo(29.009, 6);
+		expect(response.body.locationProfile.coordinate).toBeTruthy();
+		expect(response.body.locationProfile.administrative).toBeTruthy();
+		expect(response.body.locationProfile.displayAddress).toBe('Levazim, Besiktas, Istanbul');
+	});
+
 	test('PATCH /api/profiles/me/privacy returns 200 with valid payload', async () => {
 		const app = createApp();
 		const userId = 'user_priv_1';

--- a/backend/tests/unit/modules/help-requests/validators.test.js
+++ b/backend/tests/unit/modules/help-requests/validators.test.js
@@ -198,6 +198,21 @@ describe('help-requests validators', () => {
 			expect(errors).toContain('`location.coordinate.latitude` and `location.coordinate.longitude` must be provided together.');
 		});
 
+		test('rejects conflicting flat and nested coordinate values', () => {
+			const payload = buildPayload();
+			payload.location.latitude = 41.043;
+			payload.location.longitude = 29.009;
+			payload.location.coordinate = {
+				latitude: 41.111,
+				longitude: 29.009,
+				source: 'MANUAL_MAP_PIN',
+			};
+
+			const { errors } = validateCreateHelpRequest(payload);
+
+			expect(errors).toContain('`location.latitude` conflicts with `location.coordinate.latitude`.');
+		});
+
 		test('rejects invalid contact fields', () => {
 			const payload = buildPayload();
 			payload.contact.phone = 4052318546;

--- a/backend/tests/unit/modules/help-requests/validators.test.js
+++ b/backend/tests/unit/modules/help-requests/validators.test.js
@@ -170,6 +170,34 @@ describe('help-requests validators', () => {
 			expect(errors).toContain('`location.city` is required.');
 		});
 
+		test('accepts hybrid location coordinate object', () => {
+			const payload = buildPayload();
+			payload.location.coordinate = {
+				latitude: 41.043,
+				longitude: 29.009,
+				source: 'MANUAL_MAP_PIN',
+				capturedAt: '2026-04-18T11:20:00.000Z',
+			};
+
+			const { errors, value } = validateCreateHelpRequest(payload);
+
+			expect(errors).toHaveLength(0);
+			expect(value.location.coordinate).toBeTruthy();
+			expect(value.location.coordinate.latitude).toBeCloseTo(41.043, 6);
+			expect(value.location.coordinate.longitude).toBeCloseTo(29.009, 6);
+		});
+
+		test('rejects hybrid location coordinate when longitude is missing', () => {
+			const payload = buildPayload();
+			payload.location.coordinate = {
+				latitude: 41.043,
+			};
+
+			const { errors } = validateCreateHelpRequest(payload);
+
+			expect(errors).toContain('`location.coordinate.latitude` and `location.coordinate.longitude` must be provided together.');
+		});
+
 		test('rejects invalid contact fields', () => {
 			const payload = buildPayload();
 			payload.contact.phone = 4052318546;

--- a/backend/tests/unit/modules/location/validators.test.js
+++ b/backend/tests/unit/modules/location/validators.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const {
+  validateTreeQuery,
+  validateSearchQuery,
+  validateReverseQuery,
+} = require('../../../../src/modules/location/validators');
+
+describe('location validators', () => {
+  describe('validateTreeQuery', () => {
+    test('accepts valid country code', () => {
+      const result = validateTreeQuery({ countryCode: 'TR' });
+      expect(result.ok).toBe(true);
+      expect(result.value.countryCode).toBe('TR');
+    });
+
+    test('defaults to TR when missing', () => {
+      const result = validateTreeQuery({});
+      expect(result.ok).toBe(true);
+      expect(result.value.countryCode).toBe('TR');
+    });
+
+    test('rejects invalid country code', () => {
+      const result = validateTreeQuery({ countryCode: 'TUR' });
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('2-letter ISO code');
+    });
+  });
+
+  describe('validateSearchQuery', () => {
+    test('accepts valid search query', () => {
+      const result = validateSearchQuery({ q: 'Kadikoy', countryCode: 'TR', limit: '5' });
+      expect(result.ok).toBe(true);
+      expect(result.value.limit).toBe(5);
+    });
+
+    test('caps limit at 20', () => {
+      const result = validateSearchQuery({ q: 'Kadikoy', countryCode: 'TR', limit: '99' });
+      expect(result.ok).toBe(true);
+      expect(result.value.limit).toBe(20);
+    });
+
+    test('rejects too-short query', () => {
+      const result = validateSearchQuery({ q: 'a' });
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('at least 2 characters');
+    });
+
+    test('rejects too-long query', () => {
+      const result = validateSearchQuery({ q: 'a'.repeat(121), countryCode: 'TR' });
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('at most 120 characters');
+    });
+
+    test('rejects invalid limit', () => {
+      const result = validateSearchQuery({ q: 'Kadikoy', limit: '0' });
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('positive integer');
+    });
+  });
+
+  describe('validateReverseQuery', () => {
+    test('accepts valid coordinates', () => {
+      const result = validateReverseQuery({ lat: '41.043', lon: '29.009' });
+      expect(result.ok).toBe(true);
+      expect(result.value.lat).toBeCloseTo(41.043, 6);
+      expect(result.value.lon).toBeCloseTo(29.009, 6);
+    });
+
+    test('rejects out-of-range latitude', () => {
+      const result = validateReverseQuery({ lat: '100', lon: '29.009' });
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('between -90 and 90');
+    });
+
+    test('rejects out-of-range longitude', () => {
+      const result = validateReverseQuery({ lat: '41.043', lon: '190' });
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('between -180 and 180');
+    });
+  });
+});

--- a/backend/tests/unit/modules/profiles/validators.test.js
+++ b/backend/tests/unit/modules/profiles/validators.test.js
@@ -115,6 +115,20 @@ describe('profiles validators', () => {
 			expect(result.ok).toBe(false);
 			expect(result.message).toBe('coordinate.latitude and coordinate.longitude must be provided together');
 		});
+
+		test('rejects conflicting flat and nested latitude values', () => {
+			const result = validateLocationPatch({
+				latitude: 41.1,
+				longitude: 29.0,
+				coordinate: {
+					latitude: 41.2,
+					longitude: 29.0,
+				},
+			});
+
+			expect(result.ok).toBe(false);
+			expect(result.message).toBe('latitude conflicts with coordinate.latitude');
+		});
 	});
 
 	describe('validatePrivacyPatch', () => {

--- a/backend/tests/unit/modules/profiles/validators.test.js
+++ b/backend/tests/unit/modules/profiles/validators.test.js
@@ -78,6 +78,43 @@ describe('profiles validators', () => {
 			expect(result.ok).toBe(true);
 			expect(result.data).toEqual({ latitude: 41.0082, longitude: 28.9784 });
 		});
+
+		test('accepts hybrid payload with administrative and coordinate objects', () => {
+			const result = validateLocationPatch({
+				displayAddress: 'Levazim, Besiktas, Istanbul',
+				administrative: {
+					countryCode: 'TR',
+					country: 'Turkey',
+					city: 'Istanbul',
+					district: 'Besiktas',
+					neighborhood: 'Levazim',
+					extraAddress: 'Bina B',
+					postalCode: '34340',
+				},
+				coordinate: {
+					latitude: 41.043,
+					longitude: 29.009,
+					accuracyMeters: 12.5,
+					source: 'MANUAL_MAP_PIN',
+					capturedAt: '2026-04-18T11:20:00.000Z',
+				},
+			});
+
+			expect(result.ok).toBe(true);
+			expect(result.data.administrative.city).toBe('Istanbul');
+			expect(result.data.coordinate.latitude).toBeCloseTo(41.043, 6);
+		});
+
+		test('rejects coordinate object when latitude/longitude are not paired', () => {
+			const result = validateLocationPatch({
+				coordinate: {
+					latitude: 41.043,
+				},
+			});
+
+			expect(result.ok).toBe(false);
+			expect(result.message).toBe('coordinate.latitude and coordinate.longitude must be provided together');
+		});
 	});
 
 	describe('validatePrivacyPatch', () => {


### PR DESCRIPTION
This PR adds shared backend location infrastructure and extends existing flows to support hybrid location payloads (administrative fields + coordinates), while keeping backward compatibility.

Changes:

Added new location endpoints:
[GET /api/location/tree
GET /api/location/search
GET /api/location/reverse
Added provider-backed geocoding/reverse geocoding with in-memory cache.
Extended profiles and [help-requests] to accept hybrid location data.
Added validation safeguards:
search query length limit
coordinate conflict checks (flat vs nested)
protection against unintended profile location overwrites
Updated tests and backend docs.
Validation:

Unit tests: passing
Integration tests: passing

Closes #303 