### PR TITLE
feat: implement permission-aware current location sharing for android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -161,6 +161,7 @@ dependencies {
     implementation 'androidx.compose.material:material-icons-extended'
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.navigation:navigation-compose:2.9.7'
+    implementation 'com.google.android.gms:play-services-location:21.3.0'
     implementation 'androidx.room:room-runtime:2.8.4'
     implementation 'androidx.room:room-ktx:2.8.4'
     implementation 'androidx.work:work-runtime-ktx:2.11.2'

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:allowBackup="true"

--- a/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
@@ -1,5 +1,7 @@
 package com.neph.features.auth.presentation
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,10 +19,13 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import com.neph.core.network.ApiException
 import com.neph.features.auth.util.countryCodeOptions
+import com.neph.features.profile.data.CurrentLocationShareWarning
+import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.features.profile.data.ProfileRepository
 import com.neph.features.profile.data.LocationData
 import com.neph.features.profile.data.LocationTreeRepository
@@ -57,6 +62,7 @@ fun CompleteProfileScreen(
     val existingPhoneParts = remember(existingProfile.phone) { normalizePhoneParts(existingProfile.phone) }
     val spacing = LocalNephSpacing.current
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
 
     var fullName by rememberSaveable { mutableStateOf(existingProfile.fullName.orEmpty()) }
     var countryCode by rememberSaveable { mutableStateOf(existingPhoneParts.countryCode) }
@@ -83,6 +89,17 @@ fun CompleteProfileScreen(
     var availableLocationData by remember { mutableStateOf<LocationData>(locationData) }
     var locationLoading by remember { mutableStateOf(true) }
     var locationInfo by rememberSaveable { mutableStateOf("") }
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { grants ->
+        if (grants.values.any { it }) {
+            shareLocation = true
+            info = "Location permission granted. Current location will be shared when you save."
+        } else {
+            shareLocation = false
+            info = "Location permission denied. Current location sharing remains off."
+        }
+    }
 
     LaunchedEffect(Unit) {
         try {
@@ -143,28 +160,51 @@ fun CompleteProfileScreen(
         loading = true
         scope.launch {
             try {
-                ProfileRepository.syncProfile(
-                    ProfileRepository.getProfile().copy(
-                        fullName = normalizedName,
-                        phone = combinePhoneNumber(countryCode, normalizedPhone),
-                        gender = gender.takeIf(String::isNotBlank),
-                        height = heightFloat,
-                        weight = weightFloat,
-                        age = ageInt,
-                        bloodType = bloodType.takeIf(String::isNotBlank),
-                        medicalHistory = medicalHistory.takeIf(String::isNotBlank),
-                        chronicDiseases = chronicDiseases.takeIf(String::isNotBlank),
-                        allergies = allergies.takeIf(String::isNotBlank),
-                        country = country,
-                        city = city,
-                        district = district,
-                        neighborhood = neighborhood,
-                        extraAddress = extraAddress.takeIf(String::isNotBlank),
-                        shareLocation = shareLocation,
-                        profession = profession?.trim()?.takeIf(String::isNotBlank),
-                        expertise = parseListField(expertise.joinToString(", "))
-                    )
+                val profileToSync = ProfileRepository.getProfile().copy(
+                    fullName = normalizedName,
+                    phone = combinePhoneNumber(countryCode, normalizedPhone),
+                    gender = gender.takeIf(String::isNotBlank),
+                    height = heightFloat,
+                    weight = weightFloat,
+                    age = ageInt,
+                    bloodType = bloodType.takeIf(String::isNotBlank),
+                    medicalHistory = medicalHistory.takeIf(String::isNotBlank),
+                    chronicDiseases = chronicDiseases.takeIf(String::isNotBlank),
+                    allergies = allergies.takeIf(String::isNotBlank),
+                    country = country,
+                    city = city,
+                    district = district,
+                    neighborhood = neighborhood,
+                    extraAddress = extraAddress.takeIf(String::isNotBlank),
+                    shareLocation = shareLocation,
+                    profession = profession?.trim()?.takeIf(String::isNotBlank),
+                    expertise = parseListField(expertise.joinToString(", "))
                 )
+                val locationShareAttempt = DeviceLocationProvider.captureCurrentLocationForSharing(
+                    context = context,
+                    sharingEnabled = profileToSync.shareLocation == true
+                )
+
+                ProfileRepository.syncProfile(
+                    profile = profileToSync,
+                    currentDeviceLocation = locationShareAttempt.location
+                )
+
+                info = when (locationShareAttempt.warning) {
+                    CurrentLocationShareWarning.PERMISSION_DENIED ->
+                        "Profile saved. Location permission is denied, so current coordinates were not shared."
+
+                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE ->
+                        "Profile saved. Current location is unavailable, so coordinates were not shared."
+
+                    null -> {
+                        if (locationShareAttempt.location != null) {
+                            "Profile saved. Current location shared."
+                        } else {
+                            "Profile saved."
+                        }
+                    }
+                }
 
                 onComplete()
             } catch (cancellationException: CancellationException) {
@@ -352,7 +392,18 @@ fun CompleteProfileScreen(
 
             AppToggleSwitch(
                 checked = shareLocation,
-                onCheckedChange = { shareLocation = it },
+                onCheckedChange = { shareEnabled ->
+                    if (!shareEnabled) {
+                        shareLocation = false
+                        return@AppToggleSwitch
+                    }
+
+                    if (DeviceLocationProvider.hasLocationPermission(context)) {
+                        shareLocation = true
+                    } else {
+                        locationPermissionLauncher.launch(DeviceLocationProvider.RequiredLocationPermissions)
+                    }
+                },
                 label = "Share Current Location"
             )
 

--- a/android/app/src/main/java/com/neph/features/profile/data/DeviceLocationProvider.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/DeviceLocationProvider.kt
@@ -1,0 +1,146 @@
+package com.neph.features.profile.data
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.Location
+import androidx.core.app.ActivityCompat
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.google.android.gms.tasks.CancellationTokenSource
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+data class CurrentDeviceLocation(
+    val latitude: Double,
+    val longitude: Double,
+    val accuracyMeters: Double? = null,
+    val capturedAt: String,
+    val source: String = DeviceLocationProvider.DeviceLocationSource
+)
+
+enum class CurrentLocationShareWarning {
+    PERMISSION_DENIED,
+    LOCATION_UNAVAILABLE
+}
+
+data class CurrentLocationShareAttempt(
+    val location: CurrentDeviceLocation? = null,
+    val warning: CurrentLocationShareWarning? = null
+)
+
+object DeviceLocationProvider {
+    const val DeviceLocationSource = "DEVICE_GPS"
+
+    val RequiredLocationPermissions = arrayOf(
+        Manifest.permission.ACCESS_FINE_LOCATION,
+        Manifest.permission.ACCESS_COARSE_LOCATION
+    )
+
+    fun hasLocationPermission(context: Context): Boolean {
+        val appContext = context.applicationContext
+        return isPermissionGranted(appContext, Manifest.permission.ACCESS_FINE_LOCATION) ||
+            isPermissionGranted(appContext, Manifest.permission.ACCESS_COARSE_LOCATION)
+    }
+
+    suspend fun captureCurrentLocationForSharing(
+        context: Context,
+        sharingEnabled: Boolean
+    ): CurrentLocationShareAttempt {
+        if (!sharingEnabled) {
+            return CurrentLocationShareAttempt()
+        }
+
+        if (!hasLocationPermission(context)) {
+            return CurrentLocationShareAttempt(warning = CurrentLocationShareWarning.PERMISSION_DENIED)
+        }
+
+        return try {
+            val location = getCurrentLocation(context)
+            if (location == null) {
+                CurrentLocationShareAttempt(warning = CurrentLocationShareWarning.LOCATION_UNAVAILABLE)
+            } else {
+                CurrentLocationShareAttempt(location = location)
+            }
+        } catch (_: SecurityException) {
+            CurrentLocationShareAttempt(warning = CurrentLocationShareWarning.PERMISSION_DENIED)
+        } catch (_: Exception) {
+            CurrentLocationShareAttempt(warning = CurrentLocationShareWarning.LOCATION_UNAVAILABLE)
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    suspend fun getCurrentLocation(context: Context): CurrentDeviceLocation? {
+        if (!hasLocationPermission(context)) {
+            return null
+        }
+
+        val appContext = context.applicationContext
+        val fusedClient = LocationServices.getFusedLocationProviderClient(appContext)
+
+        return suspendCancellableCoroutine { continuation ->
+            val cancellationTokenSource = CancellationTokenSource()
+
+            fun resumeWithLocation(location: Location?) {
+                if (!continuation.isActive) {
+                    return
+                }
+
+                continuation.resume(location?.toCurrentDeviceLocation())
+            }
+
+            fusedClient
+                .getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, cancellationTokenSource.token)
+                .addOnSuccessListener { current ->
+                    if (current != null) {
+                        resumeWithLocation(current)
+                    } else {
+                        fusedClient.lastLocation
+                            .addOnSuccessListener { lastKnown ->
+                                resumeWithLocation(lastKnown)
+                            }
+                            .addOnFailureListener { error ->
+                                if (continuation.isActive) {
+                                    continuation.resumeWithException(error)
+                                }
+                            }
+                    }
+                }
+                .addOnFailureListener { error ->
+                    if (continuation.isActive) {
+                        continuation.resumeWithException(error)
+                    }
+                }
+
+            continuation.invokeOnCancellation {
+                cancellationTokenSource.cancel()
+            }
+        }
+    }
+
+    private fun isPermissionGranted(context: Context, permission: String): Boolean {
+        return ActivityCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun Location.toCurrentDeviceLocation(): CurrentDeviceLocation {
+        val capturedAtMillis = if (time > 0L) time else System.currentTimeMillis()
+        return CurrentDeviceLocation(
+            latitude = latitude,
+            longitude = longitude,
+            accuracyMeters = if (hasAccuracy()) accuracy.toDouble() else null,
+            capturedAt = toIsoUtc(capturedAtMillis)
+        )
+    }
+
+    private fun toIsoUtc(timestampMillis: Long): String {
+        val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+        formatter.timeZone = TimeZone.getTimeZone("UTC")
+        return formatter.format(Date(timestampMillis))
+    }
+}

--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
@@ -92,7 +92,10 @@ object ProfileRepository {
         return mapped
     }
 
-    suspend fun syncProfile(profile: ProfileData): ProfileData {
+    suspend fun syncProfile(
+        profile: ProfileData,
+        currentDeviceLocation: CurrentDeviceLocation? = null
+    ): ProfileData {
         ensureInitialized()
 
         try {
@@ -147,40 +150,7 @@ object ProfileRepository {
                 path = "/profiles/me/location",
                 method = "PATCH",
                 token = token,
-                body = JSONObject().apply {
-                    val selectedCountry = profile.country?.trim()?.takeIf(String::isNotBlank)
-                    val resolvedCountryKey = resolveCountrySelectionKey(selectedCountry)
-                    val countryLookupValue = resolvedCountryKey ?: selectedCountry
-                    val backendCountryCode = resolvedCountryKey?.uppercase(Locale.ROOT)
-                    val countryLabel = resolveCountryLabel(countryLookupValue)
-                    val cityLabel = resolveCityLabel(countryLookupValue, profile.city)
-                    val districtLabel = resolveDistrictLabel(countryLookupValue, profile.city, profile.district)
-                    val neighborhoodLabel = resolveNeighborhoodLabel(
-                        countryLookupValue,
-                        profile.city,
-                        profile.district,
-                        profile.neighborhood
-                    )
-                    val normalizedExtraAddress = profile.extraAddress?.trim()?.takeIf(String::isNotBlank)
-                    val displayAddress = buildAddress(districtLabel, neighborhoodLabel, normalizedExtraAddress)
-
-                    putNullable("country", countryLabel)
-                    putNullable("city", cityLabel)
-                    putNullable("address", displayAddress)
-                    putNullable("displayAddress", displayAddress)
-
-                    put(
-                        "administrative",
-                        JSONObject().apply {
-                            putNullable("countryCode", backendCountryCode)
-                            putNullable("country", countryLabel)
-                            putNullable("city", cityLabel)
-                            putNullable("district", districtLabel)
-                            putNullable("neighborhood", neighborhoodLabel)
-                            putNullable("extraAddress", normalizedExtraAddress)
-                        }
-                    )
-                }
+                body = buildLocationPatchPayload(profile, currentDeviceLocation)
             )
 
             JsonHttpClient.request(
@@ -225,6 +195,61 @@ object ProfileRepository {
                 // Keep the last known local state if backend refresh also fails.
             }
             throw error
+        }
+    }
+
+    internal fun buildLocationPatchPayload(
+        profile: ProfileData,
+        currentDeviceLocation: CurrentDeviceLocation? = null
+    ): JSONObject {
+        val selectedCountry = profile.country?.trim()?.takeIf(String::isNotBlank)
+        val resolvedCountryKey = resolveCountrySelectionKey(selectedCountry)
+        val countryLookupValue = resolvedCountryKey ?: selectedCountry
+        val backendCountryCode = resolvedCountryKey?.uppercase(Locale.ROOT)
+        val countryLabel = resolveCountryLabel(countryLookupValue)
+        val cityLabel = resolveCityLabel(countryLookupValue, profile.city)
+        val districtLabel = resolveDistrictLabel(countryLookupValue, profile.city, profile.district)
+        val neighborhoodLabel = resolveNeighborhoodLabel(
+            countryLookupValue,
+            profile.city,
+            profile.district,
+            profile.neighborhood
+        )
+        val normalizedExtraAddress = profile.extraAddress?.trim()?.takeIf(String::isNotBlank)
+        val displayAddress = buildAddress(districtLabel, neighborhoodLabel, normalizedExtraAddress)
+
+        return JSONObject().apply {
+            putNullable("country", countryLabel)
+            putNullable("city", cityLabel)
+            putNullable("address", displayAddress)
+            putNullable("displayAddress", displayAddress)
+
+            put(
+                "administrative",
+                JSONObject().apply {
+                    putNullable("countryCode", backendCountryCode)
+                    putNullable("country", countryLabel)
+                    putNullable("city", cityLabel)
+                    putNullable("district", districtLabel)
+                    putNullable("neighborhood", neighborhoodLabel)
+                    putNullable("extraAddress", normalizedExtraAddress)
+                }
+            )
+
+            if (profile.shareLocation == true && currentDeviceLocation != null) {
+                put("latitude", currentDeviceLocation.latitude)
+                put("longitude", currentDeviceLocation.longitude)
+                put(
+                    "coordinate",
+                    JSONObject().apply {
+                        put("latitude", currentDeviceLocation.latitude)
+                        put("longitude", currentDeviceLocation.longitude)
+                        putNullable("accuracyMeters", currentDeviceLocation.accuracyMeters)
+                        putNullable("source", currentDeviceLocation.source)
+                        putNullable("capturedAt", currentDeviceLocation.capturedAt)
+                    }
+                )
+            }
         }
     }
 

--- a/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
@@ -1,5 +1,7 @@
 package com.neph.features.profile.presentation
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,9 +19,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import com.neph.core.network.ApiException
 import com.neph.features.auth.util.countryCodeOptions
+import com.neph.features.profile.data.CurrentLocationShareWarning
+import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.features.profile.data.LocationData
 import com.neph.features.profile.data.LocationTreeRepository
 import com.neph.features.profile.data.ProfileData
@@ -73,6 +78,18 @@ fun EditProfileScreen(
 
     val scope = rememberCoroutineScope()
     val spacing = LocalNephSpacing.current
+    val context = LocalContext.current
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { grants ->
+        if (grants.values.any { it }) {
+            profile = profile.copy(shareLocation = true)
+            info = "Location permission granted. Current location will be shared when you save."
+        } else {
+            profile = profile.copy(shareLocation = false)
+            info = "Location permission denied. Current location sharing remains off."
+        }
+    }
 
     LaunchedEffect(Unit) {
         try {
@@ -154,13 +171,20 @@ fun EditProfileScreen(
         loading = true
         scope.launch {
             try {
+                val profileToSync = profile.copy(
+                    phone = combinePhoneNumber(countryCode, phone),
+                    height = heightFloat,
+                    weight = weightFloat,
+                    age = ageInt
+                )
+                val locationShareAttempt = DeviceLocationProvider.captureCurrentLocationForSharing(
+                    context = context,
+                    sharingEnabled = profileToSync.shareLocation == true
+                )
+
                 profile = ProfileRepository.syncProfile(
-                    profile.copy(
-                        phone = combinePhoneNumber(countryCode, phone),
-                        height = heightFloat,
-                        weight = weightFloat,
-                        age = ageInt
-                    )
+                    profile = profileToSync,
+                    currentDeviceLocation = locationShareAttempt.location
                 )
                 val phoneParts = normalizePhoneParts(profile.phone)
                 countryCode = phoneParts.countryCode
@@ -168,7 +192,21 @@ fun EditProfileScreen(
                 heightText = profile.height.toEditableString()
                 weightText = profile.weight.toEditableString()
                 ageText = profile.age?.toString().orEmpty()
-                info = "Profile updated successfully."
+                info = when (locationShareAttempt.warning) {
+                    CurrentLocationShareWarning.PERMISSION_DENIED ->
+                        "Profile updated successfully. Location permission is denied, so current coordinates were not shared."
+
+                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE ->
+                        "Profile updated successfully. Current location is unavailable, so coordinates were not shared."
+
+                    null -> {
+                        if (locationShareAttempt.location != null) {
+                            "Profile updated successfully. Current location shared."
+                        } else {
+                            "Profile updated successfully."
+                        }
+                    }
+                }
                 onSave(profile)
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
@@ -376,7 +414,18 @@ fun EditProfileScreen(
 
                     AppToggleSwitch(
                         checked = profile.shareLocation ?: false,
-                        onCheckedChange = { profile = profile.copy(shareLocation = it) },
+                        onCheckedChange = { shareEnabled ->
+                            if (!shareEnabled) {
+                                profile = profile.copy(shareLocation = false)
+                                return@AppToggleSwitch
+                            }
+
+                            if (DeviceLocationProvider.hasLocationPermission(context)) {
+                                profile = profile.copy(shareLocation = true)
+                            } else {
+                                locationPermissionLauncher.launch(DeviceLocationProvider.RequiredLocationPermissions)
+                            }
+                        },
                         label = "Share Current Location"
                     )
                 }

--- a/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
+++ b/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
@@ -1,0 +1,81 @@
+package com.neph.features.profile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProfileRepositoryLocationPayloadTest {
+    @Test
+    fun buildLocationPatchPayload_includesCoordinateWhenSharingEnabledAndLocationAvailable() {
+        val payload = ProfileRepository.buildLocationPatchPayload(
+            profile = ProfileData(
+                country = "tr",
+                city = "ankara",
+                district = "cankaya",
+                neighborhood = "AnitTepeCode",
+                extraAddress = "Building A",
+                shareLocation = true
+            ),
+            currentDeviceLocation = CurrentDeviceLocation(
+                latitude = 41.043,
+                longitude = 29.009,
+                accuracyMeters = 12.5,
+                capturedAt = "2026-04-20T10:20:30.000Z",
+                source = "DEVICE_GPS"
+            )
+        )
+
+        assertEquals(41.043, payload.getDouble("latitude"), 0.0)
+        assertEquals(29.009, payload.getDouble("longitude"), 0.0)
+
+        val coordinate = payload.getJSONObject("coordinate")
+        assertEquals(41.043, coordinate.getDouble("latitude"), 0.0)
+        assertEquals(29.009, coordinate.getDouble("longitude"), 0.0)
+        assertEquals(12.5, coordinate.getDouble("accuracyMeters"), 0.0)
+        assertEquals("DEVICE_GPS", coordinate.getString("source"))
+        assertEquals("2026-04-20T10:20:30.000Z", coordinate.getString("capturedAt"))
+    }
+
+    @Test
+    fun buildLocationPatchPayload_omitsCoordinateWhenSharingDisabled() {
+        val payload = ProfileRepository.buildLocationPatchPayload(
+            profile = ProfileData(
+                country = "tr",
+                city = "ankara",
+                district = "cankaya",
+                neighborhood = "AnitTepeCode",
+                shareLocation = false
+            ),
+            currentDeviceLocation = CurrentDeviceLocation(
+                latitude = 41.043,
+                longitude = 29.009,
+                accuracyMeters = null,
+                capturedAt = "2026-04-20T10:20:30.000Z"
+            )
+        )
+
+        assertFalse(payload.has("latitude"))
+        assertFalse(payload.has("longitude"))
+        assertFalse(payload.has("coordinate"))
+    }
+
+    @Test
+    fun buildLocationPatchPayload_omitsCoordinateWhenLocationUnavailable() {
+        val payload = ProfileRepository.buildLocationPatchPayload(
+            profile = ProfileData(
+                country = "tr",
+                city = "ankara",
+                district = "cankaya",
+                neighborhood = "AnitTepeCode",
+                shareLocation = true
+            ),
+            currentDeviceLocation = null
+        )
+
+        assertTrue(payload.has("administrative"))
+        assertFalse(payload.has("latitude"))
+        assertFalse(payload.has("longitude"))
+        assertFalse(payload.has("coordinate"))
+    }
+}


### PR DESCRIPTION
This PR adds Android support for Share Current Location in profile flows.

What’s included:

requests runtime location permission when users enable Share Current Location
captures current (or last-known) device coordinates on save
sends coordinates with source and capturedAt through existing profile location APIs
handles permission denied and location unavailable cases safely without blocking profile save
Scope:

Android only
no web changes
no backend changes (reuses existing backend location/privacy infrastructure)
Validation:

Android unit tests updated for location payload behavior
Android build/tests pass for the project’s e2e test variant

This PR completes the android side of the issue #290 