### PR TITLE
feat(web): add reusable location map infrastructure for shared location flows

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,6 @@
         "next": "^16.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-leaflet": "^5.0.0",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
@@ -696,17 +695,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@react-leaflet/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
-      "license": "Hippocratic-2.1",
-      "peerDependencies": {
-        "leaflet": "^1.9.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@swc/helpers": {
@@ -1677,20 +1665,6 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
-      }
-    },
-    "node_modules/react-leaflet": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
-      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
-      "license": "Hippocratic-2.1",
-      "dependencies": {
-        "@react-leaflet/core": "^3.0.0"
-      },
-      "peerDependencies": {
-        "leaflet": "^1.9.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
       }
     },
     "node_modules/scheduler": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6,13 +6,16 @@
     "": {
       "dependencies": {
         "clsx": "^2.1.1",
+        "leaflet": "^1.9.4",
         "next": "^16.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-leaflet": "^5.0.0",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.2",
+        "@types/leaflet": "^1.9.21",
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -695,6 +698,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -975,6 +989,23 @@
         "tailwindcss": "4.2.2"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
@@ -1201,6 +1232,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1640,6 +1677,20 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/scheduler": {

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,6 @@
     "next": "^16.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-leaflet": "^5.0.0",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,13 +6,16 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "leaflet": "^1.9.4",
     "next": "^16.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-leaflet": "^5.0.0",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",
+    "@types/leaflet": "^1.9.21",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/web/src/components/feature/location/LeafletLocationMap.tsx
+++ b/web/src/components/feature/location/LeafletLocationMap.tsx
@@ -44,6 +44,11 @@ export function LeafletLocationMap({
     const mapContainerRef = React.useRef<HTMLDivElement | null>(null);
     const mapRef = React.useRef<L.Map | null>(null);
     const markerRef = React.useRef<L.Marker | null>(null);
+    const onSelectPositionRef = React.useRef(onSelectPosition);
+
+    React.useEffect(() => {
+        onSelectPositionRef.current = onSelectPosition;
+    }, [onSelectPosition]);
 
     React.useEffect(() => {
         if (!mapContainerRef.current || mapRef.current) {
@@ -62,7 +67,7 @@ export function LeafletLocationMap({
         }).addTo(map);
 
         map.on("click", (event: L.LeafletMouseEvent) => {
-            onSelectPosition({
+            onSelectPositionRef.current({
                 latitude: event.latlng.lat,
                 longitude: event.latlng.lng,
             });
@@ -76,7 +81,18 @@ export function LeafletLocationMap({
             map.remove();
             mapRef.current = null;
         };
-    }, [center.latitude, center.longitude, onSelectPosition, zoom]);
+    }, []);
+
+    React.useEffect(() => {
+        const map = mapRef.current;
+        if (!map) {
+            return;
+        }
+
+        if (map.getZoom() !== zoom) {
+            map.setZoom(zoom);
+        }
+    }, [zoom]);
 
     React.useEffect(() => {
         const map = mapRef.current;
@@ -114,7 +130,7 @@ export function LeafletLocationMap({
 
             marker.on("dragend", () => {
                 const markerPosition = marker.getLatLng();
-                onSelectPosition({
+                onSelectPositionRef.current({
                     latitude: markerPosition.lat,
                     longitude: markerPosition.lng,
                 });
@@ -126,7 +142,7 @@ export function LeafletLocationMap({
         }
 
         markerRef.current.setLatLng(latLng);
-    }, [onSelectPosition, selectedPosition]);
+    }, [selectedPosition]);
 
     return (
         <div className={`overflow-hidden rounded-[10px] border border-[#e7e7ea] ${heightClassName}`}>

--- a/web/src/components/feature/location/LeafletLocationMap.tsx
+++ b/web/src/components/feature/location/LeafletLocationMap.tsx
@@ -5,13 +5,6 @@ import L from "leaflet";
 import markerIcon2xAsset from "leaflet/dist/images/marker-icon-2x.png";
 import markerIconAsset from "leaflet/dist/images/marker-icon.png";
 import markerShadowAsset from "leaflet/dist/images/marker-shadow.png";
-import {
-    MapContainer,
-    Marker,
-    TileLayer,
-    useMap,
-    useMapEvents,
-} from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 
 type LatLng = {
@@ -41,35 +34,6 @@ const locationMarkerIcon = L.icon({
     shadowSize: [41, 41],
 });
 
-function MapClickListener({
-    onSelectPosition,
-}: {
-    onSelectPosition: (position: LatLng) => void;
-}) {
-    useMapEvents({
-        click(event) {
-            onSelectPosition({
-                latitude: event.latlng.lat,
-                longitude: event.latlng.lng,
-            });
-        },
-    });
-
-    return null;
-}
-
-function RecenterOnChange({ center }: { center: LatLng }) {
-    const map = useMap();
-
-    React.useEffect(() => {
-        map.setView([center.latitude, center.longitude], map.getZoom(), {
-            animate: true,
-        });
-    }, [center.latitude, center.longitude, map]);
-
-    return null;
-}
-
 export function LeafletLocationMap({
     center,
     zoom = 12,
@@ -77,41 +41,96 @@ export function LeafletLocationMap({
     heightClassName = "h-72",
     onSelectPosition,
 }: LeafletLocationMapProps) {
+    const mapContainerRef = React.useRef<HTMLDivElement | null>(null);
+    const mapRef = React.useRef<L.Map | null>(null);
+    const markerRef = React.useRef<L.Marker | null>(null);
+
+    React.useEffect(() => {
+        if (!mapContainerRef.current || mapRef.current) {
+            return;
+        }
+
+        const map = L.map(mapContainerRef.current, {
+            center: [center.latitude, center.longitude],
+            zoom,
+            scrollWheelZoom: true,
+        });
+
+        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+            attribution:
+                '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        }).addTo(map);
+
+        map.on("click", (event: L.LeafletMouseEvent) => {
+            onSelectPosition({
+                latitude: event.latlng.lat,
+                longitude: event.latlng.lng,
+            });
+        });
+
+        mapRef.current = map;
+
+        return () => {
+            markerRef.current?.remove();
+            markerRef.current = null;
+            map.remove();
+            mapRef.current = null;
+        };
+    }, [center.latitude, center.longitude, onSelectPosition, zoom]);
+
+    React.useEffect(() => {
+        const map = mapRef.current;
+        if (!map) {
+            return;
+        }
+
+        map.setView([center.latitude, center.longitude], map.getZoom(), {
+            animate: true,
+        });
+    }, [center.latitude, center.longitude]);
+
+    React.useEffect(() => {
+        const map = mapRef.current;
+        if (!map) {
+            return;
+        }
+
+        if (!selectedPosition) {
+            markerRef.current?.remove();
+            markerRef.current = null;
+            return;
+        }
+
+        const latLng: L.LatLngExpression = [
+            selectedPosition.latitude,
+            selectedPosition.longitude,
+        ];
+
+        if (!markerRef.current) {
+            const marker = L.marker(latLng, {
+                icon: locationMarkerIcon,
+                draggable: true,
+            });
+
+            marker.on("dragend", () => {
+                const markerPosition = marker.getLatLng();
+                onSelectPosition({
+                    latitude: markerPosition.lat,
+                    longitude: markerPosition.lng,
+                });
+            });
+
+            marker.addTo(map);
+            markerRef.current = marker;
+            return;
+        }
+
+        markerRef.current.setLatLng(latLng);
+    }, [onSelectPosition, selectedPosition]);
+
     return (
         <div className={`overflow-hidden rounded-[10px] border border-[#e7e7ea] ${heightClassName}`}>
-            <MapContainer
-                center={[center.latitude, center.longitude]}
-                zoom={zoom}
-                className="h-full w-full"
-                scrollWheelZoom
-            >
-                <TileLayer
-                    attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-                />
-
-                <MapClickListener onSelectPosition={onSelectPosition} />
-                <RecenterOnChange center={center} />
-
-                {selectedPosition ? (
-                    <Marker
-                        icon={locationMarkerIcon}
-                        position={[selectedPosition.latitude, selectedPosition.longitude]}
-                        draggable
-                        eventHandlers={{
-                            dragend(event) {
-                                const marker = event.target;
-                                const latLng = marker.getLatLng();
-
-                                onSelectPosition({
-                                    latitude: latLng.lat,
-                                    longitude: latLng.lng,
-                                });
-                            },
-                        }}
-                    />
-                ) : null}
-            </MapContainer>
+            <div ref={mapContainerRef} className="h-full w-full" />
         </div>
     );
 }

--- a/web/src/components/feature/location/LeafletLocationMap.tsx
+++ b/web/src/components/feature/location/LeafletLocationMap.tsx
@@ -2,6 +2,9 @@
 
 import * as React from "react";
 import L from "leaflet";
+import markerIcon2xAsset from "leaflet/dist/images/marker-icon-2x.png";
+import markerIconAsset from "leaflet/dist/images/marker-icon.png";
+import markerShadowAsset from "leaflet/dist/images/marker-shadow.png";
 import {
     MapContainer,
     Marker,
@@ -24,10 +27,14 @@ type LeafletLocationMapProps = {
     onSelectPosition: (position: LatLng) => void;
 };
 
-const markerIcon = L.icon({
-    iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
-    iconRetinaUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
-    shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+function toAssetUrl(asset: string | { src: string }) {
+    return typeof asset === "string" ? asset : asset.src;
+}
+
+const locationMarkerIcon = L.icon({
+    iconUrl: toAssetUrl(markerIconAsset),
+    iconRetinaUrl: toAssetUrl(markerIcon2xAsset),
+    shadowUrl: toAssetUrl(markerShadowAsset),
     iconSize: [25, 41],
     iconAnchor: [12, 41],
     popupAnchor: [1, -34],
@@ -88,7 +95,7 @@ export function LeafletLocationMap({
 
                 {selectedPosition ? (
                     <Marker
-                        icon={markerIcon}
+                        icon={locationMarkerIcon}
                         position={[selectedPosition.latitude, selectedPosition.longitude]}
                         draggable
                         eventHandlers={{

--- a/web/src/components/feature/location/LeafletLocationMap.tsx
+++ b/web/src/components/feature/location/LeafletLocationMap.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import * as React from "react";
+import L from "leaflet";
+import {
+    MapContainer,
+    Marker,
+    TileLayer,
+    useMap,
+    useMapEvents,
+} from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+
+type LatLng = {
+    latitude: number;
+    longitude: number;
+};
+
+type LeafletLocationMapProps = {
+    center: LatLng;
+    zoom?: number;
+    selectedPosition: LatLng | null;
+    heightClassName?: string;
+    onSelectPosition: (position: LatLng) => void;
+};
+
+const markerIcon = L.icon({
+    iconUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png",
+    iconRetinaUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png",
+    shadowUrl: "https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png",
+    iconSize: [25, 41],
+    iconAnchor: [12, 41],
+    popupAnchor: [1, -34],
+    shadowSize: [41, 41],
+});
+
+function MapClickListener({
+    onSelectPosition,
+}: {
+    onSelectPosition: (position: LatLng) => void;
+}) {
+    useMapEvents({
+        click(event) {
+            onSelectPosition({
+                latitude: event.latlng.lat,
+                longitude: event.latlng.lng,
+            });
+        },
+    });
+
+    return null;
+}
+
+function RecenterOnChange({ center }: { center: LatLng }) {
+    const map = useMap();
+
+    React.useEffect(() => {
+        map.setView([center.latitude, center.longitude], map.getZoom(), {
+            animate: true,
+        });
+    }, [center.latitude, center.longitude, map]);
+
+    return null;
+}
+
+export function LeafletLocationMap({
+    center,
+    zoom = 12,
+    selectedPosition,
+    heightClassName = "h-72",
+    onSelectPosition,
+}: LeafletLocationMapProps) {
+    return (
+        <div className={`overflow-hidden rounded-[10px] border border-[#e7e7ea] ${heightClassName}`}>
+            <MapContainer
+                center={[center.latitude, center.longitude]}
+                zoom={zoom}
+                className="h-full w-full"
+                scrollWheelZoom
+            >
+                <TileLayer
+                    attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                />
+
+                <MapClickListener onSelectPosition={onSelectPosition} />
+                <RecenterOnChange center={center} />
+
+                {selectedPosition ? (
+                    <Marker
+                        icon={markerIcon}
+                        position={[selectedPosition.latitude, selectedPosition.longitude]}
+                        draggable
+                        eventHandlers={{
+                            dragend(event) {
+                                const marker = event.target;
+                                const latLng = marker.getLatLng();
+
+                                onSelectPosition({
+                                    latitude: latLng.lat,
+                                    longitude: latLng.lng,
+                                });
+                            },
+                        }}
+                    />
+                ) : null}
+            </MapContainer>
+        </div>
+    );
+}

--- a/web/src/components/feature/location/LocationPicker.tsx
+++ b/web/src/components/feature/location/LocationPicker.tsx
@@ -38,6 +38,19 @@ function toPickerValue(item: LocationSearchItem): LocationPickerValue {
     };
 }
 
+function toManualPickerValue(latitude: number, longitude: number): LocationPickerValue {
+    const normalizedLatitude = latitude.toFixed(6);
+    const normalizedLongitude = longitude.toFixed(6);
+
+    return {
+        placeId: `manual:${normalizedLatitude},${normalizedLongitude}`,
+        displayName: `Pinned location (${normalizedLatitude}, ${normalizedLongitude})`,
+        latitude,
+        longitude,
+        administrative: {},
+    };
+}
+
 export function LocationPicker({
     countryCode = "TR",
     value,
@@ -120,13 +133,7 @@ export function LocationPicker({
                 }
 
                 setError(err instanceof Error ? err.message : "Could not resolve selected location.");
-                onChange({
-                    placeId: "",
-                    displayName: "",
-                    latitude,
-                    longitude,
-                    administrative: {},
-                });
+                onChange(toManualPickerValue(latitude, longitude));
             } finally {
                 if (currentReverseRequestId === reverseRequestIdRef.current) {
                     setResolving(false);
@@ -178,6 +185,7 @@ export function LocationPicker({
             <div className="flex flex-col gap-2 sm:flex-row">
                 <TextInput
                     id={searchInputId}
+                    label="Search location"
                     placeholder="Search location"
                     value={query}
                     onChange={(event) => setQuery(event.target.value)}

--- a/web/src/components/feature/location/LocationPicker.tsx
+++ b/web/src/components/feature/location/LocationPicker.tsx
@@ -44,11 +44,15 @@ export function LocationPicker({
     onChange,
     label = "Select location from map",
 }: LocationPickerProps) {
+    const searchInputId = React.useId();
     const [query, setQuery] = React.useState("");
     const [searching, setSearching] = React.useState(false);
     const [resolving, setResolving] = React.useState(false);
     const [results, setResults] = React.useState<LocationSearchItem[]>([]);
     const [error, setError] = React.useState("");
+    const skipNextSearchRef = React.useRef(false);
+    const searchRequestIdRef = React.useRef(0);
+    const reverseRequestIdRef = React.useRef(0);
 
     const center = value
         ? { latitude: value.latitude, longitude: value.longitude }
@@ -60,6 +64,13 @@ export function LocationPicker({
             return;
         }
 
+        if (skipNextSearchRef.current) {
+            skipNextSearchRef.current = false;
+            return;
+        }
+
+        const currentSearchRequestId = ++searchRequestIdRef.current;
+
         try {
             setSearching(true);
             setError("");
@@ -70,23 +81,44 @@ export function LocationPicker({
                 limit: 10,
             });
 
+            if (currentSearchRequestId !== searchRequestIdRef.current) {
+                return;
+            }
+
             setResults(response.items);
         } catch (err) {
+            if (currentSearchRequestId !== searchRequestIdRef.current) {
+                return;
+            }
+
             setError(err instanceof Error ? err.message : "Could not search locations.");
         } finally {
-            setSearching(false);
+            if (currentSearchRequestId === searchRequestIdRef.current) {
+                setSearching(false);
+            }
         }
     }, [countryCode, query]);
 
     const handleResolveCoordinates = React.useCallback(
         async (latitude: number, longitude: number) => {
+            const currentReverseRequestId = ++reverseRequestIdRef.current;
+
             try {
                 setResolving(true);
                 setError("");
 
                 const response = await reverseLocation({ latitude, longitude });
+
+                if (currentReverseRequestId !== reverseRequestIdRef.current) {
+                    return;
+                }
+
                 onChange(toPickerValue(response.item));
             } catch (err) {
+                if (currentReverseRequestId !== reverseRequestIdRef.current) {
+                    return;
+                }
+
                 setError(err instanceof Error ? err.message : "Could not resolve selected location.");
                 onChange({
                     placeId: "",
@@ -96,7 +128,9 @@ export function LocationPicker({
                     administrative: {},
                 });
             } finally {
-                setResolving(false);
+                if (currentReverseRequestId === reverseRequestIdRef.current) {
+                    setResolving(false);
+                }
             }
         },
         [onChange]
@@ -143,7 +177,7 @@ export function LocationPicker({
 
             <div className="flex flex-col gap-2 sm:flex-row">
                 <TextInput
-                    id="location-search"
+                    id={searchInputId}
                     placeholder="Search location"
                     value={query}
                     onChange={(event) => setQuery(event.target.value)}
@@ -168,6 +202,7 @@ export function LocationPicker({
                             className="w-full border-b border-[#f0f0f2] px-3 py-2 text-left text-sm text-[#2b2b33] transition-colors hover:bg-[#fafafa]"
                             onClick={() => {
                                 onChange(toPickerValue(item));
+                                skipNextSearchRef.current = true;
                                 setResults([]);
                                 setQuery(item.displayName);
                             }}

--- a/web/src/components/feature/location/LocationPicker.tsx
+++ b/web/src/components/feature/location/LocationPicker.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import * as React from "react";
+import { TextInput } from "@/components/ui/inputs/TextInput";
+import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { HelperText } from "@/components/ui/display/HelperText";
+import { LocationPickerMap } from "@/components/feature/location/LocationPickerMap";
+import { reverseLocation, searchLocations } from "@/lib/location";
+import { LocationSearchItem } from "@/types/location";
+
+type LocationPickerValue = {
+    placeId: string;
+    displayName: string;
+    latitude: number;
+    longitude: number;
+    administrative: LocationSearchItem["administrative"];
+};
+
+type LocationPickerProps = {
+    countryCode?: string;
+    value: LocationPickerValue | null;
+    onChange: (value: LocationPickerValue | null) => void;
+    label?: string;
+};
+
+const DEFAULT_CENTER = {
+    latitude: 39.0,
+    longitude: 35.0,
+};
+
+function toPickerValue(item: LocationSearchItem): LocationPickerValue {
+    return {
+        placeId: item.placeId,
+        displayName: item.displayName,
+        latitude: item.latitude,
+        longitude: item.longitude,
+        administrative: item.administrative,
+    };
+}
+
+export function LocationPicker({
+    countryCode = "TR",
+    value,
+    onChange,
+    label = "Select location from map",
+}: LocationPickerProps) {
+    const [query, setQuery] = React.useState("");
+    const [searching, setSearching] = React.useState(false);
+    const [resolving, setResolving] = React.useState(false);
+    const [results, setResults] = React.useState<LocationSearchItem[]>([]);
+    const [error, setError] = React.useState("");
+
+    const center = value
+        ? { latitude: value.latitude, longitude: value.longitude }
+        : DEFAULT_CENTER;
+
+    const handleSearch = React.useCallback(async () => {
+        if (query.trim().length < 2) {
+            setResults([]);
+            return;
+        }
+
+        try {
+            setSearching(true);
+            setError("");
+
+            const response = await searchLocations({
+                q: query.trim(),
+                countryCode,
+                limit: 10,
+            });
+
+            setResults(response.items);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Could not search locations.");
+        } finally {
+            setSearching(false);
+        }
+    }, [countryCode, query]);
+
+    const handleResolveCoordinates = React.useCallback(
+        async (latitude: number, longitude: number) => {
+            try {
+                setResolving(true);
+                setError("");
+
+                const response = await reverseLocation({ latitude, longitude });
+                onChange(toPickerValue(response.item));
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "Could not resolve selected location.");
+                onChange({
+                    placeId: "",
+                    displayName: "",
+                    latitude,
+                    longitude,
+                    administrative: {},
+                });
+            } finally {
+                setResolving(false);
+            }
+        },
+        [onChange]
+    );
+
+    const handleUseCurrentLocation = React.useCallback(() => {
+        if (!navigator.geolocation) {
+            setError("Geolocation is not supported in this browser.");
+            return;
+        }
+
+        setError("");
+        setResolving(true);
+
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                void handleResolveCoordinates(
+                    position.coords.latitude,
+                    position.coords.longitude
+                );
+            },
+            (geoError) => {
+                setResolving(false);
+                setError(geoError.message || "Could not access current location.");
+            },
+            {
+                enableHighAccuracy: true,
+                timeout: 10000,
+            }
+        );
+    }, [handleResolveCoordinates]);
+
+    React.useEffect(() => {
+        const timeout = setTimeout(() => {
+            void handleSearch();
+        }, 350);
+
+        return () => clearTimeout(timeout);
+    }, [handleSearch]);
+
+    return (
+        <div className="flex flex-col gap-3">
+            <HelperText className="text-sm text-[#2b2b33]">{label}</HelperText>
+
+            <div className="flex flex-col gap-2 sm:flex-row">
+                <TextInput
+                    id="location-search"
+                    placeholder="Search location"
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                />
+
+                <PrimaryButton
+                    type="button"
+                    className="sm:w-52"
+                    onClick={handleUseCurrentLocation}
+                    loading={resolving}
+                >
+                    Use Current Location
+                </PrimaryButton>
+            </div>
+
+            {results.length > 0 ? (
+                <div className="max-h-44 overflow-auto rounded-[10px] border border-[#e7e7ea] bg-white">
+                    {results.map((item) => (
+                        <button
+                            key={`${item.placeId}-${item.latitude}-${item.longitude}`}
+                            type="button"
+                            className="w-full border-b border-[#f0f0f2] px-3 py-2 text-left text-sm text-[#2b2b33] transition-colors hover:bg-[#fafafa]"
+                            onClick={() => {
+                                onChange(toPickerValue(item));
+                                setResults([]);
+                                setQuery(item.displayName);
+                            }}
+                        >
+                            {item.displayName}
+                        </button>
+                    ))}
+                </div>
+            ) : null}
+
+            <LocationPickerMap
+                center={center}
+                selectedPosition={
+                    value
+                        ? {
+                            latitude: value.latitude,
+                            longitude: value.longitude,
+                        }
+                        : null
+                }
+                onSelectPosition={(position) => {
+                    void handleResolveCoordinates(position.latitude, position.longitude);
+                }}
+            />
+
+            {searching ? <HelperText>Searching locations...</HelperText> : null}
+            {resolving ? <HelperText>Resolving selected coordinates...</HelperText> : null}
+
+            {value ? (
+                <HelperText>
+                    Selected: {value.displayName || `${value.latitude.toFixed(6)}, ${value.longitude.toFixed(6)}`}
+                </HelperText>
+            ) : null}
+
+            {error ? <HelperText className="text-red-500">{error}</HelperText> : null}
+        </div>
+    );
+}
+
+export type { LocationPickerValue };

--- a/web/src/components/feature/location/LocationPickerMap.tsx
+++ b/web/src/components/feature/location/LocationPickerMap.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const LeafletLocationMap = dynamic(
+    () => import("@/components/feature/location/LeafletLocationMap").then((mod) => mod.LeafletLocationMap),
+    {
+        ssr: false,
+        loading: () => (
+            <div className="h-72 w-full animate-pulse rounded-[10px] border border-[#e7e7ea] bg-[#f8f8f9]" />
+        ),
+    }
+);
+
+export { LeafletLocationMap as LocationPickerMap };

--- a/web/src/components/feature/location/index.ts
+++ b/web/src/components/feature/location/index.ts
@@ -1,0 +1,2 @@
+export { LocationPicker } from "@/components/feature/location/LocationPicker";
+export type { LocationPickerValue } from "@/components/feature/location/LocationPicker";

--- a/web/src/lib/location.ts
+++ b/web/src/lib/location.ts
@@ -1,0 +1,49 @@
+import { apiRequest } from "@/lib/api";
+import {
+    LocationReverseResponse,
+    LocationSearchResponse,
+    LocationTreeResponse,
+} from "@/types/location";
+
+function buildQuery(params: Record<string, string | number | undefined>) {
+    const searchParams = new URLSearchParams();
+
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === "") {
+            continue;
+        }
+
+        searchParams.set(key, String(value));
+    }
+
+    const serialized = searchParams.toString();
+    return serialized ? `?${serialized}` : "";
+}
+
+export async function fetchLocationTree(countryCode = "TR") {
+    const query = buildQuery({ countryCode });
+    return apiRequest<LocationTreeResponse>(`/location/tree${query}`);
+}
+
+export async function searchLocations(params: {
+    q: string;
+    countryCode?: string;
+    limit?: number;
+}) {
+    const query = buildQuery({
+        q: params.q,
+        countryCode: params.countryCode || "TR",
+        limit: params.limit ?? 10,
+    });
+
+    return apiRequest<LocationSearchResponse>(`/location/search${query}`);
+}
+
+export async function reverseLocation(params: { latitude: number; longitude: number }) {
+    const query = buildQuery({
+        lat: params.latitude,
+        lon: params.longitude,
+    });
+
+    return apiRequest<LocationReverseResponse>(`/location/reverse${query}`);
+}

--- a/web/src/types/location.ts
+++ b/web/src/types/location.ts
@@ -1,0 +1,65 @@
+export type Coordinate = {
+    latitude: number;
+    longitude: number;
+    accuracyMeters?: number | null;
+    source?: string | null;
+    capturedAt?: string | null;
+};
+
+export type AdministrativeLocation = {
+    countryCode?: string | null;
+    country?: string | null;
+    city?: string | null;
+    district?: string | null;
+    neighborhood?: string | null;
+    extraAddress?: string | null;
+    postalCode?: string | null;
+};
+
+export type LocationSearchItem = {
+    placeId: string;
+    displayName: string;
+    latitude: number;
+    longitude: number;
+    administrative: AdministrativeLocation;
+};
+
+export type LocationTreeNeighborhood = {
+    label: string;
+    value: string;
+};
+
+export type LocationTreeDistrict = {
+    label: string;
+    neighborhoods: LocationTreeNeighborhood[];
+};
+
+export type LocationTreeCity = {
+    label: string;
+    districts: Record<string, LocationTreeDistrict>;
+};
+
+export type LocationTreeCountry = {
+    label: string;
+    cities: Record<string, LocationTreeCity>;
+};
+
+export type LocationTreeMeta = {
+    cityCount: number;
+    districtCount: number;
+    neighborhoodCount: number;
+};
+
+export type LocationTreeResponse = {
+    countryCode: string;
+    tree: LocationTreeCountry;
+    meta: LocationTreeMeta;
+};
+
+export type LocationSearchResponse = {
+    items: LocationSearchItem[];
+};
+
+export type LocationReverseResponse = {
+    item: LocationSearchItem;
+};


### PR DESCRIPTION
This PR introduces a reusable location/map foundation on the web side, so upcoming location-based screens can build on shared components instead of one-off implementations.

What was added:

- Reusable map components:
  - Leaflet-based map container
  - Click-to-place pin
  - Draggable marker to update coordinates
  - SSR-safe dynamic map wrapper
- Reusable LocationPicker:
  - Search integration (/api/location/search)
  - Reverse geocode integration (/api/location/reverse)
  - Current location support (navigator.geolocation)
  - Shared picker value model for downstream forms/screens
- Shared location types:
  - Tree/search/reverse response types
  - Administrative + coordinate data structures
- Location API helpers:
  - Tree, search, and reverse helper methods
- Web dependencies:
  - leaflet
  - react-leaflet
  - @types/leaflet
 
Scope and non-goals:

- No backend changes in this PR.
- No direct integration yet into existing profile/complete-profile flows.
- Test-only preview route was intentionally excluded from commit/PR.

Validation:

- npm run build completed successfully
- TypeScript checks and static route generation passed

Files included:

- package.json
- package-lock.json
- location.ts
- location.ts
- LeafletLocationMap.tsx
- LocationPickerMap.tsx
- LocationPicker.tsx
- index.ts