### PR TITLE
fix: clear shared coordinates on disable and align location-permission save flow

### DIFF
--- a/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
+import android.widget.Toast
 import com.neph.core.network.ApiException
 import com.neph.features.auth.util.countryCodeOptions
 import com.neph.features.profile.data.CurrentLocationShareWarning
@@ -184,18 +185,23 @@ fun CompleteProfileScreen(
                     context = context,
                     sharingEnabled = profileToSync.shareLocation == true
                 )
+                val syncedProfile = when (locationShareAttempt.warning) {
+                    CurrentLocationShareWarning.PERMISSION_DENIED,
+                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> profileToSync.copy(shareLocation = false)
+                    null -> profileToSync
+                }
 
                 ProfileRepository.syncProfile(
-                    profile = profileToSync,
+                    profile = syncedProfile,
                     currentDeviceLocation = locationShareAttempt.location
                 )
 
-                info = when (locationShareAttempt.warning) {
+                val completionMessage = when (locationShareAttempt.warning) {
                     CurrentLocationShareWarning.PERMISSION_DENIED ->
-                        "Profile saved. Location permission is denied, so current coordinates were not shared."
+                        "Profile saved. Location permission is denied, so location sharing was turned off and stored coordinates were cleared."
 
                     CurrentLocationShareWarning.LOCATION_UNAVAILABLE ->
-                        "Profile saved. Current location is unavailable, so coordinates were not shared."
+                        "Profile saved. Current location is unavailable, so location sharing was turned off and stored coordinates were cleared."
 
                     null -> {
                         if (locationShareAttempt.location != null) {
@@ -205,6 +211,9 @@ fun CompleteProfileScreen(
                         }
                     }
                 }
+
+                info = completionMessage
+                Toast.makeText(context, completionMessage, Toast.LENGTH_LONG).show()
 
                 onComplete()
             } catch (cancellationException: CancellationException) {

--- a/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
@@ -186,14 +186,15 @@ fun CompleteProfileScreen(
                     sharingEnabled = profileToSync.shareLocation == true
                 )
                 val syncedProfile = when (locationShareAttempt.warning) {
-                    CurrentLocationShareWarning.PERMISSION_DENIED,
-                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> profileToSync.copy(shareLocation = false)
+                    CurrentLocationShareWarning.PERMISSION_DENIED -> profileToSync.copy(shareLocation = false)
+                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> profileToSync
                     null -> profileToSync
                 }
 
                 ProfileRepository.syncProfile(
                     profile = syncedProfile,
-                    currentDeviceLocation = locationShareAttempt.location
+                    currentDeviceLocation = locationShareAttempt.location,
+                    forceClearSharedCoordinates = locationShareAttempt.warning == CurrentLocationShareWarning.LOCATION_UNAVAILABLE
                 )
 
                 val completionMessage = when (locationShareAttempt.warning) {
@@ -201,7 +202,7 @@ fun CompleteProfileScreen(
                         "Profile saved. Location permission is denied, so location sharing was turned off and stored coordinates were cleared."
 
                     CurrentLocationShareWarning.LOCATION_UNAVAILABLE ->
-                        "Profile saved. Current location is unavailable, so location sharing was turned off and stored coordinates were cleared."
+                        "Profile saved. Current location is unavailable, so sharing remains on and stale coordinates were cleared."
 
                     null -> {
                         if (locationShareAttempt.location != null) {

--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
@@ -94,7 +94,8 @@ object ProfileRepository {
 
     suspend fun syncProfile(
         profile: ProfileData,
-        currentDeviceLocation: CurrentDeviceLocation? = null
+        currentDeviceLocation: CurrentDeviceLocation? = null,
+        forceClearSharedCoordinates: Boolean = false
     ): ProfileData {
         ensureInitialized()
 
@@ -150,7 +151,11 @@ object ProfileRepository {
                 path = "/profiles/me/location",
                 method = "PATCH",
                 token = token,
-                body = buildLocationPatchPayload(profile, currentDeviceLocation)
+                body = buildLocationPatchPayload(
+                    profile = profile,
+                    currentDeviceLocation = currentDeviceLocation,
+                    forceClearSharedCoordinates = forceClearSharedCoordinates
+                )
             )
 
             JsonHttpClient.request(
@@ -200,7 +205,8 @@ object ProfileRepository {
 
     internal fun buildLocationPatchPayload(
         profile: ProfileData,
-        currentDeviceLocation: CurrentDeviceLocation? = null
+        currentDeviceLocation: CurrentDeviceLocation? = null,
+        forceClearSharedCoordinates: Boolean = false
     ): JSONObject {
         val selectedCountry = profile.country?.trim()?.takeIf(String::isNotBlank)
         val resolvedCountryKey = resolveCountrySelectionKey(selectedCountry)
@@ -237,7 +243,7 @@ object ProfileRepository {
             )
 
             when {
-                profile.shareLocation != true -> {
+                profile.shareLocation != true || forceClearSharedCoordinates -> {
                     putNullable("latitude", null)
                     putNullable("longitude", null)
                     put(

--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
@@ -236,19 +236,36 @@ object ProfileRepository {
                 }
             )
 
-            if (profile.shareLocation == true && currentDeviceLocation != null) {
-                put("latitude", currentDeviceLocation.latitude)
-                put("longitude", currentDeviceLocation.longitude)
-                put(
-                    "coordinate",
-                    JSONObject().apply {
-                        put("latitude", currentDeviceLocation.latitude)
-                        put("longitude", currentDeviceLocation.longitude)
-                        putNullable("accuracyMeters", currentDeviceLocation.accuracyMeters)
-                        putNullable("source", currentDeviceLocation.source)
-                        putNullable("capturedAt", currentDeviceLocation.capturedAt)
-                    }
-                )
+            when {
+                profile.shareLocation != true -> {
+                    putNullable("latitude", null)
+                    putNullable("longitude", null)
+                    put(
+                        "coordinate",
+                        JSONObject().apply {
+                            putNullable("latitude", null)
+                            putNullable("longitude", null)
+                            putNullable("accuracyMeters", null)
+                            putNullable("source", null)
+                            putNullable("capturedAt", null)
+                        }
+                    )
+                }
+
+                currentDeviceLocation != null -> {
+                    put("latitude", currentDeviceLocation.latitude)
+                    put("longitude", currentDeviceLocation.longitude)
+                    put(
+                        "coordinate",
+                        JSONObject().apply {
+                            put("latitude", currentDeviceLocation.latitude)
+                            put("longitude", currentDeviceLocation.longitude)
+                            putNullable("accuracyMeters", currentDeviceLocation.accuracyMeters)
+                            putNullable("source", currentDeviceLocation.source)
+                            putNullable("capturedAt", currentDeviceLocation.capturedAt)
+                        }
+                    )
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
@@ -181,9 +181,14 @@ fun EditProfileScreen(
                     context = context,
                     sharingEnabled = profileToSync.shareLocation == true
                 )
+                val syncedProfile = when (locationShareAttempt.warning) {
+                    CurrentLocationShareWarning.PERMISSION_DENIED,
+                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> profileToSync.copy(shareLocation = false)
+                    null -> profileToSync
+                }
 
                 profile = ProfileRepository.syncProfile(
-                    profile = profileToSync,
+                    profile = syncedProfile,
                     currentDeviceLocation = locationShareAttempt.location
                 )
                 val phoneParts = normalizePhoneParts(profile.phone)
@@ -194,10 +199,10 @@ fun EditProfileScreen(
                 ageText = profile.age?.toString().orEmpty()
                 info = when (locationShareAttempt.warning) {
                     CurrentLocationShareWarning.PERMISSION_DENIED ->
-                        "Profile updated successfully. Location permission is denied, so current coordinates were not shared."
+                        "Profile updated successfully. Location permission is denied, so location sharing was turned off and stored coordinates were cleared."
 
                     CurrentLocationShareWarning.LOCATION_UNAVAILABLE ->
-                        "Profile updated successfully. Current location is unavailable, so coordinates were not shared."
+                        "Profile updated successfully. Current location is unavailable, so location sharing was turned off and stored coordinates were cleared."
 
                     null -> {
                         if (locationShareAttempt.location != null) {

--- a/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
@@ -182,14 +182,15 @@ fun EditProfileScreen(
                     sharingEnabled = profileToSync.shareLocation == true
                 )
                 val syncedProfile = when (locationShareAttempt.warning) {
-                    CurrentLocationShareWarning.PERMISSION_DENIED,
-                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> profileToSync.copy(shareLocation = false)
+                    CurrentLocationShareWarning.PERMISSION_DENIED -> profileToSync.copy(shareLocation = false)
+                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> profileToSync
                     null -> profileToSync
                 }
 
                 profile = ProfileRepository.syncProfile(
                     profile = syncedProfile,
-                    currentDeviceLocation = locationShareAttempt.location
+                    currentDeviceLocation = locationShareAttempt.location,
+                    forceClearSharedCoordinates = locationShareAttempt.warning == CurrentLocationShareWarning.LOCATION_UNAVAILABLE
                 )
                 val phoneParts = normalizePhoneParts(profile.phone)
                 countryCode = phoneParts.countryCode
@@ -202,7 +203,7 @@ fun EditProfileScreen(
                         "Profile updated successfully. Location permission is denied, so location sharing was turned off and stored coordinates were cleared."
 
                     CurrentLocationShareWarning.LOCATION_UNAVAILABLE ->
-                        "Profile updated successfully. Current location is unavailable, so location sharing was turned off and stored coordinates were cleared."
+                        "Profile updated successfully. Current location is unavailable, so sharing remains on and stale coordinates were cleared."
 
                     null -> {
                         if (locationShareAttempt.location != null) {

--- a/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
+++ b/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
@@ -2,6 +2,7 @@ package com.neph.features.profile.data
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -38,7 +39,7 @@ class ProfileRepositoryLocationPayloadTest {
     }
 
     @Test
-    fun buildLocationPatchPayload_omitsCoordinateWhenSharingDisabled() {
+    fun buildLocationPatchPayload_clearsCoordinateWhenSharingDisabled() {
         val payload = ProfileRepository.buildLocationPatchPayload(
             profile = ProfileData(
                 country = "tr",
@@ -55,25 +56,34 @@ class ProfileRepositoryLocationPayloadTest {
             )
         )
 
-        assertFalse(payload.has("latitude"))
-        assertFalse(payload.has("longitude"))
-        assertFalse(payload.has("coordinate"))
+        assertTrue(payload.has("latitude"))
+        assertTrue(payload.isNull("latitude"))
+        assertTrue(payload.has("longitude"))
+        assertTrue(payload.isNull("longitude"))
+        assertTrue(payload.has("coordinate"))
+        val coordinate = payload.getJSONObject("coordinate")
+        assertTrue(coordinate.has("latitude"))
+        assertTrue(coordinate.isNull("latitude"))
+        assertTrue(coordinate.has("longitude"))
+        assertTrue(coordinate.isNull("longitude"))
     }
 
     @Test
-    fun buildLocationPatchPayload_omitsCoordinateWhenLocationUnavailable() {
+    fun buildLocationPatchPayload_omitsCoordinateWhenLocationUnavailableButKeepsAddressFields() {
         val payload = ProfileRepository.buildLocationPatchPayload(
             profile = ProfileData(
                 country = "tr",
                 city = "ankara",
                 district = "cankaya",
                 neighborhood = "AnitTepeCode",
+                extraAddress = "Building A",
                 shareLocation = true
             ),
             currentDeviceLocation = null
         )
 
         assertTrue(payload.has("administrative"))
+        assertNotNull(payload.opt("displayAddress"))
         assertFalse(payload.has("latitude"))
         assertFalse(payload.has("longitude"))
         assertFalse(payload.has("coordinate"))

--- a/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
+++ b/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
@@ -69,7 +69,7 @@ class ProfileRepositoryLocationPayloadTest {
     }
 
     @Test
-    fun buildLocationPatchPayload_omitsCoordinateWhenLocationUnavailableButKeepsAddressFields() {
+    fun buildLocationPatchPayload_clearsCoordinateWhenLocationUnavailableAndForceClearRequested() {
         val payload = ProfileRepository.buildLocationPatchPayload(
             profile = ProfileData(
                 country = "tr",
@@ -79,7 +79,37 @@ class ProfileRepositoryLocationPayloadTest {
                 extraAddress = "Building A",
                 shareLocation = true
             ),
-            currentDeviceLocation = null
+            currentDeviceLocation = null,
+            forceClearSharedCoordinates = true
+        )
+
+        assertTrue(payload.has("administrative"))
+        assertNotNull(payload.opt("displayAddress"))
+        assertTrue(payload.has("latitude"))
+        assertTrue(payload.isNull("latitude"))
+        assertTrue(payload.has("longitude"))
+        assertTrue(payload.isNull("longitude"))
+        assertTrue(payload.has("coordinate"))
+        val coordinate = payload.getJSONObject("coordinate")
+        assertTrue(coordinate.has("latitude"))
+        assertTrue(coordinate.isNull("latitude"))
+        assertTrue(coordinate.has("longitude"))
+        assertTrue(coordinate.isNull("longitude"))
+    }
+
+    @Test
+    fun buildLocationPatchPayload_omitsCoordinateWhenLocationUnavailableAndNoForceClear() {
+        val payload = ProfileRepository.buildLocationPatchPayload(
+            profile = ProfileData(
+                country = "tr",
+                city = "ankara",
+                district = "cankaya",
+                neighborhood = "AnitTepeCode",
+                extraAddress = "Building A",
+                shareLocation = true
+            ),
+            currentDeviceLocation = null,
+            forceClearSharedCoordinates = false
         )
 
         assertTrue(payload.has("administrative"))


### PR DESCRIPTION
This PR tightens Android current-location sharing behavior.

- explicitly clears stored coordinates when Share Current Location is disabled
- makes save flow consistent when permission is revoked or location is unavailable by turning sharing off and clearing coordinates
- ensures users see completion feedback in Complete Profile (toast before navigation)


adds minimal payload tests for:

- coordinates included when sharing is enabled and location is available
- coordinates cleared when sharing is disabled
- no regression for unavailable-location payload behavior

This is a fix for PR  #322 
Can one of you guys review? @erinc00 @mehmetcangurbuz08 