### PR TITLE
feat: implement gathering areas page with nearby data and resilient location states

### DIFF
--- a/android/app/src/androidTest/java/com/neph/e2e/FakeNephBackend.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/FakeNephBackend.kt
@@ -186,12 +186,106 @@ class FakeNephBackend {
             route == "/availability/my-assignment" && method == "GET" -> handleCurrentAssignment(token)
             route == "/help-requests" && method == "GET" -> handleHelpRequestList(token)
             route == "/location/tree" && method == "GET" -> handleLocationTree(uri)
+            route == "/gathering-areas/nearby" && method == "GET" -> handleNearbyGatheringAreas(uri)
             else -> throw ApiException(
                 message = "Unhandled fake backend request: $method $path",
                 status = 500,
                 code = "UNHANDLED_FAKE_ROUTE"
             )
         }
+    }
+
+    private fun handleNearbyGatheringAreas(uri: Uri): JSONObject {
+        val lat = uri.getQueryParameter("lat")?.toDoubleOrNull()
+            ?: throw ApiException("lat must be a number between -90 and 90", 400, "VALIDATION_ERROR")
+        val lon = uri.getQueryParameter("lon")?.toDoubleOrNull()
+            ?: throw ApiException("lon must be a number between -180 and 180", 400, "VALIDATION_ERROR")
+
+        if (lat !in -90.0..90.0) {
+            throw ApiException("lat must be a number between -90 and 90", 400, "VALIDATION_ERROR")
+        }
+
+        if (lon !in -180.0..180.0) {
+            throw ApiException("lon must be a number between -180 and 180", 400, "VALIDATION_ERROR")
+        }
+
+        val radius = (uri.getQueryParameter("radius")?.toIntOrNull() ?: 2000).coerceIn(1, 10_000)
+        val limit = (uri.getQueryParameter("limit")?.toIntOrNull() ?: 20).coerceIn(1, 50)
+
+        val features = JSONArray().apply {
+            put(
+                JSONObject()
+                    .put("type", "Feature")
+                    .put(
+                        "geometry",
+                        JSONObject()
+                            .put("type", "Point")
+                            .put("coordinates", JSONArray().put(lon + 0.0012).put(lat + 0.0009))
+                    )
+                    .put(
+                        "properties",
+                        JSONObject()
+                            .put("id", "fake-ga-1")
+                            .put("osmType", "node")
+                            .put("name", "Local Assembly Point")
+                            .put("category", "assembly_point")
+                            .put("distanceMeters", 180)
+                            .put(
+                                "rawTags",
+                                JSONObject()
+                                    .put("name", "Local Assembly Point")
+                                    .put("addr:street", "Ataturk Blvd")
+                            )
+                    )
+            )
+
+            put(
+                JSONObject()
+                    .put("type", "Feature")
+                    .put(
+                        "geometry",
+                        JSONObject()
+                            .put("type", "Point")
+                            .put("coordinates", JSONArray().put(lon - 0.0021).put(lat - 0.0015))
+                    )
+                    .put(
+                        "properties",
+                        JSONObject()
+                            .put("id", "fake-ga-2")
+                            .put("osmType", "node")
+                            .put("name", "Community Shelter")
+                            .put("category", "shelter")
+                            .put("distanceMeters", 360)
+                            .put(
+                                "rawTags",
+                                JSONObject()
+                                    .put("name", "Community Shelter")
+                                    .put("description", "Municipal sports hall")
+                            )
+                    )
+            )
+        }
+
+        return JSONObject()
+            .put("center", JSONObject().put("lat", lat).put("lon", lon))
+            .put("radius", radius)
+            .put("source", "overpass")
+            .put(
+                "meta",
+                JSONObject()
+                    .put("requestedLimit", limit)
+                    .put("returnedCount", minOf(limit, features.length()))
+            )
+            .put(
+                "collection",
+                JSONObject()
+                    .put("type", "FeatureCollection")
+                    .put("features", JSONArray().apply {
+                        for (i in 0 until minOf(limit, features.length())) {
+                            put(features.getJSONObject(i))
+                        }
+                    })
+            )
     }
 
     private fun handleLocationTree(uri: Uri): JSONObject {

--- a/android/app/src/main/java/com/neph/features/gatheringareas/data/GatheringAreasRepository.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/data/GatheringAreasRepository.kt
@@ -1,0 +1,245 @@
+package com.neph.features.gatheringareas.data
+
+import com.neph.core.network.JsonHttpClient
+import kotlinx.coroutines.withTimeoutOrNull
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.Locale
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+data class GatheringAreaItem(
+    val id: String,
+    val osmType: String,
+    val name: String,
+    val category: String,
+    val latitude: Double,
+    val longitude: Double,
+    val distanceMeters: Int,
+    val addressLine: String?
+)
+
+data class NearbyGatheringAreasResult(
+    val centerLatitude: Double,
+    val centerLongitude: Double,
+    val radiusMeters: Int,
+    val source: String,
+    val requestedLimit: Int,
+    val returnedCount: Int,
+    val skippedCount: Int,
+    val areas: List<GatheringAreaItem>
+)
+
+object GatheringAreasRepository {
+    private const val DefaultRadiusMeters = 2000
+    private const val DefaultLimit = 20
+    private const val MaxRadiusMeters = 10000
+    private const val MaxLimit = 50
+    private const val NearbyRequestTimeoutMillis = 8000L
+
+    suspend fun fetchNearbyGatheringAreas(
+        latitude: Double,
+        longitude: Double,
+        radiusMeters: Int = DefaultRadiusMeters,
+        limit: Int = DefaultLimit
+    ): NearbyGatheringAreasResult {
+        val normalizedRadius = radiusMeters.coerceIn(1, MaxRadiusMeters)
+        val normalizedLimit = limit.coerceIn(1, MaxLimit)
+
+        val response = withTimeoutOrNull(NearbyRequestTimeoutMillis) {
+            JsonHttpClient.request(
+                path = String.format(
+                    Locale.US,
+                    "/gathering-areas/nearby?lat=%.6f&lon=%.6f&radius=%d&limit=%d",
+                    latitude,
+                    longitude,
+                    normalizedRadius,
+                    normalizedLimit
+                )
+            )
+        } ?: return NearbyGatheringAreasResult(
+            centerLatitude = latitude,
+            centerLongitude = longitude,
+            radiusMeters = normalizedRadius,
+            source = "overpass",
+            requestedLimit = normalizedLimit,
+            returnedCount = 0,
+            skippedCount = 0,
+            areas = emptyList()
+        )
+
+        return parseNearbyGatheringAreasResponse(
+            response = response,
+            fallbackLatitude = latitude,
+            fallbackLongitude = longitude,
+            fallbackRadius = normalizedRadius,
+            fallbackLimit = normalizedLimit
+        )
+    }
+
+    internal fun parseNearbyGatheringAreasResponse(
+        response: JSONObject,
+        fallbackLatitude: Double,
+        fallbackLongitude: Double,
+        fallbackRadius: Int = DefaultRadiusMeters,
+        fallbackLimit: Int = DefaultLimit
+    ): NearbyGatheringAreasResult {
+        val centerJson = response.optJSONObject("center") ?: JSONObject()
+        val centerLatitude = centerJson.optFiniteDouble("lat") ?: fallbackLatitude
+        val centerLongitude = centerJson.optFiniteDouble("lon") ?: fallbackLongitude
+
+        val radiusMeters = response.optPositiveInt("radius") ?: fallbackRadius
+        val source = response.optString("source").trim().ifBlank { "overpass" }
+
+        val metaJson = response.optJSONObject("meta") ?: JSONObject()
+        val requestedLimit = metaJson.optPositiveInt("requestedLimit") ?: fallbackLimit
+
+        val features = response
+            .optJSONObject("collection")
+            ?.optJSONArray("features")
+            ?: JSONArray()
+
+        var skippedCount = 0
+        val parsedAreas = buildList {
+            for (index in 0 until features.length()) {
+                val feature = features.optJSONObject(index)
+                if (feature == null) {
+                    skippedCount += 1
+                    continue
+                }
+
+                val parsed = parseFeature(
+                    feature = feature,
+                    index = index,
+                    centerLatitude = centerLatitude,
+                    centerLongitude = centerLongitude
+                )
+                if (parsed == null) {
+                    skippedCount += 1
+                    continue
+                }
+
+                add(parsed)
+            }
+        }
+
+        val sortedAreas = parsedAreas.sortedBy { it.distanceMeters }
+
+        return NearbyGatheringAreasResult(
+            centerLatitude = centerLatitude,
+            centerLongitude = centerLongitude,
+            radiusMeters = radiusMeters,
+            source = source,
+            requestedLimit = requestedLimit,
+            returnedCount = sortedAreas.size,
+            skippedCount = skippedCount,
+            areas = sortedAreas
+        )
+    }
+
+    private fun parseFeature(
+        feature: JSONObject,
+        index: Int,
+        centerLatitude: Double,
+        centerLongitude: Double
+    ): GatheringAreaItem? {
+        val geometry = feature.optJSONObject("geometry") ?: return null
+        val coordinates = geometry.optJSONArray("coordinates") ?: return null
+
+        val longitude = coordinates.optFiniteDouble(0) ?: return null
+        val latitude = coordinates.optFiniteDouble(1) ?: return null
+
+        if (latitude !in -90.0..90.0 || longitude !in -180.0..180.0) {
+            return null
+        }
+
+        val properties = feature.optJSONObject("properties") ?: JSONObject()
+        val rawTags = properties.optJSONObject("rawTags") ?: JSONObject()
+
+        val id = properties.optString("id").trim().ifBlank { "feature-$index" }
+        val osmType = properties.optString("osmType").trim()
+
+        val resolvedName = properties.optString("name").trim().ifBlank {
+            rawTags.optString("name").trim().ifBlank {
+                rawTags.optString("name:tr").trim()
+            }
+        }
+
+        val category = properties.optString("category").trim().ifBlank {
+            rawTags.optString("emergency").trim().ifBlank {
+                rawTags.optString("amenity").trim().ifBlank { "unknown" }
+            }
+        }
+
+        val payloadDistance = properties.optNonNegativeInt("distanceMeters")
+        val distanceMeters = payloadDistance ?: calculateDistanceMeters(
+            fromLatitude = centerLatitude,
+            fromLongitude = centerLongitude,
+            toLatitude = latitude,
+            toLongitude = longitude
+        )
+
+        val addressLine = listOf(
+            rawTags.optString("addr:full").trim(),
+            rawTags.optString("addr:street").trim(),
+            rawTags.optString("description").trim()
+        ).firstOrNull { it.isNotBlank() }
+
+        return GatheringAreaItem(
+            id = id,
+            osmType = osmType,
+            name = resolvedName,
+            category = category,
+            latitude = latitude,
+            longitude = longitude,
+            distanceMeters = distanceMeters,
+            addressLine = addressLine
+        )
+    }
+
+    private fun calculateDistanceMeters(
+        fromLatitude: Double,
+        fromLongitude: Double,
+        toLatitude: Double,
+        toLongitude: Double
+    ): Int {
+        val earthRadiusMeters = 6_371_000.0
+        val dLat = Math.toRadians(toLatitude - fromLatitude)
+        val dLon = Math.toRadians(toLongitude - fromLongitude)
+
+        val a =
+            sin(dLat / 2) * sin(dLat / 2) +
+                cos(Math.toRadians(fromLatitude)) * cos(Math.toRadians(toLatitude)) *
+                sin(dLon / 2) * sin(dLon / 2)
+
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+        return (earthRadiusMeters * c).roundToInt()
+    }
+}
+
+private fun JSONObject.optFiniteDouble(key: String): Double? {
+    if (!has(key)) return null
+    val value = optDouble(key)
+    return if (value.isFinite()) value else null
+}
+
+private fun JSONArray.optFiniteDouble(index: Int): Double? {
+    if (index < 0 || index >= length()) return null
+    val value = optDouble(index)
+    return if (value.isFinite()) value else null
+}
+
+private fun JSONObject.optPositiveInt(key: String): Int? {
+    if (!has(key)) return null
+    val value = optInt(key)
+    return value.takeIf { it > 0 }
+}
+
+private fun JSONObject.optNonNegativeInt(key: String): Int? {
+    if (!has(key)) return null
+    val value = optInt(key)
+    return value.takeIf { it >= 0 }
+}

--- a/android/app/src/main/java/com/neph/features/gatheringareas/data/GatheringAreasRepository.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/data/GatheringAreasRepository.kt
@@ -1,5 +1,6 @@
 package com.neph.features.gatheringareas.data
 
+import com.neph.core.network.ApiException
 import com.neph.core.network.JsonHttpClient
 import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONArray
@@ -60,15 +61,10 @@ object GatheringAreasRepository {
                     normalizedLimit
                 )
             )
