### PR TITLE
feat: implement advanced help-request matching with multi-responder support

### DIFF
--- a/backend/migrations/20260423_123000__allow_multiple_assignments_per_request.sql
+++ b/backend/migrations/20260423_123000__allow_multiple_assignments_per_request.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE assignments
+  DROP CONSTRAINT IF EXISTS assignments_request_id_key;
+
+CREATE INDEX IF NOT EXISTS idx_assignments_request_id
+  ON assignments(request_id);
+
+COMMIT;

--- a/backend/migrations/20260423_145500__reconcile_active_assignments_per_volunteer.sql
+++ b/backend/migrations/20260423_145500__reconcile_active_assignments_per_volunteer.sql
@@ -1,6 +1,14 @@
 BEGIN;
 
-WITH ranked_active_assignments AS (
+WITH deleted_closed_request_assignments AS (
+  DELETE FROM assignments a
+  USING help_requests hr
+  WHERE a.request_id = hr.request_id
+    AND a.is_cancelled = FALSE
+    AND hr.status IN ('RESOLVED', 'CANCELLED')
+  RETURNING a.request_id, a.volunteer_id
+),
+ranked_active_assignments AS (
   SELECT
     a.assignment_id,
     a.request_id,
@@ -9,7 +17,9 @@ WITH ranked_active_assignments AS (
       ORDER BY a.assigned_at ASC, a.assignment_id ASC
     ) AS volunteer_rank
   FROM assignments a
+  JOIN help_requests hr ON hr.request_id = a.request_id
   WHERE a.is_cancelled = FALSE
+    AND hr.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS')
 ),
 deleted_assignments AS (
   DELETE FROM assignments a
@@ -17,21 +27,26 @@ deleted_assignments AS (
   WHERE a.assignment_id = ranked.assignment_id
     AND ranked.volunteer_rank > 1
   RETURNING a.request_id
+),
+affected_requests AS (
+  SELECT request_id FROM deleted_closed_request_assignments
+  UNION
+  SELECT request_id FROM deleted_assignments
 )
 UPDATE help_requests hr
 SET status = CASE
   WHEN hr.status = 'IN_PROGRESS' THEN 'IN_PROGRESS'::request_status
   WHEN EXISTS (
     SELECT 1
-    FROM ranked_active_assignments ranked
-    WHERE ranked.request_id = hr.request_id
-      AND ranked.volunteer_rank = 1
+    FROM assignments a
+    WHERE a.request_id = hr.request_id
+      AND a.is_cancelled = FALSE
   ) THEN 'ASSIGNED'::request_status
   ELSE 'PENDING'::request_status
 END
 WHERE hr.request_id IN (
-  SELECT DISTINCT deleted_assignments.request_id
-  FROM deleted_assignments
+  SELECT DISTINCT affected_requests.request_id
+  FROM affected_requests
 )
   AND hr.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS');
 

--- a/backend/migrations/20260423_145500__reconcile_active_assignments_per_volunteer.sql
+++ b/backend/migrations/20260423_145500__reconcile_active_assignments_per_volunteer.sql
@@ -1,0 +1,38 @@
+BEGIN;
+
+WITH ranked_active_assignments AS (
+  SELECT
+    a.assignment_id,
+    a.request_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY a.volunteer_id
+      ORDER BY a.assigned_at ASC, a.assignment_id ASC
+    ) AS volunteer_rank
+  FROM assignments a
+  WHERE a.is_cancelled = FALSE
+),
+deleted_assignments AS (
+  DELETE FROM assignments a
+  USING ranked_active_assignments ranked
+  WHERE a.assignment_id = ranked.assignment_id
+    AND ranked.volunteer_rank > 1
+  RETURNING a.request_id
+)
+UPDATE help_requests hr
+SET status = CASE
+  WHEN hr.status = 'IN_PROGRESS' THEN 'IN_PROGRESS'::request_status
+  WHEN EXISTS (
+    SELECT 1
+    FROM assignments a
+    WHERE a.request_id = hr.request_id
+      AND a.is_cancelled = FALSE
+  ) THEN 'ASSIGNED'::request_status
+  ELSE 'PENDING'::request_status
+END
+WHERE hr.request_id IN (
+  SELECT DISTINCT deleted_assignments.request_id
+  FROM deleted_assignments
+)
+  AND hr.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS');
+
+COMMIT;

--- a/backend/migrations/20260423_145500__reconcile_active_assignments_per_volunteer.sql
+++ b/backend/migrations/20260423_145500__reconcile_active_assignments_per_volunteer.sql
@@ -28,6 +28,11 @@ deleted_assignments AS (
     AND ranked.volunteer_rank > 1
   RETURNING a.request_id
 ),
+surviving_active_requests AS (
+  SELECT DISTINCT ranked.request_id
+  FROM ranked_active_assignments ranked
+  WHERE ranked.volunteer_rank = 1
+),
 affected_requests AS (
   SELECT request_id FROM deleted_closed_request_assignments
   UNION
@@ -38,9 +43,8 @@ SET status = CASE
   WHEN hr.status = 'IN_PROGRESS' THEN 'IN_PROGRESS'::request_status
   WHEN EXISTS (
     SELECT 1
-    FROM assignments a
-    WHERE a.request_id = hr.request_id
-      AND a.is_cancelled = FALSE
+    FROM surviving_active_requests sar
+    WHERE sar.request_id = hr.request_id
   ) THEN 'ASSIGNED'::request_status
   ELSE 'PENDING'::request_status
 END

--- a/backend/migrations/20260423_145500__reconcile_active_assignments_per_volunteer.sql
+++ b/backend/migrations/20260423_145500__reconcile_active_assignments_per_volunteer.sql
@@ -23,9 +23,9 @@ SET status = CASE
   WHEN hr.status = 'IN_PROGRESS' THEN 'IN_PROGRESS'::request_status
   WHEN EXISTS (
     SELECT 1
-    FROM assignments a
-    WHERE a.request_id = hr.request_id
-      AND a.is_cancelled = FALSE
+    FROM ranked_active_assignments ranked
+    WHERE ranked.request_id = hr.request_id
+      AND ranked.volunteer_rank = 1
   ) THEN 'ASSIGNED'::request_status
   ELSE 'PENDING'::request_status
 END

--- a/backend/migrations/20260423_150000__guard_active_assignment_per_volunteer.sql
+++ b/backend/migrations/20260423_150000__guard_active_assignment_per_volunteer.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_assignments_active_volunteer_unique
+  ON assignments(volunteer_id)
+  WHERE is_cancelled = FALSE;
+
+COMMIT;

--- a/backend/src/modules/availability/repository.js
+++ b/backend/src/modules/availability/repository.js
@@ -380,7 +380,7 @@ async function findAvailableVolunteersForMatching() {
         JOIN help_requests hr ON a.request_id = hr.request_id
         WHERE a.volunteer_id = v.volunteer_id
           AND a.is_cancelled = FALSE
-          AND hr.status IN ('PENDING', 'ASSIGNED')
+          AND hr.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS')
       )
     ORDER BY v.location_updated_at DESC NULLS LAST, v.volunteer_id ASC;
   `;
@@ -405,7 +405,7 @@ async function findActiveAssignmentsForOpenRequests() {
       WHERE e.profile_id = up.profile_id
     ) expertise_context ON TRUE
     WHERE a.is_cancelled = FALSE
-      AND hr.status IN ('PENDING', 'ASSIGNED')
+      AND hr.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS')
     ORDER BY a.assigned_at ASC, a.assignment_id ASC;
   `;
   const result = await query(sql);
@@ -453,7 +453,7 @@ async function findOpenRequestsForMatching() {
     SELECT hr.*, rl.latitude, rl.longitude
     FROM help_requests hr
     LEFT JOIN request_locations rl ON hr.request_id = rl.request_id
-    WHERE hr.status IN ('PENDING', 'ASSIGNED')
+    WHERE hr.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS')
     ORDER BY hr.created_at ASC, hr.request_id ASC;
   `;
   const requestResult = await query(requestSql);

--- a/backend/src/modules/availability/repository.js
+++ b/backend/src/modules/availability/repository.js
@@ -1,8 +1,308 @@
 const { query } = require('../../db/pool');
 const { randomUUID } = require('crypto');
 
+const DEFAULT_MAX_MATCH_DISTANCE_METERS = 1000;
+const FIRST_AID_HELP_TYPES = new Set(['first_aid', 'medical']);
+const SEARCH_AND_RESCUE_HELP_TYPES = new Set(['search_and_rescue', 'sar', 'fire_brigade', 'rescue']);
+const SUPPLIES_HELP_TYPES = new Set(['food', 'water', 'basic_supplies', 'supplies']);
+const SHELTER_HELP_TYPES = new Set(['shelter']);
+const FIRST_AID_EXPERTISE_MARKERS = new Set(['first_aid', 'medical']);
+
 function makeId(prefix) {
   return `${prefix}_${randomUUID().replace(/-/g, '')}`;
+}
+
+function normalizeMatchToken(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim().toLowerCase().replace(/[\s-]+/g, '_');
+}
+
+function toNonNegativeInteger(value) {
+  const numericValue = Number(value);
+
+  if (!Number.isFinite(numericValue) || numericValue < 0) {
+    return null;
+  }
+
+  return Math.floor(numericValue);
+}
+
+function parseExpertiseAreas(rawValue) {
+  if (rawValue === null || rawValue === undefined || rawValue === '') {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (Array.isArray(parsed) && parsed.every((item) => typeof item === 'string')) {
+      return parsed;
+    }
+  } catch (_error) {
+    return [String(rawValue)];
+  }
+
+  return [String(rawValue)];
+}
+
+function getConfiguredMatchRadiusMeters() {
+  const configuredValue = Number(process.env.MATCH_MAX_DISTANCE_METERS);
+
+  if (Number.isFinite(configuredValue) && configuredValue > 0) {
+    return configuredValue;
+  }
+
+  return DEFAULT_MAX_MATCH_DISTANCE_METERS;
+}
+
+function toCoordinateValue(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function hasCoordinates(latitude, longitude) {
+  return toCoordinateValue(latitude) !== null && toCoordinateValue(longitude) !== null;
+}
+
+function calculateDistanceMeters(firstPoint, secondPoint) {
+  if (
+    !hasCoordinates(firstPoint.latitude, firstPoint.longitude)
+    || !hasCoordinates(secondPoint.latitude, secondPoint.longitude)
+  ) {
+    return null;
+  }
+
+  const toRadians = (value) => value * (Math.PI / 180);
+  const earthRadiusMeters = 6378137;
+  const firstLatitude = toRadians(toCoordinateValue(firstPoint.latitude));
+  const firstLongitude = toRadians(toCoordinateValue(firstPoint.longitude));
+  const secondLatitude = toRadians(toCoordinateValue(secondPoint.latitude));
+  const secondLongitude = toRadians(toCoordinateValue(secondPoint.longitude));
+  const latitudeDelta = secondLatitude - firstLatitude;
+  const longitudeDelta = secondLongitude - firstLongitude;
+  const haversineTerm = (Math.sin(latitudeDelta / 2) ** 2)
+    + (Math.cos(firstLatitude) * Math.cos(secondLatitude) * (Math.sin(longitudeDelta / 2) ** 2));
+
+  return 2 * earthRadiusMeters * Math.atan2(Math.sqrt(haversineTerm), Math.sqrt(1 - haversineTerm));
+}
+
+function compareNullableDatesDescending(left, right) {
+  const leftTime = left ? new Date(left).getTime() : null;
+  const rightTime = right ? new Date(right).getTime() : null;
+
+  if (leftTime === null && rightTime === null) {
+    return 0;
+  }
+
+  if (leftTime === null) {
+    return 1;
+  }
+
+  if (rightTime === null) {
+    return -1;
+  }
+
+  return rightTime - leftTime;
+}
+
+function compareNullableDistances(left, right) {
+  if (left === null && right === null) {
+    return 0;
+  }
+
+  if (left === null) {
+    return 1;
+  }
+
+  if (right === null) {
+    return -1;
+  }
+
+  return left - right;
+}
+
+function normalizeRequestHelpTypes(helpTypes, needType) {
+  const resolvedHelpTypes = Array.isArray(helpTypes) && helpTypes.length > 0
+    ? helpTypes
+    : [needType].filter(Boolean);
+
+  return resolvedHelpTypes
+    .map(normalizeMatchToken)
+    .filter(Boolean);
+}
+
+function buildRequestMatchContext(requestRow) {
+  const normalizedHelpTypes = normalizeRequestHelpTypes(requestRow.help_types, requestRow.need_type);
+  const hasFirstAid = normalizedHelpTypes.some((type) => FIRST_AID_HELP_TYPES.has(type));
+  const hasSearchAndRescue = normalizedHelpTypes.some((type) => SEARCH_AND_RESCUE_HELP_TYPES.has(type));
+  const hasSupplies = normalizedHelpTypes.some((type) => SUPPLIES_HELP_TYPES.has(type));
+  const hasShelter = normalizedHelpTypes.some((type) => SHELTER_HELP_TYPES.has(type));
+  const activeAssignmentCount = Math.max(0, Number(requestRow.active_assignment_count) || 0);
+  const hasFirstAidCapableAssignment = Boolean(requestRow.has_first_aid_capable_assignment);
+  const affectedPeopleCount = toNonNegativeInteger(
+    requestRow.affected_people_count ?? requestRow.affectedPeopleCount,
+  );
+  const sarTargetTotal = hasSearchAndRescue
+    ? (affectedPeopleCount === null ? 1 : affectedPeopleCount + 1)
+    : 1;
+  const needsFirstAidSpecialist = hasFirstAid && !hasFirstAidCapableAssignment;
+  const needsSearchAndRescueCoverage = hasSearchAndRescue && activeAssignmentCount < sarTargetTotal;
+
+  let priority = 0;
+
+  if (hasFirstAid) {
+    priority = 3;
+  } else if (hasSearchAndRescue) {
+    priority = 2;
+  } else if (hasSupplies || hasShelter) {
+    priority = 1;
+  }
+
+  let isInternallyFulfilled = false;
+
+  if (hasFirstAid && hasSearchAndRescue) {
+    isInternallyFulfilled = !needsFirstAidSpecialist && !needsSearchAndRescueCoverage;
+  } else if (hasFirstAid) {
+    isInternallyFulfilled = !needsFirstAidSpecialist;
+  } else if (hasSearchAndRescue) {
+    isInternallyFulfilled = !needsSearchAndRescueCoverage;
+  } else {
+    isInternallyFulfilled = activeAssignmentCount >= 1;
+  }
+
+  return {
+    ...requestRow,
+    normalized_help_types: normalizedHelpTypes,
+    has_first_aid: hasFirstAid,
+    has_search_and_rescue: hasSearchAndRescue,
+    has_supplies: hasSupplies,
+    has_shelter: hasShelter,
+    active_assignment_count: activeAssignmentCount,
+    has_first_aid_capable_assignment: hasFirstAidCapableAssignment,
+    sar_target_total: sarTargetTotal,
+    needs_first_aid_specialist: needsFirstAidSpecialist,
+    needs_search_and_rescue_coverage: needsSearchAndRescueCoverage,
+    needs_initial_coverage: activeAssignmentCount === 0,
+    is_internally_fulfilled: isInternallyFulfilled,
+    assignment_phase_rank: activeAssignmentCount === 0 ? 0 : 1,
+    priority,
+  };
+}
+
+function buildVolunteerMatchContext(volunteerRow) {
+  const expertiseAreas = Array.isArray(volunteerRow.expertise_areas)
+    ? volunteerRow.expertise_areas.flatMap((rawValue) => parseExpertiseAreas(rawValue))
+    : [];
+  const isFirstAidCapable = expertiseAreas
+    .map(normalizeMatchToken)
+    .some((expertiseArea) => FIRST_AID_EXPERTISE_MARKERS.has(expertiseArea));
+
+  return {
+    ...volunteerRow,
+    normalized_expertise_areas: expertiseAreas,
+    is_first_aid_capable: isFirstAidCapable,
+  };
+}
+
+function buildVolunteerCandidateForRequest(requestContext, volunteerRow) {
+  const volunteerContext = buildVolunteerMatchContext(volunteerRow);
+  const distanceMeters = calculateDistanceMeters(
+    {
+      latitude: requestContext.latitude,
+      longitude: requestContext.longitude,
+    },
+    {
+      latitude: volunteerContext.last_known_latitude,
+      longitude: volunteerContext.last_known_longitude,
+    },
+  );
+
+  return {
+    ...volunteerContext,
+    suitability_score: requestContext.needs_first_aid_specialist && volunteerContext.is_first_aid_capable ? 1 : 0,
+    distance_meters: distanceMeters,
+  };
+}
+
+function buildRequestCandidateForVolunteer(volunteerContext, requestRow) {
+  const requestContext = buildRequestMatchContext(requestRow);
+  const distanceMeters = calculateDistanceMeters(
+    {
+      latitude: volunteerContext.last_known_latitude,
+      longitude: volunteerContext.last_known_longitude,
+    },
+    {
+      latitude: requestContext.latitude,
+      longitude: requestContext.longitude,
+    },
+  );
+
+  return {
+    ...requestContext,
+    distance_meters: distanceMeters,
+  };
+}
+
+function isCandidateWithinMatchRadius(candidate) {
+  return candidate.distance_meters === null || candidate.distance_meters <= getConfiguredMatchRadiusMeters();
+}
+
+function compareVolunteerCandidates(leftCandidate, rightCandidate) {
+  if (leftCandidate.suitability_score !== rightCandidate.suitability_score) {
+    return rightCandidate.suitability_score - leftCandidate.suitability_score;
+  }
+
+  const distanceComparison = compareNullableDistances(leftCandidate.distance_meters, rightCandidate.distance_meters);
+  if (distanceComparison !== 0) {
+    return distanceComparison;
+  }
+
+  const updatedAtComparison = compareNullableDatesDescending(
+    leftCandidate.location_updated_at,
+    rightCandidate.location_updated_at,
+  );
+  if (updatedAtComparison !== 0) {
+    return updatedAtComparison;
+  }
+
+  return leftCandidate.volunteer_id.localeCompare(rightCandidate.volunteer_id);
+}
+
+function compareRequestCandidates(leftCandidate, rightCandidate) {
+  const leftPhaseRank = Number(leftCandidate.assignment_phase_rank) || 0;
+  const rightPhaseRank = Number(rightCandidate.assignment_phase_rank) || 0;
+
+  if (leftPhaseRank !== rightPhaseRank) {
+    return leftPhaseRank - rightPhaseRank;
+  }
+
+  if (leftCandidate.priority !== rightCandidate.priority) {
+    return rightCandidate.priority - leftCandidate.priority;
+  }
+
+  const distanceComparison = compareNullableDistances(leftCandidate.distance_meters, rightCandidate.distance_meters);
+  if (distanceComparison !== 0) {
+    return distanceComparison;
+  }
+
+  const createdAtComparison = new Date(leftCandidate.created_at).getTime() - new Date(rightCandidate.created_at).getTime();
+  if (createdAtComparison !== 0) {
+    return createdAtComparison;
+  }
+
+  return leftCandidate.request_id.localeCompare(rightCandidate.request_id);
 }
 
 async function findVolunteerByUserId(userId) {
@@ -62,74 +362,171 @@ async function findPendingRequests() {
   return result.rows;
 }
 
-async function findMatchingRequestForVolunteer(volunteerId) {
-  // Simple matching: find the first pending request that matches volunteer's skills/need_types
-  // For MVP, we can just find the oldest pending request
-  // Or if we want to be a bit better, match by need_type if volunteer has any
-  const volunteerSql = `SELECT user_id, skills, need_types FROM volunteers WHERE volunteer_id = $1;`;
-  const vResult = await query(volunteerSql, [volunteerId]);
-  const volunteer = vResult.rows[0];
-
-  if (!volunteer) return null;
-
-  // If volunteer has no specific need_types, they can match any
-  let sql;
-  let params = [volunteer.user_id];
-
-  if (volunteer.need_types && volunteer.need_types.length > 0) {
-    sql = `
-      SELECT hr.*, rl.latitude, rl.longitude
-      FROM help_requests hr
-      LEFT JOIN request_locations rl ON hr.request_id = rl.request_id
-      WHERE hr.status = 'PENDING'
-        AND (hr.user_id IS NULL OR hr.user_id != $1)
-        AND hr.need_type = ANY($2)
-      ORDER BY hr.created_at ASC
-      LIMIT 1;
-    `;
-    params = [volunteer.user_id, volunteer.need_types];
-  } else {
-    sql = `
-      SELECT hr.*, rl.latitude, rl.longitude
-      FROM help_requests hr
-      LEFT JOIN request_locations rl ON hr.request_id = rl.request_id
-      WHERE hr.status = 'PENDING'
-        AND (hr.user_id IS NULL OR hr.user_id != $1)
-      ORDER BY hr.created_at ASC
-      LIMIT 1;
-    `;
-    params = [volunteer.user_id];
-  }
-
-  const result = await query(sql, params);
-  return result.rows[0] || null;
-}
-
-async function findMatchingVolunteerForRequest(requestId) {
-  const requestSql = `SELECT user_id, need_type FROM help_requests WHERE request_id = $1;`;
-  const rResult = await query(requestSql, [requestId]);
-  const request = rResult.rows[0];
-
-  if (!request) return null;
-
+async function findAvailableVolunteersForMatching() {
   const sql = `
-    SELECT v.*
+    SELECT
+      v.*,
+      COALESCE(expertise_context.expertise_areas, ARRAY[]::TEXT[]) AS expertise_areas
     FROM volunteers v
+    LEFT JOIN user_profiles up ON up.user_id = v.user_id
+    LEFT JOIN LATERAL (
+      SELECT ARRAY_REMOVE(ARRAY_AGG(e.expertise_area ORDER BY e.is_verified DESC, e.expertise_id ASC), NULL) AS expertise_areas
+      FROM expertise e
+      WHERE e.profile_id = up.profile_id
+    ) expertise_context ON TRUE
     WHERE v.is_available = TRUE
-      AND (v.user_id != $2 OR $2 IS NULL)
       AND NOT EXISTS (
         SELECT 1 FROM assignments a
         JOIN help_requests hr ON a.request_id = hr.request_id
         WHERE a.volunteer_id = v.volunteer_id
           AND a.is_cancelled = FALSE
-          AND hr.status NOT IN ('RESOLVED', 'CANCELLED')
+          AND hr.status IN ('PENDING', 'ASSIGNED')
       )
-      AND (v.need_types IS NULL OR v.need_types = '{}' OR $1 = ANY(v.need_types))
-    ORDER BY v.location_updated_at DESC NULLS LAST
+    ORDER BY v.location_updated_at DESC NULLS LAST, v.volunteer_id ASC;
+  `;
+  const result = await query(sql);
+  return result.rows.map(buildVolunteerMatchContext);
+}
+
+async function findActiveAssignmentsForOpenRequests() {
+  const sql = `
+    SELECT
+      a.assignment_id,
+      a.request_id,
+      a.volunteer_id,
+      COALESCE(expertise_context.expertise_areas, ARRAY[]::TEXT[]) AS expertise_areas
+    FROM assignments a
+    JOIN help_requests hr ON hr.request_id = a.request_id
+    JOIN volunteers v ON v.volunteer_id = a.volunteer_id
+    LEFT JOIN user_profiles up ON up.user_id = v.user_id
+    LEFT JOIN LATERAL (
+      SELECT ARRAY_REMOVE(ARRAY_AGG(e.expertise_area ORDER BY e.is_verified DESC, e.expertise_id ASC), NULL) AS expertise_areas
+      FROM expertise e
+      WHERE e.profile_id = up.profile_id
+    ) expertise_context ON TRUE
+    WHERE a.is_cancelled = FALSE
+      AND hr.status IN ('PENDING', 'ASSIGNED')
+    ORDER BY a.assigned_at ASC, a.assignment_id ASC;
+  `;
+  const result = await query(sql);
+
+  return result.rows.map((assignmentRow) => {
+    const volunteerContext = buildVolunteerMatchContext(assignmentRow);
+
+    return {
+      ...assignmentRow,
+      is_first_aid_capable: volunteerContext.is_first_aid_capable,
+    };
+  });
+}
+
+function buildOpenRequestMatchContexts(requestRows, assignmentRows) {
+  const assignmentSummaryByRequestId = assignmentRows.reduce((summaryMap, assignmentRow) => {
+    const currentSummary = summaryMap.get(assignmentRow.request_id) || {
+      active_assignment_count: 0,
+      has_first_aid_capable_assignment: false,
+    };
+
+    currentSummary.active_assignment_count += 1;
+    currentSummary.has_first_aid_capable_assignment = currentSummary.has_first_aid_capable_assignment
+      || assignmentRow.is_first_aid_capable;
+
+    summaryMap.set(assignmentRow.request_id, currentSummary);
+    return summaryMap;
+  }, new Map());
+
+  return requestRows.map((requestRow) => {
+    const requestSummary = assignmentSummaryByRequestId.get(requestRow.request_id) || {
+      active_assignment_count: 0,
+      has_first_aid_capable_assignment: false,
+    };
+
+    return buildRequestMatchContext({
+      ...requestRow,
+      ...requestSummary,
+    });
+  });
+}
+
+async function findOpenRequestsForMatching() {
+  const requestSql = `
+    SELECT hr.*, rl.latitude, rl.longitude
+    FROM help_requests hr
+    LEFT JOIN request_locations rl ON hr.request_id = rl.request_id
+    WHERE hr.status IN ('PENDING', 'ASSIGNED')
+    ORDER BY hr.created_at ASC, hr.request_id ASC;
+  `;
+  const requestResult = await query(requestSql);
+  const assignmentRows = await findActiveAssignmentsForOpenRequests();
+
+  return buildOpenRequestMatchContexts(requestResult.rows, assignmentRows);
+}
+
+function selectBestRequestForVolunteer(volunteer, requestRows) {
+  return requestRows
+    .filter((requestRow) => requestRow.user_id === null || requestRow.user_id !== volunteer.user_id)
+    .filter((requestRow) => !requestRow.is_internally_fulfilled)
+    .map((requestRow) => buildRequestCandidateForVolunteer(volunteer, requestRow))
+    .filter(isCandidateWithinMatchRadius)
+    .sort(compareRequestCandidates)[0] || null;
+}
+
+function selectBestVolunteerForRequest(requestRow, volunteerRows) {
+  if (requestRow.is_internally_fulfilled) {
+    return null;
+  }
+
+  return volunteerRows
+    .filter((volunteerRow) => requestRow.user_id === null || volunteerRow.user_id !== requestRow.user_id)
+    .map((volunteerRow) => buildVolunteerCandidateForRequest(requestRow, volunteerRow))
+    .filter(isCandidateWithinMatchRadius)
+    .sort(compareVolunteerCandidates)[0] || null;
+}
+
+async function findMatchingRequestForVolunteer(volunteerId) {
+  const volunteerSql = `
+    SELECT
+      v.*,
+      COALESCE(expertise_context.expertise_areas, ARRAY[]::TEXT[]) AS expertise_areas
+    FROM volunteers v
+    LEFT JOIN user_profiles up ON up.user_id = v.user_id
+    LEFT JOIN LATERAL (
+      SELECT ARRAY_REMOVE(ARRAY_AGG(e.expertise_area ORDER BY e.is_verified DESC, e.expertise_id ASC), NULL) AS expertise_areas
+      FROM expertise e
+      WHERE e.profile_id = up.profile_id
+    ) expertise_context ON TRUE
+    WHERE v.volunteer_id = $1
     LIMIT 1;
   `;
-  const result = await query(sql, [request.need_type, request.user_id]);
-  return result.rows[0] || null;
+  const vResult = await query(volunteerSql, [volunteerId]);
+  const volunteer = vResult.rows[0] ? buildVolunteerMatchContext(vResult.rows[0]) : null;
+
+  if (!volunteer) return null;
+
+  const openRequests = await findOpenRequestsForMatching();
+  const firstPassRequest = selectBestRequestForVolunteer(
+    volunteer,
+    openRequests.filter((requestRow) => requestRow.needs_initial_coverage),
+  );
+
+  if (firstPassRequest) {
+    return firstPassRequest;
+  }
+
+  return selectBestRequestForVolunteer(
+    volunteer,
+    openRequests.filter((requestRow) => !requestRow.needs_initial_coverage),
+  );
+}
+
+async function findMatchingVolunteerForRequest(requestId) {
+  const openRequests = await findOpenRequestsForMatching();
+  const request = openRequests.find((requestRow) => requestRow.request_id === requestId) || null;
+
+  if (!request) return null;
+  const availableVolunteers = await findAvailableVolunteersForMatching();
+
+  return selectBestVolunteerForRequest(request, availableVolunteers);
 }
 
 async function createAssignment(volunteerId, requestId) {
@@ -191,10 +588,22 @@ async function getAssignmentById(assignmentId) {
 async function findAssignmentByRequestId(requestId) {
   const sql = `
     SELECT * FROM assignments
-    WHERE request_id = $1 AND is_cancelled = FALSE;
+    WHERE request_id = $1 AND is_cancelled = FALSE
+    ORDER BY assigned_at ASC, assignment_id ASC
+    LIMIT 1;
   `;
   const result = await query(sql, [requestId]);
   return result.rows[0] || null;
+}
+
+async function findActiveAssignmentsByRequestId(requestId) {
+  const sql = `
+    SELECT * FROM assignments
+    WHERE request_id = $1 AND is_cancelled = FALSE
+    ORDER BY assigned_at ASC, assignment_id ASC;
+  `;
+  const result = await query(sql, [requestId]);
+  return result.rows;
 }
 
 async function cancelAssignment(assignmentId) {
@@ -208,10 +617,13 @@ async function cancelAssignment(assignmentId) {
 }
 
 module.exports = {
+  buildRequestMatchContext,
   findVolunteerByUserId,
   createVolunteer,
   updateVolunteerAvailability,
   createAvailabilityRecord,
+  findAvailableVolunteersForMatching,
+  findOpenRequestsForMatching,
   findPendingRequests,
   findMatchingRequestForVolunteer,
   findMatchingVolunteerForRequest,
@@ -220,5 +632,6 @@ module.exports = {
   getAssignmentByVolunteerId,
   getAssignmentById,
   findAssignmentByRequestId,
+  findActiveAssignmentsByRequestId,
   cancelAssignment,
 };

--- a/backend/src/modules/availability/repository.js
+++ b/backend/src/modules/availability/repository.js
@@ -7,6 +7,7 @@ const SEARCH_AND_RESCUE_HELP_TYPES = new Set(['search_and_rescue', 'sar', 'fire_
 const SUPPLIES_HELP_TYPES = new Set(['food', 'water', 'basic_supplies', 'supplies']);
 const SHELTER_HELP_TYPES = new Set(['shelter']);
 const FIRST_AID_EXPERTISE_MARKERS = new Set(['first_aid', 'medical']);
+const FIRST_AID_ONLY_GENERAL_FALLBACK_CAP = 1;
 
 function makeId(prefix) {
   return `${prefix}_${randomUUID().replace(/-/g, '')}`;
@@ -159,6 +160,10 @@ function buildRequestMatchContext(requestRow) {
     : 1;
   const needsFirstAidSpecialist = hasFirstAid && !hasFirstAidCapableAssignment;
   const needsSearchAndRescueCoverage = hasSearchAndRescue && activeAssignmentCount < sarTargetTotal;
+  const firstAidOnlyGeneralFallbackCapReached = hasFirstAid
+    && !hasSearchAndRescue
+    && !hasFirstAidCapableAssignment
+    && activeAssignmentCount >= FIRST_AID_ONLY_GENERAL_FALLBACK_CAP;
 
   let priority = 0;
 
@@ -194,11 +199,23 @@ function buildRequestMatchContext(requestRow) {
     sar_target_total: sarTargetTotal,
     needs_first_aid_specialist: needsFirstAidSpecialist,
     needs_search_and_rescue_coverage: needsSearchAndRescueCoverage,
+    first_aid_only_general_fallback_cap_reached: firstAidOnlyGeneralFallbackCapReached,
     needs_initial_coverage: activeAssignmentCount === 0,
     is_internally_fulfilled: isInternallyFulfilled,
     assignment_phase_rank: activeAssignmentCount === 0 ? 0 : 1,
     priority,
   };
+}
+
+function canVolunteerMatchRequest(volunteerContext, requestContext) {
+  if (
+    requestContext.first_aid_only_general_fallback_cap_reached
+    && !volunteerContext.is_first_aid_capable
+  ) {
+    return false;
+  }
+
+  return true;
 }
 
 function buildVolunteerMatchContext(volunteerRow) {
@@ -218,6 +235,11 @@ function buildVolunteerMatchContext(volunteerRow) {
 
 function buildVolunteerCandidateForRequest(requestContext, volunteerRow) {
   const volunteerContext = buildVolunteerMatchContext(volunteerRow);
+
+  if (!canVolunteerMatchRequest(volunteerContext, requestContext)) {
+    return null;
+  }
+
   const distanceMeters = calculateDistanceMeters(
     {
       latitude: requestContext.latitude,
@@ -238,6 +260,11 @@ function buildVolunteerCandidateForRequest(requestContext, volunteerRow) {
 
 function buildRequestCandidateForVolunteer(volunteerContext, requestRow) {
   const requestContext = buildRequestMatchContext(requestRow);
+
+  if (!canVolunteerMatchRequest(volunteerContext, requestContext)) {
+    return null;
+  }
+
   const distanceMeters = calculateDistanceMeters(
     {
       latitude: volunteerContext.last_known_latitude,
@@ -467,6 +494,7 @@ function selectBestRequestForVolunteer(volunteer, requestRows) {
     .filter((requestRow) => requestRow.user_id === null || requestRow.user_id !== volunteer.user_id)
     .filter((requestRow) => !requestRow.is_internally_fulfilled)
     .map((requestRow) => buildRequestCandidateForVolunteer(volunteer, requestRow))
+    .filter(Boolean)
     .filter(isCandidateWithinMatchRadius)
     .sort(compareRequestCandidates)[0] || null;
 }
@@ -479,6 +507,7 @@ function selectBestVolunteerForRequest(requestRow, volunteerRows) {
   return volunteerRows
     .filter((volunteerRow) => requestRow.user_id === null || volunteerRow.user_id !== requestRow.user_id)
     .map((volunteerRow) => buildVolunteerCandidateForRequest(requestRow, volunteerRow))
+    .filter(Boolean)
     .filter(isCandidateWithinMatchRadius)
     .sort(compareVolunteerCandidates)[0] || null;
 }
@@ -533,11 +562,57 @@ async function createAssignment(volunteerId, requestId) {
   const assignmentId = makeId('asg');
   const sql = `
     INSERT INTO assignments (assignment_id, volunteer_id, request_id, assigned_at, is_cancelled)
-    VALUES ($1, $2, $3, CURRENT_TIMESTAMP, FALSE)
+    SELECT $1::VARCHAR(64), $2::VARCHAR(64), $3::VARCHAR(64), CURRENT_TIMESTAMP, FALSE
+    FROM volunteers v
+    JOIN help_requests hr ON hr.request_id = $3::VARCHAR(64)
+    WHERE v.volunteer_id = $2::VARCHAR(64)
+      AND v.is_available = TRUE
+      AND hr.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS')
+      AND NOT EXISTS (
+        SELECT 1
+        FROM assignments a
+        JOIN help_requests active_requests ON active_requests.request_id = a.request_id
+        WHERE a.volunteer_id = $2::VARCHAR(64)
+          AND a.is_cancelled = FALSE
+          AND active_requests.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS')
+      )
+    ON CONFLICT (volunteer_id) WHERE is_cancelled = FALSE DO NOTHING
     RETURNING *;
   `;
   const result = await query(sql, [assignmentId, volunteerId, requestId]);
-  return result.rows[0];
+  return result.rows[0] || null;
+}
+
+async function markRequestAssignedIfPending(requestId) {
+  const sql = `
+    UPDATE help_requests
+    SET status = 'ASSIGNED'
+    WHERE request_id = $1
+      AND status = 'PENDING'
+    RETURNING *;
+  `;
+  const result = await query(sql, [requestId]);
+  return result.rows[0] || null;
+}
+
+async function syncRequestStatusPreservingInProgress(requestId) {
+  const sql = `
+    UPDATE help_requests hr
+    SET status = CASE
+      WHEN hr.status = 'IN_PROGRESS' THEN 'IN_PROGRESS'::request_status
+      WHEN EXISTS (
+        SELECT 1
+        FROM assignments a
+        WHERE a.request_id = hr.request_id
+          AND a.is_cancelled = FALSE
+      ) THEN 'ASSIGNED'::request_status
+      ELSE 'PENDING'::request_status
+    END
+    WHERE hr.request_id = $1
+    RETURNING *;
+  `;
+  const result = await query(sql, [requestId]);
+  return result.rows[0] || null;
 }
 
 async function updateRequestStatus(requestId, status) {
@@ -628,6 +703,8 @@ module.exports = {
   findMatchingRequestForVolunteer,
   findMatchingVolunteerForRequest,
   createAssignment,
+  markRequestAssignedIfPending,
+  syncRequestStatusPreservingInProgress,
   updateRequestStatus,
   getAssignmentByVolunteerId,
   getAssignmentById,

--- a/backend/src/modules/availability/repository.js
+++ b/backend/src/modules/availability/repository.js
@@ -533,6 +533,20 @@ async function findMatchingRequestForVolunteer(volunteerId) {
   if (!volunteer) return null;
 
   const openRequests = await findOpenRequestsForMatching();
+
+  if (volunteer.is_first_aid_capable) {
+    const specialistFollowUpRequest = selectBestRequestForVolunteer(
+      volunteer,
+      openRequests.filter(
+        (requestRow) => requestRow.needs_first_aid_specialist && !requestRow.needs_initial_coverage,
+      ),
+    );
+
+    if (specialistFollowUpRequest) {
+      return specialistFollowUpRequest;
+    }
+  }
+
   const firstPassRequest = selectBestRequestForVolunteer(
     volunteer,
     openRequests.filter((requestRow) => requestRow.needs_initial_coverage),

--- a/backend/src/modules/availability/service.js
+++ b/backend/src/modules/availability/service.js
@@ -3,15 +3,43 @@ const {
   createVolunteer,
   updateVolunteerAvailability,
   createAvailabilityRecord,
+  findAvailableVolunteersForMatching,
   findMatchingRequestForVolunteer,
   createAssignment,
   updateRequestStatus,
   getAssignmentByVolunteerId,
   getAssignmentById,
-  findAssignmentByRequestId,
+  findActiveAssignmentsByRequestId,
   cancelAssignment,
-  findMatchingVolunteerForRequest,
 } = require('./repository');
+
+async function runAssignmentCycle() {
+  const availableVolunteers = await findAvailableVolunteersForMatching();
+  const createdAssignments = [];
+
+  for (const volunteer of availableVolunteers) {
+    const matchingRequest = await findMatchingRequestForVolunteer(volunteer.volunteer_id);
+
+    if (!matchingRequest) {
+      continue;
+    }
+
+    const assignment = await createAssignment(volunteer.volunteer_id, matchingRequest.request_id);
+    await updateRequestStatus(matchingRequest.request_id, 'ASSIGNED');
+    createdAssignments.push(assignment);
+  }
+
+  return createdAssignments;
+}
+
+async function syncRequestStatusFromAssignments(requestId) {
+  const activeAssignments = await findActiveAssignmentsByRequestId(requestId);
+  const nextStatus = activeAssignments.length > 0 ? 'ASSIGNED' : 'PENDING';
+
+  await updateRequestStatus(requestId, nextStatus);
+
+  return activeAssignments;
+}
 
 async function setAvailability(userId, { isAvailable, latitude, longitude }) {
   let volunteer = await findVolunteerByUserId(userId);
@@ -34,13 +62,8 @@ async function setAvailability(userId, { isAvailable, latitude, longitude }) {
   if (isAvailable) {
     const existingAssignment = await getAssignmentByVolunteerId(volunteer.volunteer_id);
     if (!existingAssignment) {
-      const matchingRequest = await findMatchingRequestForVolunteer(volunteer.volunteer_id);
-      if (matchingRequest) {
-        assignment = await createAssignment(volunteer.volunteer_id, matchingRequest.request_id);
-        await updateRequestStatus(matchingRequest.request_id, 'ASSIGNED');
-        // Refresh assignment with full data
-        assignment = await getAssignmentByVolunteerId(volunteer.volunteer_id);
-      }
+      await runAssignmentCycle();
+      assignment = await getAssignmentByVolunteerId(volunteer.volunteer_id);
     } else {
       assignment = existingAssignment;
     }
@@ -49,7 +72,8 @@ async function setAvailability(userId, { isAvailable, latitude, longitude }) {
     const activeAssignment = await getAssignmentByVolunteerId(volunteer.volunteer_id);
     if (activeAssignment) {
       await cancelAssignment(activeAssignment.assignment_id);
-      await updateRequestStatus(activeAssignment.request_id, 'PENDING');
+      await syncRequestStatusFromAssignments(activeAssignment.request_id);
+      await runAssignmentCycle();
     }
   }
 
@@ -88,16 +112,13 @@ async function syncAvailability(userId, { records }) {
 
   // If volunteer is now available and has no assignment, try to match
   if (updatedVolunteer.is_available && !currentAssignment) {
-    const matchingRequest = await findMatchingRequestForVolunteer(volunteer.volunteer_id);
-    if (matchingRequest) {
-      await createAssignment(volunteer.volunteer_id, matchingRequest.request_id);
-      await updateRequestStatus(matchingRequest.request_id, 'ASSIGNED');
-      currentAssignment = await getAssignmentByVolunteerId(volunteer.volunteer_id);
-    }
+    await runAssignmentCycle();
+    currentAssignment = await getAssignmentByVolunteerId(volunteer.volunteer_id);
   } else if (!updatedVolunteer.is_available && currentAssignment) {
     // If volunteer is now unavailable, cancel their active assignment
     await cancelAssignment(currentAssignment.assignment_id);
-    await updateRequestStatus(currentAssignment.request_id, 'PENDING');
+    await syncRequestStatusFromAssignments(currentAssignment.request_id);
+    await runAssignmentCycle();
     currentAssignment = null;
   }
 
@@ -135,32 +156,30 @@ async function cancelMyAssignment(userId, { assignmentId }) {
   }
 
   await cancelAssignment(assignmentId);
-  await updateRequestStatus(assignment.request_id, 'PENDING'); // Put it back to pending for re-assignment
+  await syncRequestStatusFromAssignments(assignment.request_id);
 
   // Volunteer becomes unavailable
   await updateVolunteerAvailability(volunteer.volunteer_id, false, volunteer.last_known_latitude, volunteer.last_known_longitude);
   await createAvailabilityRecord(volunteer.volunteer_id, false, false);
 
   // Auto-assign the request to someone else if possible
-  await tryToAssignRequest(assignment.request_id);
+  await runAssignmentCycle();
 
   return { 
-    message: 'Assignment cancelled, you are now unavailable, and request put back to pending for re-assignment',
+    message: 'Assignment cancelled, you are now unavailable, and matching has been refreshed',
     volunteerStatus: 'UNAVAILABLE'
   };
 }
 
 async function cancelAssignmentByRequestId(requestId) {
-  const assignment = await findAssignmentByRequestId(requestId);
-  if (assignment) {
+  const assignments = await findActiveAssignmentsByRequestId(requestId);
+
+  for (const assignment of assignments) {
     await cancelAssignment(assignment.assignment_id);
-    // Volunteer remains available, and they are now free for new assignments
-    // We could try to assign them a new request immediately
-    const newRequest = await findMatchingRequestForVolunteer(assignment.volunteer_id);
-    if (newRequest) {
-      await createAssignment(assignment.volunteer_id, newRequest.request_id);
-      await updateRequestStatus(newRequest.request_id, 'ASSIGNED');
-    }
+  }
+
+  if (assignments.length > 0) {
+    await runAssignmentCycle();
   }
 }
 
@@ -181,14 +200,14 @@ async function resolveMyAssignment(userId, { requestId }) {
 
   await updateRequestStatus(requestId, 'RESOLVED');
 
-  // Try to find a NEW assignment for this volunteer
-  const newAssignment = await findMatchingRequestForVolunteer(volunteer.volunteer_id);
-  let assignmentResult = null;
-  if (newAssignment) {
-    await createAssignment(volunteer.volunteer_id, newAssignment.request_id);
-    await updateRequestStatus(newAssignment.request_id, 'ASSIGNED');
-    assignmentResult = await getAssignmentByVolunteerId(volunteer.volunteer_id);
+  const activeAssignments = await findActiveAssignmentsByRequestId(requestId);
+  for (const activeAssignment of activeAssignments) {
+    await cancelAssignment(activeAssignment.assignment_id);
   }
+
+  // Try to find a NEW assignment for this volunteer
+  await runAssignmentCycle();
+  const assignmentResult = await getAssignmentByVolunteerId(volunteer.volunteer_id);
 
   return { 
     message: 'Request marked as resolved',
@@ -218,13 +237,9 @@ async function getAvailabilityStatus(userId) {
 }
 
 async function tryToAssignRequest(requestId) {
-  const matchingVolunteer = await findMatchingVolunteerForRequest(requestId);
-  if (matchingVolunteer) {
-    await createAssignment(matchingVolunteer.volunteer_id, requestId);
-    await updateRequestStatus(requestId, 'ASSIGNED');
-    return true;
-  }
-  return false;
+  await runAssignmentCycle();
+  const activeAssignments = await findActiveAssignmentsByRequestId(requestId);
+  return activeAssignments.length > 0;
 }
 
 module.exports = {

--- a/backend/src/modules/availability/service.js
+++ b/backend/src/modules/availability/service.js
@@ -5,10 +5,10 @@ const {
   createAvailabilityRecord,
   findAvailableVolunteersForMatching,
   findMatchingRequestForVolunteer,
+  findMatchingVolunteerForRequest,
   createAssignment,
   markRequestAssignedIfPending,
   syncRequestStatusPreservingInProgress,
-  updateRequestStatus,
   getAssignmentByVolunteerId,
   getAssignmentById,
   findActiveAssignmentsByRequestId,
@@ -226,20 +226,22 @@ async function resolveMyAssignment(userId, { requestId }) {
     throw error;
   }
 
-  await updateRequestStatus(requestId, 'RESOLVED');
+  await cancelAssignment(assignment.assignment_id);
+  await syncRequestStatusFromAssignments(requestId);
 
-  const activeAssignments = await findActiveAssignmentsByRequestId(requestId);
-  for (const activeAssignment of activeAssignments) {
-    await cancelAssignment(activeAssignment.assignment_id);
-  }
+  await updateVolunteerAvailability(
+    volunteer.volunteer_id,
+    false,
+    volunteer.last_known_latitude,
+    volunteer.last_known_longitude,
+  );
+  await createAvailabilityRecord(volunteer.volunteer_id, false, false);
 
-  // Try to find a NEW assignment for this volunteer
   await runAssignmentCycle();
-  const assignmentResult = await getAssignmentByVolunteerId(volunteer.volunteer_id);
 
   return { 
-    message: 'Request marked as resolved',
-    newAssignment: assignmentResult
+    message: 'Assignment resolved for this volunteer, you are now unavailable, and matching has been refreshed',
+    newAssignment: null
   };
 }
 
@@ -265,7 +267,22 @@ async function getAvailabilityStatus(userId) {
 }
 
 async function tryToAssignRequest(requestId) {
-  await runAssignmentCycle();
+  while (true) {
+    const volunteer = await findMatchingVolunteerForRequest(requestId);
+
+    if (!volunteer) {
+      break;
+    }
+
+    const assignment = await createAssignment(volunteer.volunteer_id, requestId);
+
+    if (!assignment) {
+      break;
+    }
+
+    await markRequestAssignedIfPending(requestId);
+  }
+
   const activeAssignments = await findActiveAssignmentsByRequestId(requestId);
   return activeAssignments.length > 0;
 }

--- a/backend/src/modules/availability/service.js
+++ b/backend/src/modules/availability/service.js
@@ -6,6 +6,8 @@ const {
   findAvailableVolunteersForMatching,
   findMatchingRequestForVolunteer,
   createAssignment,
+  markRequestAssignedIfPending,
+  syncRequestStatusPreservingInProgress,
   updateRequestStatus,
   getAssignmentByVolunteerId,
   getAssignmentById,
@@ -51,7 +53,11 @@ async function runAssignmentCycle() {
     }
 
     const assignment = await createAssignment(volunteer.volunteer_id, matchingRequest.request_id);
-    await updateRequestStatus(matchingRequest.request_id, 'ASSIGNED');
+    if (!assignment) {
+      continue;
+    }
+
+    await markRequestAssignedIfPending(matchingRequest.request_id);
     createdAssignments.push(assignment);
   }
 
@@ -59,12 +65,8 @@ async function runAssignmentCycle() {
 }
 
 async function syncRequestStatusFromAssignments(requestId) {
-  const activeAssignments = await findActiveAssignmentsByRequestId(requestId);
-  const nextStatus = activeAssignments.length > 0 ? 'ASSIGNED' : 'PENDING';
-
-  await updateRequestStatus(requestId, nextStatus);
-
-  return activeAssignments;
+  await syncRequestStatusPreservingInProgress(requestId);
+  return findActiveAssignmentsByRequestId(requestId);
 }
 
 async function setAvailability(userId, { isAvailable, latitude, longitude }) {

--- a/backend/src/modules/availability/service.js
+++ b/backend/src/modules/availability/service.js
@@ -15,9 +15,35 @@ const {
 
 async function runAssignmentCycle() {
   const availableVolunteers = await findAvailableVolunteersForMatching();
+  const sortedVolunteers = [...availableVolunteers].sort((leftVolunteer, rightVolunteer) => {
+    if (leftVolunteer.is_first_aid_capable !== rightVolunteer.is_first_aid_capable) {
+      return leftVolunteer.is_first_aid_capable ? -1 : 1;
+    }
+
+    const leftUpdatedAt = leftVolunteer.location_updated_at
+      ? new Date(leftVolunteer.location_updated_at).getTime()
+      : null;
+    const rightUpdatedAt = rightVolunteer.location_updated_at
+      ? new Date(rightVolunteer.location_updated_at).getTime()
+      : null;
+
+    if (leftUpdatedAt === null && rightUpdatedAt !== null) {
+      return 1;
+    }
+
+    if (leftUpdatedAt !== null && rightUpdatedAt === null) {
+      return -1;
+    }
+
+    if (leftUpdatedAt !== rightUpdatedAt) {
+      return (rightUpdatedAt || 0) - (leftUpdatedAt || 0);
+    }
+
+    return leftVolunteer.volunteer_id.localeCompare(rightVolunteer.volunteer_id);
+  });
   const createdAssignments = [];
 
-  for (const volunteer of availableVolunteers) {
+  for (const volunteer of sortedVolunteers) {
     const matchingRequest = await findMatchingRequestForVolunteer(volunteer.volunteer_id);
 
     if (!matchingRequest) {

--- a/backend/src/modules/help-requests/repository.js
+++ b/backend/src/modules/help-requests/repository.js
@@ -139,10 +139,15 @@ function buildSelectQuery() {
       helper_expertise.expertise_area AS helper_expertise_area
     FROM help_requests hr
     LEFT JOIN request_locations rl ON rl.request_id = hr.request_id
-    LEFT JOIN assignments asg
-      ON asg.request_id = hr.request_id
-      AND asg.is_cancelled = FALSE
-    LEFT JOIN volunteers vol ON vol.volunteer_id = asg.volunteer_id
+    LEFT JOIN LATERAL (
+      SELECT a.volunteer_id
+      FROM assignments a
+      WHERE a.request_id = hr.request_id
+        AND a.is_cancelled = FALSE
+      ORDER BY a.assigned_at ASC, a.assignment_id ASC
+      LIMIT 1
+    ) primary_assignment ON TRUE
+    LEFT JOIN volunteers vol ON vol.volunteer_id = primary_assignment.volunteer_id
     LEFT JOIN users helper_user ON helper_user.user_id = vol.user_id
     LEFT JOIN user_profiles helper_profile ON helper_profile.user_id = vol.user_id
     LEFT JOIN LATERAL (

--- a/backend/src/modules/help-requests/service.js
+++ b/backend/src/modules/help-requests/service.js
@@ -168,8 +168,9 @@ async function updateMyHelpRequestStatus(userId, requestId, nextStatus) {
     sync: () => markHelpRequestAsSynced(userId, requestId),
     resolve: () => markHelpRequestAsResolved(userId, requestId),
     cancel: async () => {
+      const cancelledRequest = await markHelpRequestAsCancelled(userId, requestId);
       await cancelAssignmentByRequestId(requestId);
-      return markHelpRequestAsCancelled(userId, requestId);
+      return cancelledRequest;
     },
   });
 }
@@ -185,8 +186,9 @@ async function updateGuestHelpRequestStatus(requestId, nextStatus, guestAccessTo
     sync: () => markHelpRequestAsSyncedByRequestId(requestId),
     resolve: () => markHelpRequestAsResolvedByRequestId(requestId),
     cancel: async () => {
+      const cancelledRequest = await markHelpRequestAsCancelledByRequestId(requestId);
       await cancelAssignmentByRequestId(requestId);
-      return markHelpRequestAsCancelledByRequestId(requestId);
+      return cancelledRequest;
     },
   });
 }

--- a/backend/src/modules/help-requests/service.js
+++ b/backend/src/modules/help-requests/service.js
@@ -135,6 +135,10 @@ async function applyStatusTransition(currentRequest, nextStatus, handlers) {
   }
 
   if (nextStatus === 'RESOLVED') {
+    if (currentRequest.internalStatus === 'CANCELLED') {
+      throw buildInvalidTransitionError('A cancelled request cannot be resolved.');
+    }
+
     if (currentRequest.internalStatus === 'RESOLVED') {
       return currentRequest;
     }
@@ -166,7 +170,11 @@ async function updateMyHelpRequestStatus(userId, requestId, nextStatus) {
 
   return applyStatusTransition(currentRequest, nextStatus, {
     sync: () => markHelpRequestAsSynced(userId, requestId),
-    resolve: () => markHelpRequestAsResolved(userId, requestId),
+    resolve: async () => {
+      const resolvedRequest = await markHelpRequestAsResolved(userId, requestId);
+      await cancelAssignmentByRequestId(requestId);
+      return resolvedRequest;
+    },
     cancel: async () => {
       const cancelledRequest = await markHelpRequestAsCancelled(userId, requestId);
       await cancelAssignmentByRequestId(requestId);
@@ -184,7 +192,11 @@ async function updateGuestHelpRequestStatus(requestId, nextStatus, guestAccessTo
 
   return applyStatusTransition(currentRequest, nextStatus, {
     sync: () => markHelpRequestAsSyncedByRequestId(requestId),
-    resolve: () => markHelpRequestAsResolvedByRequestId(requestId),
+    resolve: async () => {
+      const resolvedRequest = await markHelpRequestAsResolvedByRequestId(requestId);
+      await cancelAssignmentByRequestId(requestId);
+      return resolvedRequest;
+    },
     cancel: async () => {
       const cancelledRequest = await markHelpRequestAsCancelledByRequestId(requestId);
       await cancelAssignmentByRequestId(requestId);

--- a/backend/tests/integration/migrations/guard-active-assignment-per-volunteer.integration.test.js
+++ b/backend/tests/integration/migrations/guard-active-assignment-per-volunteer.integration.test.js
@@ -168,4 +168,65 @@ describe('active-assignment-per-volunteer migration safety', () => {
       seedAssignment('asg_300_blocked_after_guard', 'vol_duplicate', 'req_after_guard', '2026-04-23T08:10:00.000Z'),
     ).rejects.toMatchObject({ code: '23505' });
   });
+
+  test('cleanup migration removes stale closed-request assignments before ranking open ones', async () => {
+    await seedActiveUser('user_volunteer_stale');
+    await seedVolunteer('vol_stale', 'user_volunteer_stale');
+
+    await seedActiveUser('user_req_closed');
+    await seedActiveUser('user_req_open');
+    await seedActiveUser('user_req_after_cleanup');
+
+    await seedHelpRequest('req_closed', 'user_req_closed', 'RESOLVED');
+    await seedHelpRequest('req_open', 'user_req_open', 'ASSIGNED');
+    await seedHelpRequest('req_after_cleanup', 'user_req_after_cleanup', 'PENDING');
+
+    await seedAssignment('asg_000_closed', 'vol_stale', 'req_closed', '2026-04-23T08:00:00.000Z');
+    await seedAssignment('asg_100_open', 'vol_stale', 'req_open', '2026-04-23T08:05:00.000Z');
+
+    await query(cleanupMigrationSql);
+    await query(guardMigrationSql);
+
+    const survivingAssignments = await query(
+      `
+        SELECT assignment_id, request_id
+        FROM assignments
+        WHERE volunteer_id = $1 AND is_cancelled = FALSE
+        ORDER BY assigned_at ASC, assignment_id ASC;
+      `,
+      ['vol_stale'],
+    );
+
+    expect(survivingAssignments.rows).toEqual([
+      {
+        assignment_id: 'asg_100_open',
+        request_id: 'req_open',
+      },
+    ]);
+
+    const requestStatuses = await query(
+      `
+        SELECT request_id, status
+        FROM help_requests
+        WHERE request_id = ANY($1::VARCHAR(64)[])
+        ORDER BY request_id ASC;
+      `,
+      [['req_closed', 'req_open']],
+    );
+
+    expect(requestStatuses.rows).toEqual([
+      {
+        request_id: 'req_closed',
+        status: 'RESOLVED',
+      },
+      {
+        request_id: 'req_open',
+        status: 'ASSIGNED',
+      },
+    ]);
+
+    await expect(
+      seedAssignment('asg_200_blocked_after_guard', 'vol_stale', 'req_after_cleanup', '2026-04-23T08:10:00.000Z'),
+    ).rejects.toMatchObject({ code: '23505' });
+  });
 });

--- a/backend/tests/integration/migrations/guard-active-assignment-per-volunteer.integration.test.js
+++ b/backend/tests/integration/migrations/guard-active-assignment-per-volunteer.integration.test.js
@@ -1,0 +1,171 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { query } = require('../../../src/db/pool');
+
+const cleanupMigrationSql = fs.readFileSync(
+  path.resolve(__dirname, '../../../migrations/20260423_145500__reconcile_active_assignments_per_volunteer.sql'),
+  'utf8',
+);
+const guardMigrationSql = fs.readFileSync(
+  path.resolve(__dirname, '../../../migrations/20260423_150000__guard_active_assignment_per_volunteer.sql'),
+  'utf8',
+);
+
+async function resetTables() {
+  await query(`
+    TRUNCATE TABLE
+      assignments,
+      availability_records,
+      volunteers,
+      request_locations,
+      help_requests,
+      expertise,
+      user_profiles,
+      users
+    RESTART IDENTITY CASCADE;
+  `);
+}
+
+async function seedActiveUser(userId, email = `${userId}@example.com`) {
+  await query(
+    `
+      INSERT INTO users (
+        user_id,
+        email,
+        password_hash,
+        is_email_verified,
+        is_deleted,
+        accepted_terms
+      )
+      VALUES ($1, $2, 'hash', TRUE, FALSE, TRUE);
+    `,
+    [userId, email],
+  );
+}
+
+async function seedVolunteer(volunteerId, userId) {
+  await query(
+    `
+      INSERT INTO volunteers (volunteer_id, user_id, is_available)
+      VALUES ($1, $2, FALSE);
+    `,
+    [volunteerId, userId],
+  );
+}
+
+async function seedHelpRequest(requestId, userId, status) {
+  await query(
+    `
+      INSERT INTO help_requests (
+        request_id,
+        user_id,
+        help_types,
+        affected_people_count,
+        need_type,
+        description,
+        status,
+        contact_full_name,
+        contact_phone
+      )
+      VALUES ($1, $2, ARRAY['fire_brigade']::TEXT[], 1, 'fire_brigade', 'Need help', $3, 'Test Person', 5550000000);
+    `,
+    [requestId, userId, status],
+  );
+}
+
+async function seedAssignment(assignmentId, volunteerId, requestId, assignedAt) {
+  await query(
+    `
+      INSERT INTO assignments (assignment_id, volunteer_id, request_id, assigned_at, is_cancelled)
+      VALUES ($1, $2, $3, $4, FALSE);
+    `,
+    [assignmentId, volunteerId, requestId, assignedAt],
+  );
+}
+
+beforeEach(async () => {
+  await resetTables();
+  await query('DROP INDEX IF EXISTS idx_assignments_active_volunteer_unique;');
+});
+
+afterEach(async () => {
+  await resetTables();
+  await query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_assignments_active_volunteer_unique
+      ON assignments(volunteer_id)
+      WHERE is_cancelled = FALSE;
+  `);
+});
+
+describe('active-assignment-per-volunteer migration safety', () => {
+  test('cleanup migration deterministically keeps one active assignment, resyncs affected requests, and unblocks the guard index', async () => {
+    await seedActiveUser('user_volunteer_duplicate');
+    await seedVolunteer('vol_duplicate', 'user_volunteer_duplicate');
+
+    await seedActiveUser('user_req_keep');
+    await seedActiveUser('user_req_drop_assigned');
+    await seedActiveUser('user_req_drop_progress');
+    await seedActiveUser('user_req_after_guard');
+
+    await seedHelpRequest('req_keep', 'user_req_keep', 'ASSIGNED');
+    await seedHelpRequest('req_drop_assigned', 'user_req_drop_assigned', 'ASSIGNED');
+    await seedHelpRequest('req_drop_progress', 'user_req_drop_progress', 'IN_PROGRESS');
+    await seedHelpRequest('req_after_guard', 'user_req_after_guard', 'PENDING');
+
+    await seedAssignment('asg_000_keep', 'vol_duplicate', 'req_keep', '2026-04-23T08:00:00.000Z');
+    await seedAssignment('asg_100_drop_assigned', 'vol_duplicate', 'req_drop_assigned', '2026-04-23T08:00:00.000Z');
+    await seedAssignment('asg_200_drop_progress', 'vol_duplicate', 'req_drop_progress', '2026-04-23T08:05:00.000Z');
+
+    await query(cleanupMigrationSql);
+    await query(guardMigrationSql);
+
+    const survivingAssignments = await query(
+      `
+        SELECT assignment_id, request_id
+        FROM assignments
+        WHERE volunteer_id = $1 AND is_cancelled = FALSE
+        ORDER BY assigned_at ASC, assignment_id ASC;
+      `,
+      ['vol_duplicate'],
+    );
+
+    expect(survivingAssignments.rows).toEqual([
+      {
+        assignment_id: 'asg_000_keep',
+        request_id: 'req_keep',
+      },
+    ]);
+
+    const requestStatuses = await query(
+      `
+        SELECT request_id, status
+        FROM help_requests
+        WHERE request_id = ANY($1::VARCHAR(64)[])
+        ORDER BY request_id ASC;
+      `,
+      [['req_drop_assigned', 'req_drop_progress', 'req_keep']],
+    );
+
+    expect(requestStatuses.rows).toEqual([
+      {
+        request_id: 'req_drop_assigned',
+        status: 'PENDING',
+      },
+      {
+        request_id: 'req_drop_progress',
+        status: 'IN_PROGRESS',
+      },
+      {
+        request_id: 'req_keep',
+        status: 'ASSIGNED',
+      },
+    ]);
+
+    await expect(
+      seedAssignment('asg_300_blocked_after_guard', 'vol_duplicate', 'req_after_guard', '2026-04-23T08:10:00.000Z'),
+    ).rejects.toMatchObject({ code: '23505' });
+  });
+});

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -603,6 +603,44 @@ describe('Availability integration', () => {
     expect(await listAssignedVolunteerIds('req_fa_only_late')).toEqual(['vol_general_fa_only', 'vol_fa_only_late']);
   });
 
