### PR TITLE
feat: update user location on app launch (non-blocking, permission-aware)

### DIFF
--- a/android/app/src/main/java/com/neph/MainActivity.kt
+++ b/android/app/src/main/java/com/neph/MainActivity.kt
@@ -5,17 +5,20 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.rememberNavController
 import com.neph.core.NephAppContext
 import com.neph.core.database.NephDatabaseProvider
 import com.neph.core.sync.OfflineSyncScheduler
 import com.neph.features.availability.data.AvailabilityRepository
 import com.neph.features.auth.data.AuthSessionStore
+import com.neph.features.profile.data.AppLaunchLocationUpdater
 import com.neph.features.profile.data.ProfileRepository
 import com.neph.features.requesthelp.data.RequestHelpRepository
 import com.neph.navigation.AppNavGraph
 import com.neph.navigation.Routes
 import com.neph.ui.theme.NephTheme
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -28,6 +31,9 @@ class MainActivity : ComponentActivity() {
         RequestHelpRepository.initialize(applicationContext)
         OfflineSyncScheduler.schedulePeriodicSync(applicationContext)
         OfflineSyncScheduler.enqueueSync(applicationContext, reason = "app-start")
+        lifecycleScope.launch {
+            AppLaunchLocationUpdater.updateOnAppLaunch(applicationContext)
+        }
         setContent {
             NephApp()
         }

--- a/android/app/src/main/java/com/neph/features/profile/data/AppLaunchLocationUpdater.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/AppLaunchLocationUpdater.kt
@@ -1,0 +1,117 @@
+package com.neph.features.profile.data
+
+import android.content.Context
+import android.util.Log
+import com.neph.core.network.ApiException
+import com.neph.features.auth.data.AuthSessionStore
+import kotlinx.coroutines.withTimeoutOrNull
+
+private const val Tag = "NephLaunchLocation"
+private const val LaunchLocationCaptureTimeoutMillis = 5_000L
+
+enum class LaunchLocationSyncAction {
+    SKIP,
+    UPDATE_WITH_LOCATION,
+    CLEAR_STALE_COORDINATES
+}
+
+object AppLaunchLocationUpdater {
+    suspend fun updateOnAppLaunch(context: Context) {
+        val appContext = context.applicationContext
+        val hasAccessToken = !AuthSessionStore.getAccessToken().isNullOrBlank()
+        val guestMode = AuthSessionStore.isGuestMode()
+
+        if (!shouldRunLaunchLocationUpdate(hasAccessToken, guestMode)) {
+            return
+        }
+
+        val profile = try {
+            ProfileRepository.fetchAndCacheRemoteProfile()
+        } catch (error: ApiException) {
+            Log.w(Tag, "Skipping app-launch location update due to profile fetch API error.", error)
+            return
+        } catch (error: Exception) {
+            Log.w(Tag, "Skipping app-launch location update due to profile fetch failure.", error)
+            return
+        }
+
+        val permissionGranted = DeviceLocationProvider.hasLocationPermission(appContext)
+        if (!shouldAttemptLocationCapture(profile.shareLocation == true, permissionGranted)) {
+            return
+        }
+
+        val captureAttempt = try {
+            withTimeoutOrNull(LaunchLocationCaptureTimeoutMillis) {
+                DeviceLocationProvider.captureCurrentLocationForSharing(
+                    context = appContext,
+                    sharingEnabled = true
+                )
+            } ?: CurrentLocationShareAttempt(warning = CurrentLocationShareWarning.LOCATION_UNAVAILABLE)
+        } catch (_: Exception) {
+            CurrentLocationShareAttempt(warning = CurrentLocationShareWarning.LOCATION_UNAVAILABLE)
+        }
+
+        when (mapCaptureAttemptToSyncAction(captureAttempt)) {
+            LaunchLocationSyncAction.UPDATE_WITH_LOCATION -> {
+                runLocationSyncCatching(
+                    profile = profile,
+                    currentDeviceLocation = captureAttempt.location,
+                    forceClearSharedCoordinates = false
+                )
+            }
+
+            LaunchLocationSyncAction.CLEAR_STALE_COORDINATES -> {
+                runLocationSyncCatching(
+                    profile = profile,
+                    currentDeviceLocation = null,
+                    forceClearSharedCoordinates = true
+                )
+            }
+
+            LaunchLocationSyncAction.SKIP -> {
+                // No-op by design.
+            }
+        }
+    }
+
+    internal fun shouldRunLaunchLocationUpdate(hasAccessToken: Boolean, isGuestMode: Boolean): Boolean {
+        return hasAccessToken && !isGuestMode
+    }
+
+    internal fun shouldAttemptLocationCapture(
+        shareLocationEnabled: Boolean,
+        permissionGranted: Boolean
+    ): Boolean {
+        return shareLocationEnabled && permissionGranted
+    }
+
+    internal fun mapCaptureAttemptToSyncAction(attempt: CurrentLocationShareAttempt): LaunchLocationSyncAction {
+        if (attempt.location != null) {
+            return LaunchLocationSyncAction.UPDATE_WITH_LOCATION
+        }
+
+        return when (attempt.warning) {
+            CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> LaunchLocationSyncAction.CLEAR_STALE_COORDINATES
+            CurrentLocationShareWarning.PERMISSION_DENIED,
+            null -> LaunchLocationSyncAction.SKIP
+        }
+    }
+
+    private suspend fun runLocationSyncCatching(
+        profile: ProfileData,
+        currentDeviceLocation: CurrentDeviceLocation?,
+        forceClearSharedCoordinates: Boolean
+    ) {
+        try {
+            ProfileRepository.syncLocationOnLaunch(
+                profile = profile,
+                currentDeviceLocation = currentDeviceLocation,
+                forceClearSharedCoordinates = forceClearSharedCoordinates
+            )
+        } catch (error: ApiException) {
+            Log.w(Tag, "App-launch location sync API call failed.", error)
+        } catch (error: Exception) {
+            Log.w(Tag, "App-launch location sync failed.", error)
+        }
+    }
+}

--- a/android/app/src/main/java/com/neph/features/profile/data/AppLaunchLocationUpdater.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/AppLaunchLocationUpdater.kt
@@ -11,8 +11,7 @@ private const val LaunchLocationCaptureTimeoutMillis = 5_000L
 
 enum class LaunchLocationSyncAction {
     SKIP,
-    UPDATE_WITH_LOCATION,
-    CLEAR_STALE_COORDINATES
+    UPDATE_WITH_LOCATION
 }
 
 object AppLaunchLocationUpdater {
@@ -22,6 +21,11 @@ object AppLaunchLocationUpdater {
         val guestMode = AuthSessionStore.isGuestMode()
 
         if (!shouldRunLaunchLocationUpdate(hasAccessToken, guestMode)) {
+            return
+        }
+
+        val permissionGranted = DeviceLocationProvider.hasLocationPermission(appContext)
+        if (!permissionGranted) {
             return
         }
 
@@ -35,7 +39,6 @@ object AppLaunchLocationUpdater {
             return
         }
 
-        val permissionGranted = DeviceLocationProvider.hasLocationPermission(appContext)
         if (!shouldAttemptLocationCapture(profile.shareLocation == true, permissionGranted)) {
             return
         }
@@ -55,16 +58,7 @@ object AppLaunchLocationUpdater {
             LaunchLocationSyncAction.UPDATE_WITH_LOCATION -> {
                 runLocationSyncCatching(
                     profile = profile,
-                    currentDeviceLocation = captureAttempt.location,
-                    forceClearSharedCoordinates = false
-                )
-            }
-
-            LaunchLocationSyncAction.CLEAR_STALE_COORDINATES -> {
-                runLocationSyncCatching(
-                    profile = profile,
-                    currentDeviceLocation = null,
-                    forceClearSharedCoordinates = true
+                    currentDeviceLocation = captureAttempt.location
                 )
             }
 
@@ -91,7 +85,7 @@ object AppLaunchLocationUpdater {
         }
 
         return when (attempt.warning) {
-            CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> LaunchLocationSyncAction.CLEAR_STALE_COORDINATES
+            CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
             CurrentLocationShareWarning.PERMISSION_DENIED,
             null -> LaunchLocationSyncAction.SKIP
         }
@@ -99,14 +93,12 @@ object AppLaunchLocationUpdater {
 
     private suspend fun runLocationSyncCatching(
         profile: ProfileData,
-        currentDeviceLocation: CurrentDeviceLocation?,
-        forceClearSharedCoordinates: Boolean
+        currentDeviceLocation: CurrentDeviceLocation?
     ) {
         try {
             ProfileRepository.syncLocationOnLaunch(
                 profile = profile,
-                currentDeviceLocation = currentDeviceLocation,
-                forceClearSharedCoordinates = forceClearSharedCoordinates
+                currentDeviceLocation = currentDeviceLocation
             )
         } catch (error: ApiException) {
             Log.w(Tag, "App-launch location sync API call failed.", error)

--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
@@ -147,15 +147,11 @@ object ProfileRepository {
                 }
             )
 
-            JsonHttpClient.request(
-                path = "/profiles/me/location",
-                method = "PATCH",
+            patchLocationProfile(
                 token = token,
-                body = buildLocationPatchPayload(
-                    profile = profile,
-                    currentDeviceLocation = currentDeviceLocation,
-                    forceClearSharedCoordinates = forceClearSharedCoordinates
-                )
+                profile = profile,
+                currentDeviceLocation = currentDeviceLocation,
+                forceClearSharedCoordinates = forceClearSharedCoordinates
             )
 
             JsonHttpClient.request(
@@ -201,6 +197,48 @@ object ProfileRepository {
             }
             throw error
         }
+    }
+
+    suspend fun syncLocationOnLaunch(
+        profile: ProfileData,
+        currentDeviceLocation: CurrentDeviceLocation? = null,
+        forceClearSharedCoordinates: Boolean = false
+    ) {
+        ensureInitialized()
+
+        try {
+            LocationTreeRepository.ensureLocationData()
+        } catch (_: Exception) {
+            // Keep fallback location mapping when location tree is unavailable.
+        }
+
+        val token = AuthSessionStore.getAccessToken().orEmpty()
+        check(token.isNotBlank()) { "Access token is required before sending launch location update." }
+
+        patchLocationProfile(
+            token = token,
+            profile = profile,
+            currentDeviceLocation = currentDeviceLocation,
+            forceClearSharedCoordinates = forceClearSharedCoordinates
+        )
+    }
+
+    private suspend fun patchLocationProfile(
+        token: String,
+        profile: ProfileData,
+        currentDeviceLocation: CurrentDeviceLocation? = null,
+        forceClearSharedCoordinates: Boolean = false
+    ) {
+        JsonHttpClient.request(
+            path = "/profiles/me/location",
+            method = "PATCH",
+            token = token,
+            body = buildLocationPatchPayload(
+                profile = profile,
+                currentDeviceLocation = currentDeviceLocation,
+                forceClearSharedCoordinates = forceClearSharedCoordinates
+            )
+        )
     }
 
     internal fun buildLocationPatchPayload(

--- a/android/app/src/test/java/com/neph/features/profile/data/AppLaunchLocationUpdaterTest.kt
+++ b/android/app/src/test/java/com/neph/features/profile/data/AppLaunchLocationUpdaterTest.kt
@@ -71,12 +71,12 @@ class AppLaunchLocationUpdaterTest {
     }
 
     @Test
-    fun mapCaptureAttemptToSyncAction_returnsClearOnLocationUnavailable() {
+    fun mapCaptureAttemptToSyncAction_skipsOnLocationUnavailable() {
         val action = AppLaunchLocationUpdater.mapCaptureAttemptToSyncAction(
             CurrentLocationShareAttempt(warning = CurrentLocationShareWarning.LOCATION_UNAVAILABLE)
         )
 
-        assertEquals(LaunchLocationSyncAction.CLEAR_STALE_COORDINATES, action)
+        assertEquals(LaunchLocationSyncAction.SKIP, action)
     }
 
     @Test

--- a/android/app/src/test/java/com/neph/features/profile/data/AppLaunchLocationUpdaterTest.kt
+++ b/android/app/src/test/java/com/neph/features/profile/data/AppLaunchLocationUpdaterTest.kt
@@ -1,0 +1,92 @@
+package com.neph.features.profile.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppLaunchLocationUpdaterTest {
+    @Test
+    fun shouldRunLaunchLocationUpdate_requiresAuthenticatedNonGuestUser() {
+        assertTrue(
+            AppLaunchLocationUpdater.shouldRunLaunchLocationUpdate(
+                hasAccessToken = true,
+                isGuestMode = false
+            )
+        )
+
+        assertFalse(
+            AppLaunchLocationUpdater.shouldRunLaunchLocationUpdate(
+                hasAccessToken = false,
+                isGuestMode = false
+            )
+        )
+
+        assertFalse(
+            AppLaunchLocationUpdater.shouldRunLaunchLocationUpdate(
+                hasAccessToken = true,
+                isGuestMode = true
+            )
+        )
+    }
+
+    @Test
+    fun shouldAttemptLocationCapture_requiresSharingEnabledAndPermissionGranted() {
+        assertTrue(
+            AppLaunchLocationUpdater.shouldAttemptLocationCapture(
+                shareLocationEnabled = true,
+                permissionGranted = true
+            )
+        )
+
+        assertFalse(
+            AppLaunchLocationUpdater.shouldAttemptLocationCapture(
+                shareLocationEnabled = false,
+                permissionGranted = true
+            )
+        )
+
+        assertFalse(
+            AppLaunchLocationUpdater.shouldAttemptLocationCapture(
+                shareLocationEnabled = true,
+                permissionGranted = false
+            )
+        )
+    }
+
+    @Test
+    fun mapCaptureAttemptToSyncAction_returnsUpdateWhenLocationExists() {
+        val action = AppLaunchLocationUpdater.mapCaptureAttemptToSyncAction(
+            CurrentLocationShareAttempt(
+                location = CurrentDeviceLocation(
+                    latitude = 41.1,
+                    longitude = 29.0,
+                    accuracyMeters = 8.0,
+                    capturedAt = "2026-04-21T08:00:00.000Z"
+                )
+            )
+        )
+
+        assertEquals(LaunchLocationSyncAction.UPDATE_WITH_LOCATION, action)
+    }
+
+    @Test
+    fun mapCaptureAttemptToSyncAction_returnsClearOnLocationUnavailable() {
+        val action = AppLaunchLocationUpdater.mapCaptureAttemptToSyncAction(
+            CurrentLocationShareAttempt(warning = CurrentLocationShareWarning.LOCATION_UNAVAILABLE)
+        )
+
+        assertEquals(LaunchLocationSyncAction.CLEAR_STALE_COORDINATES, action)
+    }
+
+    @Test
+    fun mapCaptureAttemptToSyncAction_skipsOnPermissionDeniedOrEmptyAttempt() {
+        val deniedAction = AppLaunchLocationUpdater.mapCaptureAttemptToSyncAction(
+            CurrentLocationShareAttempt(warning = CurrentLocationShareWarning.PERMISSION_DENIED)
+        )
+        val emptyAction = AppLaunchLocationUpdater.mapCaptureAttemptToSyncAction(CurrentLocationShareAttempt())
+
+        assertEquals(LaunchLocationSyncAction.SKIP, deniedAction)
+        assertEquals(LaunchLocationSyncAction.SKIP, emptyAction)
+    }
+}


### PR DESCRIPTION
This PR adds Android app-launch location update behavior for authenticated users.

What changed:

- triggers a non-blocking launch-time location update flow from app startup
- checks auth and guest state before attempting any launch update
- fetches profile on launch to respect existing shareLocation preference
- checks current system location permission before retrieval
- attempts location capture with timeout and safely handles failures
- updates backend location when successful, or clears stale coordinates when location is unavailable
- keeps startup/navigation usable even when location or backend calls fail


Behavior summary:

- guest user / no token: skip launch location update
- permission not granted: skip retrieval
- logged-in + sharing enabled + permission granted:
- location found → send latest location to backend
- unavailable/timeout/failure → clear stale coordinates safely
- all failures are caught and do not block app launch

Scope:

- Android/mobile only
- no web changes
- no backend changes (existing profile location infrastructure reused)

Tests:

- added unit tests for launch update decision/action logic:
- authenticated vs guest decision
- sharing+permission gating
- action mapping for success / unavailable / denied scenarios

Closes #292 