-        } ?: return NearbyGatheringAreasResult(
-            centerLatitude = latitude,
-            centerLongitude = longitude,
-            radiusMeters = normalizedRadius,
-            source = "overpass",
-            requestedLimit = normalizedLimit,
-            returnedCount = 0,
-            skippedCount = 0,
-            areas = emptyList()
+        } ?: throw ApiException(
+            message = "Gathering areas request timed out.",
+            status = 504,
+            code = "OVERPASS_TIMEOUT"
         )
 
         return parseNearbyGatheringAreasResponse(

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -1,17 +1,53 @@
 package com.neph.features.gatheringareas.presentation
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import com.neph.core.network.ApiException
+import com.neph.features.gatheringareas.data.GatheringAreaItem
+import com.neph.features.gatheringareas.data.GatheringAreasRepository
+import com.neph.features.gatheringareas.data.NearbyGatheringAreasResult
+import com.neph.features.profile.data.CurrentLocationShareWarning
+import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.navigation.Routes
+import com.neph.ui.components.buttons.SecondaryButton
+import com.neph.ui.components.buttons.TextActionButton
+import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
 import com.neph.ui.layout.AppDrawerScaffold
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import java.util.Locale
+
+private const val DefaultCenterLatitude = 39.9334
+private const val DefaultCenterLongitude = 32.8597
 
 @Composable
 fun GatheringAreasScreen(
@@ -22,6 +58,125 @@ fun GatheringAreasScreen(
     isAuthenticated: Boolean
 ) {
     val spacing = LocalNephSpacing.current
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
+    var loading by remember { mutableStateOf(true) }
+    var errorMessage by remember { mutableStateOf("") }
+    var infoMessage by remember { mutableStateOf("") }
+    var sourceLabel by remember { mutableStateOf("Ankara city center") }
+    var lastCenterLatitude by remember { mutableStateOf(DefaultCenterLatitude) }
+    var lastCenterLongitude by remember { mutableStateOf(DefaultCenterLongitude) }
+    var nearbyResult by remember { mutableStateOf<NearbyGatheringAreasResult?>(null) }
+
+    fun fetchGatheringAreas(lat: Double, lon: Double, label: String) {
+        scope.launch {
+            loading = true
+            errorMessage = ""
+            infoMessage = ""
+
+            try {
+                val result = GatheringAreasRepository.fetchNearbyGatheringAreas(
+                    latitude = lat,
+                    longitude = lon
+                )
+                nearbyResult = result
+                sourceLabel = label
+                lastCenterLatitude = result.centerLatitude
+                lastCenterLongitude = result.centerLongitude
+
+                if (result.areas.isEmpty()) {
+                    infoMessage = "No gathering areas were found in this area."
+                } else if (result.skippedCount > 0) {
+                    infoMessage = "${result.skippedCount} malformed area entries were skipped safely."
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (error: ApiException) {
+                errorMessage = when (error.code) {
+                    "OVERPASS_TIMEOUT" -> "Gathering area lookup timed out. Please retry."
+                    "OVERPASS_UNAVAILABLE" -> "Gathering area provider is temporarily unavailable."
+                    else -> error.message.ifBlank {
+                        "Could not load gathering areas right now."
+                    }
+                }
+            } catch (_: Exception) {
+                errorMessage = "Could not load gathering areas right now."
+            } finally {
+                loading = false
+            }
+        }
+    }
+
+    fun requestCurrentLocationAndRefresh() {
+        scope.launch {
+            loading = true
+            errorMessage = ""
+            infoMessage = ""
+
+            try {
+                val attempt = DeviceLocationProvider.captureCurrentLocationForSharing(
+                    context = context,
+                    sharingEnabled = true
+                )
+
+                val location = attempt.location
+                if (location != null) {
+                    fetchGatheringAreas(
+                        lat = location.latitude,
+                        lon = location.longitude,
+                        label = "your current location"
+                    )
+                    return@launch
+                }
+
+                loading = false
+                infoMessage = when (attempt.warning) {
+                    CurrentLocationShareWarning.PERMISSION_DENIED ->
+                        "Location permission is denied. You can continue with the default map area."
+
+                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
+                    null -> "Current location is unavailable. Showing the last loaded area."
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                loading = false
+                infoMessage = "Current location is unavailable. Showing the last loaded area."
+            }
+        }
+    }
+
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { grants ->
+        if (grants.values.any { it }) {
+            requestCurrentLocationAndRefresh()
+        } else {
+            infoMessage = "Location permission denied. Showing gathering areas around the default area."
+        }
+    }
+
+    fun openAreaInMap(item: GatheringAreaItem) {
+        val encodedLabel = Uri.encode(item.name.ifBlank { "Gathering Area" })
+        val geoUri = Uri.parse("geo:${item.latitude},${item.longitude}?q=${item.latitude},${item.longitude}($encodedLabel)")
+        val geoIntent = Intent(Intent.ACTION_VIEW, geoUri)
+
+        try {
+            context.startActivity(geoIntent)
+        } catch (_: ActivityNotFoundException) {
+            val browserUri = Uri.parse("https://www.openstreetmap.org/?mlat=${item.latitude}&mlon=${item.longitude}#map=17/${item.latitude}/${item.longitude}")
+            context.startActivity(Intent(Intent.ACTION_VIEW, browserUri))
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        fetchGatheringAreas(
+            lat = DefaultCenterLatitude,
+            lon = DefaultCenterLongitude,
+            label = "Ankara city center"
+        )
+    }
 
     AppDrawerScaffold(
         title = "Gathering Areas",
@@ -37,21 +192,199 @@ fun GatheringAreasScreen(
         profileBadgeText = profileBadgeText,
         profileLabel = if (isAuthenticated) "Profile" else "Login / Create Account"
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(spacing.lg)) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(spacing.lg),
+            modifier = Modifier.verticalScroll(rememberScrollState())
+        ) {
             SectionCard {
-                SectionHeader(
-                    title = "Gathering Areas",
-                    subtitle = "This page will show safe gathering locations and related guidance."
-                )
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                    SectionHeader(
+                        title = "Nearby Gathering Areas",
+                        subtitle = "Location-based assembly points and shelters are retrieved from the gathering areas service."
+                    )
 
-                Text(
-                    text = "Location data and map integrations will be added in a later step.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                    HelperText(
+                        text = "Showing results around $sourceLabel (${formatCoordinate(lastCenterLatitude)}, ${formatCoordinate(lastCenterLongitude)})."
+                    )
+
+                    SecondaryButton(
+                        text = "Use Current Location",
+                        onClick = {
+                            if (DeviceLocationProvider.hasLocationPermission(context)) {
+                                requestCurrentLocationAndRefresh()
+                            } else {
+                                locationPermissionLauncher.launch(DeviceLocationProvider.RequiredLocationPermissions)
+                            }
+                        },
+                        enabled = !loading
+                    )
+
+                    SecondaryButton(
+                        text = "Refresh Nearby Areas",
+                        onClick = {
+                            fetchGatheringAreas(
+                                lat = lastCenterLatitude,
+                                lon = lastCenterLongitude,
+                                label = sourceLabel
+                            )
+                        },
+                        enabled = !loading
+                    )
+                }
+            }
+
+            when {
+                loading -> {
+                    SectionCard {
+                        HelperText(text = "Loading nearby gathering areas...")
+                    }
+                }
+
+                errorMessage.isNotBlank() -> {
+                    SectionCard {
+                        Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                            HelperText(text = errorMessage)
+                            SecondaryButton(
+                                text = "Retry",
+                                onClick = {
+                                    fetchGatheringAreas(
+                                        lat = lastCenterLatitude,
+                                        lon = lastCenterLongitude,
+                                        label = sourceLabel
+                                    )
+                                }
+                            )
+                        }
+                    }
+                }
+
+                nearbyResult?.areas.isNullOrEmpty() -> {
+                    SectionCard {
+                        Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                            SectionHeader(
+                                title = "No Gathering Areas Found",
+                                subtitle = "Try refreshing or using your current location for a different area."
+                            )
+                            SecondaryButton(
+                                text = "Retry",
+                                onClick = {
+                                    fetchGatheringAreas(
+                                        lat = lastCenterLatitude,
+                                        lon = lastCenterLongitude,
+                                        label = sourceLabel
+                                    )
+                                }
+                            )
+                        }
+                    }
+                }
+
+                else -> {
+                    val result = nearbyResult ?: return@AppDrawerScaffold
+
+                    SectionCard {
+                        Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                            Text(
+                                text = "${result.returnedCount} areas within ${formatDistance(result.radiusMeters)}",
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontWeight = FontWeight.SemiBold
+                            )
+
+                            Text(
+                                text = "Source: ${result.source.uppercase()} • Requested limit: ${result.requestedLimit}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+
+                            if (result.skippedCount > 0) {
+                                HelperText(text = "${result.skippedCount} malformed provider entries were skipped.")
+                            }
+                        }
+                    }
+
+                    result.areas.forEachIndexed { index, area ->
+                        SectionCard {
+                            Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                                Text(
+                                    text = area.name.ifBlank { "Unnamed Gathering Area" },
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+
+                                Text(
+                                    text = "Category: ${formatCategory(area.category)}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+
+                                Text(
+                                    text = "Distance: ${formatDistance(area.distanceMeters)}",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+
+                                Text(
+                                    text = "Coordinates: ${formatCoordinate(area.latitude)}, ${formatCoordinate(area.longitude)}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+
+                                area.addressLine?.takeIf { it.isNotBlank() }?.let { address ->
+                                    Text(
+                                        text = "Address: $address",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.End
+                                ) {
+                                    TextActionButton(
+                                        text = "Open in Map",
+                                        onClick = { openAreaInMap(area) }
+                                    )
+                                }
+
+                                if (index < result.areas.lastIndex) {
+                                    Spacer(modifier = Modifier.height(spacing.xs))
+                                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (infoMessage.isNotBlank()) {
+                SectionCard {
+                    HelperText(text = infoMessage)
+                }
             }
         }
     }
+}
+
+private fun formatDistance(distanceMeters: Int): String {
+    if (distanceMeters >= 1000) {
+        return String.format(Locale.US, "%.1f km", distanceMeters / 1000.0)
+    }
+
+    return "$distanceMeters m"
+}
+
+private fun formatCategory(category: String): String {
+    return when (category.trim().lowercase()) {
+        "assembly_point" -> "Assembly Point"
+        "shelter" -> "Shelter"
+        else -> category.replace('_', ' ').replaceFirstChar { it.uppercase() }
+    }
+}
+
+private fun formatCoordinate(value: Double): String {
+    return String.format(Locale.US, "%.5f", value)
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -133,16 +133,16 @@ fun GatheringAreasScreen(
                 loading = false
                 infoMessage = when (attempt.warning) {
                     CurrentLocationShareWarning.PERMISSION_DENIED ->
-                        "Location permission is denied. You can continue with the default map area."
+                        "Location permission is denied. Nearby results were not updated."
 
                     CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
-                    null -> "Current location is unavailable. Showing the last loaded area."
+                    null -> "Current location is unavailable. Nearby results were not updated."
                 }
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (_: Exception) {
                 loading = false
-                infoMessage = "Current location is unavailable. Showing the last loaded area."
+                infoMessage = "Current location is unavailable. Nearby results were not updated."
             }
         }
     }
@@ -153,7 +153,7 @@ fun GatheringAreasScreen(
         if (grants.values.any { it }) {
             requestCurrentLocationAndRefresh()
         } else {
-            infoMessage = "Location permission denied. Showing gathering areas around the default area."
+            infoMessage = "Location permission denied. Nearby results were not updated."
         }
     }
 

--- a/android/app/src/main/java/com/neph/navigation/Routes.kt
+++ b/android/app/src/main/java/com/neph/navigation/Routes.kt
@@ -41,7 +41,8 @@ sealed class Routes(
             Home,
             News,
             MyHelpRequests,
-            EmergencyInfo
+            EmergencyInfo,
+            GatheringAreas
         )
 
         val drawerItems = authenticatedDrawerItems

--- a/android/app/src/test/java/com/neph/features/gatheringareas/data/GatheringAreasRepositoryTest.kt
+++ b/android/app/src/test/java/com/neph/features/gatheringareas/data/GatheringAreasRepositoryTest.kt
@@ -1,0 +1,116 @@
+package com.neph.features.gatheringareas.data
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GatheringAreasRepositoryTest {
+    @Test
+    fun parseNearbyGatheringAreasResponse_mapsValidFeaturesAndSkipsMalformedOnes() {
+        val response = JSONObject(
+            """
+            {
+              "center": { "lat": 41.01, "lon": 29.01 },
+              "radius": 1500,
+              "source": "overpass",
+              "meta": { "requestedLimit": 10, "returnedCount": 3 },
+              "collection": {
+                "type": "FeatureCollection",
+                "features": [
+                  {
+                    "type": "Feature",
+                    "geometry": { "type": "Point", "coordinates": [29.012, 41.011] },
+                    "properties": {
+                      "id": "node-1",
+                      "osmType": "node",
+                      "name": "Assembly Area A",
+                      "category": "assembly_point",
+                      "distanceMeters": 120,
+                      "rawTags": { "addr:street": "Main Street" }
+                    }
+                  },
+                  {
+                    "type": "Feature",
+                    "geometry": { "type": "Point", "coordinates": [29.02] },
+                    "properties": {
+                      "id": "broken"
+                    }
+                  },
+                  {
+                    "type": "Feature",
+                    "geometry": { "type": "Point", "coordinates": [29.014, 41.013] },
+                    "properties": {
+                      "id": "node-2",
+                      "osmType": "way",
+                      "name": "",
+                      "category": "shelter",
+                      "distanceMeters": 250,
+                      "rawTags": { "name": "Shelter B" }
+                    }
+                  }
+                ]
+              }
+            }
+            """.trimIndent()
+        )
+
+        val parsed = GatheringAreasRepository.parseNearbyGatheringAreasResponse(
+            response = response,
+            fallbackLatitude = 40.0,
+            fallbackLongitude = 29.0
+        )
+
+        assertEquals(2, parsed.returnedCount)
+        assertEquals(1, parsed.skippedCount)
+        assertEquals(1500, parsed.radiusMeters)
+        assertEquals("overpass", parsed.source)
+        assertEquals(10, parsed.requestedLimit)
+
+        assertEquals("node-1", parsed.areas[0].id)
+        assertEquals("Main Street", parsed.areas[0].addressLine)
+        assertEquals("shelter", parsed.areas[1].category)
+        assertEquals("Shelter B", parsed.areas[1].name)
+    }
+
+    @Test
+    fun parseNearbyGatheringAreasResponse_usesFallbackCenterAndDistanceWhenMissingInPayload() {
+        val response = JSONObject(
+            """
+            {
+              "collection": {
+                "type": "FeatureCollection",
+                "features": [
+                  {
+                    "type": "Feature",
+                    "geometry": { "type": "Point", "coordinates": [32.851, 39.922] },
+                    "properties": {
+                      "id": "fallback-1",
+                      "category": "assembly_point",
+                      "rawTags": {}
+                    }
+                  }
+                ]
+              }
+            }
+            """.trimIndent()
+        )
+
+        val parsed = GatheringAreasRepository.parseNearbyGatheringAreasResponse(
+            response = response,
+            fallbackLatitude = 39.92,
+            fallbackLongitude = 32.85,
+            fallbackRadius = 2000,
+            fallbackLimit = 20
+        )
+
+        assertEquals(39.92, parsed.centerLatitude, 0.0)
+        assertEquals(32.85, parsed.centerLongitude, 0.0)
+        assertEquals(2000, parsed.radiusMeters)
+        assertEquals(20, parsed.requestedLimit)
+        assertEquals(1, parsed.returnedCount)
+        assertNotNull(parsed.areas.first().distanceMeters)
+        assertTrue(parsed.areas.first().distanceMeters >= 0)
+    }
+}


### PR DESCRIPTION
Summary
This PR implements the Android Gathering Areas page so users can reliably view nearby gathering areas based on location data.

What changed:

- Replaced the placeholder Gathering Areas screen with a real, data-driven mobile implementation.
- Added a mobile repository for fetching nearby gathering areas from the existing backend endpoint.
- Added robust response parsing for partial or malformed entries, safely skipping invalid features.
- Added explicit UI states for loading, empty results, backend/provider failure, and successful retrieval.
- Added current-location support with contextual permission handling and safe fallback behavior.
- Added clear per-area details (name, category, distance, coordinates, address when available) and an Open in Map action.
- Added Gathering Areas to guest drawer navigation so guests can access the page.
- Added Android test backend route support for gathering-areas in mobile e2e infrastructure.
- Added unit tests for gathering areas parsing and fallback behavior.


Validation:

Android unit tests and e2e androidTest assembly pass:
:app:testE2eUnitTest
:app:assembleE2eAndroidTest


This PR completes the android part of the issue #293 

Note: Map display will be added to all location related parts of the mobile in another PR which relates to the issue #294 