### PR TITLE
feat: add guest location autofill flow to Request Help form

### DIFF
--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
@@ -16,6 +16,7 @@ import com.neph.core.sync.SyncEntityType
 import com.neph.core.sync.SyncOperationStatus
 import com.neph.core.sync.SyncOperationType
 import com.neph.core.sync.SyncStatus
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONArray
 import org.json.JSONObject
 import java.net.URLEncoder
@@ -23,6 +24,7 @@ import java.util.Locale
 import java.util.UUID
 
 private const val PendingHelpRequestStatus = "PENDING_SYNC"
+private const val ReverseGeocodeTimeoutMillis = 7000L
 
 data class RequestHelpLocationSubmission(
     val country: String,
@@ -201,14 +203,16 @@ object RequestHelpRepository {
     ): RequestHelpReverseLocation? {
         ensureInitialized()
 
-        val response = JsonHttpClient.request(
-            path = String.format(
-                Locale.US,
-                "/location/reverse?lat=%.6f&lon=%.6f",
-                latitude,
-                longitude
+        val response = withTimeoutOrNull(ReverseGeocodeTimeoutMillis) {
+            JsonHttpClient.request(
+                path = String.format(
+                    Locale.US,
+                    "/location/reverse?lat=%.6f&lon=%.6f",
+                    latitude,
+                    longitude
+                )
             )
-        )
+        } ?: return null
 
         val item = response.optJSONObject("item") ?: return null
         val administrative = item.optJSONObject("administrative") ?: JSONObject()

--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
@@ -19,6 +19,7 @@ import com.neph.core.sync.SyncStatus
 import org.json.JSONArray
 import org.json.JSONObject
 import java.net.URLEncoder
+import java.util.Locale
 import java.util.UUID
 
 private const val PendingHelpRequestStatus = "PENDING_SYNC"
@@ -29,6 +30,15 @@ data class RequestHelpLocationSubmission(
     val district: String,
     val neighborhood: String,
     val extraAddress: String
+)
+
+data class RequestHelpReverseLocation(
+    val countryCode: String? = null,
+    val country: String? = null,
+    val city: String? = null,
+    val district: String? = null,
+    val neighborhood: String? = null,
+    val extraAddress: String? = null
 )
 
 data class RequestHelpContactSubmission(
@@ -183,6 +193,34 @@ object RequestHelpRepository {
         )
 
         return response.optJSONObject("request")
+    }
+
+    suspend fun reverseGeocodeCurrentLocation(
+        latitude: Double,
+        longitude: Double
+    ): RequestHelpReverseLocation? {
+        ensureInitialized()
+
+        val response = JsonHttpClient.request(
+            path = String.format(
+                Locale.US,
+                "/location/reverse?lat=%.6f&lon=%.6f",
+                latitude,
+                longitude
+            )
+        )
+
+        val item = response.optJSONObject("item") ?: return null
+        val administrative = item.optJSONObject("administrative") ?: JSONObject()
+
+        return RequestHelpReverseLocation(
+            countryCode = administrative.optTrimmedString("countryCode"),
+            country = administrative.optTrimmedString("country"),
+            city = administrative.optTrimmedString("city"),
+            district = administrative.optTrimmedString("district"),
+            neighborhood = administrative.optTrimmedString("neighborhood"),
+            extraAddress = administrative.optTrimmedString("extraAddress")
+        )
     }
 
     internal suspend fun pushCreateOperation(operation: SyncOperationEntity, token: String?) {
@@ -371,6 +409,10 @@ object RequestHelpRepository {
             "RequestHelpRepository must be initialized before use."
         }
     }
+}
+
+private fun JSONObject.optTrimmedString(key: String): String? {
+    return optString(key).trim().takeIf { it.isNotBlank() }
 }
 
 internal fun RequestHelpSubmission.toJson(): JSONObject {

--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -323,37 +323,41 @@ internal fun resolveGuestLocationAutofillSelection(
         ?.takeIf { locations.containsKey(it) }
         .orEmpty()
     val countryFromLabel = findCountryKeyByLabel(reverseLocation.country, locations)
-    val country = countryFromCode.ifBlank {
-        countryFromLabel.ifBlank { currentCountry }
-    }
+    val mappedCountry = countryFromCode.ifBlank { countryFromLabel }
+    val country = currentCountry.ifBlank { mappedCountry }
 
-    val city = if (country.isNotBlank()) {
-        findCityKeyByLabel(country, reverseLocation.city, locations).ifBlank { currentCity }
+    val mappedCity = if (country.isNotBlank()) {
+        findCityKeyByLabel(country, reverseLocation.city, locations)
     } else {
-        currentCity
+        ""
     }
+    val city = currentCity.ifBlank { mappedCity }
 
-    val district = if (country.isNotBlank() && city.isNotBlank()) {
-        findDistrictKeyByLabel(country, city, reverseLocation.district, locations).ifBlank { currentDistrict }
+    val mappedDistrict = if (country.isNotBlank() && city.isNotBlank()) {
+        findDistrictKeyByLabel(country, city, reverseLocation.district, locations)
     } else {
-        currentDistrict
+        ""
     }
+    val district = currentDistrict.ifBlank { mappedDistrict }
 
-    val neighborhood = if (country.isNotBlank() && city.isNotBlank() && district.isNotBlank()) {
+    val mappedNeighborhood = if (country.isNotBlank() && city.isNotBlank() && district.isNotBlank()) {
         findNeighborhoodValueByLabel(
             country,
             city,
             district,
             reverseLocation.neighborhood,
             locations
-        ).ifBlank { currentNeighborhood }
+        )
     } else {
-        currentNeighborhood
+        ""
     }
+    val neighborhood = currentNeighborhood.ifBlank { mappedNeighborhood }
 
-    val shortAddress = reverseLocation.extraAddress
-        ?.takeIf { it.isNotBlank() }
-        ?: currentShortAddress
+    val shortAddress = currentShortAddress.ifBlank {
+        reverseLocation.extraAddress
+            ?.takeIf { it.isNotBlank() }
+            .orEmpty()
+    }
 
     return GuestLocationAutofillSelection(
         country = country,
@@ -390,6 +394,7 @@ fun RequestHelpScreen(
     var checkingActiveRequest by remember { mutableStateOf(isLoggedIn) }
     var guestLocationAutoFillLoading by remember { mutableStateOf(false) }
     var guestLocationPermissionHandled by rememberSaveable { mutableStateOf(false) }
+    val guestFormInteractionStarted = !isLoggedIn && formState != RequestHelpFormState()
     fun triggerGuestLocationAutofill() {
         scope.launch {
             if (guestLocationAutoFillLoading) return@launch
@@ -420,24 +425,30 @@ fun RequestHelpScreen(
                     return@launch
                 }
 
+                val previousFormState = formState
                 val autofill = resolveGuestLocationAutofillSelection(
-                    currentCountry = formState.country,
-                    currentCity = formState.city,
-                    currentDistrict = formState.district,
-                    currentNeighborhood = formState.neighborhood,
-                    currentShortAddress = formState.shortAddress,
+                    currentCountry = previousFormState.country,
+                    currentCity = previousFormState.city,
+                    currentDistrict = previousFormState.district,
+                    currentNeighborhood = previousFormState.neighborhood,
+                    currentShortAddress = previousFormState.shortAddress,
                     reverseLocation = reverseLocation,
                     locations = availableLocationData
                 )
 
-                formState = formState.copy(
+                val nextFormState = previousFormState.copy(
                     country = autofill.country,
                     city = autofill.city,
                     district = autofill.district,
                     neighborhood = autofill.neighborhood,
                     shortAddress = autofill.shortAddress
                 )
-                infoMessage = "Current location applied. You can edit location fields if needed."
+                if (nextFormState != previousFormState) {
+                    formState = nextFormState
+                    infoMessage = "Current location applied without changing non-empty fields."
+                } else {
+                    infoMessage = "Current location detected. Existing location values were kept."
+                }
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (_: Exception) {
@@ -507,8 +518,8 @@ fun RequestHelpScreen(
         }
     }
 
-    LaunchedEffect(isLoggedIn) {
-        if (isLoggedIn || guestLocationPermissionHandled) {
+    LaunchedEffect(isLoggedIn, guestFormInteractionStarted, guestLocationPermissionHandled) {
+        if (isLoggedIn || guestLocationPermissionHandled || !guestFormInteractionStarted) {
             return@LaunchedEffect
         }
 
@@ -685,6 +696,20 @@ fun RequestHelpScreen(
 
                     if (!isLoggedIn && guestLocationAutoFillLoading) {
                         HelperText(text = "Detecting your current location. You can continue filling the form while this runs.")
+                    }
+
+                    if (!isLoggedIn) {
+                        SecondaryButton(
+                            text = "Use Current Location",
+                            onClick = {
+                                if (DeviceLocationProvider.hasLocationPermission(context)) {
+                                    triggerGuestLocationAutofill()
+                                } else {
+                                    locationPermissionLauncher.launch(DeviceLocationProvider.RequiredLocationPermissions)
+                                }
+                            },
+                            enabled = !guestLocationAutoFillLoading
+                        )
                     }
 
                     LocationSelector(

--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -1,5 +1,7 @@
 package com.neph.features.requesthelp.presentation
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
@@ -11,14 +13,22 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import com.neph.core.network.ApiException
 import com.neph.features.auth.data.AuthRepository
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.auth.util.countryCodeOptions
+import com.neph.features.profile.data.CurrentLocationShareWarning
+import com.neph.features.profile.data.DeviceLocationProvider
+import com.neph.features.profile.data.findCityKeyByLabel
+import com.neph.features.profile.data.findCountryKeyByLabel
+import com.neph.features.profile.data.findDistrictKeyByLabel
+import com.neph.features.profile.data.findNeighborhoodValueByLabel
 import com.neph.features.profile.data.LocationData
 import com.neph.features.profile.data.LocationTreeRepository
 import com.neph.features.profile.data.ProfileData
@@ -31,6 +41,7 @@ import com.neph.features.profile.data.normalizePhoneParts
 import com.neph.features.requesthelp.data.RequestHelpContactSubmission
 import com.neph.features.requesthelp.data.RequestHelpLocationSubmission
 import com.neph.features.profile.presentation.components.LocationSelector
+import com.neph.features.requesthelp.data.RequestHelpReverseLocation
 import com.neph.features.requesthelp.data.RequestHelpRepository
 import com.neph.features.requesthelp.data.RequestHelpSubmission
 import com.neph.ui.components.buttons.PrimaryButton
@@ -290,6 +301,69 @@ private fun buildSubmission(
     )
 }
 
+internal data class GuestLocationAutofillSelection(
+    val country: String,
+    val city: String,
+    val district: String,
+    val neighborhood: String,
+    val shortAddress: String
+)
+
+internal fun resolveGuestLocationAutofillSelection(
+    currentCountry: String,
+    currentCity: String,
+    currentDistrict: String,
+    currentNeighborhood: String,
+    currentShortAddress: String,
+    reverseLocation: RequestHelpReverseLocation,
+    locations: LocationData
+): GuestLocationAutofillSelection {
+    val countryFromCode = reverseLocation.countryCode
+        ?.lowercase()
+        ?.takeIf { locations.containsKey(it) }
+        .orEmpty()
+    val countryFromLabel = findCountryKeyByLabel(reverseLocation.country, locations)
+    val country = countryFromCode.ifBlank {
+        countryFromLabel.ifBlank { currentCountry }
+    }
+
+    val city = if (country.isNotBlank()) {
+        findCityKeyByLabel(country, reverseLocation.city, locations).ifBlank { currentCity }
+    } else {
+        currentCity
+    }
+
+    val district = if (country.isNotBlank() && city.isNotBlank()) {
+        findDistrictKeyByLabel(country, city, reverseLocation.district, locations).ifBlank { currentDistrict }
+    } else {
+        currentDistrict
+    }
+
+    val neighborhood = if (country.isNotBlank() && city.isNotBlank() && district.isNotBlank()) {
+        findNeighborhoodValueByLabel(
+            country,
+            city,
+            district,
+            reverseLocation.neighborhood,
+            locations
+        ).ifBlank { currentNeighborhood }
+    } else {
+        currentNeighborhood
+    }
+
+    val shortAddress = reverseLocation.extraAddress
+        ?.takeIf { it.isNotBlank() }
+        ?: currentShortAddress
+
+    return GuestLocationAutofillSelection(
+        country = country,
+        city = city,
+        district = district,
+        neighborhood = neighborhood,
+        shortAddress = shortAddress
+    )
+}
+
 @Composable
 fun RequestHelpScreen(
     onNavigateBack: () -> Unit,
@@ -298,6 +372,7 @@ fun RequestHelpScreen(
 ) {
     val spacing = LocalNephSpacing.current
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
     val sessionToken = AuthSessionStore.getAccessToken().orEmpty()
     val isLoggedIn = sessionToken.isNotBlank()
 
@@ -313,6 +388,75 @@ fun RequestHelpScreen(
     var errorMessage by remember { mutableStateOf("") }
     var infoMessage by remember { mutableStateOf("") }
     var checkingActiveRequest by remember { mutableStateOf(isLoggedIn) }
+    var guestLocationAutoFillLoading by remember { mutableStateOf(false) }
+    var guestLocationPermissionHandled by rememberSaveable { mutableStateOf(false) }
+    fun triggerGuestLocationAutofill() {
+        scope.launch {
+            if (guestLocationAutoFillLoading) return@launch
+            guestLocationAutoFillLoading = true
+            try {
+                val attempt = DeviceLocationProvider.captureCurrentLocationForSharing(
+                    context = context,
+                    sharingEnabled = true
+                )
+                val location = attempt.location
+                if (location == null) {
+                    infoMessage = when (attempt.warning) {
+                        CurrentLocationShareWarning.PERMISSION_DENIED ->
+                            "Location permission is denied. You can continue with manual location entry."
+
+                        CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
+                        null -> "Could not retrieve your current location. You can continue with manual location entry."
+                    }
+                    return@launch
+                }
+
+                val reverseLocation = RequestHelpRepository.reverseGeocodeCurrentLocation(
+                    latitude = location.latitude,
+                    longitude = location.longitude
+                )
+                if (reverseLocation == null) {
+                    infoMessage = "Could not resolve your current location. You can continue with manual location entry."
+                    return@launch
+                }
+
+                val autofill = resolveGuestLocationAutofillSelection(
+                    currentCountry = formState.country,
+                    currentCity = formState.city,
+                    currentDistrict = formState.district,
+                    currentNeighborhood = formState.neighborhood,
+                    currentShortAddress = formState.shortAddress,
+                    reverseLocation = reverseLocation,
+                    locations = availableLocationData
+                )
+
+                formState = formState.copy(
+                    country = autofill.country,
+                    city = autofill.city,
+                    district = autofill.district,
+                    neighborhood = autofill.neighborhood,
+                    shortAddress = autofill.shortAddress
+                )
+                infoMessage = "Current location applied. You can edit location fields if needed."
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                infoMessage = "Could not retrieve your current location. You can continue with manual location entry."
+            } finally {
+                guestLocationAutoFillLoading = false
+            }
+        }
+    }
+
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { grants ->
+        if (grants.values.any { it }) {
+            triggerGuestLocationAutofill()
+        } else {
+            infoMessage = "Location permission is denied. You can continue with manual location entry."
+        }
+    }
 
     LaunchedEffect(Unit) {
         try {
@@ -361,6 +505,21 @@ fun RequestHelpScreen(
         } finally {
             checkingActiveRequest = false
         }
+    }
+
+    LaunchedEffect(isLoggedIn) {
+        if (isLoggedIn || guestLocationPermissionHandled) {
+            return@LaunchedEffect
+        }
+
+        guestLocationPermissionHandled = true
+
+        if (DeviceLocationProvider.hasLocationPermission(context)) {
+            triggerGuestLocationAutofill()
+            return@LaunchedEffect
+        }
+
+        locationPermissionLauncher.launch(DeviceLocationProvider.RequiredLocationPermissions)
     }
 
     fun handleSubmit() {
@@ -522,6 +681,10 @@ fun RequestHelpScreen(
 
                     if (locationLoading) {
                         HelperText(text = "Loading location options...")
+                    }
+
+                    if (!isLoggedIn && guestLocationAutoFillLoading) {
+                        HelperText(text = "Detecting your current location. You can continue filling the form while this runs.")
                     }
 
                     LocationSelector(

--- a/android/app/src/test/java/com/neph/features/requesthelp/presentation/RequestHelpGuestLocationAutofillTest.kt
+++ b/android/app/src/test/java/com/neph/features/requesthelp/presentation/RequestHelpGuestLocationAutofillTest.kt
@@ -57,4 +57,30 @@ class RequestHelpGuestLocationAutofillTest {
         assertEquals("anittepe", result.neighborhood)
         assertEquals("Existing Address", result.shortAddress)
     }
+
+    @Test
+    fun resolveGuestLocationAutofillSelection_doesNotOverwriteManualLocationValues() {
+        val result = resolveGuestLocationAutofillSelection(
+            currentCountry = "tr",
+            currentCity = "ankara",
+            currentDistrict = "cankaya",
+            currentNeighborhood = "anittepe",
+            currentShortAddress = "Manual Address",
+            reverseLocation = RequestHelpReverseLocation(
+                countryCode = "TR",
+                country = "Turkey",
+                city = "Istanbul",
+                district = "Beşiktaş",
+                neighborhood = "Balmumcu",
+                extraAddress = "Autofill Address"
+            ),
+            locations = locationData
+        )
+
+        assertEquals("tr", result.country)
+        assertEquals("ankara", result.city)
+        assertEquals("cankaya", result.district)
+        assertEquals("anittepe", result.neighborhood)
+        assertEquals("Manual Address", result.shortAddress)
+    }
 }

--- a/android/app/src/test/java/com/neph/features/requesthelp/presentation/RequestHelpGuestLocationAutofillTest.kt
+++ b/android/app/src/test/java/com/neph/features/requesthelp/presentation/RequestHelpGuestLocationAutofillTest.kt
@@ -1,0 +1,60 @@
+package com.neph.features.requesthelp.presentation
+
+import com.neph.features.profile.data.locationData
+import com.neph.features.requesthelp.data.RequestHelpReverseLocation
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RequestHelpGuestLocationAutofillTest {
+    @Test
+    fun resolveGuestLocationAutofillSelection_mapsReverseAdministrativeLabelsToSelectorKeys() {
+        val result = resolveGuestLocationAutofillSelection(
+            currentCountry = "",
+            currentCity = "",
+            currentDistrict = "",
+            currentNeighborhood = "",
+            currentShortAddress = "",
+            reverseLocation = RequestHelpReverseLocation(
+                countryCode = "TR",
+                country = "Turkey",
+                city = "Istanbul",
+                district = "Beşiktaş",
+                neighborhood = "Balmumcu",
+                extraAddress = "Buyukdere Cd."
+            ),
+            locations = locationData
+        )
+
+        assertEquals("tr", result.country)
+        assertEquals("istanbul", result.city)
+        assertEquals("besiktas", result.district)
+        assertEquals("balmumcu", result.neighborhood)
+        assertEquals("Buyukdere Cd.", result.shortAddress)
+    }
+
+    @Test
+    fun resolveGuestLocationAutofillSelection_keepsExistingValuesWhenReverseDataCannotBeMapped() {
+        val result = resolveGuestLocationAutofillSelection(
+            currentCountry = "tr",
+            currentCity = "ankara",
+            currentDistrict = "cankaya",
+            currentNeighborhood = "anittepe",
+            currentShortAddress = "Existing Address",
+            reverseLocation = RequestHelpReverseLocation(
+                countryCode = null,
+                country = "Unknown Country",
+                city = "Unknown City",
+                district = "Unknown District",
+                neighborhood = "Unknown Neighborhood",
+                extraAddress = null
+            ),
+            locations = locationData
+        )
+
+        assertEquals("tr", result.country)
+        assertEquals("ankara", result.city)
+        assertEquals("cankaya", result.district)
+        assertEquals("anittepe", result.neighborhood)
+        assertEquals("Existing Address", result.shortAddress)
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements the guest-user location flow inside the **Request Help** experience on Android.

Instead of asking for location on app launch, guest users are now handled in the screen where location is actually useful.

## What changed

- added guest location handling inside the **Request Help** flow
- keeps the **Request Help** screen usable immediately without blocking the form
- requests location permission in the **Request Help** screen context
- if permission is granted, retrieves current location asynchronously and autofills the relevant location fields
- if permission is denied or location retrieval fails, the form remains fully usable with manual location input
- added test coverage for guest location autofill behavior

## Behavior

- guest users are **not** asked for location on app launch
- guest users can open **Request Help** first and start filling the form immediately
- location permission is requested only when relevant to that flow
- location autofill improves speed when available, but is never required to continue

## Scope

- Android/mobile only
- no web changes
- no backend changes
- focused implementation with only the Request Help guest-location flow and related test coverage

This PR follows #325 