### PR TITLE
feat(web): persist current location coordinates in profile flows

### DIFF
--- a/web/src/components/feature/auth/CompleteProfileForm.tsx
+++ b/web/src/components/feature/auth/CompleteProfileForm.tsx
@@ -280,6 +280,13 @@ export default function CompleteProfileForm() {
             form.extraAddress ||
             locationPickerValue?.administrative.extraAddress ||
             "";
+        const hasCoordinateSelection =
+            typeof locationPickerValue?.latitude === "number" &&
+            typeof locationPickerValue?.longitude === "number";
+        const resolvedCountryCode =
+            (locationPickerValue?.administrative.countryCode || "").trim().toUpperCase() ||
+            (form.country || "").trim().toUpperCase() ||
+            null;
 
         if (!form.height || !form.weight) {
             setError("Please fill in all required fields.");
@@ -328,6 +335,33 @@ export default function CompleteProfileForm() {
                         neighborhood: resolvedNeighborhoodLabel,
                         extraAddress: resolvedExtraAddress,
                     }) || null,
+                latitude: hasCoordinateSelection
+                    ? locationPickerValue.latitude
+                    : undefined,
+                longitude: hasCoordinateSelection
+                    ? locationPickerValue.longitude
+                    : undefined,
+                displayAddress: locationPickerValue?.displayName || undefined,
+                placeId: locationPickerValue?.placeId || undefined,
+                administrative: {
+                    countryCode: resolvedCountryCode,
+                    country: resolvedCountryLabel || null,
+                    city: resolvedCityLabel || null,
+                    district: resolvedDistrictLabel || null,
+                    neighborhood: resolvedNeighborhoodLabel || null,
+                    extraAddress: resolvedExtraAddress || null,
+                },
+                coordinate: hasCoordinateSelection
+                    ? {
+                        latitude: locationPickerValue.latitude,
+                        longitude: locationPickerValue.longitude,
+                        accuracyMeters: locationPickerValue.accuracyMeters ?? null,
+                        source: locationPickerValue.source || "profile_form",
+                        capturedAt:
+                            locationPickerValue.capturedAt ||
+                            new Date().toISOString(),
+                    }
+                    : undefined,
             });
 
             await patchMyPrivacy(token, {

--- a/web/src/components/feature/location/LocationPicker.tsx
+++ b/web/src/components/feature/location/LocationPicker.tsx
@@ -13,6 +13,9 @@ type LocationPickerValue = {
     displayName: string;
     latitude: number;
     longitude: number;
+    accuracyMeters?: number | null;
+    source?: string | null;
+    capturedAt?: string | null;
     administrative: LocationSearchItem["administrative"];
 };
 
@@ -34,6 +37,9 @@ function toPickerValue(item: LocationSearchItem): LocationPickerValue {
         displayName: item.displayName,
         latitude: item.latitude,
         longitude: item.longitude,
+        accuracyMeters: null,
+        source: "search",
+        capturedAt: new Date().toISOString(),
         administrative: item.administrative,
     };
 }
@@ -47,6 +53,9 @@ function toManualPickerValue(latitude: number, longitude: number): LocationPicke
         displayName: `Pinned location (${normalizedLatitude}, ${normalizedLongitude})`,
         latitude,
         longitude,
+        accuracyMeters: null,
+        source: "map_pin",
+        capturedAt: new Date().toISOString(),
         administrative: {},
     };
 }
