### PR TITLE
feat(web): add shared gathering-areas contracts and api helper

### DIFF
--- a/docs/frontend/location-contracts.md
+++ b/docs/frontend/location-contracts.md
@@ -1,0 +1,49 @@
+# Location And Map Contracts (Web)
+
+This document defines shared web-side contracts for location/map features.
+It is intentionally infrastructure-focused and does not define page-level UI behavior.
+
+## Base Location Endpoints
+
+- `GET /api/location/tree?countryCode=TR`
+  - Response shape:
+    - `countryCode: string`
+    - `tree: LocationTreeCountry`
+    - `meta: { cityCount, districtCount, neighborhoodCount }`
+- `GET /api/location/search?q=...&countryCode=TR&limit=10`
+  - Response shape:
+    - `items: LocationSearchItem[]`
+- `GET /api/location/reverse?lat=...&lon=...`
+  - Response shape:
+    - `item: LocationSearchItem`
+
+Web client helpers:
+
+- `web/src/lib/location.ts`
+
+## Gathering Areas (Overpass-backed) Contract
+
+- `GET /api/gathering-areas/nearby?lat=...&lon=...&radius=...&limit=...`
+  - Response shape:
+    - `center: { lat, lon }`
+    - `radius: number`
+    - `source: string`
+    - `meta: { requestedLimit, returnedCount }`
+    - `collection: FeatureCollection`
+
+Feature contract notes:
+
+- GeoJSON ordering uses `[longitude, latitude]`.
+- Feature geometry type is `Point`.
+- `properties` includes map-ready metadata:
+  - `id`, `osmType`, `name`, `category`, `distanceMeters`, `rawTags`.
+
+Web shared contracts and helper:
+
+- `web/src/types/location.ts`
+- `web/src/lib/gatheringAreas.ts`
+
+## Scope Guard
+
+This contract layer is reusable infrastructure.
+Gathering areas screen/page rendering behavior is handled in a separate feature issue.

--- a/web/src/lib/gatheringAreas.ts
+++ b/web/src/lib/gatheringAreas.ts
@@ -1,0 +1,39 @@
+import { apiRequest } from "@/lib/api";
+import { NearbyGatheringAreasResponse } from "@/types/location";
+
+type NearbyGatheringAreasQuery = {
+    latitude: number;
+    longitude: number;
+    radius?: number;
+    limit?: number;
+};
+
+function buildQuery(params: Record<string, string | number | undefined>) {
+    const searchParams = new URLSearchParams();
+
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === "") {
+            continue;
+        }
+
+        searchParams.set(key, String(value));
+    }
+
+    const serialized = searchParams.toString();
+    return serialized ? `?${serialized}` : "";
+}
+
+export async function fetchNearbyGatheringAreas(
+    params: NearbyGatheringAreasQuery
+) {
+    const query = buildQuery({
+        lat: params.latitude,
+        lon: params.longitude,
+        radius: params.radius,
+        limit: params.limit,
+    });
+
+    return apiRequest<NearbyGatheringAreasResponse>(
+        `/gathering-areas/nearby${query}`
+    );
+}

--- a/web/src/types/location.ts
+++ b/web/src/types/location.ts
@@ -63,3 +63,42 @@ export type LocationSearchResponse = {
 export type LocationReverseResponse = {
     item: LocationSearchItem;
 };
+
+export type GeoJsonPointGeometry = {
+    type: "Point";
+    coordinates: [number, number];
+};
+
+export type GatheringAreaFeatureProperties = {
+    id: string;
+    osmType: string;
+    name: string;
+    category: string;
+    distanceMeters: number;
+    rawTags: Record<string, unknown>;
+};
+
+export type GatheringAreaFeature = {
+    type: "Feature";
+    geometry: GeoJsonPointGeometry;
+    properties: GatheringAreaFeatureProperties;
+};
+
+export type GatheringAreaFeatureCollection = {
+    type: "FeatureCollection";
+    features: GatheringAreaFeature[];
+};
+
+export type NearbyGatheringAreasResponse = {
+    center: {
+        lat: number;
+        lon: number;
+    };
+    radius: number;
+    source: "overpass";
+    meta: {
+        requestedLimit: number;
+        returnedCount: number;
+    };
+    collection: GatheringAreaFeatureCollection;
+};


### PR DESCRIPTION
This PR completes the remaining web-side infrastructure work for the shared map/location foundation issue, without implementing the Gathering Areas page feature itself.

What Changed
- Added shared web contract types for gathering areas and GeoJSON shapes. -> location.ts
- Added reusable web API helper for nearby gathering areas. -> gatheringAreas.ts
- Added infrastructure-focused contract documentation for web location/map endpoints. -> location-contracts.md