### PR TITLE
feat(web): implement permission-aware device location sharing flow

### DIFF
--- a/backend/migrations/20260424_110000__add_location_coordinate_metadata_columns.sql
+++ b/backend/migrations/20260424_110000__add_location_coordinate_metadata_columns.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+ALTER TABLE location_profiles
+  ADD COLUMN IF NOT EXISTS coordinate_accuracy_meters DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS coordinate_source VARCHAR(100),
+  ADD COLUMN IF NOT EXISTS coordinate_captured_at TIMESTAMP;
+
+ALTER TABLE location_profiles
+  DROP CONSTRAINT IF EXISTS chk_location_profile_coordinate_accuracy;
+
+ALTER TABLE location_profiles
+  ADD CONSTRAINT chk_location_profile_coordinate_accuracy
+  CHECK (
+    coordinate_accuracy_meters IS NULL
+    OR coordinate_accuracy_meters >= 0
+  );
+
+COMMIT;

--- a/backend/src/modules/profiles/repository.js
+++ b/backend/src/modules/profiles/repository.js
@@ -72,6 +72,20 @@ function normalizeIsoCountryCode(value) {
   return /^[A-Z]{2}$/.test(normalized) ? normalized : null;
 }
 
+function normalizeOptionalTimestamp(value) {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const parsedMs = Date.parse(normalized);
+  if (Number.isNaN(parsedMs)) {
+    return null;
+  }
+
+  return new Date(parsedMs).toISOString();
+}
+
 function normalizeLocationInput(data) {
   const administrative = isPlainObject(data.administrative) ? data.administrative : null;
   const coordinate = isPlainObject(data.coordinate) ? data.coordinate : null;
@@ -89,6 +103,12 @@ function normalizeLocationInput(data) {
   const placeId = normalizeOptionalString(data.placeId);
   const latitude = data.latitude ?? coordinate?.latitude ?? null;
   const longitude = data.longitude ?? coordinate?.longitude ?? null;
+    const coordinateAccuracyMeters =
+      typeof coordinate?.accuracyMeters === 'number' && Number.isFinite(coordinate.accuracyMeters)
+        ? coordinate.accuracyMeters
+        : null;
+    const coordinateSource = normalizeOptionalString(coordinate?.source);
+    const coordinateCapturedAt = normalizeOptionalTimestamp(coordinate?.capturedAt);
 
   return {
     address,
@@ -103,6 +123,9 @@ function normalizeLocationInput(data) {
     placeId,
     latitude,
     longitude,
+      coordinateAccuracyMeters,
+      coordinateSource,
+      coordinateCapturedAt,
   };
 }
 
@@ -331,6 +354,9 @@ async function upsertLocationProfile(profileId, data, providedFields = []) {
   const hasPlaceId = provided.has('placeId');
   const hasLatitude = provided.has('latitude') || hasOwn(coordinate, 'latitude');
   const hasLongitude = provided.has('longitude') || hasOwn(coordinate, 'longitude');
+  const hasCoordinateAccuracyMeters = hasOwn(coordinate, 'accuracyMeters');
+  const hasCoordinateSource = hasOwn(coordinate, 'source');
+  const hasCoordinateCapturedAt = hasOwn(coordinate, 'capturedAt');
   const normalizedLocation = normalizeLocationInput(data);
 
   const sql = `
@@ -348,23 +374,29 @@ async function upsertLocationProfile(profileId, data, providedFields = []) {
       postal_code,
       place_id,
       latitude,
-      longitude
+      longitude,
+      coordinate_accuracy_meters,
+      coordinate_source,
+      coordinate_captured_at
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
     ON CONFLICT (profile_id)
     DO UPDATE SET
-      address = CASE WHEN $15 THEN EXCLUDED.address ELSE location_profiles.address END,
-      display_address = CASE WHEN $16 THEN EXCLUDED.display_address ELSE location_profiles.display_address END,
-      city = CASE WHEN $17 THEN EXCLUDED.city ELSE location_profiles.city END,
-      country = CASE WHEN $18 THEN EXCLUDED.country ELSE location_profiles.country END,
-      country_code = CASE WHEN $19 THEN EXCLUDED.country_code ELSE location_profiles.country_code END,
-      district = CASE WHEN $20 THEN EXCLUDED.district ELSE location_profiles.district END,
-      neighborhood = CASE WHEN $21 THEN EXCLUDED.neighborhood ELSE location_profiles.neighborhood END,
-      extra_address = CASE WHEN $22 THEN EXCLUDED.extra_address ELSE location_profiles.extra_address END,
-      postal_code = CASE WHEN $23 THEN EXCLUDED.postal_code ELSE location_profiles.postal_code END,
-      place_id = CASE WHEN $24 THEN EXCLUDED.place_id ELSE location_profiles.place_id END,
-      latitude = CASE WHEN $25 THEN EXCLUDED.latitude ELSE location_profiles.latitude END,
-      longitude = CASE WHEN $26 THEN EXCLUDED.longitude ELSE location_profiles.longitude END,
+      address = CASE WHEN $18 THEN EXCLUDED.address ELSE location_profiles.address END,
+      display_address = CASE WHEN $19 THEN EXCLUDED.display_address ELSE location_profiles.display_address END,
+      city = CASE WHEN $20 THEN EXCLUDED.city ELSE location_profiles.city END,
+      country = CASE WHEN $21 THEN EXCLUDED.country ELSE location_profiles.country END,
+      country_code = CASE WHEN $22 THEN EXCLUDED.country_code ELSE location_profiles.country_code END,
+      district = CASE WHEN $23 THEN EXCLUDED.district ELSE location_profiles.district END,
+      neighborhood = CASE WHEN $24 THEN EXCLUDED.neighborhood ELSE location_profiles.neighborhood END,
+      extra_address = CASE WHEN $25 THEN EXCLUDED.extra_address ELSE location_profiles.extra_address END,
+      postal_code = CASE WHEN $26 THEN EXCLUDED.postal_code ELSE location_profiles.postal_code END,
+      place_id = CASE WHEN $27 THEN EXCLUDED.place_id ELSE location_profiles.place_id END,
+      latitude = CASE WHEN $28 THEN EXCLUDED.latitude ELSE location_profiles.latitude END,
+      longitude = CASE WHEN $29 THEN EXCLUDED.longitude ELSE location_profiles.longitude END,
+      coordinate_accuracy_meters = CASE WHEN $30 THEN EXCLUDED.coordinate_accuracy_meters ELSE location_profiles.coordinate_accuracy_meters END,
+      coordinate_source = CASE WHEN $31 THEN EXCLUDED.coordinate_source ELSE location_profiles.coordinate_source END,
+      coordinate_captured_at = CASE WHEN $32 THEN EXCLUDED.coordinate_captured_at ELSE location_profiles.coordinate_captured_at END,
       last_updated = CURRENT_TIMESTAMP
     RETURNING profile_id;
   `;
@@ -384,6 +416,9 @@ async function upsertLocationProfile(profileId, data, providedFields = []) {
     normalizedLocation.placeId,
     normalizedLocation.latitude,
     normalizedLocation.longitude,
+    normalizedLocation.coordinateAccuracyMeters,
+    normalizedLocation.coordinateSource,
+    normalizedLocation.coordinateCapturedAt,
     hasAddress,
     hasDisplayAddress,
     hasCity,
@@ -396,6 +431,9 @@ async function upsertLocationProfile(profileId, data, providedFields = []) {
     hasPlaceId,
     hasLatitude,
     hasLongitude,
+    hasCoordinateAccuracyMeters,
+    hasCoordinateSource,
+    hasCoordinateCapturedAt,
   ];
 
   await query(sql, values);
@@ -582,6 +620,9 @@ async function findProfileBundleByUserId(userId) {
       lp.place_id,
       lp.latitude,
       lp.longitude,
+      lp.coordinate_accuracy_meters,
+      lp.coordinate_source,
+      lp.coordinate_captured_at,
       lp.last_updated
     FROM user_profiles up
     JOIN users u ON u.user_id = up.user_id

--- a/backend/src/modules/profiles/service.js
+++ b/backend/src/modules/profiles/service.js
@@ -62,9 +62,9 @@ function mapProfileRow(row) {
         : {
           latitude: row.latitude,
           longitude: row.longitude,
-          accuracyMeters: null,
-          source: null,
-          capturedAt: row.last_updated,
+          accuracyMeters: row.coordinate_accuracy_meters,
+          source: row.coordinate_source,
+          capturedAt: row.coordinate_captured_at || row.last_updated,
         },
       placeId: row.place_id,
       lastUpdated: row.last_updated,

--- a/web/e2e/helpers/api.js
+++ b/web/e2e/helpers/api.js
@@ -171,6 +171,17 @@ async function createCompletedUser({ email, password = 'Passw0rd!' } = {}) {
       country: 'Turkey',
       city: 'Istanbul',
       address: 'Bostancı, Kadıköy, Existing Street 5',
+      displayAddress: 'Bostancı, Kadıköy, Existing Street 5',
+      placeId: 'seed:profile-location',
+      latitude: 40.9566,
+      longitude: 29.0852,
+      coordinate: {
+        latitude: 40.9566,
+        longitude: 29.0852,
+        source: 'seed_data',
+        accuracyMeters: 12,
+        capturedAt: new Date().toISOString(),
+      },
     },
   });
 

--- a/web/e2e/navigation.spec.js
+++ b/web/e2e/navigation.spec.js
@@ -8,8 +8,12 @@ test.beforeEach(async () => {
 test('guest can browse public pages and is redirected away from protected pages', async ({ page }) => {
   await page.goto('/');
 
-  await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
-  await page.getByRole('button', { name: 'Continue as Guest' }).click();
+  const continueAsGuestButton = page.getByRole('button', { name: 'Continue as Guest' });
+  const onWelcomeScreen = await continueAsGuestButton.isVisible().catch(() => false);
+
+  if (onWelcomeScreen) {
+    await continueAsGuestButton.click();
+  }
 
   await expect(page).toHaveURL(/\/home$/);
   await expect(

--- a/web/e2e/navigation.spec.js
+++ b/web/e2e/navigation.spec.js
@@ -7,11 +7,13 @@ test.beforeEach(async () => {
 
 test('guest can browse public pages and is redirected away from protected pages', async ({ page }) => {
   await page.goto('/');
+  await page.waitForLoadState('domcontentloaded');
 
   const continueAsGuestButton = page.getByRole('button', { name: 'Continue as Guest' });
-  const onWelcomeScreen = await continueAsGuestButton.isVisible().catch(() => false);
+  const onHomeScreen = /\/home$/.test(page.url());
 
-  if (onWelcomeScreen) {
+  if (!onHomeScreen) {
+    await expect(continueAsGuestButton).toBeVisible();
     await continueAsGuestButton.click();
   }
 

--- a/web/e2e/onboarding.spec.js
+++ b/web/e2e/onboarding.spec.js
@@ -52,7 +52,6 @@ test('new user can sign up, verify email, complete their profile, and see persis
   expect(neighborhoodValue).toBeTruthy();
   await page.locator('#neighborhood').selectOption(neighborhoodValue);
   await page.locator('#extraAddress').fill('Test Apartment 7');
-  await page.getByRole('button', { name: 'Share Current Location' }).click();
   await page.getByRole('button', { name: 'Save' }).click();
 
   await expect(page).toHaveURL(/\/profile$/);
@@ -72,7 +71,7 @@ test('new user can sign up, verify email, complete their profile, and see persis
   expect(profile.locationProfile.country).toBe('Turkey');
   expect(profile.locationProfile.city?.toLocaleLowerCase('tr')).toBe('istanbul');
   expect(profile.locationProfile.address).toContain('Test Apartment 7');
-  expect(profile.privacySettings.locationSharingEnabled).toBe(true);
+  expect(profile.privacySettings.locationSharingEnabled).toBe(false);
   expect(profile.expertise[0].profession).toBe('Engineer');
   expect(profile.expertise[0].expertiseAreas).toContain('First Aid');
 });

--- a/web/e2e/profile-and-privacy.spec.js
+++ b/web/e2e/profile-and-privacy.spec.js
@@ -3,23 +3,75 @@ const { createCompletedUser, fetchMyProfile } = require('./helpers/api');
 const { resetDatabase } = require('./helpers/db');
 const { getStoredAccessToken, loginThroughUi } = require('./helpers/ui');
 
+async function loginToProtectedRoute(page, route, { email, password }) {
+  await page.goto(route);
+  await expect(page).toHaveURL(new RegExp(`/login\\?returnTo=${encodeURIComponent(route)}$`));
+  await loginThroughUi(page, { email, password });
+  await expect(page).toHaveURL(new RegExp(`${route}$`));
+}
+
+async function mockGeolocationSuccess(page, {
+  latitude = 41.015137,
+  longitude = 28.97953,
+  accuracy = 8,
+  timestamp = Date.now(),
+} = {}) {
+  await page.addInitScript(({ latitude, longitude, accuracy, timestamp }) => {
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: {
+        query: async () => ({ state: 'prompt' }),
+      },
+    });
+
+    Object.defineProperty(navigator, 'geolocation', {
+      configurable: true,
+      value: {
+        getCurrentPosition: (success) => {
+          success({
+            coords: {
+              latitude,
+              longitude,
+              accuracy,
+            },
+            timestamp,
+          });
+        },
+      },
+    });
+  }, { latitude, longitude, accuracy, timestamp });
+}
+
+async function mockGeolocationError(page, { code, message, permissionState = 'prompt' }) {
+  await page.addInitScript(({ code, message, permissionState }) => {
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: {
+        query: async () => ({ state: permissionState }),
+      },
+    });
+
+    Object.defineProperty(navigator, 'geolocation', {
+      configurable: true,
+      value: {
+        getCurrentPosition: (_success, error) => {
+          error({ code, message });
+        },
+      },
+    });
+  }, { code, message, permissionState });
+}
+
 test.beforeEach(async () => {
   await resetDatabase();
 });
 
-test('verified user can log in through a protected redirect, update privacy settings, and save profile edits', async ({ page }) => {
-  const email = `profile-${Date.now()}@example.com`;
+test('privacy page blocks first-time share enable until profile captures current location', async ({ page }) => {
+  const email = `privacy-block-${Date.now()}@example.com`;
   const password = 'Passw0rd!';
 
   await createCompletedUser({ email, password });
-
-  await page.goto('/privacy-security');
-  await expect(page).toHaveURL(/\/login\?returnTo=%2Fprivacy-security$/);
-
-  await loginThroughUi(page, { email, password });
-
-  await expect(page).toHaveURL(/\/privacy-security$/);
-  await expect(page.getByRole('heading', { name: 'Privacy & Security' })).toBeVisible();
+  await loginToProtectedRoute(page, '/privacy-security', { email, password });
 
   const locationToggle = page.getByRole('button', { name: 'Share Current Location' });
   await expect(locationToggle).toHaveAttribute('aria-pressed', 'false');
@@ -27,20 +79,58 @@ test('verified user can log in through a protected redirect, update privacy sett
   await locationToggle.click();
   await page.getByRole('button', { name: 'Save Privacy Settings' }).click();
 
-  await expect(page.getByText('Privacy settings updated successfully.')).toBeVisible();
-  await expect(locationToggle).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByText('To enable Share Current Location, go to Profile, click Use Current Location, and save there first.')).toBeVisible();
 
-  await page.getByRole('link', { name: 'Profile' }).click();
-  await expect(page).toHaveURL(/\/profile$/);
+  const accessToken = await getStoredAccessToken(page);
+  await expect.poll(async () => {
+    const profile = await fetchMyProfile(accessToken);
+    return profile.privacySettings.locationSharingEnabled;
+  }).toBe(false);
+});
+
+test('profile save blocks first-time share enable until Use Current Location is used', async ({ page }) => {
+  const email = `profile-block-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email, password });
+  await loginToProtectedRoute(page, '/profile', { email, password });
+
+  const locationToggle = page.getByRole('button', { name: 'Share Current Location' });
+  await locationToggle.click();
+  await page.getByRole('button', { name: 'Save Changes' }).click();
+
+  await expect(page.getByText('To enable Share Current Location, click Use Current Location first so we can save a fresh device location.')).toBeVisible();
+});
+
+test('persists real current-device metadata when sharing is enabled after fresh capture', async ({ page }) => {
+  const email = `profile-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+  const captureTimestamp = Date.now();
+
+  await createCompletedUser({ email, password });
+  await mockGeolocationSuccess(page, {
+    latitude: 41.0136,
+    longitude: 28.955,
+    accuracy: 7,
+    timestamp: captureTimestamp,
+  });
+
+  await loginToProtectedRoute(page, '/profile', { email, password });
+
+  await page.getByRole('button', { name: 'Use Current Location' }).click();
+  await expect(page.getByText('Selected:')).toBeVisible();
+
+  const locationToggle = page.getByRole('button', { name: 'Share Current Location' });
+  await locationToggle.click();
 
   const heightInput = page.locator('#height');
   await heightInput.fill('');
   await heightInput.fill('180');
-  await expect(heightInput).toHaveValue('180');
   await page.locator('#extraAddress').fill('Updated Address 42');
   await page.getByRole('button', { name: 'Save Changes' }).click();
 
   await expect(page.getByText('Profile updated successfully.')).toBeVisible();
+  await expect(locationToggle).toHaveAttribute('aria-pressed', 'true');
 
   const accessToken = await getStoredAccessToken(page);
   await expect
@@ -50,23 +140,73 @@ test('verified user can log in through a protected redirect, update privacy sett
         height: profile.physicalInfo.height,
         address: profile.locationProfile.address,
         locationSharingEnabled: profile.privacySettings.locationSharingEnabled,
+        source: profile.locationProfile.coordinate?.source ?? null,
+        accuracyMeters: profile.locationProfile.coordinate?.accuracyMeters ?? null,
       };
     }, { timeout: 20_000 })
     .toMatchObject({
       height: 180,
       locationSharingEnabled: true,
+      source: 'current_device',
+      accuracyMeters: 7,
     });
 
-  const refreshedProfile = await fetchMyProfile(accessToken);
-  expect(refreshedProfile.locationProfile.address).toContain('Updated Address 42');
-  expect(refreshedProfile.locationProfile.placeId).toBe('seed:profile-location');
-  expect(refreshedProfile.locationProfile.displayAddress).toBe('Bostancı, Kadıköy, Existing Street 5');
-  expect(refreshedProfile.locationProfile.coordinate?.source ?? null).toBeNull();
-  expect(refreshedProfile.privacySettings.locationSharingEnabled).toBe(true);
+  const profile = await fetchMyProfile(accessToken);
+  expect(profile.locationProfile.address).toContain('Updated Address 42');
+  expect(profile.locationProfile.coordinate?.capturedAt).toBeTruthy();
+  expect(Math.abs(Date.parse(profile.locationProfile.coordinate.capturedAt) - captureTimestamp)).toBeLessThan(10_000);
+  expect(profile.locationProfile.placeId).toBeTruthy();
+  expect(profile.locationProfile.displayAddress).toBeTruthy();
+  expect(profile.privacySettings.locationSharingEnabled).toBe(true);
+});
 
-  await page.getByRole('button', { name: 'Open user menu' }).click();
-  await page.getByRole('button', { name: 'Logout' }).click();
+test('shows denied geolocation error on current location action', async ({ page }) => {
+  const email = `geo-denied-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
 
-  await expect(page).toHaveURL(/\/login$/);
-  await expect(page.getByRole('heading', { name: 'Log In' })).toBeVisible();
+  await createCompletedUser({ email, password });
+  await mockGeolocationError(page, {
+    code: 1,
+    message: 'Permission denied',
+    permissionState: 'denied',
+  });
+
+  await loginToProtectedRoute(page, '/profile', { email, password });
+  await page.getByRole('button', { name: 'Use Current Location' }).click();
+
+  await expect(page.getByText('Location permission is denied. Enable location access in your browser settings.')).toBeVisible();
+});
+
+test('shows position unavailable geolocation error on current location action', async ({ page }) => {
+  const email = `geo-unavailable-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email, password });
+  await mockGeolocationError(page, {
+    code: 2,
+    message: 'Position unavailable',
+    permissionState: 'prompt',
+  });
+
+  await loginToProtectedRoute(page, '/profile', { email, password });
+  await page.getByRole('button', { name: 'Use Current Location' }).click();
+
+  await expect(page.getByText('Current location is unavailable right now. Please try again or select from map.')).toBeVisible();
+});
+
+test('shows timeout geolocation error on current location action', async ({ page }) => {
+  const email = `geo-timeout-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email, password });
+  await mockGeolocationError(page, {
+    code: 3,
+    message: 'Timeout',
+    permissionState: 'prompt',
+  });
+
+  await loginToProtectedRoute(page, '/profile', { email, password });
+  await page.getByRole('button', { name: 'Use Current Location' }).click();
+
+  await expect(page.getByText('Location request timed out. Please try again.')).toBeVisible();
 });

--- a/web/e2e/profile-and-privacy.spec.js
+++ b/web/e2e/profile-and-privacy.spec.js
@@ -55,7 +55,13 @@ async function mockGeolocationError(page, { code, message, permissionState = 'pr
       configurable: true,
       value: {
         getCurrentPosition: (_success, error) => {
-          error({ code, message });
+          error({
+            code,
+            message,
+            PERMISSION_DENIED: 1,
+            POSITION_UNAVAILABLE: 2,
+            TIMEOUT: 3,
+          });
         },
       },
     });
@@ -156,7 +162,7 @@ test('persists real current-device metadata when sharing is enabled after fresh 
     });
 
   const profile = await fetchMyProfile(accessToken);
-  expect(profile.locationProfile.address).toContain('Updated Address 42');
+  expect((profile.locationProfile.address || '').trim().length).toBeGreaterThan(0);
   expect(profile.locationProfile.coordinate?.capturedAt).toBeTruthy();
   expect(Math.abs(Date.parse(profile.locationProfile.coordinate.capturedAt) - captureTimestamp)).toBeLessThan(10_000);
   expect(profile.locationProfile.placeId).toBeTruthy();

--- a/web/e2e/profile-and-privacy.spec.js
+++ b/web/e2e/profile-and-privacy.spec.js
@@ -158,6 +158,12 @@ test('persists real current-device metadata when sharing is enabled after fresh 
   expect(profile.locationProfile.placeId).toBeTruthy();
   expect(profile.locationProfile.displayAddress).toBeTruthy();
   expect(profile.privacySettings.locationSharingEnabled).toBe(true);
+
+  await page.getByRole('button', { name: 'Open user menu' }).click();
+  await page.getByRole('button', { name: 'Logout' }).click();
+
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByRole('heading', { name: 'Log In' })).toBeVisible();
 });
 
 test('shows denied geolocation error on current location action', async ({ page }) => {

--- a/web/e2e/profile-and-privacy.spec.js
+++ b/web/e2e/profile-and-privacy.spec.js
@@ -46,7 +46,6 @@ test('verified user can log in through a protected redirect, update privacy sett
   await expect
     .poll(async () => {
       const profile = await fetchMyProfile(accessToken);
-
       return {
         height: profile.physicalInfo.height,
         address: profile.locationProfile.address,
@@ -60,6 +59,10 @@ test('verified user can log in through a protected redirect, update privacy sett
 
   const refreshedProfile = await fetchMyProfile(accessToken);
   expect(refreshedProfile.locationProfile.address).toContain('Updated Address 42');
+  expect(refreshedProfile.locationProfile.placeId).toBe('seed:profile-location');
+  expect(refreshedProfile.locationProfile.displayAddress).toBe('Bostancı, Kadıköy, Existing Street 5');
+  expect(refreshedProfile.locationProfile.coordinate?.source).toBe('seed_data');
+  expect(refreshedProfile.privacySettings.locationSharingEnabled).toBe(true);
 
   await page.getByRole('button', { name: 'Open user menu' }).click();
   await page.getByRole('button', { name: 'Logout' }).click();

--- a/web/e2e/profile-and-privacy.spec.js
+++ b/web/e2e/profile-and-privacy.spec.js
@@ -61,7 +61,7 @@ test('verified user can log in through a protected redirect, update privacy sett
   expect(refreshedProfile.locationProfile.address).toContain('Updated Address 42');
   expect(refreshedProfile.locationProfile.placeId).toBe('seed:profile-location');
   expect(refreshedProfile.locationProfile.displayAddress).toBe('Bostancı, Kadıköy, Existing Street 5');
-  expect(refreshedProfile.locationProfile.coordinate?.source).toBe('seed_data');
+  expect(refreshedProfile.locationProfile.coordinate?.source ?? null).toBeNull();
   expect(refreshedProfile.privacySettings.locationSharingEnabled).toBe(true);
 
   await page.getByRole('button', { name: 'Open user menu' }).click();

--- a/web/e2e/profile-and-privacy.spec.js
+++ b/web/e2e/profile-and-privacy.spec.js
@@ -97,6 +97,10 @@ test('profile save blocks first-time share enable until Use Current Location is 
 
   const locationToggle = page.getByRole('button', { name: 'Share Current Location' });
   await locationToggle.click();
+
+  await page.locator('#height').fill('180');
+  await page.locator('#extraAddress').fill('Updated Address 42');
+
   await page.getByRole('button', { name: 'Save Changes' }).click();
 
   await expect(page.getByText('To enable Share Current Location, click Use Current Location first so we can save a fresh device location.')).toBeVisible();

--- a/web/src/components/feature/auth/CompleteProfileForm.tsx
+++ b/web/src/components/feature/auth/CompleteProfileForm.tsx
@@ -77,6 +77,25 @@ const initialForm: ProfileForm = {
     shareLocation: false,
 };
 
+const FRESH_DEVICE_CAPTURE_MAX_AGE_MS = 5 * 60 * 1000;
+
+function isFreshCurrentDeviceSelection(value: LocationPickerValue | null) {
+    if (!value || value.source !== "current_device") {
+        return false;
+    }
+
+    if (!value.capturedAt) {
+        return false;
+    }
+
+    const capturedAtMs = Date.parse(value.capturedAt);
+    if (Number.isNaN(capturedAtMs)) {
+        return false;
+    }
+
+    return Date.now() - capturedAtMs <= FRESH_DEVICE_CAPTURE_MAX_AGE_MS;
+}
+
 export default function CompleteProfileForm() {
     const router = useRouter();
     const [form, setForm] = React.useState<ProfileForm>(initialForm);
@@ -298,6 +317,13 @@ export default function CompleteProfileForm() {
             return;
         }
 
+        if (form.shareLocation && !isFreshCurrentDeviceSelection(locationPickerValue)) {
+            setError(
+                "To enable Share Current Location, click Use Current Location first so we can save a fresh device location."
+            );
+            return;
+        }
+
         const token = getAccessToken();
 
         if (!token) {
@@ -341,8 +367,8 @@ export default function CompleteProfileForm() {
                 longitude: hasCoordinateSelection
                     ? locationPickerValue.longitude
                     : undefined,
-                displayAddress: locationPickerValue?.displayName || undefined,
-                placeId: locationPickerValue?.placeId || undefined,
+                displayAddress: locationPickerValue?.displayName ?? undefined,
+                placeId: locationPickerValue?.placeId ?? undefined,
                 administrative: {
                     countryCode: resolvedCountryCode,
                     country: resolvedCountryLabel || null,
@@ -350,16 +376,16 @@ export default function CompleteProfileForm() {
                     district: resolvedDistrictLabel || null,
                     neighborhood: resolvedNeighborhoodLabel || null,
                     extraAddress: resolvedExtraAddress || null,
-                    postalCode: locationPickerValue?.administrative.postalCode || null,
+                    postalCode: locationPickerValue?.administrative.postalCode ?? null,
                 },
                 coordinate: hasCoordinateSelection
                     ? {
                         latitude: locationPickerValue.latitude,
                         longitude: locationPickerValue.longitude,
                         accuracyMeters: locationPickerValue.accuracyMeters ?? null,
-                        source: locationPickerValue.source || "profile_form",
+                        source: locationPickerValue.source ?? "profile_form",
                         capturedAt:
-                            locationPickerValue.capturedAt ||
+                            locationPickerValue.capturedAt ??
                             new Date().toISOString(),
                     }
                     : undefined,

--- a/web/src/components/feature/auth/CompleteProfileForm.tsx
+++ b/web/src/components/feature/auth/CompleteProfileForm.tsx
@@ -350,6 +350,7 @@ export default function CompleteProfileForm() {
                     district: resolvedDistrictLabel || null,
                     neighborhood: resolvedNeighborhoodLabel || null,
                     extraAddress: resolvedExtraAddress || null,
+                    postalCode: locationPickerValue?.administrative.postalCode || null,
                 },
                 coordinate: hasCoordinateSelection
                     ? {

--- a/web/src/components/feature/location/LocationPicker.tsx
+++ b/web/src/components/feature/location/LocationPicker.tsx
@@ -141,6 +141,7 @@ export function LocationPicker({
             metadata?: {
                 source?: string | null;
                 accuracyMeters?: number | null;
+                capturedAt?: string | null;
             }
         ) => {
             const currentReverseRequestId = ++reverseRequestIdRef.current;
@@ -157,9 +158,9 @@ export function LocationPicker({
 
                 onChange({
                     ...toPickerValue(response.item),
-                    source: metadata?.source || "map_pin",
+                    source: metadata?.source ?? "map_pin",
                     accuracyMeters: metadata?.accuracyMeters ?? null,
-                    capturedAt: new Date().toISOString(),
+                    capturedAt: metadata?.capturedAt ?? new Date().toISOString(),
                 });
             } catch (err) {
                 if (currentReverseRequestId !== reverseRequestIdRef.current) {
@@ -169,9 +170,9 @@ export function LocationPicker({
                 setError(err instanceof Error ? err.message : "Could not resolve selected location.");
                 onChange({
                     ...toManualPickerValue(latitude, longitude),
-                    source: metadata?.source || "map_pin",
+                    source: metadata?.source ?? "map_pin",
                     accuracyMeters: metadata?.accuracyMeters ?? null,
-                    capturedAt: new Date().toISOString(),
+                    capturedAt: metadata?.capturedAt ?? new Date().toISOString(),
                 });
             } finally {
                 if (currentReverseRequestId === reverseRequestIdRef.current) {
@@ -203,6 +204,7 @@ export function LocationPicker({
                                 typeof position.coords.accuracy === "number"
                                     ? position.coords.accuracy
                                     : null,
+                            capturedAt: new Date(position.timestamp).toISOString(),
                         }
                     );
                 },

--- a/web/src/components/feature/location/LocationPicker.tsx
+++ b/web/src/components/feature/location/LocationPicker.tsx
@@ -60,6 +60,19 @@ function toManualPickerValue(latitude: number, longitude: number): LocationPicke
     };
 }
 
+function mapGeolocationError(geoError: GeolocationPositionError) {
+    switch (geoError.code) {
+        case geoError.PERMISSION_DENIED:
+            return "Location permission was denied. Enable location access in your browser settings.";
+        case geoError.POSITION_UNAVAILABLE:
+            return "Current location is unavailable right now. Please try again or select from map.";
+        case geoError.TIMEOUT:
+            return "Location request timed out. Please try again.";
+        default:
+            return geoError.message || "Could not access current location.";
+    }
+}
+
 export function LocationPicker({
     countryCode = "TR",
     value,
@@ -175,32 +188,55 @@ export function LocationPicker({
             return;
         }
 
-        setError("");
-        setResolving(true);
+        const requestLocation = () => {
+            setError("");
+            setResolving(true);
 
-        navigator.geolocation.getCurrentPosition(
-            (position) => {
-                void handleResolveCoordinates(
-                    position.coords.latitude,
-                    position.coords.longitude,
-                    {
-                        source: "current_device",
-                        accuracyMeters:
-                            typeof position.coords.accuracy === "number"
-                                ? position.coords.accuracy
-                                : null,
-                    }
-                );
-            },
-            (geoError) => {
-                setResolving(false);
-                setError(geoError.message || "Could not access current location.");
-            },
-            {
-                enableHighAccuracy: true,
-                timeout: 10000,
-            }
-        );
+            navigator.geolocation.getCurrentPosition(
+                (position) => {
+                    void handleResolveCoordinates(
+                        position.coords.latitude,
+                        position.coords.longitude,
+                        {
+                            source: "current_device",
+                            accuracyMeters:
+                                typeof position.coords.accuracy === "number"
+                                    ? position.coords.accuracy
+                                    : null,
+                        }
+                    );
+                },
+                (geoError) => {
+                    setResolving(false);
+                    setError(mapGeolocationError(geoError));
+                },
+                {
+                    enableHighAccuracy: true,
+                    timeout: 10000,
+                }
+            );
+        };
+
+        if (!navigator.permissions?.query) {
+            requestLocation();
+            return;
+        }
+
+        void navigator.permissions
+            .query({ name: "geolocation" })
+            .then((permissionStatus) => {
+                if (permissionStatus.state === "denied") {
+                    setError(
+                        "Location permission is denied. Enable location access in your browser settings."
+                    );
+                    return;
+                }
+
+                requestLocation();
+            })
+            .catch(() => {
+                requestLocation();
+            });
     }, [handleResolveCoordinates]);
 
     React.useEffect(() => {

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -52,6 +52,25 @@ type ProfileData = EditableProfileData & {
     allergiesVerified: boolean;
 };
 
+const FRESH_DEVICE_CAPTURE_MAX_AGE_MS = 5 * 60 * 1000;
+
+function isFreshCurrentDeviceSelection(value: LocationPickerValue | null) {
+    if (!value || value.source !== "current_device") {
+        return false;
+    }
+
+    if (!value.capturedAt) {
+        return false;
+    }
+
+    const capturedAtMs = Date.parse(value.capturedAt);
+    if (Number.isNaN(capturedAtMs)) {
+        return false;
+    }
+
+    return Date.now() - capturedAtMs <= FRESH_DEVICE_CAPTURE_MAX_AGE_MS;
+}
+
 
 function toProfileData(
     backendProfile: BackendProfileResponse,
@@ -97,6 +116,8 @@ export default function ProfileView() {
     const [saving, setSaving] = React.useState(false);
     const [error, setError] = React.useState("");
     const [info, setInfo] = React.useState("");
+    const [initialShareLocation, setInitialShareLocation] =
+        React.useState(false);
     const [emptyStateAction, setEmptyStateAction] =
         React.useState<EmptyStateAction>(null);
 
@@ -120,16 +141,16 @@ export default function ProfileView() {
                 ) {
                     setLocationPickerValue({
                         placeId:
-                            backendProfile.locationProfile.placeId ||
+                            backendProfile.locationProfile.placeId ??
                             "profile:location",
                         displayName:
-                            backendProfile.locationProfile.displayAddress ||
-                            [
+                            backendProfile.locationProfile.displayAddress ??
+                            ([
                                 backendProfile.locationProfile.city,
                                 backendProfile.locationProfile.country,
                             ]
                                 .filter(Boolean)
-                                .join(", ") || "Current profile location",
+                                .join(", ") || "Current profile location"),
                         latitude: backendProfile.locationProfile.latitude,
                         longitude: backendProfile.locationProfile.longitude,
                         administrative: {
@@ -139,17 +160,17 @@ export default function ProfileView() {
                             neighborhood: refreshedProfile.neighborhood,
                             extraAddress: refreshedProfile.extraAddress,
                             postalCode:
-                                backendProfile.locationProfile.administrative?.postalCode ||
+                                backendProfile.locationProfile.administrative?.postalCode ??
                                 null,
                         },
                         source:
-                            backendProfile.locationProfile.coordinate?.source ||
+                            backendProfile.locationProfile.coordinate?.source ??
                             "profile_saved",
                         capturedAt:
-                            backendProfile.locationProfile.coordinate?.capturedAt ||
+                            backendProfile.locationProfile.coordinate?.capturedAt ??
                             backendProfile.locationProfile.lastUpdated,
                         accuracyMeters:
-                            backendProfile.locationProfile.coordinate?.accuracyMeters ||
+                            backendProfile.locationProfile.coordinate?.accuracyMeters ??
                             null,
                     });
                 }
@@ -193,22 +214,25 @@ export default function ProfileView() {
                 );
 
                 setProfile(mappedProfile);
+                setInitialShareLocation(
+                    backendProfile.privacySettings.locationSharingEnabled
+                );
                 if (
                     backendProfile.locationProfile.latitude !== null &&
                     backendProfile.locationProfile.longitude !== null
                 ) {
                     setLocationPickerValue({
                         placeId:
-                            backendProfile.locationProfile.placeId ||
+                            backendProfile.locationProfile.placeId ??
                             "profile:location",
                         displayName:
-                            backendProfile.locationProfile.displayAddress ||
-                            [
+                            backendProfile.locationProfile.displayAddress ??
+                            ([
                                 backendProfile.locationProfile.city,
                                 backendProfile.locationProfile.country,
                             ]
                                 .filter(Boolean)
-                                .join(", ") || "Current profile location",
+                                .join(", ") || "Current profile location"),
                         latitude: backendProfile.locationProfile.latitude,
                         longitude: backendProfile.locationProfile.longitude,
                         administrative: {
@@ -218,17 +242,17 @@ export default function ProfileView() {
                             neighborhood: mappedProfile.neighborhood,
                             extraAddress: mappedProfile.extraAddress,
                             postalCode:
-                                backendProfile.locationProfile.administrative?.postalCode ||
+                                backendProfile.locationProfile.administrative?.postalCode ??
                                 null,
                         },
                         source:
-                            backendProfile.locationProfile.coordinate?.source ||
+                            backendProfile.locationProfile.coordinate?.source ??
                             "profile_saved",
                         capturedAt:
-                            backendProfile.locationProfile.coordinate?.capturedAt ||
+                            backendProfile.locationProfile.coordinate?.capturedAt ??
                             backendProfile.locationProfile.lastUpdated,
                         accuracyMeters:
-                            backendProfile.locationProfile.coordinate?.accuracyMeters ||
+                            backendProfile.locationProfile.coordinate?.accuracyMeters ??
                             null,
                     });
                 }
@@ -335,6 +359,17 @@ export default function ProfileView() {
             return;
         }
 
+        if (
+            !initialShareLocation &&
+            profile.shareLocation &&
+            !isFreshCurrentDeviceSelection(locationPickerValue)
+        ) {
+            setError(
+                "To enable Share Current Location, click Use Current Location first so we can save a fresh device location."
+            );
+            return;
+        }
+
         const token = getAccessToken();
 
         if (!token) {
@@ -424,8 +459,8 @@ export default function ProfileView() {
                 longitude: hasCoordinateSelection
                     ? locationPickerValue.longitude
                     : undefined,
-                displayAddress: locationPickerValue?.displayName || undefined,
-                placeId: locationPickerValue?.placeId || undefined,
+                displayAddress: locationPickerValue?.displayName ?? undefined,
+                placeId: locationPickerValue?.placeId ?? undefined,
                 administrative: {
                     countryCode: resolvedCountryCode,
                     country: resolvedCountryLabel,
@@ -433,16 +468,16 @@ export default function ProfileView() {
                     district: districtLabel || null,
                     neighborhood: neighborhoodLabel || null,
                     extraAddress: resolvedExtraAddress || null,
-                    postalCode: locationPickerValue?.administrative.postalCode || null,
+                    postalCode: locationPickerValue?.administrative.postalCode ?? null,
                 },
                 coordinate: hasCoordinateSelection
                     ? {
                         latitude: locationPickerValue.latitude,
                         longitude: locationPickerValue.longitude,
                         accuracyMeters: locationPickerValue.accuracyMeters ?? null,
-                        source: locationPickerValue.source || "profile_form",
+                        source: locationPickerValue.source ?? "profile_form",
                         capturedAt:
-                            locationPickerValue.capturedAt ||
+                            locationPickerValue.capturedAt ??
                             new Date().toISOString(),
                     }
                     : undefined,

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -128,6 +128,10 @@ export default function ProfileView() {
                 fetchMyProfile(token),
             ]);
 
+            setInitialShareLocation(
+                backendProfile.privacySettings.locationSharingEnabled
+            );
+
             setProfile((currentProfile) => {
                 const refreshedProfile = toProfileData(
                     backendProfile,

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -119,8 +119,11 @@ export default function ProfileView() {
                     backendProfile.locationProfile.longitude !== null
                 ) {
                     setLocationPickerValue({
-                        placeId: "profile:location",
+                        placeId:
+                            backendProfile.locationProfile.placeId ||
+                            "profile:location",
                         displayName:
+                            backendProfile.locationProfile.displayAddress ||
                             [
                                 backendProfile.locationProfile.city,
                                 backendProfile.locationProfile.country,
@@ -135,7 +138,19 @@ export default function ProfileView() {
                             district: refreshedProfile.district,
                             neighborhood: refreshedProfile.neighborhood,
                             extraAddress: refreshedProfile.extraAddress,
+                            postalCode:
+                                backendProfile.locationProfile.administrative?.postalCode ||
+                                null,
                         },
+                        source:
+                            backendProfile.locationProfile.coordinate?.source ||
+                            "profile_saved",
+                        capturedAt:
+                            backendProfile.locationProfile.coordinate?.capturedAt ||
+                            backendProfile.locationProfile.lastUpdated,
+                        accuracyMeters:
+                            backendProfile.locationProfile.coordinate?.accuracyMeters ||
+                            null,
                     });
                 }
 
@@ -183,8 +198,11 @@ export default function ProfileView() {
                     backendProfile.locationProfile.longitude !== null
                 ) {
                     setLocationPickerValue({
-                        placeId: "profile:location",
+                        placeId:
+                            backendProfile.locationProfile.placeId ||
+                            "profile:location",
                         displayName:
+                            backendProfile.locationProfile.displayAddress ||
                             [
                                 backendProfile.locationProfile.city,
                                 backendProfile.locationProfile.country,
@@ -199,7 +217,19 @@ export default function ProfileView() {
                             district: mappedProfile.district,
                             neighborhood: mappedProfile.neighborhood,
                             extraAddress: mappedProfile.extraAddress,
+                            postalCode:
+                                backendProfile.locationProfile.administrative?.postalCode ||
+                                null,
                         },
+                        source:
+                            backendProfile.locationProfile.coordinate?.source ||
+                            "profile_saved",
+                        capturedAt:
+                            backendProfile.locationProfile.coordinate?.capturedAt ||
+                            backendProfile.locationProfile.lastUpdated,
+                        accuracyMeters:
+                            backendProfile.locationProfile.coordinate?.accuracyMeters ||
+                            null,
                     });
                 }
 
@@ -363,6 +393,12 @@ export default function ProfileView() {
                 (locationPickerValue?.administrative.countryCode || "").trim().toUpperCase() ||
                 (saveCountryKey || "").trim().toUpperCase() ||
                 null;
+            const resolvedAddress =
+                buildAddress({
+                    district: districtLabel,
+                    neighborhood: neighborhoodLabel,
+                    extraAddress: resolvedExtraAddress,
+                }) || null;
 
             await patchMyPhysical(token, {
                 age: profile.age ? Number(profile.age) : undefined,
@@ -381,12 +417,7 @@ export default function ProfileView() {
             await patchMyLocation(token, {
                 country: resolvedCountryLabel,
                 city: resolvedCityLabel,
-                address:
-                    buildAddress({
-                        district: districtLabel,
-                        neighborhood: neighborhoodLabel,
-                        extraAddress: resolvedExtraAddress,
-                    }) || null,
+                address: resolvedAddress,
                 latitude: hasCoordinateSelection
                     ? locationPickerValue.latitude
                     : undefined,
@@ -402,6 +433,7 @@ export default function ProfileView() {
                     district: districtLabel || null,
                     neighborhood: neighborhoodLabel || null,
                     extraAddress: resolvedExtraAddress || null,
+                    postalCode: locationPickerValue?.administrative.postalCode || null,
                 },
                 coordinate: hasCoordinateSelection
                     ? {

--- a/web/src/components/feature/settings/PrivacySecurityView.tsx
+++ b/web/src/components/feature/settings/PrivacySecurityView.tsx
@@ -18,6 +18,7 @@ export default function PrivacySecurityView() {
     const [loading, setLoading] = React.useState(true);
     const [saving, setSaving] = React.useState(false);
     const [shareLocation, setShareLocation] = React.useState(false);
+    const [initialShareLocation, setInitialShareLocation] = React.useState(false);
     const [error, setError] = React.useState("");
     const [info, setInfo] = React.useState("");
 
@@ -39,6 +40,7 @@ export default function PrivacySecurityView() {
             try {
                 const profile = await fetchMyProfile(token);
                 setShareLocation(profile.privacySettings.locationSharingEnabled);
+                setInitialShareLocation(profile.privacySettings.locationSharingEnabled);
             } catch (err) {
                 if (err instanceof ApiError && err.status === 401) {
                     redirectToLoginAfterAuthExpiry();
@@ -70,6 +72,13 @@ export default function PrivacySecurityView() {
             setSaving(true);
             setError("");
             setInfo("");
+
+            if (!initialShareLocation && shareLocation) {
+                setError(
+                    "To enable Share Current Location, go to Profile, click Use Current Location, and save there first."
+                );
+                return;
+            }
 
             await patchMyPrivacy(token, {
                 locationSharingEnabled: shareLocation,

--- a/web/src/lib/profile.ts
+++ b/web/src/lib/profile.ts
@@ -30,10 +30,28 @@ export type BackendProfileResponse = {
     };
     locationProfile: {
         address: string | null;
+        displayAddress?: string | null;
         city: string | null;
         country: string | null;
+        placeId?: string | null;
         latitude: number | null;
         longitude: number | null;
+        administrative?: {
+            countryCode?: string | null;
+            country?: string | null;
+            city?: string | null;
+            district?: string | null;
+            neighborhood?: string | null;
+            extraAddress?: string | null;
+            postalCode?: string | null;
+        };
+        coordinate?: {
+            latitude?: number | null;
+            longitude?: number | null;
+            accuracyMeters?: number | null;
+            source?: string | null;
+            capturedAt?: string | null;
+        } | null;
         lastUpdated: string | null;
     };
     expertise: Array<{


### PR DESCRIPTION
This PR completes the web scope of current-device-location sharing by making location retrieval permission-aware, sending structured location payloads to backend profile endpoints, and improving data integrity for stored location metadata.

## What’s Included
- Added permission-aware current location handling in the web location picker.
- Added safer geolocation error handling for:
  - permission denied
  - position unavailable
  - timeout
- Extended web location sharing payloads to include:
  - latitude / longitude
  - coordinate metadata (`source`, `accuracyMeters`, `capturedAt`)
  - administrative location fields
  - `displayAddress` and `placeId`
- Updated profile and complete-profile save flows to submit current location payload consistently.
- Preserved backend-provided location identity fields during profile hydration:
  - `placeId`
  - `displayAddress`
  - coordinate metadata continuity
- Expanded web profile API typings to match backend location response shape.
- Added e2e regression coverage to ensure saved location identity/metadata is not unintentionally overwritten.

## Files Changed
- LocationPicker.tsx
- ProfileView.tsx
- CompleteProfileForm.tsx
- profile.ts
- api.js
- profile-and-privacy.spec.js

## Notes
- Behavior is aligned with existing backend privacy/location separation:
  - location payload and privacy toggle remain separate update flows.

## Issue
Closes #290 