@@ -113,7 +122,14 @@ export function LocationPicker({
     }, [countryCode, query]);
 
     const handleResolveCoordinates = React.useCallback(
-        async (latitude: number, longitude: number) => {
+        async (
+            latitude: number,
+            longitude: number,
+            metadata?: {
+                source?: string | null;
+                accuracyMeters?: number | null;
+            }
+        ) => {
             const currentReverseRequestId = ++reverseRequestIdRef.current;
 
             try {
@@ -126,14 +142,24 @@ export function LocationPicker({
                     return;
                 }
 
-                onChange(toPickerValue(response.item));
+                onChange({
+                    ...toPickerValue(response.item),
+                    source: metadata?.source || "map_pin",
+                    accuracyMeters: metadata?.accuracyMeters ?? null,
+                    capturedAt: new Date().toISOString(),
+                });
             } catch (err) {
                 if (currentReverseRequestId !== reverseRequestIdRef.current) {
                     return;
                 }
 
                 setError(err instanceof Error ? err.message : "Could not resolve selected location.");
-                onChange(toManualPickerValue(latitude, longitude));
+                onChange({
+                    ...toManualPickerValue(latitude, longitude),
+                    source: metadata?.source || "map_pin",
+                    accuracyMeters: metadata?.accuracyMeters ?? null,
+                    capturedAt: new Date().toISOString(),
+                });
             } finally {
                 if (currentReverseRequestId === reverseRequestIdRef.current) {
                     setResolving(false);
@@ -156,7 +182,14 @@ export function LocationPicker({
             (position) => {
                 void handleResolveCoordinates(
                     position.coords.latitude,
-                    position.coords.longitude
+                    position.coords.longitude,
+                    {
+                        source: "current_device",
+                        accuracyMeters:
+                            typeof position.coords.accuracy === "number"
+                                ? position.coords.accuracy
+                                : null,
+                    }
                 );
             },
             (geoError) => {
@@ -209,7 +242,11 @@ export function LocationPicker({
                             type="button"
                             className="w-full border-b border-[#f0f0f2] px-3 py-2 text-left text-sm text-[#2b2b33] transition-colors hover:bg-[#fafafa]"
                             onClick={() => {
-                                onChange(toPickerValue(item));
+                                onChange({
+                                    ...toPickerValue(item),
+                                    source: "search",
+                                    capturedAt: new Date().toISOString(),
+                                });
                                 skipNextSearchRef.current = true;
                                 setResults([]);
                                 setQuery(item.displayName);
@@ -232,7 +269,10 @@ export function LocationPicker({
                         : null
                 }
                 onSelectPosition={(position) => {
-                    void handleResolveCoordinates(position.latitude, position.longitude);
+                    void handleResolveCoordinates(position.latitude, position.longitude, {
+                        source: "map_pin",
+                        accuracyMeters: null,
+                    });
                 }}
             />
 

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -342,6 +342,27 @@ export default function ProfileView() {
                 )?.label ||
                 locationPickerValue?.administrative.neighborhood ||
                 profile.neighborhood;
+            const hasCoordinateSelection =
+                typeof locationPickerValue?.latitude === "number" &&
+                typeof locationPickerValue?.longitude === "number";
+            const resolvedCountryLabel =
+                countryData?.label ||
+                locationPickerValue?.administrative.country ||
+                profile.country ||
+                null;
+            const resolvedCityLabel =
+                countryData?.cities[saveCityKey]?.label ||
+                locationPickerValue?.administrative.city ||
+                profile.city ||
+                null;
+            const resolvedExtraAddress =
+                profile.extraAddress ||
+                locationPickerValue?.administrative.extraAddress ||
+                "";
+            const resolvedCountryCode =
+                (locationPickerValue?.administrative.countryCode || "").trim().toUpperCase() ||
+                (saveCountryKey || "").trim().toUpperCase() ||
+                null;
 
             await patchMyPhysical(token, {
                 age: profile.age ? Number(profile.age) : undefined,
@@ -358,25 +379,41 @@ export default function ProfileView() {
             });
 
             await patchMyLocation(token, {
-                country:
-                    countryData?.label ||
-                    locationPickerValue?.administrative.country ||
-                    profile.country ||
-                    null,
-                city:
-                    countryData?.cities[saveCityKey]?.label ||
-                    locationPickerValue?.administrative.city ||
-                    profile.city ||
-                    null,
+                country: resolvedCountryLabel,
+                city: resolvedCityLabel,
                 address:
                     buildAddress({
                         district: districtLabel,
                         neighborhood: neighborhoodLabel,
-                        extraAddress:
-                            profile.extraAddress ||
-                            locationPickerValue?.administrative.extraAddress ||
-                            "",
+                        extraAddress: resolvedExtraAddress,
                     }) || null,
+                latitude: hasCoordinateSelection
+                    ? locationPickerValue.latitude
+                    : undefined,
+                longitude: hasCoordinateSelection
+                    ? locationPickerValue.longitude
+                    : undefined,
+                displayAddress: locationPickerValue?.displayName || undefined,
+                placeId: locationPickerValue?.placeId || undefined,
+                administrative: {
+                    countryCode: resolvedCountryCode,
+                    country: resolvedCountryLabel,
+                    city: resolvedCityLabel,
+                    district: districtLabel || null,
+                    neighborhood: neighborhoodLabel || null,
+                    extraAddress: resolvedExtraAddress || null,
+                },
+                coordinate: hasCoordinateSelection
+                    ? {
+                        latitude: locationPickerValue.latitude,
+                        longitude: locationPickerValue.longitude,
+                        accuracyMeters: locationPickerValue.accuracyMeters ?? null,
+                        source: locationPickerValue.source || "profile_form",
+                        capturedAt:
+                            locationPickerValue.capturedAt ||
+                            new Date().toISOString(),
+                    }
+                    : undefined,
             });
 
             await patchMyPrivacy(token, {

--- a/web/src/lib/profile.ts
+++ b/web/src/lib/profile.ts
@@ -260,7 +260,31 @@ export async function patchMyHealth(
 
 export async function patchMyLocation(
     token: string,
-    payload: { address?: string | null; city?: string | null; country?: string | null }
+    payload: {
+        address?: string | null;
+        city?: string | null;
+        country?: string | null;
+        latitude?: number | null;
+        longitude?: number | null;
+        displayAddress?: string | null;
+        placeId?: string | null;
+        administrative?: {
+            countryCode?: string | null;
+            country?: string | null;
+            city?: string | null;
+            district?: string | null;
+            neighborhood?: string | null;
+            extraAddress?: string | null;
+            postalCode?: string | null;
+        };
+        coordinate?: {
+            latitude?: number | null;
+            longitude?: number | null;
+            accuracyMeters?: number | null;
+            source?: string | null;
+            capturedAt?: string | null;
+        };
+    }
 ) {
     return apiRequest<BackendProfileResponse>("/profiles/me/location", {
         method: "PATCH",


### PR DESCRIPTION
- Added coordinate persistence to web profile location save flows.
- Extended location picker output to carry selection metadata (source and accuracy) for current device, map pin, and search selections.
- Included latitude, longitude, coordinate, and administrative fields in location patch requests from both complete-profile and profile-edit forms.
- Expanded web location patch payload typing to align with backend location contract.
- Replaced hardcoded country code with dynamically resolved country code.