### PR TITLE
feat: add reusable shared map integration

### DIFF
--- a/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
@@ -26,6 +26,7 @@ import android.widget.Toast
 import com.neph.core.network.ApiException
 import com.neph.features.auth.util.countryCodeOptions
 import com.neph.features.profile.data.CurrentLocationShareWarning
+import com.neph.features.profile.data.CurrentDeviceLocation
 import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.features.profile.data.ProfileRepository
 import com.neph.features.profile.data.LocationData
@@ -50,6 +51,8 @@ import com.neph.ui.components.inputs.AppTextField
 import com.neph.ui.components.selection.AppCheckbox
 import com.neph.ui.components.selection.AppToggleSwitch
 import com.neph.ui.layout.AuthScaffold
+import com.neph.ui.map.NephMapIntegration
+import com.neph.ui.map.buildLocationSelectionMapQuery
 import com.neph.ui.theme.LocalNephSpacing
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
@@ -90,6 +93,7 @@ fun CompleteProfileScreen(
     var availableLocationData by remember { mutableStateOf<LocationData>(locationData) }
     var locationLoading by remember { mutableStateOf(true) }
     var locationInfo by rememberSaveable { mutableStateOf("") }
+    var lastSharedLocation by remember { mutableStateOf<CurrentDeviceLocation?>(null) }
     val locationPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions()
     ) { grants ->
@@ -189,6 +193,10 @@ fun CompleteProfileScreen(
                     CurrentLocationShareWarning.PERMISSION_DENIED -> profileToSync.copy(shareLocation = false)
                     CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> profileToSync
                     null -> profileToSync
+                }
+
+                if (locationShareAttempt.location != null) {
+                    lastSharedLocation = locationShareAttempt.location
                 }
 
                 ProfileRepository.syncProfile(
@@ -399,6 +407,66 @@ fun CompleteProfileScreen(
                 label = "Extra Address",
                 testTag = "complete_profile_extra_address"
             )
+
+            val selectedLocationQuery = buildLocationSelectionMapQuery(
+                countryKeyOrLabel = country,
+                cityKeyOrLabel = city,
+                districtKeyOrLabel = district,
+                neighborhoodValueOrLabel = neighborhood,
+                extraAddress = extraAddress,
+                locations = availableLocationData
+            )
+            if (selectedLocationQuery.isNotBlank()) {
+                Text(
+                    text = "Selected location can be opened in your map app.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    com.neph.ui.components.buttons.TextActionButton(
+                        text = "Open Selected Location in Map",
+                        onClick = {
+                            val opened = NephMapIntegration.openLocationQuery(
+                                context = context,
+                                query = selectedLocationQuery
+                            )
+                            if (!opened) {
+                                info = "Could not open map application."
+                            }
+                        },
+                        enabled = !loading
+                    )
+                }
+            }
+
+            lastSharedLocation?.let { sharedLocation ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    com.neph.ui.components.buttons.TextActionButton(
+                        text = "Open Shared Coordinates in Map",
+                        onClick = {
+                            val opened = NephMapIntegration.openCoordinates(
+                                context = context,
+                                latitude = sharedLocation.latitude,
+                                longitude = sharedLocation.longitude,
+                                label = "Shared Current Location"
+                            )
+                            if (!opened) {
+                                info = "Could not open map application."
+                            }
+                        },
+                        enabled = !loading
+                    )
+                }
+            }
 
             AppToggleSwitch(
                 checked = shareLocation,

--- a/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
@@ -1,11 +1,11 @@
 package com.neph.features.auth.presentation
 
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -17,20 +17,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
-import android.widget.Toast
 import com.neph.core.network.ApiException
 import com.neph.features.auth.util.countryCodeOptions
 import com.neph.features.profile.data.CurrentLocationShareWarning
-import com.neph.features.profile.data.CurrentDeviceLocation
 import com.neph.features.profile.data.DeviceLocationProvider
-import com.neph.features.profile.data.ProfileRepository
 import com.neph.features.profile.data.LocationData
 import com.neph.features.profile.data.LocationTreeRepository
+import com.neph.features.profile.data.ProfileRepository
 import com.neph.features.profile.data.bloodTypeOptions
 import com.neph.features.profile.data.combinePhoneNumber
 import com.neph.features.profile.data.expertiseOptionsFor
@@ -51,8 +48,8 @@ import com.neph.ui.components.inputs.AppTextField
 import com.neph.ui.components.selection.AppCheckbox
 import com.neph.ui.components.selection.AppToggleSwitch
 import com.neph.ui.layout.AuthScaffold
-import com.neph.ui.map.NephMapIntegration
-import com.neph.ui.map.buildLocationSelectionMapQuery
+import com.neph.ui.map.LocationSelectionMapAction
+import com.neph.ui.map.SharedCoordinatesMapAction
 import com.neph.ui.theme.LocalNephSpacing
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
@@ -90,10 +87,12 @@ fun CompleteProfileScreen(
     var loading by rememberSaveable { mutableStateOf(false) }
     var error by rememberSaveable { mutableStateOf("") }
     var info by rememberSaveable { mutableStateOf("") }
+    var mapActionInfo by rememberSaveable { mutableStateOf("") }
     var availableLocationData by remember { mutableStateOf<LocationData>(locationData) }
     var locationLoading by remember { mutableStateOf(true) }
     var locationInfo by rememberSaveable { mutableStateOf("") }
-    var lastSharedLocation by remember { mutableStateOf<CurrentDeviceLocation?>(null) }
+    var syncedSharedLatitude by rememberSaveable { mutableStateOf(existingProfile.sharedLatitude) }
+    var syncedSharedLongitude by rememberSaveable { mutableStateOf(existingProfile.sharedLongitude) }
     val locationPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions()
     ) { grants ->
@@ -122,6 +121,7 @@ fun CompleteProfileScreen(
     fun handleSave() {
         error = ""
         info = ""
+        mapActionInfo = ""
 
         val normalizedName = fullName.trim()
         val normalizedPhone = phone.trim()
@@ -189,21 +189,20 @@ fun CompleteProfileScreen(
                     context = context,
                     sharingEnabled = profileToSync.shareLocation == true
                 )
-                val syncedProfile = when (locationShareAttempt.warning) {
+                val profileWithSharePolicy = when (locationShareAttempt.warning) {
                     CurrentLocationShareWarning.PERMISSION_DENIED -> profileToSync.copy(shareLocation = false)
                     CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> profileToSync
                     null -> profileToSync
                 }
 
-                if (locationShareAttempt.location != null) {
-                    lastSharedLocation = locationShareAttempt.location
-                }
-
-                ProfileRepository.syncProfile(
-                    profile = syncedProfile,
+                val syncedProfile = ProfileRepository.syncProfile(
+                    profile = profileWithSharePolicy,
                     currentDeviceLocation = locationShareAttempt.location,
                     forceClearSharedCoordinates = locationShareAttempt.warning == CurrentLocationShareWarning.LOCATION_UNAVAILABLE
                 )
+                shareLocation = syncedProfile.shareLocation ?: false
+                syncedSharedLatitude = syncedProfile.sharedLatitude
+                syncedSharedLongitude = syncedProfile.sharedLongitude
 
                 val completionMessage = when (locationShareAttempt.warning) {
                     CurrentLocationShareWarning.PERMISSION_DENIED ->
@@ -319,19 +318,19 @@ fun CompleteProfileScreen(
             AppTextArea(
                 value = medicalHistory,
                 onValueChange = { medicalHistory = it },
-                label = "Medical History (optional — comma-separated)"
+                label = "Medical History (optional - comma-separated)"
             )
 
             AppTextArea(
                 value = chronicDiseases,
                 onValueChange = { chronicDiseases = it },
-                label = "Chronic Diseases (optional — comma-separated)"
+                label = "Chronic Diseases (optional - comma-separated)"
             )
 
             AppTextArea(
                 value = allergies,
                 onValueChange = { allergies = it },
-                label = "Allergies (optional — comma-separated)"
+                label = "Allergies (optional - comma-separated)"
             )
 
             Text("Profession", style = MaterialTheme.typography.titleMedium)
@@ -408,65 +407,25 @@ fun CompleteProfileScreen(
                 testTag = "complete_profile_extra_address"
             )
 
-            val selectedLocationQuery = buildLocationSelectionMapQuery(
+            LocationSelectionMapAction(
                 countryKeyOrLabel = country,
                 cityKeyOrLabel = city,
                 districtKeyOrLabel = district,
                 neighborhoodValueOrLabel = neighborhood,
                 extraAddress = extraAddress,
-                locations = availableLocationData
+                locations = availableLocationData,
+                enabled = !loading,
+                onOpenFailure = { mapActionInfo = it },
+                onOpenSuccess = { mapActionInfo = "" }
             )
-            if (selectedLocationQuery.isNotBlank()) {
-                Text(
-                    text = "Selected location can be opened in your map app.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
 
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    com.neph.ui.components.buttons.TextActionButton(
-                        text = "Open Selected Location in Map",
-                        onClick = {
-                            val opened = NephMapIntegration.openLocationQuery(
-                                context = context,
-                                query = selectedLocationQuery
-                            )
-                            if (!opened) {
-                                info = "Could not open map application."
-                            }
-                        },
-                        enabled = !loading
-                    )
-                }
-            }
-
-            lastSharedLocation?.let { sharedLocation ->
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    com.neph.ui.components.buttons.TextActionButton(
-                        text = "Open Shared Coordinates in Map",
-                        onClick = {
-                            val opened = NephMapIntegration.openCoordinates(
-                                context = context,
-                                latitude = sharedLocation.latitude,
-                                longitude = sharedLocation.longitude,
-                                label = "Shared Current Location"
-                            )
-                            if (!opened) {
-                                info = "Could not open map application."
-                            }
-                        },
-                        enabled = !loading
-                    )
-                }
-            }
+            SharedCoordinatesMapAction(
+                latitude = syncedSharedLatitude,
+                longitude = syncedSharedLongitude,
+                enabled = !loading,
+                onOpenFailure = { mapActionInfo = it },
+                onOpenSuccess = { mapActionInfo = "" }
+            )
 
             AppToggleSwitch(
                 checked = shareLocation,
@@ -491,6 +450,10 @@ fun CompleteProfileScreen(
 
             if (info.isNotBlank()) {
                 HelperText(text = info)
+            }
+
+            if (mapActionInfo.isNotBlank()) {
+                HelperText(text = mapActionInfo)
             }
 
             SaveActionBar(onSave = ::handleSave, loading = loading)

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -1,8 +1,5 @@
 package com.neph.features.gatheringareas.presentation
 
-import android.content.ActivityNotFoundException
-import android.content.Intent
-import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -40,6 +37,8 @@ import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
 import com.neph.ui.layout.AppDrawerScaffold
+import com.neph.ui.map.NephMapIntegration
+import com.neph.ui.map.formatMapCoordinate
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
 import kotlinx.coroutines.CancellationException
@@ -158,15 +157,14 @@ fun GatheringAreasScreen(
     }
 
     fun openAreaInMap(item: GatheringAreaItem) {
-        val encodedLabel = Uri.encode(item.name.ifBlank { "Gathering Area" })
-        val geoUri = Uri.parse("geo:${item.latitude},${item.longitude}?q=${item.latitude},${item.longitude}($encodedLabel)")
-        val geoIntent = Intent(Intent.ACTION_VIEW, geoUri)
-
-        try {
-            context.startActivity(geoIntent)
-        } catch (_: ActivityNotFoundException) {
-            val browserUri = Uri.parse("https://www.openstreetmap.org/?mlat=${item.latitude}&mlon=${item.longitude}#map=17/${item.latitude}/${item.longitude}")
-            context.startActivity(Intent(Intent.ACTION_VIEW, browserUri))
+        val opened = NephMapIntegration.openCoordinates(
+            context = context,
+            latitude = item.latitude,
+            longitude = item.longitude,
+            label = item.name.ifBlank { "Gathering Area" }
+        )
+        if (!opened) {
+            infoMessage = "Could not open map application."
         }
     }
 
@@ -204,7 +202,7 @@ fun GatheringAreasScreen(
                     )
 
                     HelperText(
-                        text = "Showing results around $sourceLabel (${formatCoordinate(lastCenterLatitude)}, ${formatCoordinate(lastCenterLongitude)})."
+                        text = "Showing results around $sourceLabel (${formatMapCoordinate(lastCenterLatitude)}, ${formatMapCoordinate(lastCenterLongitude)})."
                     )
 
                     SecondaryButton(
@@ -325,7 +323,7 @@ fun GatheringAreasScreen(
                                 )
 
                                 Text(
-                                    text = "Coordinates: ${formatCoordinate(area.latitude)}, ${formatCoordinate(area.longitude)}",
+                                    text = "Coordinates: ${formatMapCoordinate(area.latitude)}, ${formatMapCoordinate(area.longitude)}",
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
@@ -381,10 +379,6 @@ private fun formatCategory(category: String): String {
         "shelter" -> "Shelter"
         else -> category.replace('_', ' ').replaceFirstChar { it.uppercase() }
     }
-}
-
-private fun formatCoordinate(value: Double): String {
-    return String.format(Locale.US, "%.5f", value)
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileData.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileData.kt
@@ -12,7 +12,7 @@ data class ProfileData(
     val bloodType: String? = null,
     val gender: String? = null,
     val age: Int? = null,
-    
+
     val medicalHistory: String? = null,
 
     val chronicDiseases: String? = null,
@@ -24,5 +24,7 @@ data class ProfileData(
     val neighborhood: String? = null,
     val extraAddress: String? = null,
 
-    val shareLocation: Boolean? = null
+    val shareLocation: Boolean? = null,
+    val sharedLatitude: Double? = null,
+    val sharedLongitude: Double? = null
 )

--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
@@ -335,6 +335,8 @@ object ProfileRepository {
             putString("neighborhood", profile.neighborhood)
             putString("extraAddress", profile.extraAddress)
             putBoolean("shareLocation", profile.shareLocation ?: false)
+            putString("sharedLatitude", profile.sharedLatitude?.toString())
+            putString("sharedLongitude", profile.sharedLongitude?.toString())
         }.apply()
     }
 
@@ -369,7 +371,9 @@ object ProfileRepository {
             district = prefs.getString("district", null),
             neighborhood = prefs.getString("neighborhood", null),
             extraAddress = prefs.getString("extraAddress", null),
-            shareLocation = if (prefs.contains("shareLocation")) prefs.getBoolean("shareLocation", false) else null
+            shareLocation = if (prefs.contains("shareLocation")) prefs.getBoolean("shareLocation", false) else null,
+            sharedLatitude = prefs.getString("sharedLatitude", null)?.toDoubleOrNull(),
+            sharedLongitude = prefs.getString("sharedLongitude", null)?.toDoubleOrNull()
         )
     }
 
@@ -385,6 +389,7 @@ object ProfileRepository {
         val privacySettings = profileJson.optJSONObject("privacySettings") ?: JSONObject()
         val expertise = profileJson.optJSONArray("expertise")?.optJSONObject(0)
         val administrative = locationProfile.optJSONObject("administrative") ?: JSONObject()
+        val coordinate = locationProfile.optJSONObject("coordinate") ?: JSONObject()
 
         val countryLabel = administrative.optStringOrNull("country")
             ?: locationProfile.optStringOrNull("country")
@@ -414,6 +419,10 @@ object ProfileRepository {
         val neighborhoodValue = neighborhoodFromAdministrative.ifBlank { parsedAddress.second }
         val extraAddressFromBackend = administrative.optStringOrNull("extraAddress")
             ?: parsedAddress.third
+        val sharedLatitude = coordinate.optNullableDouble("latitude")
+            ?: locationProfile.optNullableDouble("latitude")
+        val sharedLongitude = coordinate.optNullableDouble("longitude")
+            ?: locationProfile.optNullableDouble("longitude")
 
         return ProfileData(
             fullName = listOf(
@@ -442,7 +451,9 @@ object ProfileRepository {
                 .takeIf { it.isNotBlank() },
             extraAddress = extraAddressFromBackend
                 ?: cachedProfileSnapshot.extraAddress,
-            shareLocation = privacySettings.optNullableBoolean("locationSharingEnabled")
+            shareLocation = privacySettings.optNullableBoolean("locationSharingEnabled"),
+            sharedLatitude = sharedLatitude,
+            sharedLongitude = sharedLongitude
         )
     }
 
@@ -548,6 +559,10 @@ object ProfileRepository {
 
     private fun JSONObject.optNullableBoolean(key: String): Boolean? {
         return if (has(key) && !isNull(key)) optBoolean(key) else null
+    }
+
+    private fun JSONObject.optNullableDouble(key: String): Double? {
+        return if (has(key) && !isNull(key)) optDouble(key) else null
     }
 
     private fun ensureInitialized() {

--- a/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
@@ -5,7 +5,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -17,14 +16,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import com.neph.core.network.ApiException
 import com.neph.features.auth.util.countryCodeOptions
 import com.neph.features.profile.data.CurrentLocationShareWarning
-import com.neph.features.profile.data.CurrentDeviceLocation
 import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.features.profile.data.LocationData
 import com.neph.features.profile.data.LocationTreeRepository
@@ -52,8 +49,8 @@ import com.neph.ui.components.inputs.AppTextField
 import com.neph.ui.components.selection.AppCheckbox
 import com.neph.ui.components.selection.AppToggleSwitch
 import com.neph.ui.layout.AppScaffold
-import com.neph.ui.map.NephMapIntegration
-import com.neph.ui.map.buildLocationSelectionMapQuery
+import com.neph.ui.map.LocationSelectionMapAction
+import com.neph.ui.map.SharedCoordinatesMapAction
 import com.neph.ui.theme.LocalNephSpacing
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
@@ -69,6 +66,7 @@ fun EditProfileScreen(
     var loading by rememberSaveable { mutableStateOf(false) }
     var error by rememberSaveable { mutableStateOf("") }
     var info by rememberSaveable { mutableStateOf("") }
+    var mapActionInfo by rememberSaveable { mutableStateOf("") }
 
     var countryCode by rememberSaveable { mutableStateOf(initialPhoneParts.countryCode) }
     var phone by rememberSaveable { mutableStateOf(initialPhoneParts.phone) }
@@ -78,7 +76,8 @@ fun EditProfileScreen(
     var availableLocationData by remember { mutableStateOf<LocationData>(locationData) }
     var locationLoading by remember { mutableStateOf(true) }
     var locationInfo by rememberSaveable { mutableStateOf("") }
-    var lastSharedLocation by remember { mutableStateOf<CurrentDeviceLocation?>(null) }
+    var syncedSharedLatitude by remember { mutableStateOf(profile.sharedLatitude) }
+    var syncedSharedLongitude by remember { mutableStateOf(profile.sharedLongitude) }
 
     val scope = rememberCoroutineScope()
     val spacing = LocalNephSpacing.current
@@ -98,6 +97,8 @@ fun EditProfileScreen(
     LaunchedEffect(Unit) {
         try {
             profile = ProfileRepository.fetchAndCacheRemoteProfile()
+            syncedSharedLatitude = profile.sharedLatitude
+            syncedSharedLongitude = profile.sharedLongitude
             val phoneParts = normalizePhoneParts(profile.phone)
             countryCode = phoneParts.countryCode
             phone = phoneParts.phone
@@ -108,6 +109,8 @@ fun EditProfileScreen(
             throw cancellationException
         } catch (_: ApiException) {
             profile = ProfileRepository.getProfile()
+            syncedSharedLatitude = profile.sharedLatitude
+            syncedSharedLongitude = profile.sharedLongitude
             val phoneParts = normalizePhoneParts(profile.phone)
             countryCode = phoneParts.countryCode
             phone = phoneParts.phone
@@ -116,6 +119,8 @@ fun EditProfileScreen(
             ageText = profile.age?.toString().orEmpty()
         } catch (_: Exception) {
             profile = ProfileRepository.getProfile()
+            syncedSharedLatitude = profile.sharedLatitude
+            syncedSharedLongitude = profile.sharedLongitude
             val phoneParts = normalizePhoneParts(profile.phone)
             countryCode = phoneParts.countryCode
             phone = phoneParts.phone
@@ -142,6 +147,7 @@ fun EditProfileScreen(
     fun handleSave() {
         error = ""
         info = ""
+        mapActionInfo = ""
 
         val (firstName, lastName) = splitFullName(profile.fullName.orEmpty())
         if (firstName.isBlank() || lastName.isBlank()) {
@@ -185,21 +191,20 @@ fun EditProfileScreen(
                     context = context,
                     sharingEnabled = profileToSync.shareLocation == true
                 )
-                val syncedProfile = when (locationShareAttempt.warning) {
+                val profileWithSharePolicy = when (locationShareAttempt.warning) {
                     CurrentLocationShareWarning.PERMISSION_DENIED -> profileToSync.copy(shareLocation = false)
                     CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> profileToSync
                     null -> profileToSync
                 }
 
-                if (locationShareAttempt.location != null) {
-                    lastSharedLocation = locationShareAttempt.location
-                }
-
                 profile = ProfileRepository.syncProfile(
-                    profile = syncedProfile,
+                    profile = profileWithSharePolicy,
                     currentDeviceLocation = locationShareAttempt.location,
                     forceClearSharedCoordinates = locationShareAttempt.warning == CurrentLocationShareWarning.LOCATION_UNAVAILABLE
                 )
+                syncedSharedLatitude = profile.sharedLatitude
+                syncedSharedLongitude = profile.sharedLongitude
+
                 val phoneParts = normalizePhoneParts(profile.phone)
                 countryCode = phoneParts.countryCode
                 phone = phoneParts.phone
@@ -426,65 +431,25 @@ fun EditProfileScreen(
                         label = "Extra Address"
                     )
 
-                    val selectedLocationQuery = buildLocationSelectionMapQuery(
+                    LocationSelectionMapAction(
                         countryKeyOrLabel = profile.country,
                         cityKeyOrLabel = profile.city,
                         districtKeyOrLabel = profile.district,
                         neighborhoodValueOrLabel = profile.neighborhood,
                         extraAddress = profile.extraAddress,
-                        locations = availableLocationData
+                        locations = availableLocationData,
+                        enabled = !loading,
+                        onOpenFailure = { mapActionInfo = it },
+                        onOpenSuccess = { mapActionInfo = "" }
                     )
-                    if (selectedLocationQuery.isNotBlank()) {
-                        Text(
-                            text = "Selected location can be opened in your map app.",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
 
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.End,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            com.neph.ui.components.buttons.TextActionButton(
-                                text = "Open Selected Location in Map",
-                                onClick = {
-                                    val opened = NephMapIntegration.openLocationQuery(
-                                        context = context,
-                                        query = selectedLocationQuery
-                                    )
-                                    if (!opened) {
-                                        info = "Could not open map application."
-                                    }
-                                },
-                                enabled = !loading
-                            )
-                        }
-                    }
-
-                    lastSharedLocation?.let { sharedLocation ->
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.End,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            com.neph.ui.components.buttons.TextActionButton(
-                                text = "Open Shared Coordinates in Map",
-                                onClick = {
-                                    val opened = NephMapIntegration.openCoordinates(
-                                        context = context,
-                                        latitude = sharedLocation.latitude,
-                                        longitude = sharedLocation.longitude,
-                                        label = "Shared Current Location"
-                                    )
-                                    if (!opened) {
-                                        info = "Could not open map application."
-                                    }
-                                },
-                                enabled = !loading
-                            )
-                        }
-                    }
+                    SharedCoordinatesMapAction(
+                        latitude = syncedSharedLatitude,
+                        longitude = syncedSharedLongitude,
+                        enabled = !loading,
+                        onOpenFailure = { mapActionInfo = it },
+                        onOpenSuccess = { mapActionInfo = "" }
+                    )
 
                     AppToggleSwitch(
                         checked = profile.shareLocation ?: false,
@@ -511,6 +476,10 @@ fun EditProfileScreen(
 
             if (info.isNotBlank()) {
                 HelperText(text = info)
+            }
+
+            if (mapActionInfo.isNotBlank()) {
+                HelperText(text = mapActionInfo)
             }
 
             PrimaryButton(

--- a/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import com.neph.core.network.ApiException
 import com.neph.features.auth.util.countryCodeOptions
 import com.neph.features.profile.data.CurrentLocationShareWarning
+import com.neph.features.profile.data.CurrentDeviceLocation
 import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.features.profile.data.LocationData
 import com.neph.features.profile.data.LocationTreeRepository
@@ -51,6 +52,8 @@ import com.neph.ui.components.inputs.AppTextField
 import com.neph.ui.components.selection.AppCheckbox
 import com.neph.ui.components.selection.AppToggleSwitch
 import com.neph.ui.layout.AppScaffold
+import com.neph.ui.map.NephMapIntegration
+import com.neph.ui.map.buildLocationSelectionMapQuery
 import com.neph.ui.theme.LocalNephSpacing
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
@@ -75,6 +78,7 @@ fun EditProfileScreen(
     var availableLocationData by remember { mutableStateOf<LocationData>(locationData) }
     var locationLoading by remember { mutableStateOf(true) }
     var locationInfo by rememberSaveable { mutableStateOf("") }
+    var lastSharedLocation by remember { mutableStateOf<CurrentDeviceLocation?>(null) }
 
     val scope = rememberCoroutineScope()
     val spacing = LocalNephSpacing.current
@@ -185,6 +189,10 @@ fun EditProfileScreen(
                     CurrentLocationShareWarning.PERMISSION_DENIED -> profileToSync.copy(shareLocation = false)
                     CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> profileToSync
                     null -> profileToSync
+                }
+
+                if (locationShareAttempt.location != null) {
+                    lastSharedLocation = locationShareAttempt.location
                 }
 
                 profile = ProfileRepository.syncProfile(
@@ -417,6 +425,66 @@ fun EditProfileScreen(
                         onValueChange = { profile = profile.copy(extraAddress = it) },
                         label = "Extra Address"
                     )
+
+                    val selectedLocationQuery = buildLocationSelectionMapQuery(
+                        countryKeyOrLabel = profile.country,
+                        cityKeyOrLabel = profile.city,
+                        districtKeyOrLabel = profile.district,
+                        neighborhoodValueOrLabel = profile.neighborhood,
+                        extraAddress = profile.extraAddress,
+                        locations = availableLocationData
+                    )
+                    if (selectedLocationQuery.isNotBlank()) {
+                        Text(
+                            text = "Selected location can be opened in your map app.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            com.neph.ui.components.buttons.TextActionButton(
+                                text = "Open Selected Location in Map",
+                                onClick = {
+                                    val opened = NephMapIntegration.openLocationQuery(
+                                        context = context,
+                                        query = selectedLocationQuery
+                                    )
+                                    if (!opened) {
+                                        info = "Could not open map application."
+                                    }
+                                },
+                                enabled = !loading
+                            )
+                        }
+                    }
+
+                    lastSharedLocation?.let { sharedLocation ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            com.neph.ui.components.buttons.TextActionButton(
+                                text = "Open Shared Coordinates in Map",
+                                onClick = {
+                                    val opened = NephMapIntegration.openCoordinates(
+                                        context = context,
+                                        latitude = sharedLocation.latitude,
+                                        longitude = sharedLocation.longitude,
+                                        label = "Shared Current Location"
+                                    )
+                                    if (!opened) {
+                                        info = "Could not open map application."
+                                    }
+                                },
+                                enabled = !loading
+                            )
+                        }
+                    }
 
                     AppToggleSwitch(
                         checked = profile.shareLocation ?: false,

--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -46,6 +46,7 @@ import com.neph.features.requesthelp.data.RequestHelpRepository
 import com.neph.features.requesthelp.data.RequestHelpSubmission
 import com.neph.ui.components.buttons.PrimaryButton
 import com.neph.ui.components.buttons.SecondaryButton
+import com.neph.ui.components.buttons.TextActionButton
 import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
@@ -55,6 +56,8 @@ import com.neph.ui.components.inputs.AppTextField
 import com.neph.ui.components.selection.AppCheckbox
 import com.neph.ui.components.selection.AppMultiSelectChipGroup
 import com.neph.ui.layout.AppScaffold
+import com.neph.ui.map.NephMapIntegration
+import com.neph.ui.map.buildLocationSelectionMapQuery
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
 import kotlinx.coroutines.CancellationException
@@ -690,6 +693,15 @@ fun RequestHelpScreen(
                         subtitle = "Use the same location structure as your profile."
                     )
 
+                    val selectedLocationMapQuery = buildLocationSelectionMapQuery(
+                        countryKeyOrLabel = formState.country,
+                        cityKeyOrLabel = formState.city,
+                        districtKeyOrLabel = formState.district,
+                        neighborhoodValueOrLabel = formState.neighborhood,
+                        extraAddress = formState.shortAddress,
+                        locations = availableLocationData
+                    )
+
                     if (locationLoading) {
                         HelperText(text = "Loading location options...")
                     }
@@ -743,6 +755,27 @@ fun RequestHelpScreen(
                         label = "Short Address / Address Description",
                         error = fieldErrors.shortAddress
                     )
+
+                    if (selectedLocationMapQuery.isNotBlank()) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End
+                        ) {
+                            TextActionButton(
+                                text = "Open Selected Location in Map",
+                                onClick = {
+                                    val opened = NephMapIntegration.openLocationQuery(
+                                        context = context,
+                                        query = selectedLocationMapQuery
+                                    )
+                                    if (!opened) {
+                                        infoMessage = "Could not open map application."
+                                    }
+                                },
+                                enabled = !loading
+                            )
+                        }
+                    }
                 }
             }
 

--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -46,7 +46,6 @@ import com.neph.features.requesthelp.data.RequestHelpRepository
 import com.neph.features.requesthelp.data.RequestHelpSubmission
 import com.neph.ui.components.buttons.PrimaryButton
 import com.neph.ui.components.buttons.SecondaryButton
-import com.neph.ui.components.buttons.TextActionButton
 import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
@@ -56,8 +55,7 @@ import com.neph.ui.components.inputs.AppTextField
 import com.neph.ui.components.selection.AppCheckbox
 import com.neph.ui.components.selection.AppMultiSelectChipGroup
 import com.neph.ui.layout.AppScaffold
-import com.neph.ui.map.NephMapIntegration
-import com.neph.ui.map.buildLocationSelectionMapQuery
+import com.neph.ui.map.LocationSelectionMapAction
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
 import kotlinx.coroutines.CancellationException
@@ -394,6 +392,7 @@ fun RequestHelpScreen(
     var loading by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf("") }
     var infoMessage by remember { mutableStateOf("") }
+    var mapActionMessage by rememberSaveable { mutableStateOf("") }
     var checkingActiveRequest by remember { mutableStateOf(isLoggedIn) }
     var guestLocationAutoFillLoading by remember { mutableStateOf(false) }
     var guestLocationPermissionHandled by rememberSaveable { mutableStateOf(false) }
@@ -541,6 +540,7 @@ fun RequestHelpScreen(
         fieldErrors = nextFieldErrors
         errorMessage = ""
         infoMessage = ""
+        mapActionMessage = ""
 
         if (nextFieldErrors.hasAny()) {
             return
@@ -693,15 +693,6 @@ fun RequestHelpScreen(
                         subtitle = "Use the same location structure as your profile."
                     )
 
-                    val selectedLocationMapQuery = buildLocationSelectionMapQuery(
-                        countryKeyOrLabel = formState.country,
-                        cityKeyOrLabel = formState.city,
-                        districtKeyOrLabel = formState.district,
-                        neighborhoodValueOrLabel = formState.neighborhood,
-                        extraAddress = formState.shortAddress,
-                        locations = availableLocationData
-                    )
-
                     if (locationLoading) {
                         HelperText(text = "Loading location options...")
                     }
@@ -756,26 +747,17 @@ fun RequestHelpScreen(
                         error = fieldErrors.shortAddress
                     )
 
-                    if (selectedLocationMapQuery.isNotBlank()) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.End
-                        ) {
-                            TextActionButton(
-                                text = "Open Selected Location in Map",
-                                onClick = {
-                                    val opened = NephMapIntegration.openLocationQuery(
-                                        context = context,
-                                        query = selectedLocationMapQuery
-                                    )
-                                    if (!opened) {
-                                        infoMessage = "Could not open map application."
-                                    }
-                                },
-                                enabled = !loading
-                            )
-                        }
-                    }
+                    LocationSelectionMapAction(
+                        countryKeyOrLabel = formState.country,
+                        cityKeyOrLabel = formState.city,
+                        districtKeyOrLabel = formState.district,
+                        neighborhoodValueOrLabel = formState.neighborhood,
+                        extraAddress = formState.shortAddress,
+                        locations = availableLocationData,
+                        enabled = !loading,
+                        onOpenFailure = { mapActionMessage = it },
+                        onOpenSuccess = { mapActionMessage = "" }
+                    )
                 }
             }
 
@@ -854,6 +836,10 @@ fun RequestHelpScreen(
 
             if (infoMessage.isNotBlank()) {
                 HelperText(text = infoMessage)
+            }
+
+            if (mapActionMessage.isNotBlank()) {
+                HelperText(text = mapActionMessage)
             }
 
             PrimaryButton(

--- a/android/app/src/main/java/com/neph/ui/map/NephMapIntegration.kt
+++ b/android/app/src/main/java/com/neph/ui/map/NephMapIntegration.kt
@@ -1,0 +1,101 @@
+package com.neph.ui.map
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import com.neph.features.profile.data.LocationData
+import com.neph.features.profile.data.locationData
+import com.neph.features.profile.data.resolveCityLabel
+import com.neph.features.profile.data.resolveCountryLabel
+import com.neph.features.profile.data.resolveDistrictLabel
+import com.neph.features.profile.data.resolveNeighborhoodLabel
+import java.util.Locale
+
+object NephMapIntegration {
+    fun openCoordinates(
+        context: Context,
+        latitude: Double,
+        longitude: Double,
+        label: String
+    ): Boolean {
+        val encodedLabel = Uri.encode(label.ifBlank { "Location" })
+        val geoUri = Uri.parse("geo:$latitude,$longitude?q=$latitude,$longitude($encodedLabel)")
+        val geoIntent = Intent(Intent.ACTION_VIEW, geoUri)
+
+        return runCatching {
+            context.startActivity(geoIntent)
+            true
+        }.recoverCatching {
+            if (it is ActivityNotFoundException) {
+                val browserUri = Uri.parse(
+                    "https://www.openstreetmap.org/?mlat=$latitude&mlon=$longitude#map=17/$latitude/$longitude"
+                )
+                context.startActivity(Intent(Intent.ACTION_VIEW, browserUri))
+                true
+            } else {
+                throw it
+            }
+        }.getOrElse { false }
+    }
+
+    fun openLocationQuery(
+        context: Context,
+        query: String
+    ): Boolean {
+        val normalizedQuery = query.trim()
+        if (normalizedQuery.isBlank()) {
+            return false
+        }
+
+        val encodedQuery = Uri.encode(normalizedQuery)
+        val geoUri = Uri.parse("geo:0,0?q=$encodedQuery")
+        val geoIntent = Intent(Intent.ACTION_VIEW, geoUri)
+
+        return runCatching {
+            context.startActivity(geoIntent)
+            true
+        }.recoverCatching {
+            if (it is ActivityNotFoundException) {
+                val browserUri = Uri.parse("https://www.openstreetmap.org/search?query=$encodedQuery")
+                context.startActivity(Intent(Intent.ACTION_VIEW, browserUri))
+                true
+            } else {
+                throw it
+            }
+        }.getOrElse { false }
+    }
+}
+
+fun buildLocationSelectionMapQuery(
+    countryKeyOrLabel: String?,
+    cityKeyOrLabel: String?,
+    districtKeyOrLabel: String?,
+    neighborhoodValueOrLabel: String?,
+    extraAddress: String?,
+    locations: LocationData = locationData
+): String {
+    val countryLabel = resolveCountryLabel(countryKeyOrLabel, locations)
+    val cityLabel = resolveCityLabel(countryKeyOrLabel, cityKeyOrLabel, locations)
+    val districtLabel = resolveDistrictLabel(countryKeyOrLabel, cityKeyOrLabel, districtKeyOrLabel, locations)
+    val neighborhoodLabel = resolveNeighborhoodLabel(
+        countryKeyOrLabel,
+        cityKeyOrLabel,
+        districtKeyOrLabel,
+        neighborhoodValueOrLabel,
+        locations
+    )
+    val normalizedExtraAddress = extraAddress?.trim().orEmpty().takeIf { it.isNotBlank() }
+
+    return listOf(
+        normalizedExtraAddress,
+        neighborhoodLabel,
+        districtLabel,
+        cityLabel,
+        countryLabel
+    ).filterNotNull().filter { it.isNotBlank() }.joinToString(", ")
+}
+
+fun formatMapCoordinate(value: Double): String {
+    return String.format(Locale.US, "%.5f", value)
+}

--- a/android/app/src/main/java/com/neph/ui/map/NephMapIntegration.kt
+++ b/android/app/src/main/java/com/neph/ui/map/NephMapIntegration.kt
@@ -4,12 +4,21 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import com.neph.features.profile.data.LocationData
 import com.neph.features.profile.data.locationData
 import com.neph.features.profile.data.resolveCityLabel
 import com.neph.features.profile.data.resolveCountryLabel
 import com.neph.features.profile.data.resolveDistrictLabel
 import com.neph.features.profile.data.resolveNeighborhoodLabel
+import com.neph.ui.components.buttons.TextActionButton
 import java.util.Locale
 
 object NephMapIntegration {
@@ -98,4 +107,98 @@ fun buildLocationSelectionMapQuery(
 
 fun formatMapCoordinate(value: Double): String {
     return String.format(Locale.US, "%.5f", value)
+}
+
+@Composable
+fun LocationSelectionMapAction(
+    countryKeyOrLabel: String?,
+    cityKeyOrLabel: String?,
+    districtKeyOrLabel: String?,
+    neighborhoodValueOrLabel: String?,
+    extraAddress: String?,
+    locations: LocationData = locationData,
+    enabled: Boolean = true,
+    helperText: String = "Selected location can be opened in your map app.",
+    actionText: String = "Open Selected Location in Map",
+    onOpenFailure: (String) -> Unit,
+    onOpenSuccess: (() -> Unit)? = null
+) {
+    val context = LocalContext.current
+    val query = buildLocationSelectionMapQuery(
+        countryKeyOrLabel = countryKeyOrLabel,
+        cityKeyOrLabel = cityKeyOrLabel,
+        districtKeyOrLabel = districtKeyOrLabel,
+        neighborhoodValueOrLabel = neighborhoodValueOrLabel,
+        extraAddress = extraAddress,
+        locations = locations
+    )
+
+    if (query.isBlank()) {
+        return
+    }
+
+    Text(
+        text = helperText,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End
+    ) {
+        TextActionButton(
+            text = actionText,
+            onClick = {
+                val opened = NephMapIntegration.openLocationQuery(
+                    context = context,
+                    query = query
+                )
+                if (opened) {
+                    onOpenSuccess?.invoke()
+                } else {
+                    onOpenFailure("Could not open map application.")
+                }
+            },
+            enabled = enabled
+        )
+    }
+}
+
+@Composable
+fun SharedCoordinatesMapAction(
+    latitude: Double?,
+    longitude: Double?,
+    label: String = "Shared Current Location",
+    enabled: Boolean = true,
+    actionText: String = "Open Shared Coordinates in Map",
+    onOpenFailure: (String) -> Unit,
+    onOpenSuccess: (() -> Unit)? = null
+) {
+    val context = LocalContext.current
+    val lat = latitude ?: return
+    val lon = longitude ?: return
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End
+    ) {
+        TextActionButton(
+            text = actionText,
+            onClick = {
+                val opened = NephMapIntegration.openCoordinates(
+                    context = context,
+                    latitude = lat,
+                    longitude = lon,
+                    label = label
+                )
+                if (opened) {
+                    onOpenSuccess?.invoke()
+                } else {
+                    onOpenFailure("Could not open map application.")
+                }
+            },
+            enabled = enabled
+        )
+    }
 }

--- a/android/app/src/test/java/com/neph/ui/map/NephMapIntegrationTest.kt
+++ b/android/app/src/test/java/com/neph/ui/map/NephMapIntegrationTest.kt
@@ -1,0 +1,41 @@
+package com.neph.ui.map
+
+import com.neph.features.profile.data.locationData
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NephMapIntegrationTest {
+    @Test
+    fun buildLocationSelectionMapQuery_resolvesLabelsFromSelectionKeys() {
+        val query = buildLocationSelectionMapQuery(
+            countryKeyOrLabel = "tr",
+            cityKeyOrLabel = "istanbul",
+            districtKeyOrLabel = "besiktas",
+            neighborhoodValueOrLabel = "balmumcu",
+            extraAddress = "Buyukdere Cd.",
+            locations = locationData
+        )
+
+        assertEquals("Buyukdere Cd., Balmumcu, Beşiktaş, Istanbul, Turkey", query)
+    }
+
+    @Test
+    fun buildLocationSelectionMapQuery_returnsEmptyWhenAllPartsAreBlank() {
+        val query = buildLocationSelectionMapQuery(
+            countryKeyOrLabel = "",
+            cityKeyOrLabel = "",
+            districtKeyOrLabel = "",
+            neighborhoodValueOrLabel = "",
+            extraAddress = " ",
+            locations = locationData
+        )
+
+        assertTrue(query.isBlank())
+    }
+
+    @Test
+    fun formatMapCoordinate_formatsToFiveDecimals() {
+        assertEquals("41.01235", formatMapCoordinate(41.0123456))
+    }
+}


### PR DESCRIPTION
This PR introduces a reusable Android shared map integration and adopts it across existing location-based mobile flows to reduce duplication and keep behavior consistent.

What changed:

- Added a shared mobile map integration utility for:
- opening coordinates in map apps with browser fallback
- opening location query text in map apps with browser fallback
- building normalized map query text from selected location fields
- consistent coordinate formatting
- Migrated Gathering Areas to use the shared map integration for Open in Map and coordinate display formatting.
- Migrated Edit Profile and Complete Profile location sections to use shared map actions:
- Open Selected Location in Map
- Open Shared Coordinates in Map (after successful current-location capture)
- Added the same follow-up map action to Request Help:
- Open Selected Location in Map
- preserved existing Use Current Location autofill behavior without changing its logic
- Added unit tests for shared map query building and coordinate formatting.


Validation
Android checks passed:
:app:testE2eUnitTest
:app:assembleE2eAndroidTest

Completes the android part of the issue #294 