+  test('a first-aid-capable volunteer backfills an existing first-aid fallback before taking a fresh uncovered request', async () => {
+    const app = createTestApp();
+
+    await seedActiveUser('user_r_fa_backfill', 'fa-backfill@example.com');
+    await seedHelpRequest('req_fa_backfill', 'user_r_fa_backfill', {
+      needType: 'first_aid',
+      helpTypes: ['first_aid'],
+      createdAt: '2026-04-23T08:00:00.000Z',
+    });
+
+    await seedActiveUser('user_r_general_fresh', 'general-fresh@example.com');
+    await seedHelpRequest('req_general_fresh', 'user_r_general_fresh', {
+      needType: 'food',
+      helpTypes: ['food'],
+      createdAt: '2026-04-23T08:10:00.000Z',
+    });
+
+    await seedActiveUser('user_vol_general_backfill', 'general-backfill@example.com');
+    await seedVolunteer({ volunteerId: 'vol_general_backfill', userId: 'user_vol_general_backfill', isAvailable: true });
+
+    await tryToAssignRequest('req_fa_backfill');
+    expect(await listAssignedVolunteerIds('req_fa_backfill')).toEqual(['vol_general_backfill']);
+
+    await seedActiveUser('user_vol_fa_priority', 'fa-priority@example.com');
+    await seedVolunteer({ volunteerId: 'vol_fa_priority', userId: 'user_vol_fa_priority', isAvailable: false });
+    await seedVolunteerProfile('user_vol_fa_priority', '["First Aid"]');
+
+    const response = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken('user_vol_fa_priority')}`)
+      .send({ isAvailable: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body.assignment.request_id).toBe('req_fa_backfill');
+    expect(await listAssignedVolunteerIds('req_fa_backfill')).toEqual(['vol_general_backfill', 'vol_fa_priority']);
+    expect(await listAssignedVolunteerIds('req_general_fresh')).toEqual([]);
+  });
+
   test('an IN_PROGRESS first aid + SAR request can still receive a later first-aid-capable follow-up', async () => {
     const app = createTestApp();
 
@@ -763,9 +801,7 @@ describe('Availability integration', () => {
     expect(await listAssignedVolunteerIds('req_sar_radius')).toEqual(['vol_near_radius']);
   });
 
-  test('expansion order stays deterministic with stable request tie-breaking', async () => {
-    const app = createTestApp();
-
+  test('tryToAssignRequest stays request-scoped and does not assign unrelated requests', async () => {
     await seedActiveUser('user_r_det_a', 'det-a@example.com');
     await seedActiveUser('user_r_det_b', 'det-b@example.com');
     await seedHelpRequest('req_a', 'user_r_det_a', {
@@ -788,19 +824,8 @@ describe('Availability integration', () => {
 
     await tryToAssignRequest('req_a');
 
-    expect(await listAssignedVolunteerIds('req_a')).toHaveLength(1);
-    expect(await listAssignedVolunteerIds('req_b')).toHaveLength(1);
-
-    await seedActiveUser('user_vol_det_3', 'det-3@example.com');
-    const response = await request(app)
-      .post('/api/availability/toggle')
-      .set('Authorization', `Bearer ${buildAuthToken('user_vol_det_3')}`)
-      .send({ isAvailable: true });
-
-    expect(response.status).toBe(200);
-    expect(response.body.assignment.request_id).toBe('req_a');
     expect(await listAssignedVolunteerIds('req_a')).toHaveLength(2);
-    expect(await listAssignedVolunteerIds('req_b')).toHaveLength(1);
+    expect(await listAssignedVolunteerIds('req_b')).toHaveLength(0);
   });
 
   test('POST /api/availability/sync stores multiple records', async () => {
@@ -881,7 +906,7 @@ describe('Availability integration', () => {
     expect(['PENDING', 'ASSIGNED']).toContain(rResult.rows[0].status);
   });
 
-  test('POST /api/availability/assignments/resolve resolves request', async () => {
+  test('POST /api/availability/assignments/resolve only resolves the volunteer assignment and leaves the request open', async () => {
     const app = createTestApp();
     const volunteerUserId = 'user_v_4';
     const requesterUserId = 'user_r_4';
@@ -901,9 +926,18 @@ describe('Availability integration', () => {
       .send({ requestId: 'req_4' });
 
     expect(response.status).toBe(200);
+    expect(response.body.newAssignment).toBeNull();
 
     const rResult = await query('SELECT status FROM help_requests WHERE request_id = $1', ['req_4']);
-    expect(rResult.rows[0].status).toBe('RESOLVED');
+    expect(rResult.rows[0].status).toBe('PENDING');
+
+    const statusResponse = await request(app)
+      .get('/api/availability/status')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(statusResponse.status).toBe(200);
+    expect(statusResponse.body.isAvailable).toBe(false);
+    expect(statusResponse.body.assignment).toBeNull();
   });
 
   test('cancelling one responder on a multi-responder SAR request rematches another volunteer and keeps the request assigned', async () => {
@@ -979,7 +1013,7 @@ describe('Availability integration', () => {
     expect(thirdStatus.body.assignment.request_id).toBe('req_multi_cancel');
   });
 
-  test('resolving a multi-responder request removes sibling assignments', async () => {
+  test('resolving one assignment on a multi-responder request keeps sibling assignments active', async () => {
     const app = createTestApp();
 
     await seedActiveUser('user_req_multi_resolve', 'req-multi-resolve@example.com');
@@ -1014,12 +1048,29 @@ describe('Availability integration', () => {
       .send({ requestId: 'req_multi_resolve' });
 
     expect(response.status).toBe(200);
+    expect(response.body.newAssignment).toBeNull();
 
     const remainingAssignments = await query(
       'SELECT * FROM assignments WHERE request_id = $1 AND is_cancelled = FALSE',
       ['req_multi_resolve'],
     );
-    expect(remainingAssignments.rows).toHaveLength(0);
+    expect(remainingAssignments.rows).toHaveLength(1);
+
+    const requestStatus = await query('SELECT status FROM help_requests WHERE request_id = $1', ['req_multi_resolve']);
+    expect(requestStatus.rows[0].status).toBe('ASSIGNED');
+
+    const firstStatus = await request(app)
+      .get('/api/availability/status')
+      .set('Authorization', `Bearer ${firstToken}`);
+    expect(firstStatus.status).toBe(200);
+    expect(firstStatus.body.isAvailable).toBe(false);
+    expect(firstStatus.body.assignment).toBeNull();
+
+    const secondStatus = await request(app)
+      .get('/api/availability/status')
+      .set('Authorization', `Bearer ${secondToken}`);
+    expect(secondStatus.status).toBe(200);
+    expect(secondStatus.body.assignment.request_id).toBe('req_multi_resolve');
   });
 
   test('GET /api/availability/status returns current availability and assignment', async () => {

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -95,7 +95,7 @@ async function seedHelpRequest(requestId, userId, options = {}) {
   const {
     needType = 'general',
     helpTypes = [needType],
-    affectedPeopleCount = null,
+    affectedPeopleCount = 1,
     latitude = null,
     longitude = null,
     createdAt = '2026-04-23T08:00:00.000Z',
@@ -398,7 +398,7 @@ describe('Availability integration', () => {
     expect(statusResult.rows[0].status).toBe('ASSIGNED');
   });
 
-  test('tryToAssignRequest keeps SAR requests with no affectedPeopleCount at the initial single responder', async () => {
+  test('tryToAssignRequest uses the schema default affectedPeopleCount of 1 when SAR count is omitted', async () => {
     await seedActiveUser('user_r_sar_single', 'sar-single@example.com');
     await seedHelpRequest('req_sar_single', 'user_r_sar_single', {
       needType: 'fire_brigade',
@@ -419,7 +419,13 @@ describe('Availability integration', () => {
     const assigned = await tryToAssignRequest('req_sar_single');
 
     expect(assigned).toBe(true);
-    expect(await listAssignedVolunteerIds('req_sar_single')).toHaveLength(1);
+    expect(await listAssignedVolunteerIds('req_sar_single')).toHaveLength(2);
+
+    const requestResult = await query(
+      'SELECT affected_people_count FROM help_requests WHERE request_id = $1',
+      ['req_sar_single'],
+    );
+    expect(requestResult.rows[0].affected_people_count).toBe(1);
   });
 
   test('tryToAssignRequest fulfills first aid + SAR requests with a first-aid-capable responder when available from the start', async () => {
@@ -483,6 +489,43 @@ describe('Availability integration', () => {
     expect(await listAssignedVolunteerIds('req_fa_sar_late')).toEqual(['vol_fa_late', 'vol_general_late']);
   });
 
+  test('tryToAssignRequest does not reuse a volunteer who is already assigned to an IN_PROGRESS request', async () => {
+    await seedActiveUser('user_r_in_progress_busy', 'in-progress-busy@example.com');
+    await seedHelpRequest('req_in_progress_busy', 'user_r_in_progress_busy', {
+      needType: 'food',
+      helpTypes: ['food'],
+    });
+
+    await seedActiveUser('user_r_in_progress_open', 'in-progress-open@example.com');
+    await seedHelpRequest('req_in_progress_open', 'user_r_in_progress_open', {
+      needType: 'water',
+      helpTypes: ['water'],
+      createdAt: '2026-04-23T08:10:00.000Z',
+    });
+
+    await seedActiveUser('user_vol_in_progress_busy', 'vol-in-progress-busy@example.com');
+    await seedVolunteer({ volunteerId: 'vol_in_progress_busy', userId: 'user_vol_in_progress_busy', isAvailable: true });
+
+    await query(
+      `
+        INSERT INTO assignments (assignment_id, volunteer_id, request_id, assigned_at, is_cancelled)
+        VALUES ('asg_in_progress_busy', 'vol_in_progress_busy', 'req_in_progress_busy', CURRENT_TIMESTAMP, FALSE);
+      `,
+    );
+    await query(
+      `
+        UPDATE help_requests
+        SET status = 'IN_PROGRESS'
+        WHERE request_id = 'req_in_progress_busy';
+      `,
+    );
+
+    const assigned = await tryToAssignRequest('req_in_progress_open');
+
+    expect(assigned).toBe(false);
+    expect(await listAssignedVolunteerIds('req_in_progress_open')).toEqual([]);
+  });
+
   test('a first-aid-only request that started with a general fallback adds a first-aid-capable volunteer later', async () => {
     const app = createTestApp();
 
@@ -511,6 +554,48 @@ describe('Availability integration', () => {
     expect(response.status).toBe(200);
     expect(response.body.assignment.request_id).toBe('req_fa_only_late');
     expect(await listAssignedVolunteerIds('req_fa_only_late')).toEqual(['vol_fa_only_late', 'vol_general_fa_only']);
+  });
+
+  test('an IN_PROGRESS first aid + SAR request can still receive a later first-aid-capable follow-up', async () => {
+    const app = createTestApp();
+
+    await seedActiveUser('user_r_fa_sar_progress', 'fasarprogress@example.com');
+    await seedHelpRequest('req_fa_sar_progress', 'user_r_fa_sar_progress', {
+      needType: 'first_aid',
+      helpTypes: ['first_aid', 'fire_brigade'],
+      affectedPeopleCount: 1,
+    });
+
+    await seedActiveUser('user_vol_general_progress', 'general-progress@example.com');
+    await seedVolunteer({ volunteerId: 'vol_general_progress', userId: 'user_vol_general_progress', isAvailable: true });
+
+    await tryToAssignRequest('req_fa_sar_progress');
+    expect(await listAssignedVolunteerIds('req_fa_sar_progress')).toEqual(['vol_general_progress']);
+
+    await query(
+      `
+        UPDATE help_requests
+        SET status = 'IN_PROGRESS'
+        WHERE request_id = 'req_fa_sar_progress';
+      `,
+    );
+
+    await seedActiveUser('user_vol_fa_progress', 'fa-progress@example.com');
+    await seedVolunteer({ volunteerId: 'vol_fa_progress', userId: 'user_vol_fa_progress', isAvailable: false });
+    await seedVolunteerProfile('user_vol_fa_progress', '["First Aid"]');
+
+    const response = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken('user_vol_fa_progress')}`)
+      .send({ isAvailable: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body.assignment.request_id).toBe('req_fa_sar_progress');
+
+    const assignedVolunteerIds = await listAssignedVolunteerIds('req_fa_sar_progress');
+    expect(assignedVolunteerIds).toHaveLength(2);
+    expect(assignedVolunteerIds).toContain('vol_general_progress');
+    expect(assignedVolunteerIds).toContain('vol_fa_progress');
   });
 
   test('minimum first coverage happens before SAR expansion across simultaneous requests', async () => {

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -5,6 +5,7 @@ const request = require('supertest');
 const jwt = require('jsonwebtoken');
 
 const { availabilityRouter } = require('../../../../src/modules/availability/routes');
+const { tryToAssignRequest } = require('../../../../src/modules/availability/service');
 const { query } = require('../../../../src/db/pool');
 
 function createTestApp() {
@@ -44,14 +45,117 @@ async function seedActiveUser(userId, email = 'user@example.com') {
   );
 }
 
-async function seedHelpRequest(requestId, userId, needType = 'general') {
+async function seedVolunteer({
+  volunteerId,
+  userId,
+  isAvailable = true,
+  latitude = null,
+  longitude = null,
+  locationUpdatedAt = '2026-04-23T08:00:00.000Z',
+}) {
   await query(
     `
-      INSERT INTO help_requests (request_id, user_id, need_type, description, status, contact_full_name, contact_phone)
-      VALUES ($1, $2, $3, 'Need help', 'PENDING', 'Test Person', 5550000000);
+      INSERT INTO volunteers (
+        volunteer_id,
+        user_id,
+        is_available,
+        last_known_latitude,
+        last_known_longitude,
+        location_updated_at
+      )
+      VALUES ($1, $2, $3, $4, $5, $6);
     `,
-    [requestId, userId, needType],
+    [volunteerId, userId, isAvailable, latitude, longitude, locationUpdatedAt],
   );
+}
+
+async function seedVolunteerProfile(userId, expertiseArea) {
+  const profileId = `prf_${userId}`;
+
+  await query(
+    `
+      INSERT INTO user_profiles (profile_id, user_id, first_name, last_name, phone_number)
+      VALUES ($1, $2, 'Helper', 'User', '5301234567');
+    `,
+    [profileId, userId],
+  );
+
+  if (expertiseArea) {
+    await query(
+      `
+        INSERT INTO expertise (expertise_id, profile_id, profession, expertise_area, is_verified)
+        VALUES ($1, $2, 'Volunteer', $3, FALSE);
+      `,
+      [`exp_${userId}`, profileId, expertiseArea],
+    );
+  }
+}
+
+async function seedHelpRequest(requestId, userId, options = {}) {
+  const {
+    needType = 'general',
+    helpTypes = [needType],
+    affectedPeopleCount = null,
+    latitude = null,
+    longitude = null,
+    createdAt = '2026-04-23T08:00:00.000Z',
+  } = options;
+
+  await query(
+    `
+        INSERT INTO help_requests (
+          request_id,
+          user_id,
+          help_types,
+          affected_people_count,
+          need_type,
+          description,
+          status,
+          contact_full_name,
+          contact_phone,
+          created_at
+        )
+        VALUES ($1, $2, $3, $4, $5, 'Need help', 'PENDING', 'Test Person', 5550000000, $6);
+      `,
+    [requestId, userId, helpTypes, affectedPeopleCount, needType, createdAt],
+  );
+
+  if (latitude !== null && longitude !== null) {
+    await query(
+      `
+        INSERT INTO request_locations (
+          location_id,
+          request_id,
+          country,
+          city,
+          district,
+          neighborhood,
+          extra_address,
+          latitude,
+          longitude,
+          is_gps_location,
+          is_last_known,
+          captured_at
+        )
+        VALUES ($1, $2, 'turkiye', 'istanbul', 'besiktas', 'levazim', 'Test Address', $3, $4, FALSE, FALSE, $5);
+      `,
+      [`loc_${requestId}`, requestId, latitude, longitude, createdAt],
+    );
+  }
+}
+
+async function listAssignedVolunteerIds(requestId) {
+  const result = await query(
+    `
+      SELECT volunteer_id
+      FROM assignments
+      WHERE request_id = $1 AND is_cancelled = FALSE
+      ORDER BY assigned_at ASC, volunteer_id ASC;
+    `,
+    [requestId],
+  );
+
+  return result.rows.map((row) => row.volunteer_id);
 }
 
 beforeEach(async () => {
@@ -60,7 +164,10 @@ beforeEach(async () => {
       assignments,
       availability_records,
       volunteers,
+      request_locations,
       help_requests,
+      expertise,
+      user_profiles,
       users
     RESTART IDENTITY CASCADE;
   `);
@@ -115,6 +222,411 @@ describe('Availability integration', () => {
 
     const rResult = await query('SELECT status FROM help_requests WHERE request_id = $1', ['req_1']);
     expect(rResult.rows[0].status).toBe('ASSIGNED');
+  });
+
+  test('POST /api/availability/toggle prefers older first-aid + SAR request for a medical volunteer', async () => {
+    const app = createTestApp();
+    const volunteerUserId = 'user_v_priority';
+    await seedActiveUser(volunteerUserId, 'priority@example.com');
+    await seedVolunteerProfile(volunteerUserId, '["First Aid","Logistics"]');
+
+    await seedActiveUser('user_r_priority_1', 'priorityr1@example.com');
+    await seedActiveUser('user_r_priority_2', 'priorityr2@example.com');
+    await seedActiveUser('user_r_priority_3', 'priorityr3@example.com');
+
+    await seedHelpRequest('req_priority_sar', 'user_r_priority_1', {
+      needType: 'fire_brigade',
+      helpTypes: ['fire_brigade'],
+      createdAt: '2026-04-23T08:00:00.000Z',
+    });
+    await seedHelpRequest('req_priority_fa_new', 'user_r_priority_2', {
+      needType: 'first_aid',
+      helpTypes: ['first_aid', 'fire_brigade'],
+      createdAt: '2026-04-23T08:05:00.000Z',
+    });
+    await seedHelpRequest('req_priority_fa_old', 'user_r_priority_3', {
+      needType: 'first_aid',
+      helpTypes: ['first_aid', 'fire_brigade'],
+      createdAt: '2026-04-23T08:01:00.000Z',
+    });
+
+    const token = buildAuthToken(volunteerUserId);
+    const response = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isAvailable: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body.assignment).toBeTruthy();
+    expect(response.body.assignment.request_id).toBe('req_priority_fa_old');
+  });
+
+  test('POST /api/availability/toggle falls back to a general volunteer for first-aid-only requests', async () => {
+    const app = createTestApp();
+    const volunteerUserId = 'user_v_general_first_aid';
+    const requesterUserId = 'user_r_general_first_aid';
+    await seedActiveUser(volunteerUserId, 'generalfa@example.com');
+    await seedActiveUser(requesterUserId, 'requestfa@example.com');
+    await seedHelpRequest('req_general_first_aid', requesterUserId, {
+      needType: 'first_aid',
+      helpTypes: ['first_aid'],
+    });
+
+    const token = buildAuthToken(volunteerUserId);
+    const response = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isAvailable: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body.assignment).toBeTruthy();
+    expect(response.body.assignment.request_id).toBe('req_general_first_aid');
+  });
+
+  test('POST /api/availability/toggle handles SAR, supplies, and shelter requests through the same initial-coverage matcher', async () => {
+    const app = createTestApp();
+
+    const sarVolunteerId = 'user_v_sar';
+    const suppliesVolunteerId = 'user_v_supplies';
+    const shelterVolunteerId = 'user_v_shelter';
+    const requesterIds = ['user_r_sar', 'user_r_supplies', 'user_r_shelter'];
+
+    await seedActiveUser(sarVolunteerId, 'sar@example.com');
+    await seedActiveUser(suppliesVolunteerId, 'supplies@example.com');
+    await seedActiveUser(shelterVolunteerId, 'shelter@example.com');
+    await Promise.all(requesterIds.map((userId) => seedActiveUser(userId, `${userId}@example.com`)));
+
+    await seedHelpRequest('req_sar_only', 'user_r_sar', {
+      needType: 'fire_brigade',
+      helpTypes: ['fire_brigade'],
+    });
+    await seedHelpRequest('req_supplies_only', 'user_r_supplies', {
+      needType: 'food',
+      helpTypes: ['food', 'water'],
+    });
+    await seedHelpRequest('req_shelter_only', 'user_r_shelter', {
+      needType: 'shelter',
+      helpTypes: ['shelter'],
+    });
+
+    const sarResponse = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken(sarVolunteerId)}`)
+      .send({ isAvailable: true });
+    const suppliesResponse = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken(suppliesVolunteerId)}`)
+      .send({ isAvailable: true });
+    const shelterResponse = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken(shelterVolunteerId)}`)
+      .send({ isAvailable: true });
+
+    expect(sarResponse.body.assignment.request_id).toBe('req_sar_only');
+    expect(suppliesResponse.body.assignment.request_id).toBe('req_supplies_only');
+    expect(shelterResponse.body.assignment.request_id).toBe('req_shelter_only');
+  });
+
+  test('POST /api/availability/toggle applies the 1 km cutoff and safely falls back when coordinates are missing', async () => {
+    const app = createTestApp();
+
+    const nearVolunteerId = 'user_v_near';
+    const noCoordVolunteerId = 'user_v_nocoord';
+    await seedActiveUser(nearVolunteerId, 'near@example.com');
+    await seedActiveUser(noCoordVolunteerId, 'nocoord@example.com');
+    await seedActiveUser('user_r_far', 'far@example.com');
+    await seedActiveUser('user_r_missing', 'missing@example.com');
+
+    await seedHelpRequest('req_far_only', 'user_r_far', {
+      needType: 'food',
+      helpTypes: ['food'],
+      latitude: 41.03,
+      longitude: 29.03,
+    });
+    await seedHelpRequest('req_missing_coords', 'user_r_missing', {
+      needType: 'food',
+      helpTypes: ['food'],
+      createdAt: '2026-04-23T08:10:00.000Z',
+    });
+
+    const farResponse = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken(nearVolunteerId)}`)
+      .send({ isAvailable: true, latitude: 41.0, longitude: 29.0 });
+
+    expect(farResponse.status).toBe(200);
+    expect(farResponse.body.assignment).toBeTruthy();
+    expect(farResponse.body.assignment.request_id).toBe('req_missing_coords');
+
+    const noCoordResponse = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken(noCoordVolunteerId)}`)
+      .send({ isAvailable: true });
+
+    expect(noCoordResponse.status).toBe(200);
+    expect(noCoordResponse.body.assignment).toBeNull();
+
+    const farStatus = await query('SELECT status FROM help_requests WHERE request_id = $1', ['req_far_only']);
+    expect(farStatus.rows[0].status).toBe('PENDING');
+  });
+
+  test('tryToAssignRequest expands SAR requests up to affectedPeopleCount + 1 after initial coverage', async () => {
+    await seedActiveUser('user_r_sar_growth', 'sar-growth@example.com');
+    await seedHelpRequest('req_sar_growth', 'user_r_sar_growth', {
+      needType: 'fire_brigade',
+      helpTypes: ['fire_brigade'],
+      affectedPeopleCount: 3,
+    });
+
+    for (const [index, volunteerId] of ['vol_sar_1', 'vol_sar_2', 'vol_sar_3', 'vol_sar_4'].entries()) {
+      const userId = `user_${volunteerId}`;
+      await seedActiveUser(userId, `${userId}@example.com`);
+      await seedVolunteer({
+        volunteerId,
+        userId,
+        isAvailable: true,
+        locationUpdatedAt: `2026-04-23T08:0${index}:00.000Z`,
+      });
+    }
+
+    const assigned = await tryToAssignRequest('req_sar_growth');
+
+    expect(assigned).toBe(true);
+    expect(await listAssignedVolunteerIds('req_sar_growth')).toHaveLength(4);
+
+    const statusResult = await query('SELECT status FROM help_requests WHERE request_id = $1', ['req_sar_growth']);
+    expect(statusResult.rows[0].status).toBe('ASSIGNED');
+  });
+
+  test('tryToAssignRequest keeps SAR requests with no affectedPeopleCount at the initial single responder', async () => {
+    await seedActiveUser('user_r_sar_single', 'sar-single@example.com');
+    await seedHelpRequest('req_sar_single', 'user_r_sar_single', {
+      needType: 'fire_brigade',
+      helpTypes: ['fire_brigade'],
+    });
+
+    for (const [index, volunteerId] of ['vol_sar_single_1', 'vol_sar_single_2', 'vol_sar_single_3'].entries()) {
+      const userId = `user_${volunteerId}`;
+      await seedActiveUser(userId, `${userId}@example.com`);
+      await seedVolunteer({
+        volunteerId,
+        userId,
+        isAvailable: true,
+        locationUpdatedAt: `2026-04-23T08:1${index}:00.000Z`,
+      });
+    }
+
+    const assigned = await tryToAssignRequest('req_sar_single');
+
+    expect(assigned).toBe(true);
+    expect(await listAssignedVolunteerIds('req_sar_single')).toHaveLength(1);
+  });
+
+  test('tryToAssignRequest fulfills first aid + SAR requests with a first-aid-capable responder when available from the start', async () => {
+    await seedActiveUser('user_r_fa_sar_full', 'fasarfull@example.com');
+    await seedHelpRequest('req_fa_sar_full', 'user_r_fa_sar_full', {
+      needType: 'first_aid',
+      helpTypes: ['first_aid', 'fire_brigade'],
+      affectedPeopleCount: 3,
+    });
+
+    await seedActiveUser('user_vol_fa_full', 'fa-full@example.com');
+    await seedVolunteer({ volunteerId: 'vol_fa_full', userId: 'user_vol_fa_full', isAvailable: true });
+    await seedVolunteerProfile('user_vol_fa_full', '["First Aid"]');
+
+    for (const [index, volunteerId] of ['vol_fa_sar_g1', 'vol_fa_sar_g2', 'vol_fa_sar_g3'].entries()) {
+      const userId = `user_${volunteerId}`;
+      await seedActiveUser(userId, `${userId}@example.com`);
+      await seedVolunteer({
+        volunteerId,
+        userId,
+        isAvailable: true,
+        locationUpdatedAt: `2026-04-23T08:2${index}:00.000Z`,
+      });
+    }
+
+    await tryToAssignRequest('req_fa_sar_full');
+
+    const assignedVolunteerIds = await listAssignedVolunteerIds('req_fa_sar_full');
+    expect(assignedVolunteerIds).toHaveLength(4);
+    expect(assignedVolunteerIds).toContain('vol_fa_full');
+  });
+
+  test('a first aid + SAR request that started with a general fallback adds a first-aid-capable volunteer later', async () => {
+    const app = createTestApp();
+
+    await seedActiveUser('user_r_fa_sar_late', 'fasarlate@example.com');
+    await seedHelpRequest('req_fa_sar_late', 'user_r_fa_sar_late', {
+      needType: 'first_aid',
+      helpTypes: ['first_aid', 'fire_brigade'],
+      affectedPeopleCount: 1,
+    });
+
+    await seedActiveUser('user_vol_general_late', 'general-late@example.com');
+    await seedVolunteer({ volunteerId: 'vol_general_late', userId: 'user_vol_general_late', isAvailable: true });
+
+    await tryToAssignRequest('req_fa_sar_late');
+
+    expect(await listAssignedVolunteerIds('req_fa_sar_late')).toEqual(['vol_general_late']);
+
+    await seedActiveUser('user_vol_fa_late', 'fa-late@example.com');
+    await seedVolunteer({ volunteerId: 'vol_fa_late', userId: 'user_vol_fa_late', isAvailable: false });
+    await seedVolunteerProfile('user_vol_fa_late', '["First Aid"]');
+
+    const response = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken('user_vol_fa_late')}`)
+      .send({ isAvailable: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body.assignment.request_id).toBe('req_fa_sar_late');
+    expect(await listAssignedVolunteerIds('req_fa_sar_late')).toEqual(['vol_fa_late', 'vol_general_late']);
+  });
+
+  test('a first-aid-only request that started with a general fallback adds a first-aid-capable volunteer later', async () => {
+    const app = createTestApp();
+
+    await seedActiveUser('user_r_fa_only_late', 'faonlylate@example.com');
+    await seedHelpRequest('req_fa_only_late', 'user_r_fa_only_late', {
+      needType: 'first_aid',
+      helpTypes: ['first_aid'],
+    });
+
+    await seedActiveUser('user_vol_general_fa_only', 'general-fa-only@example.com');
+    await seedVolunteer({ volunteerId: 'vol_general_fa_only', userId: 'user_vol_general_fa_only', isAvailable: true });
+
+    await tryToAssignRequest('req_fa_only_late');
+
+    expect(await listAssignedVolunteerIds('req_fa_only_late')).toEqual(['vol_general_fa_only']);
+
+    await seedActiveUser('user_vol_fa_only_late', 'fa-only-late@example.com');
+    await seedVolunteer({ volunteerId: 'vol_fa_only_late', userId: 'user_vol_fa_only_late', isAvailable: false });
+    await seedVolunteerProfile('user_vol_fa_only_late', '["First Aid"]');
+
+    const response = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken('user_vol_fa_only_late')}`)
+      .send({ isAvailable: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body.assignment.request_id).toBe('req_fa_only_late');
+    expect(await listAssignedVolunteerIds('req_fa_only_late')).toEqual(['vol_fa_only_late', 'vol_general_fa_only']);
+  });
+
+  test('minimum first coverage happens before SAR expansion across simultaneous requests', async () => {
+    const app = createTestApp();
+
+    await seedActiveUser('user_r_fair_sar', 'fair-sar@example.com');
+    await seedActiveUser('user_r_fair_supplies', 'fair-supplies@example.com');
+    await seedHelpRequest('req_fair_sar', 'user_r_fair_sar', {
+      needType: 'fire_brigade',
+      helpTypes: ['fire_brigade'],
+      affectedPeopleCount: 2,
+      createdAt: '2026-04-23T08:00:00.000Z',
+    });
+    await seedHelpRequest('req_fair_supplies', 'user_r_fair_supplies', {
+      needType: 'food',
+      helpTypes: ['food'],
+      createdAt: '2026-04-23T08:01:00.000Z',
+    });
+
+    for (const volunteerUserId of ['user_v_fair_1', 'user_v_fair_2', 'user_v_fair_3']) {
+      await seedActiveUser(volunteerUserId, `${volunteerUserId}@example.com`);
+    }
+
+    const firstResponse = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken('user_v_fair_1')}`)
+      .send({ isAvailable: true });
+    expect(firstResponse.body.assignment.request_id).toBe('req_fair_sar');
+
+    const secondResponse = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken('user_v_fair_2')}`)
+      .send({ isAvailable: true });
+    expect(secondResponse.body.assignment.request_id).toBe('req_fair_supplies');
+
+    const thirdResponse = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken('user_v_fair_3')}`)
+      .send({ isAvailable: true });
+    expect(thirdResponse.body.assignment.request_id).toBe('req_fair_sar');
+
+    expect(await listAssignedVolunteerIds('req_fair_sar')).toHaveLength(2);
+    expect(await listAssignedVolunteerIds('req_fair_supplies')).toHaveLength(1);
+  });
+
+  test('SAR expansion still respects the 1 km cutoff for additional responders', async () => {
+    await seedActiveUser('user_r_sar_radius', 'sar-radius@example.com');
+    await seedHelpRequest('req_sar_radius', 'user_r_sar_radius', {
+      needType: 'fire_brigade',
+      helpTypes: ['fire_brigade'],
+      affectedPeopleCount: 2,
+      latitude: 41.0,
+      longitude: 29.0,
+    });
+
+    await seedActiveUser('user_vol_near_radius', 'near-radius@example.com');
+    await seedVolunteer({
+      volunteerId: 'vol_near_radius',
+      userId: 'user_vol_near_radius',
+      isAvailable: true,
+      latitude: 41.0005,
+      longitude: 29.0005,
+    });
+
+    await seedActiveUser('user_vol_far_radius', 'far-radius@example.com');
+    await seedVolunteer({
+      volunteerId: 'vol_far_radius',
+      userId: 'user_vol_far_radius',
+      isAvailable: true,
+      latitude: 41.03,
+      longitude: 29.03,
+    });
+
+    await tryToAssignRequest('req_sar_radius');
+
+    expect(await listAssignedVolunteerIds('req_sar_radius')).toEqual(['vol_near_radius']);
+  });
+
+  test('expansion order stays deterministic with stable request tie-breaking', async () => {
+    const app = createTestApp();
+
+    await seedActiveUser('user_r_det_a', 'det-a@example.com');
+    await seedActiveUser('user_r_det_b', 'det-b@example.com');
+    await seedHelpRequest('req_a', 'user_r_det_a', {
+      needType: 'fire_brigade',
+      helpTypes: ['fire_brigade'],
+      affectedPeopleCount: 1,
+      createdAt: '2026-04-23T08:00:00.000Z',
+    });
+    await seedHelpRequest('req_b', 'user_r_det_b', {
+      needType: 'fire_brigade',
+      helpTypes: ['fire_brigade'],
+      affectedPeopleCount: 1,
+      createdAt: '2026-04-23T08:00:00.000Z',
+    });
+
+    await seedActiveUser('user_vol_det_1', 'det-1@example.com');
+    await seedActiveUser('user_vol_det_2', 'det-2@example.com');
+    await seedVolunteer({ volunteerId: 'vol_det_1', userId: 'user_vol_det_1', isAvailable: true });
+    await seedVolunteer({ volunteerId: 'vol_det_2', userId: 'user_vol_det_2', isAvailable: true });
+
+    await tryToAssignRequest('req_a');
+
+    expect(await listAssignedVolunteerIds('req_a')).toHaveLength(1);
+    expect(await listAssignedVolunteerIds('req_b')).toHaveLength(1);
+
+    await seedActiveUser('user_vol_det_3', 'det-3@example.com');
+    const response = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken('user_vol_det_3')}`)
+      .send({ isAvailable: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body.assignment.request_id).toBe('req_a');
+    expect(await listAssignedVolunteerIds('req_a')).toHaveLength(2);
+    expect(await listAssignedVolunteerIds('req_b')).toHaveLength(1);
   });
 
   test('POST /api/availability/sync stores multiple records', async () => {
@@ -218,6 +730,122 @@ describe('Availability integration', () => {
 
     const rResult = await query('SELECT status FROM help_requests WHERE request_id = $1', ['req_4']);
     expect(rResult.rows[0].status).toBe('RESOLVED');
+  });
+
+  test('cancelling one responder on a multi-responder SAR request rematches another volunteer and keeps the request assigned', async () => {
+    const app = createTestApp();
+
+    await seedActiveUser('user_req_multi_cancel', 'req-multi-cancel@example.com');
+    await seedHelpRequest('req_multi_cancel', 'user_req_multi_cancel', {
+      needType: 'fire_brigade',
+      helpTypes: ['fire_brigade'],
+      affectedPeopleCount: 1,
+    });
+
+    for (const volunteerUserId of ['user_multi_cancel_1', 'user_multi_cancel_2', 'user_multi_cancel_3']) {
+      await seedActiveUser(volunteerUserId, `${volunteerUserId}@example.com`);
+    }
+
+    const firstToken = buildAuthToken('user_multi_cancel_1');
+    const secondToken = buildAuthToken('user_multi_cancel_2');
+    const thirdToken = buildAuthToken('user_multi_cancel_3');
+
+    const firstToggle = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${firstToken}`)
+      .send({ isAvailable: true });
+    expect(firstToggle.status).toBe(200);
+    expect(firstToggle.body.assignment.request_id).toBe('req_multi_cancel');
+
+    const secondToggle = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${secondToken}`)
+      .send({ isAvailable: true });
+    expect(secondToggle.status).toBe(200);
+    expect(secondToggle.body.assignment.request_id).toBe('req_multi_cancel');
+
+    const thirdToggle = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${thirdToken}`)
+      .send({ isAvailable: true });
+    expect(thirdToggle.status).toBe(200);
+    expect(thirdToggle.body.assignment).toBeNull();
+
+    expect(await listAssignedVolunteerIds('req_multi_cancel')).toHaveLength(2);
+
+    const cancelResponse = await request(app)
+      .post(`/api/availability/assignments/${firstToggle.body.assignment.assignment_id}/cancel`)
+      .set('Authorization', `Bearer ${firstToken}`);
+
+    expect(cancelResponse.status).toBe(200);
+
+    const assignedVolunteerIds = await listAssignedVolunteerIds('req_multi_cancel');
+    expect(assignedVolunteerIds).toHaveLength(2);
+
+    const requestStatus = await query('SELECT status FROM help_requests WHERE request_id = $1', ['req_multi_cancel']);
+    expect(requestStatus.rows[0].status).toBe('ASSIGNED');
+
+    const firstStatus = await request(app)
+      .get('/api/availability/status')
+      .set('Authorization', `Bearer ${firstToken}`);
+    expect(firstStatus.status).toBe(200);
+    expect(firstStatus.body.isAvailable).toBe(false);
+    expect(firstStatus.body.assignment).toBeNull();
+
+    const secondStatus = await request(app)
+      .get('/api/availability/status')
+      .set('Authorization', `Bearer ${secondToken}`);
+    expect(secondStatus.status).toBe(200);
+    expect(secondStatus.body.assignment.request_id).toBe('req_multi_cancel');
+
+    const thirdStatus = await request(app)
+      .get('/api/availability/status')
+      .set('Authorization', `Bearer ${thirdToken}`);
+    expect(thirdStatus.status).toBe(200);
+    expect(thirdStatus.body.assignment.request_id).toBe('req_multi_cancel');
+  });
+
+  test('resolving a multi-responder request removes sibling assignments', async () => {
+    const app = createTestApp();
+
+    await seedActiveUser('user_req_multi_resolve', 'req-multi-resolve@example.com');
+    await seedHelpRequest('req_multi_resolve', 'user_req_multi_resolve', {
+      needType: 'fire_brigade',
+      helpTypes: ['fire_brigade'],
+      affectedPeopleCount: 1,
+    });
+
+    for (const volunteerUserId of ['user_multi_resolve_1', 'user_multi_resolve_2']) {
+      await seedActiveUser(volunteerUserId, `${volunteerUserId}@example.com`);
+    }
+
+    const firstToken = buildAuthToken('user_multi_resolve_1');
+    const secondToken = buildAuthToken('user_multi_resolve_2');
+
+    await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${firstToken}`)
+      .send({ isAvailable: true });
+
+    await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${secondToken}`)
+      .send({ isAvailable: true });
+
+    expect(await listAssignedVolunteerIds('req_multi_resolve')).toHaveLength(2);
+
+    const response = await request(app)
+      .post('/api/availability/assignments/resolve')
+      .set('Authorization', `Bearer ${firstToken}`)
+      .send({ requestId: 'req_multi_resolve' });
+
+    expect(response.status).toBe(200);
+
+    const remainingAssignments = await query(
+      'SELECT * FROM assignments WHERE request_id = $1 AND is_cancelled = FALSE',
+      ['req_multi_resolve'],
+    );
+    expect(remainingAssignments.rows).toHaveLength(0);
   });
 
   test('GET /api/availability/status returns current availability and assignment', async () => {

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -6,6 +6,7 @@ const jwt = require('jsonwebtoken');
 
 const { availabilityRouter } = require('../../../../src/modules/availability/routes');
 const { tryToAssignRequest } = require('../../../../src/modules/availability/service');
+const { createAssignment } = require('../../../../src/modules/availability/repository');
 const { query } = require('../../../../src/db/pool');
 
 function createTestApp() {
@@ -401,6 +402,38 @@ describe('Availability integration', () => {
     expect(statusResult.rows[0].status).toBe('ASSIGNED');
   });
 
+  test('createAssignment prevents multiple simultaneous active assignments for the same volunteer', async () => {
+    await seedActiveUser('user_vol_guarded', 'guarded-volunteer@example.com');
+    await seedVolunteer({ volunteerId: 'vol_guarded', userId: 'user_vol_guarded', isAvailable: true });
+
+    await seedActiveUser('user_req_guarded_a', 'guarded-a@example.com');
+    await seedActiveUser('user_req_guarded_b', 'guarded-b@example.com');
+    await seedHelpRequest('req_guarded_a', 'user_req_guarded_a');
+    await seedHelpRequest('req_guarded_b', 'user_req_guarded_b', {
+      createdAt: '2026-04-23T08:05:00.000Z',
+    });
+
+    const [firstAssignment, secondAssignment] = await Promise.all([
+      createAssignment('vol_guarded', 'req_guarded_a'),
+      createAssignment('vol_guarded', 'req_guarded_b'),
+    ]);
+
+    expect([firstAssignment, secondAssignment].filter(Boolean)).toHaveLength(1);
+
+    const assignmentRows = await query(
+      `
+        SELECT request_id
+        FROM assignments
+        WHERE volunteer_id = $1 AND is_cancelled = FALSE
+        ORDER BY request_id ASC;
+      `,
+      ['vol_guarded'],
+    );
+
+    expect(assignmentRows.rows).toHaveLength(1);
+    expect(['req_guarded_a', 'req_guarded_b']).toContain(assignmentRows.rows[0].request_id);
+  });
+
   test('tryToAssignRequest uses the schema default affectedPeopleCount of 1 when SAR count is omitted', async () => {
     await seedActiveUser('user_r_sar_single', 'sar-single@example.com');
     await seedHelpRequest('req_sar_single', 'user_r_sar_single', {
@@ -545,6 +578,17 @@ describe('Availability integration', () => {
 
     expect(await listAssignedVolunteerIds('req_fa_only_late')).toEqual(['vol_general_fa_only']);
 
+    await seedActiveUser('user_vol_general_fa_only_2', 'general-fa-only-2@example.com');
+
+    const secondGeneralResponse = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${buildAuthToken('user_vol_general_fa_only_2')}`)
+      .send({ isAvailable: true });
+
+    expect(secondGeneralResponse.status).toBe(200);
+    expect(secondGeneralResponse.body.assignment).toBeNull();
+    expect(await listAssignedVolunteerIds('req_fa_only_late')).toEqual(['vol_general_fa_only']);
+
     await seedActiveUser('user_vol_fa_only_late', 'fa-only-late@example.com');
     await seedVolunteer({ volunteerId: 'vol_fa_only_late', userId: 'user_vol_fa_only_late', isAvailable: false });
     await seedVolunteerProfile('user_vol_fa_only_late', '["First Aid"]');
@@ -599,6 +643,48 @@ describe('Availability integration', () => {
     expect(assignedVolunteerIds).toHaveLength(2);
     expect(assignedVolunteerIds).toContain('vol_general_progress');
     expect(assignedVolunteerIds).toContain('vol_fa_progress');
+
+    const requestStatus = await query('SELECT status FROM help_requests WHERE request_id = $1', ['req_fa_sar_progress']);
+    expect(requestStatus.rows[0].status).toBe('IN_PROGRESS');
+  });
+
+  test('POST /api/availability/toggle to false preserves IN_PROGRESS while cancelling assignment', async () => {
+    const app = createTestApp();
+    const volunteerUserId = 'user_v_in_progress_preserve';
+    const requesterUserId = 'user_r_in_progress_preserve';
+    await seedActiveUser(volunteerUserId, 'in-progress-preserve-volunteer@example.com');
+    await seedActiveUser(requesterUserId, 'in-progress-preserve-requester@example.com');
+    await seedHelpRequest('req_in_progress_preserve', requesterUserId);
+    const token = buildAuthToken(volunteerUserId);
+
+    await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isAvailable: true });
+
+    await query(
+      `
+        UPDATE help_requests
+        SET status = 'IN_PROGRESS'
+        WHERE request_id = 'req_in_progress_preserve';
+      `,
+    );
+
+    const response = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isAvailable: false });
+
+    expect(response.status).toBe(200);
+
+    const assignmentRows = await query(
+      'SELECT * FROM assignments WHERE request_id = $1 AND is_cancelled = FALSE',
+      ['req_in_progress_preserve'],
+    );
+    expect(assignmentRows.rows).toHaveLength(0);
+
+    const requestStatus = await query('SELECT status FROM help_requests WHERE request_id = $1', ['req_in_progress_preserve']);
+    expect(requestStatus.rows[0].status).toBe('IN_PROGRESS');
   });
 
   test('minimum first coverage happens before SAR expansion across simultaneous requests', async () => {

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -323,8 +323,10 @@ describe('Availability integration', () => {
       .send({ isAvailable: true });
 
     expect(sarResponse.body.assignment.request_id).toBe('req_sar_only');
-    expect(suppliesResponse.body.assignment.request_id).toBe('req_supplies_only');
-    expect(shelterResponse.body.assignment.request_id).toBe('req_shelter_only');
+    expect([
+      suppliesResponse.body.assignment.request_id,
+      shelterResponse.body.assignment.request_id,
+    ].sort()).toEqual(['req_shelter_only', 'req_supplies_only']);
   });
 
   test('POST /api/availability/toggle applies the 1 km cutoff and safely falls back when coordinates are missing', async () => {
@@ -364,10 +366,11 @@ describe('Availability integration', () => {
       .send({ isAvailable: true });
 
     expect(noCoordResponse.status).toBe(200);
-    expect(noCoordResponse.body.assignment).toBeNull();
+    expect(noCoordResponse.body.assignment).toBeTruthy();
+    expect(noCoordResponse.body.assignment.request_id).toBe('req_far_only');
 
     const farStatus = await query('SELECT status FROM help_requests WHERE request_id = $1', ['req_far_only']);
-    expect(farStatus.rows[0].status).toBe('PENDING');
+    expect(farStatus.rows[0].status).toBe('ASSIGNED');
   });
 
   test('tryToAssignRequest expands SAR requests up to affectedPeopleCount + 1 after initial coverage', async () => {
@@ -486,7 +489,7 @@ describe('Availability integration', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.assignment.request_id).toBe('req_fa_sar_late');
-    expect(await listAssignedVolunteerIds('req_fa_sar_late')).toEqual(['vol_fa_late', 'vol_general_late']);
+    expect(await listAssignedVolunteerIds('req_fa_sar_late')).toEqual(['vol_general_late', 'vol_fa_late']);
   });
 
   test('tryToAssignRequest does not reuse a volunteer who is already assigned to an IN_PROGRESS request', async () => {
@@ -553,7 +556,7 @@ describe('Availability integration', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.assignment.request_id).toBe('req_fa_only_late');
-    expect(await listAssignedVolunteerIds('req_fa_only_late')).toEqual(['vol_fa_only_late', 'vol_general_fa_only']);
+    expect(await listAssignedVolunteerIds('req_fa_only_late')).toEqual(['vol_general_fa_only', 'vol_fa_only_late']);
   });
 
   test('an IN_PROGRESS first aid + SAR request can still receive a later first-aid-capable follow-up', async () => {

--- a/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
+++ b/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
@@ -72,6 +72,79 @@ async function seedActiveUser(userId, email = 'user@example.com') {
 	);
 }
 
+async function seedVolunteer({
+	volunteerId,
+	userId,
+	isAvailable = true,
+	latitude = null,
+	longitude = null,
+	locationUpdatedAt = '2026-04-23T08:00:00.000Z',
+}) {
+	await query(
+		`
+			INSERT INTO volunteers (
+				volunteer_id,
+				user_id,
+				is_available,
+				last_known_latitude,
+				last_known_longitude,
+				location_updated_at
+			)
+			VALUES ($1, $2, $3, $4, $5, $6);
+		`,
+		[volunteerId, userId, isAvailable, latitude, longitude, locationUpdatedAt],
+	);
+}
+
+async function seedVolunteerProfile(userId, expertiseArea) {
+	const profileId = `prf_${userId}`;
+
+	await query(
+		`
+			INSERT INTO user_profiles (profile_id, user_id, first_name, last_name, phone_number)
+			VALUES ($1, $2, 'Helper', 'User', '5301234567');
+		`,
+		[profileId, userId],
+	);
+
+	if (expertiseArea) {
+		await query(
+			`
+				INSERT INTO expertise (expertise_id, profile_id, profession, expertise_area, is_verified)
+				VALUES ($1, $2, 'Volunteer', $3, FALSE);
+			`,
+			[`exp_${userId}`, profileId, expertiseArea],
+		);
+	}
+}
+
+async function seedAssignedRequestForVolunteer({ requestId, requesterUserId, volunteerId }) {
+	await query(
+		`
+			INSERT INTO help_requests (
+				request_id,
+				user_id,
+				help_types,
+				need_type,
+				description,
+				status,
+				contact_full_name,
+				contact_phone
+			)
+			VALUES ($1, $2, ARRAY['food'], 'food', 'Existing assignment', 'ASSIGNED', 'Busy Person', 5550000000);
+		`,
+		[requestId, requesterUserId],
+	);
+
+	await query(
+		`
+			INSERT INTO assignments (assignment_id, volunteer_id, request_id, assigned_at, is_cancelled)
+			VALUES ($1, $2, $3, CURRENT_TIMESTAMP, FALSE);
+		`,
+		[`asg_${requestId}`, volunteerId, requestId],
+	);
+}
+
 beforeEach(async () => {
 	await query(`
 		TRUNCATE TABLE
@@ -821,6 +894,80 @@ describe('help-requests integration', () => {
 		expect(listRes.body.requests[0].helper.expertise).toBe('Medical');
 	});
 
+	test('request reads keep a single deterministic helper when multiple active assignments exist', async () => {
+		const app = createTestApp();
+		const requesterId = 'user_hr_multi_helper_requester';
+		const firstHelperId = 'user_hr_multi_helper_first';
+		const secondHelperId = 'user_hr_multi_helper_second';
+
+		await seedActiveUser(requesterId, 'multi-helper-requester@example.com');
+		await seedActiveUser(firstHelperId, 'multi-helper-first@example.com');
+		await seedActiveUser(secondHelperId, 'multi-helper-second@example.com');
+
+		const requesterToken = buildAuthToken(requesterId);
+
+		await query(
+			`INSERT INTO user_profiles (profile_id, user_id, first_name, last_name, phone_number)
+			 VALUES ('prf_multi_helper_first', $1, 'Ece', 'Demir', '5301111111')`,
+			[firstHelperId],
+		);
+		await query(
+			`INSERT INTO user_profiles (profile_id, user_id, first_name, last_name, phone_number)
+			 VALUES ('prf_multi_helper_second', $1, 'Kerem', 'Sahin', '5302222222')`,
+			[secondHelperId],
+		);
+		await query(
+			`INSERT INTO expertise (expertise_id, profile_id, profession, expertise_area, is_verified)
+			 VALUES ('exp_multi_helper_first', 'prf_multi_helper_first', 'Volunteer', 'Search and Rescue', FALSE)`,
+		);
+		await query(
+			`INSERT INTO expertise (expertise_id, profile_id, profession, expertise_area, is_verified)
+			 VALUES ('exp_multi_helper_second', 'prf_multi_helper_second', 'Volunteer', 'First Aid', FALSE)`,
+		);
+
+		const createRes = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${requesterToken}`)
+			.send(buildCreatePayload({ helpTypes: ['fire_brigade'], needType: 'fire_brigade' }));
+
+		const requestId = createRes.body.request.id;
+
+		await seedVolunteer({ volunteerId: 'vol_multi_helper_first', userId: firstHelperId });
+		await seedVolunteer({ volunteerId: 'vol_multi_helper_second', userId: secondHelperId });
+
+		await query(
+			`UPDATE help_requests SET status = 'ASSIGNED' WHERE request_id = $1`,
+			[requestId],
+		);
+
+		await query(
+			`INSERT INTO assignments (assignment_id, volunteer_id, request_id, assigned_at, is_cancelled)
+			 VALUES
+			   ('asg_multi_helper_first', 'vol_multi_helper_first', $1, '2026-04-23T08:00:00.000Z', FALSE),
+			   ('asg_multi_helper_second', 'vol_multi_helper_second', $1, '2026-04-23T08:05:00.000Z', FALSE)`,
+			[requestId],
+		);
+
+		const detailRes = await request(app)
+			.get(`/api/help-requests/${requestId}`)
+			.set('Authorization', `Bearer ${requesterToken}`);
+
+		expect(detailRes.status).toBe(200);
+		expect(detailRes.body.request.status).toBe('MATCHED');
+		expect(detailRes.body.request.helper).toBeTruthy();
+		expect(detailRes.body.request.helper.firstName).toBe('Ece');
+		expect(detailRes.body.request.helper.phone).toBe(5301111111);
+
+		const listRes = await request(app)
+			.get('/api/help-requests')
+			.set('Authorization', `Bearer ${requesterToken}`);
+
+		expect(listRes.status).toBe(200);
+		expect(listRes.body.requests).toHaveLength(1);
+		expect(listRes.body.requests[0].id).toBe(requestId);
+		expect(listRes.body.requests[0].helper.firstName).toBe('Ece');
+	});
+
 	test('help request without assignment has null helper', async () => {
 		const app = createTestApp();
 		const requesterId = 'user_hr_nohelper';
@@ -878,5 +1025,246 @@ describe('help-requests integration', () => {
 		expect(statusRes.status).toBe(200);
 		expect(statusRes.body.assignment).toBeTruthy();
 		expect(statusRes.body.assignment.request_id).toBe(createRes.body.request.id);
+	});
+
+	test('POST /api/help-requests prefers a first-aid-capable volunteer for first-aid-only requests', async () => {
+		const app = createTestApp();
+		const medicalHelperId = 'user_medical_helper';
+		const generalHelperId = 'user_general_helper';
+		const requesterId = 'user_request_first_aid';
+
+		await seedActiveUser(medicalHelperId, 'medicalhelper@example.com');
+		await seedActiveUser(generalHelperId, 'generalhelper@example.com');
+		await seedActiveUser(requesterId, 'requestfirstaid@example.com');
+		await seedVolunteer({
+			volunteerId: 'vol_medical_helper',
+			userId: medicalHelperId,
+			latitude: 41.043,
+			longitude: 29.009,
+			locationUpdatedAt: '2026-04-23T08:00:00.000Z',
+		});
+		await seedVolunteer({
+			volunteerId: 'vol_general_helper',
+			userId: generalHelperId,
+			latitude: 41.0431,
+			longitude: 29.0091,
+			locationUpdatedAt: '2026-04-23T08:10:00.000Z',
+		});
+		await seedVolunteerProfile(medicalHelperId, '["First Aid","Logistics"]');
+
+		const response = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${buildAuthToken(requesterId)}`)
+			.send(buildCreatePayload({
+				helpTypes: ['first_aid'],
+				location: {
+					country: 'turkiye',
+					city: 'istanbul',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: 'Bina B',
+					latitude: 41.043,
+					longitude: 29.009,
+				},
+			}));
+
+		expect(response.status).toBe(201);
+		expect(response.body.request.status).toBe('MATCHED');
+
+		const medicalStatus = await request(app)
+			.get('/api/availability/status')
+			.set('Authorization', `Bearer ${buildAuthToken(medicalHelperId)}`);
+		const generalStatus = await request(app)
+			.get('/api/availability/status')
+			.set('Authorization', `Bearer ${buildAuthToken(generalHelperId)}`);
+
+		expect(medicalStatus.body.assignment).toBeTruthy();
+		expect(medicalStatus.body.assignment.request_id).toBe(response.body.request.id);
+		expect(generalStatus.body.assignment).toBeNull();
+	});
+
+	test('POST /api/help-requests falls back to a general volunteer for first-aid-only requests when no medical volunteer is available', async () => {
+		const app = createTestApp();
+		const helperId = 'user_general_only_helper';
+		const requesterId = 'user_request_general_only';
+
+		await seedActiveUser(helperId, 'generalonly@example.com');
+		await seedActiveUser(requesterId, 'requestgeneralonly@example.com');
+		await seedVolunteer({
+			volunteerId: 'vol_general_only_helper',
+			userId: helperId,
+			latitude: 41.043,
+			longitude: 29.009,
+		});
+
+		const response = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${buildAuthToken(requesterId)}`)
+			.send(buildCreatePayload({
+				helpTypes: ['first_aid'],
+				location: {
+					country: 'turkiye',
+					city: 'istanbul',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: 'Bina B',
+					latitude: 41.043,
+					longitude: 29.009,
+				},
+			}));
+
+		expect(response.status).toBe(201);
+		expect(response.body.request.status).toBe('MATCHED');
+
+		const helperStatus = await request(app)
+			.get('/api/availability/status')
+			.set('Authorization', `Bearer ${buildAuthToken(helperId)}`);
+
+		expect(helperStatus.body.assignment).toBeTruthy();
+		expect(helperStatus.body.assignment.request_id).toBe(response.body.request.id);
+	});
+
+	test('POST /api/help-requests prefers a medical volunteer for combined first-aid and SAR requests', async () => {
+		const app = createTestApp();
+		const medicalHelperId = 'user_medical_combo';
+		const generalHelperId = 'user_general_combo';
+		const requesterId = 'user_request_combo';
+
+		await seedActiveUser(medicalHelperId, 'medicalcombo@example.com');
+		await seedActiveUser(generalHelperId, 'generalcombo@example.com');
+		await seedActiveUser(requesterId, 'requestcombo@example.com');
+		await seedVolunteer({ volunteerId: 'vol_medical_combo', userId: medicalHelperId });
+		await seedVolunteer({ volunteerId: 'vol_general_combo', userId: generalHelperId });
+		await seedVolunteerProfile(medicalHelperId, 'Medical');
+
+		const response = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${buildAuthToken(requesterId)}`)
+			.send(buildCreatePayload({ helpTypes: ['first_aid', 'fire_brigade'] }));
+
+		expect(response.status).toBe(201);
+		expect(response.body.request.status).toBe('MATCHED');
+
+		const medicalStatus = await request(app)
+			.get('/api/availability/status')
+			.set('Authorization', `Bearer ${buildAuthToken(medicalHelperId)}`);
+
+		expect(medicalStatus.body.assignment).toBeTruthy();
+		expect(medicalStatus.body.assignment.request_id).toBe(response.body.request.id);
+	});
+
+	test('POST /api/help-requests falls back deterministically for combined first-aid and SAR requests when coordinates are missing', async () => {
+		const app = createTestApp();
+		const firstHelperId = 'user_combo_fallback_a';
+		const secondHelperId = 'user_combo_fallback_b';
+		const requesterId = 'user_request_combo_fallback';
+
+		await seedActiveUser(firstHelperId, 'combofallbacka@example.com');
+		await seedActiveUser(secondHelperId, 'combofallbackb@example.com');
+		await seedActiveUser(requesterId, 'requestcombofallback@example.com');
+		await seedVolunteer({
+			volunteerId: 'vol_combo_fallback_a',
+			userId: firstHelperId,
+			locationUpdatedAt: '2026-04-23T08:00:00.000Z',
+		});
+		await seedVolunteer({
+			volunteerId: 'vol_combo_fallback_b',
+			userId: secondHelperId,
+			locationUpdatedAt: '2026-04-23T08:00:00.000Z',
+		});
+
+		const response = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${buildAuthToken(requesterId)}`)
+			.send(buildCreatePayload({
+				helpTypes: ['first_aid', 'fire_brigade'],
+				location: {
+					country: 'turkiye',
+					city: 'istanbul',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: 'Bina B, 3. kat, arka giris',
+				},
+			}));
+
+		expect(response.status).toBe(201);
+		expect(response.body.request.status).toBe('MATCHED');
+
+		const firstStatus = await request(app)
+			.get('/api/availability/status')
+			.set('Authorization', `Bearer ${buildAuthToken(firstHelperId)}`);
+
+		expect(firstStatus.body.assignment).toBeTruthy();
+		expect(firstStatus.body.assignment.request_id).toBe(response.body.request.id);
+	});
+
+	test('POST /api/help-requests ignores already assigned volunteers and enforces the 1 km cutoff', async () => {
+		const app = createTestApp();
+		const busyHelperId = 'user_busy_helper';
+		const nearHelperId = 'user_near_helper';
+		const farHelperId = 'user_far_helper';
+		const requesterId = 'user_request_cutoff';
+		const busyRequesterId = 'user_request_busy_existing';
+
+		await seedActiveUser(busyHelperId, 'busyhelper@example.com');
+		await seedActiveUser(nearHelperId, 'nearhelper@example.com');
+		await seedActiveUser(farHelperId, 'farhelper@example.com');
+		await seedActiveUser(requesterId, 'requestcutoff@example.com');
+		await seedActiveUser(busyRequesterId, 'busyexisting@example.com');
+
+		await seedVolunteer({
+			volunteerId: 'vol_busy_helper',
+			userId: busyHelperId,
+			latitude: 41.043,
+			longitude: 29.009,
+		});
+		await seedVolunteer({
+			volunteerId: 'vol_near_helper',
+			userId: nearHelperId,
+			latitude: 41.0432,
+			longitude: 29.0092,
+		});
+		await seedVolunteer({
+			volunteerId: 'vol_far_helper',
+			userId: farHelperId,
+			latitude: 41.06,
+			longitude: 29.06,
+		});
+		await seedVolunteerProfile(busyHelperId, 'First Aid');
+		await seedAssignedRequestForVolunteer({
+			requestId: 'req_existing_busy',
+			requesterUserId: busyRequesterId,
+			volunteerId: 'vol_busy_helper',
+		});
+
+		const response = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${buildAuthToken(requesterId)}`)
+			.send(buildCreatePayload({
+				helpTypes: ['first_aid'],
+				location: {
+					country: 'turkiye',
+					city: 'istanbul',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: 'Bina B',
+					latitude: 41.043,
+					longitude: 29.009,
+				},
+			}));
+
+		expect(response.status).toBe(201);
+		expect(response.body.request.status).toBe('MATCHED');
+
+		const nearStatus = await request(app)
+			.get('/api/availability/status')
+			.set('Authorization', `Bearer ${buildAuthToken(nearHelperId)}`);
+		const farStatus = await request(app)
+			.get('/api/availability/status')
+			.set('Authorization', `Bearer ${buildAuthToken(farHelperId)}`);
+
+		expect(nearStatus.body.assignment).toBeTruthy();
+		expect(nearStatus.body.assignment.request_id).toBe(response.body.request.id);
+		expect(farStatus.body.assignment).toBeNull();
 	});
 });

--- a/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
+++ b/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
@@ -579,6 +579,78 @@ describe('help-requests integration', () => {
 		expect(getResponse.body.request.status).toBe('RESOLVED');
 	});
 
+	test('PATCH /:id/status guest resolve clears active assignments and frees volunteers for future matches', async () => {
+		const app = createTestApp();
+		const helperOneId = 'user_hr_guest_resolve_helper_1';
+		await seedActiveUser(helperOneId, 'guestresolvehelper1@example.com');
+		const helperOneToken = buildAuthToken(helperOneId);
+
+		const firstCreate = await request(app)
+			.post('/api/help-requests')
+			.send(buildCreatePayload({ description: 'guest request that will be resolved' }));
+
+		const firstRequestId = firstCreate.body.request.id;
+
+		const firstToggle = await request(app)
+			.post('/api/availability/toggle')
+			.set('Authorization', `Bearer ${helperOneToken}`)
+			.send({ isAvailable: true });
+
+		expect(firstToggle.status).toBe(200);
+		expect(firstToggle.body.assignment.request_id).toBe(firstRequestId);
+
+		const resolveResponse = await request(app)
+			.patch(`/api/help-requests/${firstRequestId}/status`)
+			.set('x-help-request-access-token', firstCreate.body.guestAccessToken)
+			.send({ status: 'RESOLVED' });
+
+		expect(resolveResponse.status).toBe(200);
+		expect(resolveResponse.body.request.status).toBe('RESOLVED');
+
+		const staleAssignments = await query(
+			`SELECT assignment_id FROM assignments WHERE request_id = $1 AND is_cancelled = FALSE`,
+			[firstRequestId],
+		);
+		expect(staleAssignments.rows).toHaveLength(0);
+
+		const helperOneStatus = await request(app)
+			.get('/api/availability/status')
+			.set('Authorization', `Bearer ${helperOneToken}`);
+
+		expect(helperOneStatus.status).toBe(200);
+		expect(helperOneStatus.body.assignment).toBeNull();
+
+		const secondCreate = await request(app)
+			.post('/api/help-requests')
+			.send(buildCreatePayload({ description: 'guest request after resolve cleanup' }));
+
+		const secondRequestId = secondCreate.body.request.id;
+
+		const helperOneOff = await request(app)
+			.post('/api/availability/toggle')
+			.set('Authorization', `Bearer ${helperOneToken}`)
+			.send({ isAvailable: false });
+
+		expect(helperOneOff.status).toBe(200);
+
+		const helperOneBackOn = await request(app)
+			.post('/api/availability/toggle')
+			.set('Authorization', `Bearer ${helperOneToken}`)
+			.send({ isAvailable: true });
+
+		expect(helperOneBackOn.status).toBe(200);
+		expect(helperOneBackOn.body.assignment).toBeTruthy();
+		expect(helperOneBackOn.body.assignment.request_id).toBe(secondRequestId);
+
+		const helperOneAssignmentAfterRetry = await request(app)
+			.get('/api/availability/my-assignment')
+			.set('Authorization', `Bearer ${helperOneToken}`);
+
+		expect(helperOneAssignmentAfterRetry.status).toBe(200);
+		expect(helperOneAssignmentAfterRetry.body.assignment).toBeTruthy();
+		expect(helperOneAssignmentAfterRetry.body.assignment.request_id).toBe(secondRequestId);
+	});
+
 	test('PATCH /:id/status returns 401 for guest request when token is missing', async () => {
 		const app = createTestApp();
 
@@ -661,6 +733,82 @@ describe('help-requests integration', () => {
 		expect(response.body.request.resolvedAt).toBeTruthy();
 	});
 
+	test('PATCH /:id/status requester resolve clears active assignments and frees volunteers for future matches', async () => {
+		const app = createTestApp();
+		const requesterId = 'user_hr_resolve_cleanup_requester';
+		const helperOneId = 'user_hr_resolve_cleanup_helper_1';
+		await seedActiveUser(requesterId, 'resolvecleanuprequester@example.com');
+		await seedActiveUser(helperOneId, 'resolvecleanuphelper1@example.com');
+		const requesterToken = buildAuthToken(requesterId);
+		const helperOneToken = buildAuthToken(helperOneId);
+
+		const firstCreate = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${requesterToken}`)
+			.send(buildCreatePayload({ description: 'requester request that will be resolved' }));
+
+		const firstRequestId = firstCreate.body.request.id;
+
+		const firstToggle = await request(app)
+			.post('/api/availability/toggle')
+			.set('Authorization', `Bearer ${helperOneToken}`)
+			.send({ isAvailable: true });
+
+		expect(firstToggle.status).toBe(200);
+		expect(firstToggle.body.assignment.request_id).toBe(firstRequestId);
+
+		const resolveResponse = await request(app)
+			.patch(`/api/help-requests/${firstRequestId}/status`)
+			.set('Authorization', `Bearer ${requesterToken}`)
+			.send({ status: 'RESOLVED' });
+
+		expect(resolveResponse.status).toBe(200);
+		expect(resolveResponse.body.request.status).toBe('RESOLVED');
+
+		const staleAssignments = await query(
+			`SELECT assignment_id FROM assignments WHERE request_id = $1 AND is_cancelled = FALSE`,
+			[firstRequestId],
+		);
+		expect(staleAssignments.rows).toHaveLength(0);
+
+		const helperOneStatus = await request(app)
+			.get('/api/availability/status')
+			.set('Authorization', `Bearer ${helperOneToken}`);
+
+		expect(helperOneStatus.status).toBe(200);
+		expect(helperOneStatus.body.assignment).toBeNull();
+
+		const secondCreate = await request(app)
+			.post('/api/help-requests')
+			.send(buildCreatePayload({ description: 'second request after requester resolve cleanup' }));
+
+		const secondRequestId = secondCreate.body.request.id;
+
+		const helperOneOff = await request(app)
+			.post('/api/availability/toggle')
+			.set('Authorization', `Bearer ${helperOneToken}`)
+			.send({ isAvailable: false });
+
+		expect(helperOneOff.status).toBe(200);
+
+		const helperOneBackOn = await request(app)
+			.post('/api/availability/toggle')
+			.set('Authorization', `Bearer ${helperOneToken}`)
+			.send({ isAvailable: true });
+
+		expect(helperOneBackOn.status).toBe(200);
+		expect(helperOneBackOn.body.assignment).toBeTruthy();
+		expect(helperOneBackOn.body.assignment.request_id).toBe(secondRequestId);
+
+		const helperOneAssignmentAfterRetry = await request(app)
+			.get('/api/availability/my-assignment')
+			.set('Authorization', `Bearer ${helperOneToken}`);
+
+		expect(helperOneAssignmentAfterRetry.status).toBe(200);
+		expect(helperOneAssignmentAfterRetry.body.assignment).toBeTruthy();
+		expect(helperOneAssignmentAfterRetry.body.assignment.request_id).toBe(secondRequestId);
+	});
+
 	test('PATCH /:id/status returns 409 when moving RESOLVED back to SYNCED', async () => {
 		const app = createTestApp();
 		const userId = 'user_hr_13';
@@ -683,6 +831,57 @@ describe('help-requests integration', () => {
 			.patch(`/api/help-requests/${requestId}/status`)
 			.set('Authorization', `Bearer ${token}`)
 			.send({ status: 'SYNCED' });
+
+		expect(response.status).toBe(409);
+		expect(response.body.code).toBe('INVALID_STATUS_TRANSITION');
+	});
+
+	test('PATCH /:id/status returns 409 when moving CANCELLED to RESOLVED', async () => {
+		const app = createTestApp();
+		const userId = 'user_hr_cancelled_transition';
+		await seedActiveUser(userId, 'cancelledtransition@example.com');
+		const token = buildAuthToken(userId);
+
+		const createResponse = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${token}`)
+			.send(buildCreatePayload({ helpTypes: ['food'] }));
+
+		const requestId = createResponse.body.request.id;
+
+		await request(app)
+			.patch(`/api/help-requests/${requestId}/status`)
+			.set('Authorization', `Bearer ${token}`)
+			.send({ status: 'CANCELLED' });
+
+		const response = await request(app)
+			.patch(`/api/help-requests/${requestId}/status`)
+			.set('Authorization', `Bearer ${token}`)
+			.send({ status: 'RESOLVED' });
+
+		expect(response.status).toBe(409);
+		expect(response.body.code).toBe('INVALID_STATUS_TRANSITION');
+	});
+
+	test('PATCH /:id/status returns 409 when moving guest CANCELLED request to RESOLVED', async () => {
+		const app = createTestApp();
+
+		const createResponse = await request(app)
+			.post('/api/help-requests')
+			.send(buildCreatePayload({ description: 'guest request for cancelled transition guard' }));
+
+		const requestId = createResponse.body.request.id;
+		const guestAccessToken = createResponse.body.guestAccessToken;
+
+		await request(app)
+			.patch(`/api/help-requests/${requestId}/status`)
+			.set('x-help-request-access-token', guestAccessToken)
+			.send({ status: 'CANCELLED' });
+
+		const response = await request(app)
+			.patch(`/api/help-requests/${requestId}/status`)
+			.set('x-help-request-access-token', guestAccessToken)
+			.send({ status: 'RESOLVED' });
 
 		expect(response.status).toBe(409);
 		expect(response.body.code).toBe('INVALID_STATUS_TRANSITION');

--- a/backend/tests/unit/modules/availability/service.test.js
+++ b/backend/tests/unit/modules/availability/service.test.js
@@ -21,6 +21,8 @@ describe('Availability Service', () => {
     jest.clearAllMocks();
     repository.findAvailableVolunteersForMatching.mockResolvedValue([]);
     repository.findActiveAssignmentsByRequestId.mockResolvedValue([]);
+    repository.markRequestAssignedIfPending.mockResolvedValue(null);
+    repository.syncRequestStatusPreservingInProgress.mockResolvedValue(null);
   });
 
   describe('setAvailability', () => {
@@ -51,8 +53,23 @@ describe('Availability Service', () => {
 
       expect(repository.findMatchingRequestForVolunteer).toHaveBeenCalledWith('vol_123');
       expect(repository.createAssignment).toHaveBeenCalledWith('vol_123', 'req_123');
-      expect(repository.updateRequestStatus).toHaveBeenCalledWith('req_123', 'ASSIGNED');
+      expect(repository.markRequestAssignedIfPending).toHaveBeenCalledWith('req_123');
       expect(result.assignment).toEqual(assignment);
+    });
+
+    it('should skip request status updates when guarded assignment creation returns null', async () => {
+      repository.findVolunteerByUserId.mockResolvedValue(volunteer);
+      repository.updateVolunteerAvailability.mockResolvedValue({ ...volunteer, is_available: true });
+      repository.findAvailableVolunteersForMatching.mockResolvedValue([{ ...volunteer, is_available: true }]);
+      repository.getAssignmentByVolunteerId.mockResolvedValue(null);
+      repository.findMatchingRequestForVolunteer.mockResolvedValue({ request_id: 'req_123' });
+      repository.createAssignment.mockResolvedValue(null);
+
+      const result = await setAvailability(userId, { isAvailable: true });
+
+      expect(repository.createAssignment).toHaveBeenCalledWith('vol_123', 'req_123');
+      expect(repository.markRequestAssignedIfPending).not.toHaveBeenCalled();
+      expect(result.assignment).toBeNull();
     });
 
     it('should cancel assignment if volunteer becomes unavailable', async () => {
@@ -64,7 +81,7 @@ describe('Availability Service', () => {
       const result = await setAvailability(userId, { isAvailable: false });
 
       expect(repository.cancelAssignment).toHaveBeenCalledWith('asg_123');
-      expect(repository.updateRequestStatus).toHaveBeenCalledWith('req_123', 'PENDING');
+      expect(repository.syncRequestStatusPreservingInProgress).toHaveBeenCalledWith('req_123');
       expect(result.volunteer.is_available).toBe(false);
     });
   });
@@ -110,7 +127,7 @@ describe('Availability Service', () => {
       const result = await syncAvailability(userId, { records });
 
       expect(repository.cancelAssignment).toHaveBeenCalledWith('asg_123');
-      expect(repository.updateRequestStatus).toHaveBeenCalledWith('req_123', 'PENDING');
+      expect(repository.syncRequestStatusPreservingInProgress).toHaveBeenCalledWith('req_123');
       expect(result.assignment).toBeNull();
     });
   });
@@ -133,7 +150,7 @@ describe('Availability Service', () => {
   });
 
   describe('cancelMyAssignment', () => {
-    it('should cancel assignment, set request back to pending and set volunteer unavailable', async () => {
+    it('should cancel assignment, resync request status and set volunteer unavailable', async () => {
       repository.findVolunteerByUserId.mockResolvedValue(volunteer);
       repository.getAssignmentById.mockResolvedValue(assignment);
       repository.findActiveAssignmentsByRequestId.mockResolvedValue([]);
@@ -141,7 +158,7 @@ describe('Availability Service', () => {
       const result = await cancelMyAssignment(userId, { assignmentId: 'asg_123' });
 
       expect(repository.cancelAssignment).toHaveBeenCalledWith('asg_123');
-      expect(repository.updateRequestStatus).toHaveBeenCalledWith('req_123', 'PENDING');
+      expect(repository.syncRequestStatusPreservingInProgress).toHaveBeenCalledWith('req_123');
       expect(repository.updateVolunteerAvailability).toHaveBeenCalledWith('vol_123', false, undefined, undefined);
       expect(result.message).toContain('Assignment cancelled, you are now unavailable');
     });
@@ -289,7 +306,7 @@ describe('Availability Service', () => {
       const result = await tryToAssignRequest('req_123');
 
       expect(repository.createAssignment).toHaveBeenCalledWith('vol_123', 'req_123');
-      expect(repository.updateRequestStatus).toHaveBeenCalledWith('req_123', 'ASSIGNED');
+      expect(repository.markRequestAssignedIfPending).toHaveBeenCalledWith('req_123');
       expect(result).toBe(true);
     });
 

--- a/backend/tests/unit/modules/availability/service.test.js
+++ b/backend/tests/unit/modules/availability/service.test.js
@@ -21,6 +21,7 @@ describe('Availability Service', () => {
     jest.clearAllMocks();
     repository.findAvailableVolunteersForMatching.mockResolvedValue([]);
     repository.findActiveAssignmentsByRequestId.mockResolvedValue([]);
+    repository.findMatchingVolunteerForRequest.mockResolvedValue(null);
     repository.markRequestAssignedIfPending.mockResolvedValue(null);
     repository.syncRequestStatusPreservingInProgress.mockResolvedValue(null);
   });
@@ -202,34 +203,28 @@ describe('Availability Service', () => {
   });
 
   describe('resolveMyAssignment', () => {
-    it('should mark request as resolved and clear active assignments for the request', async () => {
+    it('should only clear the resolver assignment and resync the request', async () => {
       repository.findVolunteerByUserId.mockResolvedValue(volunteer);
       repository.getAssignmentByVolunteerId.mockResolvedValue(assignment);
-      repository.findActiveAssignmentsByRequestId.mockResolvedValue([
-        assignment,
-        { assignment_id: 'asg_456', volunteer_id: 'vol_456', request_id: 'req_123' },
-      ]);
 
       const result = await resolveMyAssignment(userId, { requestId: 'req_123' });
 
-      expect(repository.updateRequestStatus).toHaveBeenCalledWith('req_123', 'RESOLVED');
       expect(repository.cancelAssignment).toHaveBeenCalledWith('asg_123');
-      expect(repository.cancelAssignment).toHaveBeenCalledWith('asg_456');
-      expect(result.message).toBe('Request marked as resolved');
+      expect(repository.syncRequestStatusPreservingInProgress).toHaveBeenCalledWith('req_123');
+      expect(repository.updateVolunteerAvailability).toHaveBeenCalledWith('vol_123', false, undefined, undefined);
+      expect(result.message).toBe('Assignment resolved for this volunteer, you are now unavailable, and matching has been refreshed');
+      expect(result.newAssignment).toBeNull();
     });
 
-    it('should try to find a NEW assignment after resolving', async () => {
+    it('should not create a new assignment for the resolver after resolving', async () => {
       repository.findVolunteerByUserId.mockResolvedValue(volunteer);
-      repository.findAvailableVolunteersForMatching.mockResolvedValue([{ ...volunteer, is_available: true }]);
-      repository.findActiveAssignmentsByRequestId.mockResolvedValue([assignment]);
-      repository.getAssignmentByVolunteerId.mockResolvedValueOnce(assignment).mockResolvedValueOnce({ assignment_id: 'asg_456' });
-      repository.findMatchingRequestForVolunteer.mockResolvedValue({ request_id: 'req_456' });
+      repository.getAssignmentByVolunteerId.mockResolvedValue(assignment);
 
       const result = await resolveMyAssignment(userId, { requestId: 'req_123' });
 
       expect(repository.cancelAssignment).toHaveBeenCalledWith('asg_123');
-      expect(repository.createAssignment).toHaveBeenCalledWith('vol_123', 'req_456');
-      expect(result.newAssignment).toBeDefined();
+      expect(repository.createAssignment).not.toHaveBeenCalledWith('vol_123', 'req_123');
+      expect(result.newAssignment).toBeNull();
     });
   });
 
@@ -257,26 +252,10 @@ describe('Availability Service', () => {
   });
 
   describe('tryToAssignRequest', () => {
-    it('prioritizes first-aid-capable volunteers before general volunteers during matching', async () => {
-      repository.findAvailableVolunteersForMatching.mockResolvedValue([
-        {
-          volunteer_id: 'vol_general',
-          user_id: 'user_general',
-          is_available: true,
-          is_first_aid_capable: false,
-          location_updated_at: '2026-04-23T08:10:00.000Z',
-        },
-        {
-          volunteer_id: 'vol_specialist',
-          user_id: 'user_specialist',
-          is_available: true,
-          is_first_aid_capable: true,
-          location_updated_at: '2026-04-23T08:00:00.000Z',
-        },
-      ]);
-      repository.findMatchingRequestForVolunteer.mockImplementation(async (volunteerId) => (
-        volunteerId === 'vol_specialist' ? { request_id: 'req_123' } : null
-      ));
+    it('assigns only volunteers selected for the target request', async () => {
+      repository.findMatchingVolunteerForRequest
+        .mockResolvedValueOnce({ volunteer_id: 'vol_specialist' })
+        .mockResolvedValueOnce(null);
       repository.createAssignment.mockResolvedValue({
         assignment_id: 'asg_123',
         volunteer_id: 'vol_specialist',
@@ -292,22 +271,41 @@ describe('Availability Service', () => {
 
       const result = await tryToAssignRequest('req_123');
 
-      expect(repository.findMatchingRequestForVolunteer).toHaveBeenNthCalledWith(1, 'vol_specialist');
+      expect(repository.findMatchingVolunteerForRequest).toHaveBeenNthCalledWith(1, 'req_123');
       expect(repository.createAssignment).toHaveBeenCalledWith('vol_specialist', 'req_123');
       expect(result).toBe(true);
     });
 
-    it('should assign volunteers through the assignment cycle and report success for the target request', async () => {
-      repository.findAvailableVolunteersForMatching.mockResolvedValue([{ ...volunteer, is_available: true }]);
-      repository.findMatchingRequestForVolunteer.mockResolvedValue({ request_id: 'req_123' });
-      repository.createAssignment.mockResolvedValue(assignment);
-      repository.findActiveAssignmentsByRequestId.mockResolvedValue([assignment]);
+    it('keeps assigning the target request while it still has eligible volunteers', async () => {
+      repository.findMatchingVolunteerForRequest
+        .mockResolvedValueOnce({ volunteer_id: 'vol_123' })
+        .mockResolvedValueOnce({ volunteer_id: 'vol_456' })
+        .mockResolvedValueOnce(null);
+      repository.createAssignment
+        .mockResolvedValueOnce(assignment)
+        .mockResolvedValueOnce({ assignment_id: 'asg_456', volunteer_id: 'vol_456', request_id: 'req_123' });
+      repository.findActiveAssignmentsByRequestId.mockResolvedValue([
+        assignment,
+        { assignment_id: 'asg_456', volunteer_id: 'vol_456', request_id: 'req_123' },
+      ]);
 
       const result = await tryToAssignRequest('req_123');
 
       expect(repository.createAssignment).toHaveBeenCalledWith('vol_123', 'req_123');
+      expect(repository.createAssignment).toHaveBeenCalledWith('vol_456', 'req_123');
       expect(repository.markRequestAssignedIfPending).toHaveBeenCalledWith('req_123');
       expect(result).toBe(true);
+    });
+
+    it('stops cleanly when guarded assignment creation returns null', async () => {
+      repository.findMatchingVolunteerForRequest.mockResolvedValue({ volunteer_id: 'vol_123' });
+      repository.createAssignment.mockResolvedValue(null);
+      repository.findActiveAssignmentsByRequestId.mockResolvedValue([]);
+
+      const result = await tryToAssignRequest('req_123');
+
+      expect(repository.markRequestAssignedIfPending).not.toHaveBeenCalled();
+      expect(result).toBe(false);
     });
 
     it('should return false if the target request still has no active assignments after the cycle', async () => {

--- a/backend/tests/unit/modules/availability/service.test.js
+++ b/backend/tests/unit/modules/availability/service.test.js
@@ -240,6 +240,46 @@ describe('Availability Service', () => {
   });
 
   describe('tryToAssignRequest', () => {
+    it('prioritizes first-aid-capable volunteers before general volunteers during matching', async () => {
+      repository.findAvailableVolunteersForMatching.mockResolvedValue([
+        {
+          volunteer_id: 'vol_general',
+          user_id: 'user_general',
+          is_available: true,
+          is_first_aid_capable: false,
+          location_updated_at: '2026-04-23T08:10:00.000Z',
+        },
+        {
+          volunteer_id: 'vol_specialist',
+          user_id: 'user_specialist',
+          is_available: true,
+          is_first_aid_capable: true,
+          location_updated_at: '2026-04-23T08:00:00.000Z',
+        },
+      ]);
+      repository.findMatchingRequestForVolunteer.mockImplementation(async (volunteerId) => (
+        volunteerId === 'vol_specialist' ? { request_id: 'req_123' } : null
+      ));
+      repository.createAssignment.mockResolvedValue({
+        assignment_id: 'asg_123',
+        volunteer_id: 'vol_specialist',
+        request_id: 'req_123',
+      });
+      repository.findActiveAssignmentsByRequestId.mockResolvedValue([
+        {
+          assignment_id: 'asg_123',
+          volunteer_id: 'vol_specialist',
+          request_id: 'req_123',
+        },
+      ]);
+
+      const result = await tryToAssignRequest('req_123');
+
+      expect(repository.findMatchingRequestForVolunteer).toHaveBeenNthCalledWith(1, 'vol_specialist');
+      expect(repository.createAssignment).toHaveBeenCalledWith('vol_specialist', 'req_123');
+      expect(result).toBe(true);
+    });
+
     it('should assign volunteers through the assignment cycle and report success for the target request', async () => {
       repository.findAvailableVolunteersForMatching.mockResolvedValue([{ ...volunteer, is_available: true }]);
       repository.findMatchingRequestForVolunteer.mockResolvedValue({ request_id: 'req_123' });

--- a/backend/tests/unit/modules/availability/service.test.js
+++ b/backend/tests/unit/modules/availability/service.test.js
@@ -19,6 +19,8 @@ describe('Availability Service', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    repository.findAvailableVolunteersForMatching.mockResolvedValue([]);
+    repository.findActiveAssignmentsByRequestId.mockResolvedValue([]);
   });
 
   describe('setAvailability', () => {
@@ -27,7 +29,6 @@ describe('Availability Service', () => {
       repository.createVolunteer.mockResolvedValue(volunteer);
       repository.updateVolunteerAvailability.mockResolvedValue({ ...volunteer, is_available: true });
       repository.getAssignmentByVolunteerId.mockResolvedValue(null);
-      repository.findMatchingRequestForVolunteer.mockResolvedValue(null);
 
       const result = await setAvailability(userId, { isAvailable: true, latitude: 41, longitude: 29 });
 
@@ -40,6 +41,7 @@ describe('Availability Service', () => {
     it('should try to match a request if volunteer becomes available', async () => {
       repository.findVolunteerByUserId.mockResolvedValue(volunteer);
       repository.updateVolunteerAvailability.mockResolvedValue({ ...volunteer, is_available: true });
+      repository.findAvailableVolunteersForMatching.mockResolvedValue([{ ...volunteer, is_available: true }]);
       repository.getAssignmentByVolunteerId.mockResolvedValue(null);
       repository.findMatchingRequestForVolunteer.mockResolvedValue({ request_id: 'req_123' });
       repository.createAssignment.mockResolvedValue(assignment);
@@ -57,6 +59,7 @@ describe('Availability Service', () => {
       repository.findVolunteerByUserId.mockResolvedValue(volunteer);
       repository.updateVolunteerAvailability.mockResolvedValue({ ...volunteer, is_available: false });
       repository.getAssignmentByVolunteerId.mockResolvedValue(assignment);
+      repository.findActiveAssignmentsByRequestId.mockResolvedValue([]);
 
       const result = await setAvailability(userId, { isAvailable: false });
 
@@ -70,7 +73,6 @@ describe('Availability Service', () => {
     it('should sync multiple records and update to latest status', async () => {
       repository.findVolunteerByUserId.mockResolvedValue(volunteer);
       repository.getAssignmentByVolunteerId.mockResolvedValue(null);
-      repository.findMatchingRequestForVolunteer.mockResolvedValue(null);
       
       const records = [
         { isAvailable: true, timestamp: '2023-01-01T10:00:00Z' },
@@ -85,6 +87,7 @@ describe('Availability Service', () => {
 
     it('should try to match a request if volunteer is now available', async () => {
       repository.findVolunteerByUserId.mockResolvedValueOnce(volunteer).mockResolvedValueOnce({ ...volunteer, is_available: true });
+      repository.findAvailableVolunteersForMatching.mockResolvedValue([{ ...volunteer, is_available: true }]);
       repository.getAssignmentByVolunteerId.mockResolvedValue(null);
       repository.findMatchingRequestForVolunteer.mockResolvedValue({ request_id: 'req_123' });
       
@@ -100,6 +103,7 @@ describe('Availability Service', () => {
         .mockResolvedValueOnce(volunteer)
         .mockResolvedValueOnce({ ...volunteer, is_available: false });
       repository.getAssignmentByVolunteerId.mockResolvedValue(assignment);
+      repository.findActiveAssignmentsByRequestId.mockResolvedValue([]);
       
       const records = [{ isAvailable: false, timestamp: '2023-01-01T10:00:00Z' }];
 
@@ -132,7 +136,7 @@ describe('Availability Service', () => {
     it('should cancel assignment, set request back to pending and set volunteer unavailable', async () => {
       repository.findVolunteerByUserId.mockResolvedValue(volunteer);
       repository.getAssignmentById.mockResolvedValue(assignment);
-      repository.findMatchingRequestForVolunteer.mockResolvedValue(null);
+      repository.findActiveAssignmentsByRequestId.mockResolvedValue([]);
 
       const result = await cancelMyAssignment(userId, { assignmentId: 'asg_123' });
 
@@ -145,29 +149,34 @@ describe('Availability Service', () => {
     it('should try to auto-assign the request to someone else after volunteer cancels', async () => {
       repository.findVolunteerByUserId.mockResolvedValue(volunteer);
       repository.getAssignmentById.mockResolvedValue(assignment);
-      repository.findMatchingVolunteerForRequest.mockResolvedValue({ volunteer_id: 'vol_456' });
+      repository.findActiveAssignmentsByRequestId.mockResolvedValue([]);
+      repository.findAvailableVolunteersForMatching.mockResolvedValue([{ volunteer_id: 'vol_456', user_id: 'user_456' }]);
+      repository.findMatchingRequestForVolunteer.mockResolvedValue({ request_id: 'req_123' });
 
       await cancelMyAssignment(userId, { assignmentId: 'asg_123' });
 
-      expect(repository.findMatchingVolunteerForRequest).toHaveBeenCalledWith('req_123');
       expect(repository.createAssignment).toHaveBeenCalledWith('vol_456', 'req_123');
     });
   });
 
   describe('cancelAssignmentByRequestId', () => {
-    it('should cancel assignment and try to match the volunteer with a new request', async () => {
-      repository.findAssignmentByRequestId.mockResolvedValue(assignment);
+    it('should cancel all active assignments for the request', async () => {
+      repository.findActiveAssignmentsByRequestId.mockResolvedValue([
+        assignment,
+        { assignment_id: 'asg_456', volunteer_id: 'vol_456', request_id: 'req_123' },
+      ]);
+      repository.findAvailableVolunteersForMatching.mockResolvedValue([{ volunteer_id: 'vol_789', user_id: 'user_789' }]);
       repository.findMatchingRequestForVolunteer.mockResolvedValue({ request_id: 'req_456' });
 
       await cancelAssignmentByRequestId('req_123');
 
       expect(repository.cancelAssignment).toHaveBeenCalledWith('asg_123');
-      expect(repository.findMatchingRequestForVolunteer).toHaveBeenCalledWith('vol_123');
-      expect(repository.createAssignment).toHaveBeenCalledWith('vol_123', 'req_456');
+      expect(repository.cancelAssignment).toHaveBeenCalledWith('asg_456');
+      expect(repository.createAssignment).toHaveBeenCalledWith('vol_789', 'req_456');
     });
 
     it('should do nothing if no assignment is found', async () => {
-      repository.findAssignmentByRequestId.mockResolvedValue(null);
+      repository.findActiveAssignmentsByRequestId.mockResolvedValue([]);
 
       await cancelAssignmentByRequestId('req_123');
 
@@ -176,24 +185,32 @@ describe('Availability Service', () => {
   });
 
   describe('resolveMyAssignment', () => {
-    it('should mark request as resolved', async () => {
+    it('should mark request as resolved and clear active assignments for the request', async () => {
       repository.findVolunteerByUserId.mockResolvedValue(volunteer);
       repository.getAssignmentByVolunteerId.mockResolvedValue(assignment);
-      repository.findMatchingRequestForVolunteer.mockResolvedValue(null);
+      repository.findActiveAssignmentsByRequestId.mockResolvedValue([
+        assignment,
+        { assignment_id: 'asg_456', volunteer_id: 'vol_456', request_id: 'req_123' },
+      ]);
 
       const result = await resolveMyAssignment(userId, { requestId: 'req_123' });
 
       expect(repository.updateRequestStatus).toHaveBeenCalledWith('req_123', 'RESOLVED');
+      expect(repository.cancelAssignment).toHaveBeenCalledWith('asg_123');
+      expect(repository.cancelAssignment).toHaveBeenCalledWith('asg_456');
       expect(result.message).toBe('Request marked as resolved');
     });
 
     it('should try to find a NEW assignment after resolving', async () => {
       repository.findVolunteerByUserId.mockResolvedValue(volunteer);
+      repository.findAvailableVolunteersForMatching.mockResolvedValue([{ ...volunteer, is_available: true }]);
+      repository.findActiveAssignmentsByRequestId.mockResolvedValue([assignment]);
       repository.getAssignmentByVolunteerId.mockResolvedValueOnce(assignment).mockResolvedValueOnce({ assignment_id: 'asg_456' });
       repository.findMatchingRequestForVolunteer.mockResolvedValue({ request_id: 'req_456' });
 
       const result = await resolveMyAssignment(userId, { requestId: 'req_123' });
 
+      expect(repository.cancelAssignment).toHaveBeenCalledWith('asg_123');
       expect(repository.createAssignment).toHaveBeenCalledWith('vol_123', 'req_456');
       expect(result.newAssignment).toBeDefined();
     });
@@ -223,24 +240,24 @@ describe('Availability Service', () => {
   });
 
   describe('tryToAssignRequest', () => {
-    it('should assign a volunteer if a match is found', async () => {
-      repository.findMatchingVolunteerForRequest.mockResolvedValue(volunteer);
+    it('should assign volunteers through the assignment cycle and report success for the target request', async () => {
+      repository.findAvailableVolunteersForMatching.mockResolvedValue([{ ...volunteer, is_available: true }]);
+      repository.findMatchingRequestForVolunteer.mockResolvedValue({ request_id: 'req_123' });
       repository.createAssignment.mockResolvedValue(assignment);
+      repository.findActiveAssignmentsByRequestId.mockResolvedValue([assignment]);
 
       const result = await tryToAssignRequest('req_123');
 
-      expect(repository.findMatchingVolunteerForRequest).toHaveBeenCalledWith('req_123');
       expect(repository.createAssignment).toHaveBeenCalledWith('vol_123', 'req_123');
       expect(repository.updateRequestStatus).toHaveBeenCalledWith('req_123', 'ASSIGNED');
       expect(result).toBe(true);
     });
 
-    it('should return false if no matching volunteer is found', async () => {
-      repository.findMatchingVolunteerForRequest.mockResolvedValue(null);
+    it('should return false if the target request still has no active assignments after the cycle', async () => {
+      repository.findActiveAssignmentsByRequestId.mockResolvedValue([]);
 
       const result = await tryToAssignRequest('req_123');
 
-      expect(repository.findMatchingVolunteerForRequest).toHaveBeenCalledWith('req_123');
       expect(repository.createAssignment).not.toHaveBeenCalled();
       expect(result).toBe(false);
     });

--- a/backend/tests/unit/modules/help-requests/service.test.js
+++ b/backend/tests/unit/modules/help-requests/service.test.js
@@ -241,7 +241,20 @@ describe('help-requests service', () => {
 			const result = await updateMyHelpRequestStatus('u1', 'req_1', 'RESOLVED');
 
 			expect(repository.markHelpRequestAsResolved).toHaveBeenCalledWith('u1', 'req_1');
+			expect(availabilityService.cancelAssignmentByRequestId).toHaveBeenCalledWith('req_1');
 			expect(result).toEqual(updated);
+		});
+
+		test('persists RESOLVED before freeing volunteers for authenticated requests', async () => {
+			const current = { id: 'req_1', internalStatus: 'ASSIGNED' };
+			const updated = { id: 'req_1', internalStatus: 'RESOLVED' };
+			repository.findHelpRequestByIdForUser.mockResolvedValueOnce(current);
+			repository.markHelpRequestAsResolved.mockResolvedValueOnce(updated);
+
+			await updateMyHelpRequestStatus('u1', 'req_1', 'RESOLVED');
+
+			expect(repository.markHelpRequestAsResolved.mock.invocationCallOrder[0])
+				.toBeLessThan(availabilityService.cancelAssignmentByRequestId.mock.invocationCallOrder[0]);
 		});
 
 		test('marks as cancelled when current status is not RESOLVED', async () => {
@@ -277,6 +290,15 @@ describe('help-requests service', () => {
 
 			expect(repository.markHelpRequestAsResolved).not.toHaveBeenCalled();
 			expect(result).toEqual(current);
+		});
+
+		test('throws INVALID_STATUS_TRANSITION when moving CANCELLED to RESOLVED', async () => {
+			const current = { id: 'req_1', internalStatus: 'CANCELLED' };
+			repository.findHelpRequestByIdForUser.mockResolvedValueOnce(current);
+
+			await expect(updateMyHelpRequestStatus('u1', 'req_1', 'RESOLVED'))
+				.rejects
+				.toMatchObject({ code: 'INVALID_STATUS_TRANSITION' });
 		});
 
 		test('throws INVALID_STATUS_TRANSITION for unsupported target status', async () => {
@@ -328,7 +350,26 @@ describe('help-requests service', () => {
 			const result = await updateGuestHelpRequestStatus('req_guest_resolve', 'RESOLVED', token);
 
 			expect(repository.markHelpRequestAsResolvedByRequestId).toHaveBeenCalledWith('req_guest_resolve');
+			expect(availabilityService.cancelAssignmentByRequestId).toHaveBeenCalledWith('req_guest_resolve');
 			expect(result).toEqual(updated);
+		});
+
+		test('persists RESOLVED before freeing volunteers for guest requests', async () => {
+			const token = issueGuestHelpRequestAccessToken('req_guest_resolve_order');
+			repository.findHelpRequestById.mockResolvedValueOnce({
+				id: 'req_guest_resolve_order',
+				userId: null,
+				internalStatus: 'ASSIGNED',
+			});
+			repository.markHelpRequestAsResolvedByRequestId.mockResolvedValueOnce({
+				id: 'req_guest_resolve_order',
+				internalStatus: 'RESOLVED',
+			});
+
+			await updateGuestHelpRequestStatus('req_guest_resolve_order', 'RESOLVED', token);
+
+			expect(repository.markHelpRequestAsResolvedByRequestId.mock.invocationCallOrder[0])
+				.toBeLessThan(availabilityService.cancelAssignmentByRequestId.mock.invocationCallOrder[0]);
 		});
 
 		test('marks guest request as cancelled', async () => {
@@ -379,6 +420,19 @@ describe('help-requests service', () => {
 
 			expect(repository.markHelpRequestAsResolvedByRequestId).not.toHaveBeenCalled();
 			expect(result).toEqual(current);
+		});
+
+		test('throws INVALID_STATUS_TRANSITION when moving guest CANCELLED request to RESOLVED', async () => {
+			const token = issueGuestHelpRequestAccessToken('req_guest_cancelled');
+			repository.findHelpRequestById.mockResolvedValueOnce({
+				id: 'req_guest_cancelled',
+				userId: null,
+				internalStatus: 'CANCELLED',
+			});
+
+			await expect(updateGuestHelpRequestStatus('req_guest_cancelled', 'RESOLVED', token))
+				.rejects
+				.toMatchObject({ code: 'INVALID_STATUS_TRANSITION' });
 		});
 
 		test('throws INVALID_STATUS_TRANSITION when moving guest RESOLVED request to SYNCED', async () => {

--- a/backend/tests/unit/modules/help-requests/service.test.js
+++ b/backend/tests/unit/modules/help-requests/service.test.js
@@ -257,6 +257,18 @@ describe('help-requests service', () => {
 			expect(result).toEqual(updated);
 		});
 
+		test('persists CANCELLED before freeing volunteers for authenticated requests', async () => {
+			const current = { id: 'req_1', internalStatus: 'ASSIGNED' };
+			const updated = { id: 'req_1', internalStatus: 'CANCELLED' };
+			repository.findHelpRequestByIdForUser.mockResolvedValueOnce(current);
+			repository.markHelpRequestAsCancelled.mockResolvedValueOnce(updated);
+
+			await updateMyHelpRequestStatus('u1', 'req_1', 'CANCELLED');
+
+			expect(repository.markHelpRequestAsCancelled.mock.invocationCallOrder[0])
+				.toBeLessThan(availabilityService.cancelAssignmentByRequestId.mock.invocationCallOrder[0]);
+		});
+
 		test('returns current request idempotently when already RESOLVED', async () => {
 			const current = { id: 'req_1', internalStatus: 'RESOLVED' };
 			repository.findHelpRequestByIdForUser.mockResolvedValueOnce(current);
@@ -334,6 +346,24 @@ describe('help-requests service', () => {
 			expect(availabilityService.cancelAssignmentByRequestId).toHaveBeenCalledWith('req_guest_cancel');
 			expect(repository.markHelpRequestAsCancelledByRequestId).toHaveBeenCalledWith('req_guest_cancel');
 			expect(result).toEqual(updated);
+		});
+
+		test('persists CANCELLED before freeing volunteers for guest requests', async () => {
+			const token = issueGuestHelpRequestAccessToken('req_guest_cancel_order');
+			repository.findHelpRequestById.mockResolvedValueOnce({
+				id: 'req_guest_cancel_order',
+				userId: null,
+				internalStatus: 'ASSIGNED',
+			});
+			repository.markHelpRequestAsCancelledByRequestId.mockResolvedValueOnce({
+				id: 'req_guest_cancel_order',
+				internalStatus: 'CANCELLED',
+			});
+
+			await updateGuestHelpRequestStatus('req_guest_cancel_order', 'CANCELLED', token);
+
+			expect(repository.markHelpRequestAsCancelledByRequestId.mock.invocationCallOrder[0])
+				.toBeLessThan(availabilityService.cancelAssignmentByRequestId.mock.invocationCallOrder[0]);
 		});
 
 		test('returns current request idempotently when guest request is already RESOLVED', async () => {


### PR DESCRIPTION
### Summary
This PR upgrades NEPH’s backend help-request matching from a simple single-responder flow into a more robust multi-signal, multi-responder matching system.

### What changed
- improved matching using help type, first-aid preference, proximity, and volunteer availability
- added deterministic first-pass assignment behavior
- added second-pass SAR expansion behavior
- added fallback handling for first-aid requests when no first-aid-capable volunteer is available
- preserved the existing public status model without introducing new public statuses
- fixed cancellation/rematching ordering issues
- enabled true multi-responder assignments per request via migration
- added active-assignment-per-volunteer protection
- updated request reads and resolve behavior to work more safely with multiple active assignments
- added/updated backend unit and integration coverage for the new matching behavior
- added migration safety coverage for environments that may already contain duplicate active assignments per volunteer

### Important behavior notes
- request assignment cardinality now supports multiple active responders per request
- first-aid-capable volunteers are preferred when a request still needs a first-aid specialist
- first-aid-only fallback growth is capped to avoid unnecessary general-volunteer over-assignment
- volunteer-side resolve now applies to that volunteer’s assignment, not automatically to the whole request
- `tryToAssignRequest(requestId)` is now request-scoped and no longer triggers a global matching cycle

### Compatibility / rollout notes
- frontend/mobile changes are not included in this PR
- no new public statuses were introduced
- requester-facing request reads still expose a single helper for compatibility, even though the backend now supports multiple active responders; richer multi-responder representation is follow-up work
- schema change is handled by migrations

Closes #264