### PR TITLE
feat(web): integrate hybrid location picker into profile flows

### DIFF
--- a/web/src/components/feature/auth/CompleteProfileForm.tsx
+++ b/web/src/components/feature/auth/CompleteProfileForm.tsx
@@ -10,10 +10,19 @@ import { Checkbox } from "@/components/ui/selection/Checkbox";
 import { ProfileInfoRow } from "../../ui/display/ProfileInfoRow";
 import { SaveActionBar } from "../../ui/display/SaveActionBar";
 import { HelperText } from "@/components/ui/display/HelperText";
+import { LocationPicker, LocationPickerValue } from "@/components/feature/location";
 import { bloodTypeOptions } from "@/lib/bloodTypes";
 import { countryCodeOptions } from "@/lib/countryCodes";
 import { expertiseOptions, professionOptions } from "@/lib/profileOptions";
 import { getAccessToken, SIGNUP_DRAFT_KEY } from "@/lib/auth";
+import { fetchLocationTree } from "@/lib/location";
+import {
+    findCityKeyByLabel,
+    findCountryKeyByLabel,
+    findDistrictKeyByLabel,
+    findNeighborhoodValueByLabel,
+    LocationTreeByCountry,
+} from "@/lib/locationTree";
 import {
     buildAddress,
     parseListField,
@@ -48,64 +57,6 @@ type ProfileForm = {
     shareLocation: boolean;
 };
 
-type Neighborhood = {
-    label: string;
-    value: string;
-};
-
-type District = {
-    label: string;
-    neighborhoods: Neighborhood[];
-};
-
-type City = {
-    label: string;
-    districts: Record<string, District>;
-};
-
-type Country = {
-    label: string;
-    cities: Record<string, City>;
-};
-
-type LocationData = Record<string, Country>;
-
-const locationData: LocationData = {
-    tr: {
-        label: "Turkey",
-        cities: {
-            istanbul: {
-                label: "Istanbul",
-                districts: {
-                    kadikoy: {
-                        label: "Kadıköy",
-                        neighborhoods: [
-                            { label: "Bostancı", value: "bostanci" },
-                            { label: "Erenköy", value: "erenkoy" },
-                        ],
-                    },
-                    besiktas: {
-                        label: "Beşiktaş",
-                        neighborhoods: [
-                            { label: "Balmumcu", value: "balmumcu" },
-                            { label: "Kuruçeşme", value: "kurucesme" },
-                        ],
-                    },
-                },
-            },
-            ankara: {
-                label: "Ankara",
-                districts: {
-                    cankaya: {
-                        label: "Çankaya",
-                        neighborhoods: [{ label: "Anıttepe", value: "anittepe" }],
-                    },
-                },
-            },
-        },
-    },
-};
-
 const initialForm: ProfileForm = {
     fullName: "",
     countryCode: "+90",
@@ -131,6 +82,10 @@ export default function CompleteProfileForm() {
     const [form, setForm] = React.useState<ProfileForm>(initialForm);
     const [loading, setLoading] = React.useState(false);
     const [error, setError] = React.useState("");
+    const [locationTree, setLocationTree] = React.useState<LocationTreeByCountry>({});
+    const [locationTreeError, setLocationTreeError] = React.useState("");
+    const [locationPickerValue, setLocationPickerValue] =
+        React.useState<LocationPickerValue | null>(null);
 
     React.useEffect(() => {
         const savedDraft = sessionStorage.getItem(SIGNUP_DRAFT_KEY);
@@ -153,9 +108,81 @@ export default function CompleteProfileForm() {
         }
     }, []);
 
-    const countryData = locationData[form.country] ?? undefined;
+    React.useEffect(() => {
+        let mounted = true;
 
-    const countryOptions = Object.entries(locationData).map(([key, value]) => ({
+        async function loadLocationTree() {
+            try {
+                const response = await fetchLocationTree("TR");
+
+                if (!mounted) {
+                    return;
+                }
+
+                setLocationTree({ [response.countryCode.toLowerCase()]: response.tree });
+                setLocationTreeError("");
+            } catch (err) {
+                if (!mounted) {
+                    return;
+                }
+
+                setLocationTreeError(
+                    err instanceof Error
+                        ? err.message
+                        : "Could not load location options."
+                );
+            }
+        }
+
+        void loadLocationTree();
+
+        return () => {
+            mounted = false;
+        };
+    }, []);
+
+    React.useEffect(() => {
+        if (!locationPickerValue) {
+            return;
+        }
+
+        const countryKey = findCountryKeyByLabel(
+            locationTree,
+            locationPickerValue.administrative.country || ""
+        );
+        const cityKey = findCityKeyByLabel(
+            locationTree,
+            countryKey,
+            locationPickerValue.administrative.city || ""
+        );
+        const districtKey = findDistrictKeyByLabel(
+            locationTree,
+            countryKey,
+            cityKey,
+            locationPickerValue.administrative.district || ""
+        );
+        const neighborhoods =
+            locationTree[countryKey]?.cities[cityKey]?.districts[districtKey]?.neighborhoods ||
+            [];
+        const neighborhoodValue = findNeighborhoodValueByLabel(
+            neighborhoods,
+            locationPickerValue.administrative.neighborhood || ""
+        );
+
+        setForm((currentForm) => ({
+            ...currentForm,
+            country: countryKey || currentForm.country,
+            city: cityKey || currentForm.city,
+            district: districtKey || currentForm.district,
+            neighborhood: neighborhoodValue || currentForm.neighborhood,
+            extraAddress:
+                locationPickerValue.administrative.extraAddress || currentForm.extraAddress,
+        }));
+    }, [locationPickerValue, locationTree]);
+
+    const countryData = form.country ? locationTree[form.country] : undefined;
+
+    const countryOptions = Object.entries(locationTree).map(([key, value]) => ({
         label: value.label,
         value: key,
     }));
@@ -229,8 +256,38 @@ export default function CompleteProfileForm() {
             return;
         }
 
-        if (!form.height || !form.weight || !form.country || !form.city) {
+        const resolvedCountryLabel =
+            countryData?.label ||
+            locationPickerValue?.administrative.country ||
+            form.country ||
+            "";
+        const resolvedCityLabel =
+            countryData?.cities[form.city]?.label ||
+            locationPickerValue?.administrative.city ||
+            form.city ||
+            "";
+        const resolvedDistrictLabel =
+            countryData?.cities[form.city]?.districts[form.district]?.label ||
+            locationPickerValue?.administrative.district ||
+            form.district;
+        const resolvedNeighborhoodLabel =
+            countryData?.cities[form.city]?.districts[form.district]?.neighborhoods.find(
+                (item) => item.value === form.neighborhood
+            )?.label ||
+            locationPickerValue?.administrative.neighborhood ||
+            form.neighborhood;
+        const resolvedExtraAddress =
+            form.extraAddress ||
+            locationPickerValue?.administrative.extraAddress ||
+            "";
+
+        if (!form.height || !form.weight) {
             setError("Please fill in all required fields.");
+            return;
+        }
+
+        if (!resolvedCountryLabel || !resolvedCityLabel) {
+            setError("Please select your location from map or dropdown.");
             return;
         }
 
@@ -263,13 +320,13 @@ export default function CompleteProfileForm() {
             });
 
             await patchMyLocation(token, {
-                country: countryData?.label || form.country,
-                city: countryData?.cities[form.city]?.label || form.city,
+                country: resolvedCountryLabel || null,
+                city: resolvedCityLabel || null,
                 address:
                     buildAddress({
-                        district: form.district,
-                        neighborhood: form.neighborhood,
-                        extraAddress: form.extraAddress,
+                        district: resolvedDistrictLabel,
+                        neighborhood: resolvedNeighborhoodLabel,
+                        extraAddress: resolvedExtraAddress,
                     }) || null,
             });
 
@@ -459,6 +516,12 @@ export default function CompleteProfileForm() {
             </ProfileInfoRow>
 
             <ProfileInfoRow label="Address">
+                <LocationPicker
+                    value={locationPickerValue}
+                    onChange={setLocationPickerValue}
+                    label="Select location from map or search"
+                />
+
                 <SelectInput
                     id="country"
                     options={[{ label: "Select Country", value: "" }, ...countryOptions]}
@@ -528,9 +591,12 @@ export default function CompleteProfileForm() {
                     }
                 />
                 <HelperText>
-                    District and neighborhood are flattened into the backend address field
-                    until dedicated backend fields exist.
+                    District and neighborhood are sent with their labels and merged into
+                    the backend address field for compatibility.
                 </HelperText>
+                {locationTreeError ? (
+                    <HelperText className="text-red-500">{locationTreeError}</HelperText>
+                ) : null}
             </ProfileInfoRow>
 
             <div className="flex items-center justify-between">

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -166,23 +166,15 @@ export default function ProfileView() {
             }
 
             try {
-                const [user, backendProfile, treeResponse] = await Promise.all([
+                const [user, backendProfile] = await Promise.all([
                     fetchCurrentUser(token),
                     fetchMyProfile(token),
-                    fetchLocationTree("TR"),
                 ]);
-
-                const activeLocationTree = {
-                    [treeResponse.countryCode.toLowerCase()]: treeResponse.tree,
-                };
-
-                setLocationTree(activeLocationTree);
-                setLocationTreeError("");
 
                 const mappedProfile = toProfileData(
                     backendProfile,
                     user.email,
-                    activeLocationTree
+                    {}
                 );
 
                 setProfile(mappedProfile);
@@ -212,6 +204,23 @@ export default function ProfileView() {
                 }
 
                 setEmptyStateAction(null);
+
+                void (async () => {
+                    try {
+                        const treeResponse = await fetchLocationTree("TR");
+                        setLocationTree({
+                            [treeResponse.countryCode.toLowerCase()]: treeResponse.tree,
+                        });
+                        setLocationTreeError("");
+                    } catch (treeError) {
+                        setLocationTree({});
+                        setLocationTreeError(
+                            treeError instanceof Error
+                                ? treeError.message
+                                : "Could not load location tree."
+                        );
+                    }
+                })();
             } catch (err) {
                 if (err instanceof ApiError && err.status === 401) {
                     clearAccessToken();
@@ -222,9 +231,6 @@ export default function ProfileView() {
                     setError("");
                     setEmptyStateAction("complete-profile");
                 } else {
-                    setLocationTreeError(
-                        err instanceof Error ? err.message : "Could not load location tree."
-                    );
                     setError(
                         err instanceof Error
                             ? err.message
@@ -312,13 +318,26 @@ export default function ProfileView() {
             setError("");
             setInfo("");
 
-            const countryData = profile.country ? locationTree[profile.country] : undefined;
+            const saveCountryKey = findCountryKeyByLabel(locationTree, profile.country);
+            const saveCityKey = findCityKeyByLabel(
+                locationTree,
+                saveCountryKey,
+                profile.city
+            );
+            const saveDistrictKey = findDistrictKeyByLabel(
+                locationTree,
+                saveCountryKey,
+                saveCityKey,
+                profile.district
+            );
+
+            const countryData = saveCountryKey ? locationTree[saveCountryKey] : undefined;
             const districtLabel =
-                countryData?.cities[profile.city]?.districts[profile.district]?.label ||
+                countryData?.cities[saveCityKey]?.districts[saveDistrictKey]?.label ||
                 locationPickerValue?.administrative.district ||
                 profile.district;
             const neighborhoodLabel =
-                countryData?.cities[profile.city]?.districts[profile.district]?.neighborhoods.find(
+                countryData?.cities[saveCityKey]?.districts[saveDistrictKey]?.neighborhoods.find(
                     (item) => item.value === profile.neighborhood
                 )?.label ||
                 locationPickerValue?.administrative.neighborhood ||
@@ -345,7 +364,7 @@ export default function ProfileView() {
                     profile.country ||
                     null,
                 city:
-                    countryData?.cities[profile.city]?.label ||
+                    countryData?.cities[saveCityKey]?.label ||
                     locationPickerValue?.administrative.city ||
                     profile.city ||
                     null,
@@ -472,7 +491,20 @@ export default function ProfileView() {
         );
     }
 
-    const countryData = profile.country ? locationTree[profile.country] : undefined;
+    const resolvedCountryKey = findCountryKeyByLabel(locationTree, profile.country);
+    const resolvedCityKey = findCityKeyByLabel(
+        locationTree,
+        resolvedCountryKey,
+        profile.city
+    );
+    const resolvedDistrictKey = findDistrictKeyByLabel(
+        locationTree,
+        resolvedCountryKey,
+        resolvedCityKey,
+        profile.district
+    );
+
+    const countryData = resolvedCountryKey ? locationTree[resolvedCountryKey] : undefined;
 
     const countryOptions = Object.entries(locationTree).map(([key, value]) => ({
         label: value.label,
@@ -487,8 +519,8 @@ export default function ProfileView() {
         : [];
 
     const districtOptions =
-        profile.city && countryData?.cities[profile.city]
-            ? Object.entries(countryData.cities[profile.city].districts).map(
+        resolvedCityKey && countryData?.cities[resolvedCityKey]
+            ? Object.entries(countryData.cities[resolvedCityKey].districts).map(
                 ([key, value]) => ({
                     label: value.label,
                     value: key,
@@ -497,11 +529,16 @@ export default function ProfileView() {
             : [];
 
     const neighborhoodOptions =
-        profile.city &&
-            profile.district &&
-            countryData?.cities[profile.city]?.districts[profile.district]
-            ? countryData.cities[profile.city].districts[profile.district].neighborhoods
+        resolvedCityKey &&
+            resolvedDistrictKey &&
+            countryData?.cities[resolvedCityKey]?.districts[resolvedDistrictKey]
+            ? countryData.cities[resolvedCityKey].districts[resolvedDistrictKey].neighborhoods
             : [];
+
+    const resolvedNeighborhoodValue = findNeighborhoodValueByLabel(
+        neighborhoodOptions,
+        profile.neighborhood
+    );
 
     return (
         <div className="flex gap-10">
@@ -812,7 +849,7 @@ export default function ProfileView() {
                         <SelectInput
                             id="country"
                             label="Country"
-                            value={profile.country}
+                            value={resolvedCountryKey}
                             options={[{ label: "Select Country", value: "" }, ...countryOptions]}
                             onChange={(e) =>
                                 setProfile({
@@ -828,8 +865,8 @@ export default function ProfileView() {
                         <SelectInput
                             id="city"
                             label="City"
-                            value={profile.city}
-                            disabled={!profile.country}
+                            value={resolvedCityKey}
+                            disabled={!resolvedCountryKey}
                             options={[{ label: "Select City", value: "" }, ...cityOptions]}
                             onChange={(e) =>
                                 setProfile({
@@ -844,8 +881,8 @@ export default function ProfileView() {
                         <SelectInput
                             id="district"
                             label="District"
-                            value={profile.district}
-                            disabled={!profile.city}
+                            value={resolvedDistrictKey}
+                            disabled={!resolvedCityKey}
                             options={[
                                 { label: "Select District", value: "" },
                                 ...districtOptions,
@@ -862,8 +899,8 @@ export default function ProfileView() {
                         <SelectInput
                             id="neighborhood"
                             label="Neighborhood"
-                            value={profile.neighborhood}
-                            disabled={!profile.district}
+                            value={resolvedNeighborhoodValue}
+                            disabled={!resolvedDistrictKey}
                             options={[
                                 { label: "Select Neighborhood", value: "" },
                                 ...neighborhoodOptions,

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -12,10 +12,20 @@ import { ToggleSwitch } from "@/components/ui/selection/ToggleSwitch";
 import { Checkbox } from "@/components/ui/selection/Checkbox";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
 import { HelperText } from "@/components/ui/display/HelperText";
+import { LocationPicker, LocationPickerValue } from "@/components/feature/location";
 import { bloodTypeOptions } from "@/lib/bloodTypes";
 import { expertiseOptions, professionOptions } from "@/lib/profileOptions";
 import { clearAccessToken, fetchCurrentUser, getAccessToken } from "@/lib/auth";
 import { ApiError } from "@/lib/api";
+import { fetchLocationTree } from "@/lib/location";
+import {
+    findCityKeyByLabel,
+    findCountryKeyByLabel,
+    findDistrictKeyByLabel,
+    findNeighborhoodValueByLabel,
+    LocationTreeByCountry,
+    parseLocationAddress,
+} from "@/lib/locationTree";
 import {
     BackendProfileResponse,
     EditableProfileData,
@@ -31,12 +41,6 @@ import {
     validateExpertiseAreas,
     putMyExpertiseAreas,
 } from "@/lib/profile";
-
-type Neighborhood = { label: string; value: string };
-type District = { label: string; neighborhoods: Neighborhood[] };
-type City = { label: string; districts: Record<string, District> };
-type Country = { label: string; cities: Record<string, City> };
-type LocationData = Record<string, Country>;
 type UploadedFile = { name: string; data: string };
 type UploadField = "chronicDiseasesFiles" | "allergiesFiles";
 type EmptyStateAction = "login" | "complete-profile" | null;
@@ -48,150 +52,28 @@ type ProfileData = EditableProfileData & {
     allergiesVerified: boolean;
 };
 
-const locationData: LocationData = {
-    tr: {
-        label: "Turkey",
-        cities: {
-            istanbul: {
-                label: "Istanbul",
-                districts: {
-                    kadikoy: {
-                        label: "Kadıköy",
-                        neighborhoods: [
-                            { label: "Bostancı", value: "bostanci" },
-                            { label: "Erenköy", value: "erenkoy" },
-                        ],
-                    },
-                    besiktas: {
-                        label: "Beşiktaş",
-                        neighborhoods: [
-                            { label: "Balmumcu", value: "balmumcu" },
-                            { label: "Kuruçeşme", value: "kurucesme" },
-                        ],
-                    },
-                },
-            },
-            ankara: {
-                label: "Ankara",
-                districts: {
-                    cankaya: {
-                        label: "Çankaya",
-                        neighborhoods: [{ label: "Anıttepe", value: "anittepe" }],
-                    },
-                },
-            },
-        },
-    },
-};
-
-function findCountryKeyByLabel(label: string) {
-    return (
-        Object.entries(locationData).find(([, country]) => country.label === label)?.[0] ||
-        ""
-    );
-}
-
-function findCityKeyByLabel(countryKey: string, label: string) {
-    const country = locationData[countryKey];
-
-    if (!country) {
-        return "";
-    }
-
-    return (
-        Object.entries(country.cities).find(([, city]) => city.label === label)?.[0] ||
-        ""
-    );
-}
-
-function normalizeAddressPart(value: string) {
-    return value
-        .toLocaleLowerCase("tr")
-        .normalize("NFD")
-        .replace(/[\u0300-\u036f]/g, "")
-        .trim();
-}
-
-function parseLocationAddress(countryKey: string, cityKey: string, address: string) {
-    const tokens = address
-        .split(",")
-        .map((part) => part.trim())
-        .filter(Boolean);
-
-    if (!countryKey || !cityKey || tokens.length === 0) {
-        return {
-            district: "",
-            neighborhood: "",
-            extraAddress: address,
-        };
-    }
-
-    const city = locationData[countryKey]?.cities[cityKey];
-    if (!city) {
-        return {
-            district: "",
-            neighborhood: "",
-            extraAddress: address,
-        };
-    }
-
-    const remainingTokens = new Map(
-        tokens.map((token) => [normalizeAddressPart(token), token])
-    );
-
-    let district = "";
-    let neighborhood = "";
-
-    for (const [districtKey, districtValue] of Object.entries(city.districts)) {
-        const matchedDistrict = [districtKey, districtValue.label]
-            .map(normalizeAddressPart)
-            .find((candidate) => remainingTokens.has(candidate));
-
-        if (!matchedDistrict) {
-            continue;
-        }
-
-        district = districtKey;
-        remainingTokens.delete(matchedDistrict);
-
-        const matchedNeighborhood = districtValue.neighborhoods.find((item) =>
-            [item.value, item.label]
-                .map(normalizeAddressPart)
-                .some((candidate) => remainingTokens.has(candidate))
-        );
-
-        if (matchedNeighborhood) {
-            neighborhood = matchedNeighborhood.value;
-            for (const candidate of [matchedNeighborhood.value, matchedNeighborhood.label].map(
-                normalizeAddressPart
-            )) {
-                remainingTokens.delete(candidate);
-            }
-        }
-
-        break;
-    }
-
-    return {
-        district,
-        neighborhood,
-        extraAddress: Array.from(remainingTokens.values()).join(", "),
-    };
-}
 
 function toProfileData(
     backendProfile: BackendProfileResponse,
-    email: string
+    email: string,
+    locationTree: LocationTreeByCountry
 ): ProfileData {
     const mapped = mapBackendProfileToEditableProfile(backendProfile, email);
-    const countryKey = findCountryKeyByLabel(mapped.country);
-    const cityKey = countryKey ? findCityKeyByLabel(countryKey, mapped.city) : "";
-    const parsedAddress = parseLocationAddress(countryKey, cityKey, mapped.extraAddress);
+    const countryKey = findCountryKeyByLabel(locationTree, mapped.country);
+    const cityKey = countryKey
+        ? findCityKeyByLabel(locationTree, countryKey, mapped.city)
+        : "";
+    const parsedAddress = parseLocationAddress(
+        locationTree,
+        countryKey,
+        cityKey,
+        mapped.extraAddress
+    );
 
     return {
         ...mapped,
-        country: countryKey,
-        city: cityKey,
+        country: countryKey || mapped.country,
+        city: cityKey || mapped.city,
         district: parsedAddress.district,
         neighborhood: parsedAddress.neighborhood,
         extraAddress: parsedAddress.extraAddress,
@@ -205,6 +87,10 @@ function toProfileData(
 export default function ProfileView() {
     const router = useRouter();
     const [profile, setProfile] = React.useState<ProfileData | null>(null);
+    const [locationTree, setLocationTree] = React.useState<LocationTreeByCountry>({});
+    const [locationTreeError, setLocationTreeError] = React.useState("");
+    const [locationPickerValue, setLocationPickerValue] =
+        React.useState<LocationPickerValue | null>(null);
     const [uploading, setUploading] = React.useState<string | null>(null);
     const [progress] = React.useState<number>(100);
     const [loading, setLoading] = React.useState(true);
@@ -215,14 +101,43 @@ export default function ProfileView() {
         React.useState<EmptyStateAction>(null);
 
     const refreshProfileFromBackend = React.useCallback(
-        async (token: string) => {
+        async (token: string, activeLocationTree: LocationTreeByCountry) => {
             const [user, backendProfile] = await Promise.all([
                 fetchCurrentUser(token),
                 fetchMyProfile(token),
             ]);
 
             setProfile((currentProfile) => {
-                const refreshedProfile = toProfileData(backendProfile, user.email);
+                const refreshedProfile = toProfileData(
+                    backendProfile,
+                    user.email,
+                    activeLocationTree
+                );
+
+                if (
+                    backendProfile.locationProfile.latitude !== null &&
+                    backendProfile.locationProfile.longitude !== null
+                ) {
+                    setLocationPickerValue({
+                        placeId: "profile:location",
+                        displayName:
+                            [
+                                backendProfile.locationProfile.city,
+                                backendProfile.locationProfile.country,
+                            ]
+                                .filter(Boolean)
+                                .join(", ") || "Current profile location",
+                        latitude: backendProfile.locationProfile.latitude,
+                        longitude: backendProfile.locationProfile.longitude,
+                        administrative: {
+                            country: backendProfile.locationProfile.country,
+                            city: backendProfile.locationProfile.city,
+                            district: refreshedProfile.district,
+                            neighborhood: refreshedProfile.neighborhood,
+                            extraAddress: refreshedProfile.extraAddress,
+                        },
+                    });
+                }
 
                 return currentProfile
                     ? {
@@ -251,12 +166,51 @@ export default function ProfileView() {
             }
 
             try {
-                const [user, backendProfile] = await Promise.all([
+                const [user, backendProfile, treeResponse] = await Promise.all([
                     fetchCurrentUser(token),
                     fetchMyProfile(token),
+                    fetchLocationTree("TR"),
                 ]);
 
-                setProfile(toProfileData(backendProfile, user.email));
+                const activeLocationTree = {
+                    [treeResponse.countryCode.toLowerCase()]: treeResponse.tree,
+                };
+
+                setLocationTree(activeLocationTree);
+                setLocationTreeError("");
+
+                const mappedProfile = toProfileData(
+                    backendProfile,
+                    user.email,
+                    activeLocationTree
+                );
+
+                setProfile(mappedProfile);
+                if (
+                    backendProfile.locationProfile.latitude !== null &&
+                    backendProfile.locationProfile.longitude !== null
+                ) {
+                    setLocationPickerValue({
+                        placeId: "profile:location",
+                        displayName:
+                            [
+                                backendProfile.locationProfile.city,
+                                backendProfile.locationProfile.country,
+                            ]
+                                .filter(Boolean)
+                                .join(", ") || "Current profile location",
+                        latitude: backendProfile.locationProfile.latitude,
+                        longitude: backendProfile.locationProfile.longitude,
+                        administrative: {
+                            country: backendProfile.locationProfile.country,
+                            city: backendProfile.locationProfile.city,
+                            district: mappedProfile.district,
+                            neighborhood: mappedProfile.neighborhood,
+                            extraAddress: mappedProfile.extraAddress,
+                        },
+                    });
+                }
+
                 setEmptyStateAction(null);
             } catch (err) {
                 if (err instanceof ApiError && err.status === 401) {
@@ -268,6 +222,9 @@ export default function ProfileView() {
                     setError("");
                     setEmptyStateAction("complete-profile");
                 } else {
+                    setLocationTreeError(
+                        err instanceof Error ? err.message : "Could not load location tree."
+                    );
                     setError(
                         err instanceof Error
                             ? err.message
@@ -281,7 +238,53 @@ export default function ProfileView() {
         }
 
         void loadProfile();
-    }, [refreshProfileFromBackend]);
+    }, []);
+
+    React.useEffect(() => {
+        if (!locationPickerValue) {
+            return;
+        }
+
+        const countryKey = findCountryKeyByLabel(
+            locationTree,
+            locationPickerValue.administrative.country || ""
+        );
+        const cityKey = findCityKeyByLabel(
+            locationTree,
+            countryKey,
+            locationPickerValue.administrative.city || ""
+        );
+        const districtKey = findDistrictKeyByLabel(
+            locationTree,
+            countryKey,
+            cityKey,
+            locationPickerValue.administrative.district || ""
+        );
+        const neighborhoods =
+            locationTree[countryKey]?.cities[cityKey]?.districts[districtKey]?.neighborhoods ||
+            [];
+        const neighborhoodValue = findNeighborhoodValueByLabel(
+            neighborhoods,
+            locationPickerValue.administrative.neighborhood || ""
+        );
+
+        setProfile((currentProfile) => {
+            if (!currentProfile) {
+                return currentProfile;
+            }
+
+            return {
+                ...currentProfile,
+                country: countryKey || currentProfile.country,
+                city: cityKey || currentProfile.city,
+                district: districtKey || currentProfile.district,
+                neighborhood: neighborhoodValue || currentProfile.neighborhood,
+                extraAddress:
+                    locationPickerValue.administrative.extraAddress ||
+                    currentProfile.extraAddress,
+            };
+        });
+    }, [locationPickerValue, locationTree]);
 
     const handleSave = async () => {
         if (!profile) {
@@ -309,14 +312,17 @@ export default function ProfileView() {
             setError("");
             setInfo("");
 
+            const countryData = profile.country ? locationTree[profile.country] : undefined;
             const districtLabel =
-                locationData[profile.country]?.cities[profile.city]?.districts[profile.district]
-                    ?.label || profile.district;
+                countryData?.cities[profile.city]?.districts[profile.district]?.label ||
+                locationPickerValue?.administrative.district ||
+                profile.district;
             const neighborhoodLabel =
-                locationData[profile.country]?.cities[profile.city]?.districts[
-                    profile.district
-                ]?.neighborhoods.find((item) => item.value === profile.neighborhood)
-                    ?.label || profile.neighborhood;
+                countryData?.cities[profile.city]?.districts[profile.district]?.neighborhoods.find(
+                    (item) => item.value === profile.neighborhood
+                )?.label ||
+                locationPickerValue?.administrative.neighborhood ||
+                profile.neighborhood;
 
             await patchMyPhysical(token, {
                 age: profile.age ? Number(profile.age) : undefined,
@@ -333,16 +339,24 @@ export default function ProfileView() {
             });
 
             await patchMyLocation(token, {
-                country: locationData[profile.country]?.label || profile.country || null,
+                country:
+                    countryData?.label ||
+                    locationPickerValue?.administrative.country ||
+                    profile.country ||
+                    null,
                 city:
-                    locationData[profile.country]?.cities[profile.city]?.label ||
+                    countryData?.cities[profile.city]?.label ||
+                    locationPickerValue?.administrative.city ||
                     profile.city ||
                     null,
                 address:
                     buildAddress({
                         district: districtLabel,
                         neighborhood: neighborhoodLabel,
-                        extraAddress: profile.extraAddress,
+                        extraAddress:
+                            profile.extraAddress ||
+                            locationPickerValue?.administrative.extraAddress ||
+                            "",
                     }) || null,
             });
 
@@ -358,12 +372,12 @@ export default function ProfileView() {
                 expertiseAreas,
             });
 
-            await refreshProfileFromBackend(token);
+            await refreshProfileFromBackend(token, locationTree);
 
             setInfo("Profile updated successfully.");
         } catch (err) {
             try {
-                await refreshProfileFromBackend(token);
+                await refreshProfileFromBackend(token, locationTree);
             } catch {
             }
 
@@ -458,9 +472,9 @@ export default function ProfileView() {
         );
     }
 
-    const countryData = profile.country ? locationData[profile.country] : undefined;
+    const countryData = profile.country ? locationTree[profile.country] : undefined;
 
-    const countryOptions = Object.entries(locationData).map(([key, value]) => ({
+    const countryOptions = Object.entries(locationTree).map(([key, value]) => ({
         label: value.label,
         value: key,
     }));
@@ -786,6 +800,14 @@ export default function ProfileView() {
                         Your location may help emergency services reach you faster.
                     </p>
 
+                    <div className="mb-4">
+                        <LocationPicker
+                            value={locationPickerValue}
+                            onChange={setLocationPickerValue}
+                            label="Select location from map or search"
+                        />
+                    </div>
+
                     <div className="grid grid-cols-2 gap-4">
                         <SelectInput
                             id="country"
@@ -867,9 +889,14 @@ export default function ProfileView() {
                                 }
                             />
                             <HelperText>
-                                District and neighborhood are flattened into a single backend
-                                address field for now.
+                                District and neighborhood are sent with their labels and
+                                merged into the backend address field for compatibility.
                             </HelperText>
+                            {locationTreeError ? (
+                                <HelperText className="text-red-500">
+                                    {locationTreeError}
+                                </HelperText>
+                            ) : null}
                         </div>
                     </div>
 

--- a/web/src/lib/locationTree.ts
+++ b/web/src/lib/locationTree.ts
@@ -1,0 +1,150 @@
+import { LocationTreeCountry, LocationTreeNeighborhood } from "@/types/location";
+
+export type LocationTreeByCountry = Record<string, LocationTreeCountry>;
+
+function normalize(value: string) {
+    return value
+        .toLocaleLowerCase("tr")
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .trim();
+}
+
+export function findCountryKeyByLabel(
+    locationTree: LocationTreeByCountry,
+    label: string
+) {
+    if (!label.trim()) {
+        return "";
+    }
+
+    return (
+        Object.entries(locationTree).find(([, country]) => country.label === label)?.[0] ||
+        ""
+    );
+}
+
+export function findCityKeyByLabel(
+    locationTree: LocationTreeByCountry,
+    countryKey: string,
+    label: string
+) {
+    if (!countryKey || !label.trim()) {
+        return "";
+    }
+
+    const country = locationTree[countryKey];
+    if (!country) {
+        return "";
+    }
+
+    return (
+        Object.entries(country.cities).find(([, city]) => city.label === label)?.[0] ||
+        ""
+    );
+}
+
+export function findDistrictKeyByLabel(
+    locationTree: LocationTreeByCountry,
+    countryKey: string,
+    cityKey: string,
+    label: string
+) {
+    if (!countryKey || !cityKey || !label.trim()) {
+        return "";
+    }
+
+    const districts = locationTree[countryKey]?.cities[cityKey]?.districts;
+    if (!districts) {
+        return "";
+    }
+
+    return (
+        Object.entries(districts).find(([, district]) => district.label === label)?.[0] ||
+        ""
+    );
+}
+
+export function findNeighborhoodValueByLabel(
+    neighborhoods: LocationTreeNeighborhood[],
+    label: string
+) {
+    if (!label.trim()) {
+        return "";
+    }
+
+    return (
+        neighborhoods.find((item) => item.label === label || item.value === label)?.value ||
+        ""
+    );
+}
+
+export function parseLocationAddress(
+    locationTree: LocationTreeByCountry,
+    countryKey: string,
+    cityKey: string,
+    address: string
+) {
+    const tokens = address
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean);
+
+    if (!countryKey || !cityKey || tokens.length === 0) {
+        return {
+            district: "",
+            neighborhood: "",
+            extraAddress: address,
+        };
+    }
+
+    const city = locationTree[countryKey]?.cities[cityKey];
+    if (!city) {
+        return {
+            district: "",
+            neighborhood: "",
+            extraAddress: address,
+        };
+    }
+
+    const remainingTokens = new Map(tokens.map((token) => [normalize(token), token]));
+
+    let district = "";
+    let neighborhood = "";
+
+    for (const [districtKey, districtValue] of Object.entries(city.districts)) {
+        const matchedDistrict = [districtKey, districtValue.label]
+            .map(normalize)
+            .find((candidate) => remainingTokens.has(candidate));
+
+        if (!matchedDistrict) {
+            continue;
+        }
+
+        district = districtKey;
+        remainingTokens.delete(matchedDistrict);
+
+        const matchedNeighborhood = districtValue.neighborhoods.find((item) =>
+            [item.value, item.label]
+                .map(normalize)
+                .some((candidate) => remainingTokens.has(candidate))
+        );
+
+        if (matchedNeighborhood) {
+            neighborhood = matchedNeighborhood.value;
+            for (const candidate of [matchedNeighborhood.value, matchedNeighborhood.label].map(
+                normalize
+            )) {
+                remainingTokens.delete(candidate);
+            }
+        }
+
+        break;
+    }
+
+    return {
+        district,
+        neighborhood,
+        extraAddress: Array.from(remainingTokens.values()).join(", "),
+    };
+}

--- a/web/src/lib/locationTree.ts
+++ b/web/src/lib/locationTree.ts
@@ -10,6 +10,10 @@ function normalize(value: string) {
         .trim();
 }
 
+function normalizeIfPresent(value: string | undefined | null) {
+    return normalize(value || "");
+}
+
 export function findCountryKeyByLabel(
     locationTree: LocationTreeByCountry,
     label: string
@@ -18,8 +22,15 @@ export function findCountryKeyByLabel(
         return "";
     }
 
+    const normalizedLabel = normalize(label);
+
     return (
-        Object.entries(locationTree).find(([, country]) => country.label === label)?.[0] ||
+        Object.entries(locationTree).find(([key, country]) => {
+            return (
+                normalizeIfPresent(key) === normalizedLabel ||
+                normalizeIfPresent(country.label) === normalizedLabel
+            );
+        })?.[0] ||
         ""
     );
 }
@@ -38,8 +49,15 @@ export function findCityKeyByLabel(
         return "";
     }
 
+    const normalizedLabel = normalize(label);
+
     return (
-        Object.entries(country.cities).find(([, city]) => city.label === label)?.[0] ||
+        Object.entries(country.cities).find(([key, city]) => {
+            return (
+                normalizeIfPresent(key) === normalizedLabel ||
+                normalizeIfPresent(city.label) === normalizedLabel
+            );
+        })?.[0] ||
         ""
     );
 }
@@ -59,8 +77,15 @@ export function findDistrictKeyByLabel(
         return "";
     }
 
+    const normalizedLabel = normalize(label);
+
     return (
-        Object.entries(districts).find(([, district]) => district.label === label)?.[0] ||
+        Object.entries(districts).find(([key, district]) => {
+            return (
+                normalizeIfPresent(key) === normalizedLabel ||
+                normalizeIfPresent(district.label) === normalizedLabel
+            );
+        })?.[0] ||
         ""
     );
 }
@@ -73,8 +98,15 @@ export function findNeighborhoodValueByLabel(
         return "";
     }
 
+    const normalizedLabel = normalize(label);
+
     return (
-        neighborhoods.find((item) => item.label === label || item.value === label)?.value ||
+        neighborhoods.find((item) => {
+            return (
+                normalizeIfPresent(item.label) === normalizedLabel ||
+                normalizeIfPresent(item.value) === normalizedLabel
+            );
+        })?.value ||
         ""
     );
 }


### PR DESCRIPTION
This PR integrates the shared hybrid location selection flow into profile-related web forms by combining:

- Map/search-based location picking
- Backend-driven location tree dropdowns
- Compatibility-safe location payload mapping for existing backend fields

Changes
- Refactored complete profile form to use shared location infrastructure.
  - CompleteProfileForm.tsx
- Refactored profile edit view to use the same hybrid location flow.
  - ProfileView.tsx
 - Added shared location-tree helper utilities for key/label mapping and address parsing.
   - locationTree.ts