### PR TITLE
feat: add admin dashboard page with guarded access and emergency overview

### DIFF
--- a/backend/src/modules/auth/routes.js
+++ b/backend/src/modules/auth/routes.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const rateLimit = require('express-rate-limit');
+const { env } = require('../../config/env');
 const { adminRouter } = require('../admin/routes');
 
 const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 10, // max 10 requests
+  skip: () => env.nodeEnv === 'test',
   message: {
     code: 'TOO_MANY_REQUESTS',
     message: 'Too many requests, please try again later',

--- a/web/e2e/admin-dashboard.spec.js
+++ b/web/e2e/admin-dashboard.spec.js
@@ -11,10 +11,15 @@ const { loginThroughUi } = require('./helpers/ui');
 async function ensureOverviewReady(page) {
   const retryButton = page.getByRole('button', { name: 'Retry' });
   const loadRegionButton = page.getByRole('button', { name: 'Load Region Summary' });
+  const hideRegionButton = page.getByRole('button', { name: 'Hide Region Summary' });
   const deadline = Date.now() + 20_000;
 
   while (Date.now() < deadline) {
     if (await loadRegionButton.isVisible().catch(() => false)) {
+      return;
+    }
+
+    if (await hideRegionButton.isVisible().catch(() => false)) {
       return;
     }
 
@@ -70,10 +75,15 @@ test('authenticated admin can open dashboard and toggle region summary', async (
   await expect(page.getByRole('heading', { name: 'Admin Dashboard' })).toBeVisible();
   await ensureOverviewReady(page);
 
+  const loadRegionButton = page.getByRole('button', { name: 'Load Region Summary' });
+  const hideRegionButton = page.getByRole('button', { name: 'Hide Region Summary' });
+
   await expect(page.getByRole('columnheader', { name: 'City' })).toHaveCount(0);
-  await page.getByRole('button', { name: 'Load Region Summary' }).click();
+  if (await loadRegionButton.isVisible().catch(() => false)) {
+    await loadRegionButton.click();
+  }
   await expect(page.getByRole('columnheader', { name: 'City' })).toBeVisible();
-  await page.getByRole('button', { name: 'Hide Region Summary' }).click();
+  await hideRegionButton.click();
   await expect(page.getByRole('columnheader', { name: 'City' })).toHaveCount(0);
 
   // keep variable usage explicit for lint/readability in CI logs
@@ -118,8 +128,10 @@ test('initial overview fetch error can be retried successfully', async ({ page }
   await loginThroughUi(page, { email, password });
 
   let failUntilRetried = true;
+  let initialFailCount = 0;
   await page.route('**/api/admin/emergency-overview*', async (route) => {
-    if (failUntilRetried) {
+    if (failUntilRetried && initialFailCount < 2) {
+      initialFailCount += 1;
       await route.fulfill({
         status: 500,
         contentType: 'application/json',
@@ -132,6 +144,7 @@ test('initial overview fetch error can be retried successfully', async ({ page }
   });
 
   await page.goto('/admin');
+  await expect.poll(() => initialFailCount, { timeout: 20_000 }).toBeGreaterThan(0);
   await page.getByRole('button', { name: 'Retry' }).waitFor({ state: 'visible', timeout: 20_000 });
   failUntilRetried = false;
   await page.getByRole('button', { name: 'Retry' }).click();

--- a/web/e2e/admin-dashboard.spec.js
+++ b/web/e2e/admin-dashboard.spec.js
@@ -66,6 +66,16 @@ async function ensureOverviewReady(page, { allowRetryClick = false } = {}) {
   throw new Error(`Admin overview did not become ready. Current URL: ${page.url()}`);
 }
 
+async function readMetricValue(page, label) {
+  const valueText = await page
+    .locator('.admin-metric-tile', { hasText: label })
+    .locator('.admin-metric-value')
+    .first()
+    .innerText();
+
+  return Number.parseInt(valueText, 10);
+}
+
 test.beforeEach(async () => {
   await resetDatabase();
 });
@@ -121,6 +131,80 @@ test('authenticated admin can open dashboard and toggle region summary', async (
 
   // keep variable usage explicit for lint/readability in CI logs
   expect(completedUser.accessToken).toBeDefined();
+});
+
+test('aggregate metrics reflect mixed status and urgency records', async ({ page }) => {
+  const email = `admin-metrics-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email, password });
+  const dbUser = await waitForUserByEmail(email);
+  await promoteUserToAdmin({ userId: dbUser.user_id });
+
+  await seedEmergencyOverviewRecord({
+    requestId: 'e2e_mix_pending_low',
+    status: 'PENDING',
+    city: 'ankara',
+    createdAtHoursAgo: 2,
+    affectedPeopleCount: 1,
+    riskFlags: [],
+  });
+  await seedEmergencyOverviewRecord({
+    requestId: 'e2e_mix_progress_high',
+    status: 'IN_PROGRESS',
+    city: 'izmir',
+    createdAtHoursAgo: 3,
+    affectedPeopleCount: 6,
+    riskFlags: ['injury', 'flood'],
+  });
+  await seedEmergencyOverviewRecord({
+    requestId: 'e2e_mix_resolved_medium',
+    status: 'RESOLVED',
+    city: 'bursa',
+    createdAtHoursAgo: 4,
+    affectedPeopleCount: 2,
+    riskFlags: ['injury'],
+  });
+  await seedEmergencyOverviewRecord({
+    requestId: 'e2e_mix_cancelled_medium',
+    status: 'CANCELLED',
+    city: 'adana',
+    createdAtHoursAgo: 5,
+    affectedPeopleCount: 3,
+    riskFlags: [],
+  });
+
+  await page.goto('/login');
+  await loginThroughUi(page, { email, password });
+  await expect(page.getByRole('link', { name: 'Admin' })).toBeVisible();
+
+  await page.goto('/admin');
+  await expect(page).toHaveURL(/\/admin$/);
+  await ensureOverviewReady(page, { allowRetryClick: true });
+
+  await expect.poll(async () => ({
+    total: await readMetricValue(page, 'Total Emergencies'),
+    active: await readMetricValue(page, 'Active'),
+    resolved: await readMetricValue(page, 'Resolved'),
+    closed: await readMetricValue(page, 'Closed'),
+    pending: await readMetricValue(page, 'Pending'),
+    inProgress: await readMetricValue(page, 'In Progress'),
+    cancelled: await readMetricValue(page, 'Cancelled'),
+    urgencyLow: await readMetricValue(page, 'Low'),
+    urgencyMedium: await readMetricValue(page, 'Medium'),
+    urgencyHigh: await readMetricValue(page, 'High'),
+  })).toMatchObject({
+    total: 4,
+    active: 2,
+    resolved: 1,
+    closed: 2,
+    pending: 1,
+    inProgress: 1,
+    cancelled: 1,
+    urgencyLow: 1,
+    urgencyMedium: 2,
+    urgencyHigh: 1,
+  });
 });
 
 test('navbar admin link visibility is role-aware', async ({ page }) => {

--- a/web/e2e/admin-dashboard.spec.js
+++ b/web/e2e/admin-dashboard.spec.js
@@ -11,12 +11,21 @@ const { loginThroughUi } = require('./helpers/ui');
 async function ensureOverviewReady(page) {
   const retryButton = page.getByRole('button', { name: 'Retry' });
   const loadRegionButton = page.getByRole('button', { name: 'Load Region Summary' });
+  const deadline = Date.now() + 20_000;
 
-  if (await retryButton.isVisible().catch(() => false)) {
-    await retryButton.click();
+  while (Date.now() < deadline) {
+    if (await loadRegionButton.isVisible().catch(() => false)) {
+      return;
+    }
+
+    if (await retryButton.isVisible().catch(() => false)) {
+      await retryButton.click();
+    }
+
+    await page.waitForTimeout(250);
   }
 
-  await expect(loadRegionButton).toBeVisible();
+  throw new Error('Admin overview did not become ready (neither Load Region Summary nor Retry became visible).');
 }
 
 test.beforeEach(async () => {
@@ -123,7 +132,7 @@ test('initial overview fetch error can be retried successfully', async ({ page }
   });
 
   await page.goto('/admin');
-  await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+  await page.getByRole('button', { name: 'Retry' }).waitFor({ state: 'visible', timeout: 20_000 });
   failUntilRetried = false;
   await page.getByRole('button', { name: 'Retry' }).click();
   await ensureOverviewReady(page);

--- a/web/e2e/admin-dashboard.spec.js
+++ b/web/e2e/admin-dashboard.spec.js
@@ -8,23 +8,56 @@ const {
 } = require('./helpers/db');
 const { loginThroughUi } = require('./helpers/ui');
 
-async function ensureOverviewReady(page) {
+function getOverviewUiState(page) {
   const retryButton = page.getByRole('button', { name: 'Retry Overview' });
   const loadRegionButton = page.getByRole('button', { name: 'Load Region Summary' });
   const hideRegionButton = page.getByRole('button', { name: 'Hide Region Summary' });
+  const url = page.url();
+
+  if (/\/login(\?|$)/.test(url)) {
+    return "redirected-login";
+  }
+
+  if (/\/home(\?|$)/.test(url)) {
+    return "redirected-home";
+  }
+
+  return Promise.all([
+    loadRegionButton.isVisible().catch(() => false),
+    hideRegionButton.isVisible().catch(() => false),
+    retryButton.isVisible().catch(() => false),
+  ]).then(([isLoadVisible, isHideVisible, isRetryVisible]) => {
+    if (isLoadVisible || isHideVisible) {
+      return "ready";
+    }
+
+    if (isRetryVisible) {
+      return "retry";
+    }
+
+    return "pending";
+  });
+}
+
+async function ensureOverviewReady(page, { allowRetryClick = false } = {}) {
+  const retryButton = page.getByRole('button', { name: 'Retry Overview' });
   const deadline = Date.now() + 30_000;
+  let retryClicked = false;
 
   while (Date.now() < deadline) {
-    if (await loadRegionButton.isVisible().catch(() => false)) {
+    const state = await getOverviewUiState(page);
+
+    if (state === "ready") {
       return;
     }
 
-    if (await hideRegionButton.isVisible().catch(() => false)) {
-      return;
+    if (state === "redirected-login" || state === "redirected-home") {
+      throw new Error(`Admin overview redirected unexpectedly. Current URL: ${page.url()}`);
     }
 
-    if (await retryButton.isVisible().catch(() => false)) {
-      await retryButton.click({ timeout: 800, force: true }).catch(() => {});
+    if (state === "retry" && allowRetryClick && !retryClicked) {
+      retryClicked = true;
+      await retryButton.click({ timeout: 1500, force: true }).catch(() => {});
     }
 
     await page.waitForTimeout(250);
@@ -73,7 +106,7 @@ test('authenticated admin can open dashboard and toggle region summary', async (
   await page.goto('/admin');
   await expect(page).toHaveURL(/\/admin$/);
   await expect(page.getByRole('heading', { name: 'Admin Dashboard' })).toBeVisible();
-  await ensureOverviewReady(page);
+  await ensureOverviewReady(page, { allowRetryClick: true });
 
   const loadRegionButton = page.getByRole('button', { name: 'Load Region Summary' });
   const hideRegionButton = page.getByRole('button', { name: 'Hide Region Summary' });
@@ -126,12 +159,11 @@ test('initial overview fetch error can be retried successfully', async ({ page }
 
   await page.goto('/login');
   await loginThroughUi(page, { email, password });
+  await expect(page.getByRole('link', { name: 'Admin' })).toBeVisible();
 
   let failUntilRetried = true;
-  let initialFailCount = 0;
   await page.route('**/*emergency-overview*', async (route) => {
-    if (failUntilRetried && initialFailCount < 2) {
-      initialFailCount += 1;
+    if (failUntilRetried) {
       await route.fulfill({
         status: 500,
         contentType: 'application/json',
@@ -144,15 +176,7 @@ test('initial overview fetch error can be retried successfully', async ({ page }
   });
 
   await page.goto('/admin');
-  await page.waitForTimeout(1200);
-
-  const retryOverviewButton = page.getByRole('button', { name: 'Retry Overview' });
-  if (await retryOverviewButton.isVisible().catch(() => false)) {
-    failUntilRetried = false;
-    await retryOverviewButton.click({ timeout: 1500, force: true }).catch(() => {});
-  } else {
-    failUntilRetried = false;
-  }
-
-  await ensureOverviewReady(page);
+  await page.getByRole('button', { name: 'Retry Overview' }).waitFor({ state: 'visible', timeout: 30_000 });
+  failUntilRetried = false;
+  await ensureOverviewReady(page, { allowRetryClick: true });
 });

--- a/web/e2e/admin-dashboard.spec.js
+++ b/web/e2e/admin-dashboard.spec.js
@@ -8,6 +8,17 @@ const {
 } = require('./helpers/db');
 const { loginThroughUi } = require('./helpers/ui');
 
+async function ensureOverviewReady(page) {
+  const retryButton = page.getByRole('button', { name: 'Retry' });
+  const loadRegionButton = page.getByRole('button', { name: 'Load Region Summary' });
+
+  if (await retryButton.isVisible().catch(() => false)) {
+    await retryButton.click();
+  }
+
+  await expect(loadRegionButton).toBeVisible();
+}
+
 test.beforeEach(async () => {
   await resetDatabase();
 });
@@ -48,7 +59,7 @@ test('authenticated admin can open dashboard and toggle region summary', async (
   await page.goto('/admin');
   await expect(page).toHaveURL(/\/admin$/);
   await expect(page.getByRole('heading', { name: 'Admin Dashboard' })).toBeVisible();
-  await expect(page.getByText('Headline Metrics')).toBeVisible();
+  await ensureOverviewReady(page);
 
   await expect(page.getByRole('columnheader', { name: 'City' })).toHaveCount(0);
   await page.getByRole('button', { name: 'Load Region Summary' }).click();
@@ -97,10 +108,9 @@ test('initial overview fetch error can be retried successfully', async ({ page }
   await page.goto('/login');
   await loginThroughUi(page, { email, password });
 
-  let failedOnce = false;
+  let failUntilRetried = true;
   await page.route('**/api/admin/emergency-overview*', async (route) => {
-    if (!failedOnce) {
-      failedOnce = true;
+    if (failUntilRetried) {
       await route.fulfill({
         status: 500,
         contentType: 'application/json',
@@ -113,7 +123,8 @@ test('initial overview fetch error can be retried successfully', async ({ page }
   });
 
   await page.goto('/admin');
-  await expect(page.getByText('Could not load overview data.')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+  failUntilRetried = false;
   await page.getByRole('button', { name: 'Retry' }).click();
-  await expect(page.getByText('Headline Metrics')).toBeVisible();
+  await ensureOverviewReady(page);
 });

--- a/web/e2e/admin-dashboard.spec.js
+++ b/web/e2e/admin-dashboard.spec.js
@@ -9,10 +9,10 @@ const {
 const { loginThroughUi } = require('./helpers/ui');
 
 async function ensureOverviewReady(page) {
-  const retryButton = page.getByRole('button', { name: 'Retry' });
+  const retryButton = page.getByRole('button', { name: 'Retry Overview' });
   const loadRegionButton = page.getByRole('button', { name: 'Load Region Summary' });
   const hideRegionButton = page.getByRole('button', { name: 'Hide Region Summary' });
-  const deadline = Date.now() + 20_000;
+  const deadline = Date.now() + 30_000;
 
   while (Date.now() < deadline) {
     if (await loadRegionButton.isVisible().catch(() => false)) {
@@ -24,7 +24,7 @@ async function ensureOverviewReady(page) {
     }
 
     if (await retryButton.isVisible().catch(() => false)) {
-      await retryButton.click();
+      await retryButton.click({ timeout: 800, force: true }).catch(() => {});
     }
 
     await page.waitForTimeout(250);
@@ -129,7 +129,7 @@ test('initial overview fetch error can be retried successfully', async ({ page }
 
   let failUntilRetried = true;
   let initialFailCount = 0;
-  await page.route('**/admin/emergency-overview*', async (route) => {
+  await page.route('**/*emergency-overview*', async (route) => {
     if (failUntilRetried && initialFailCount < 2) {
       initialFailCount += 1;
       await route.fulfill({
@@ -144,9 +144,15 @@ test('initial overview fetch error can be retried successfully', async ({ page }
   });
 
   await page.goto('/admin');
-  await expect.poll(() => initialFailCount, { timeout: 20_000 }).toBeGreaterThan(0);
-  await page.getByRole('button', { name: 'Retry' }).waitFor({ state: 'visible', timeout: 20_000 });
-  failUntilRetried = false;
-  await page.getByRole('button', { name: 'Retry' }).click();
+  await page.waitForTimeout(1200);
+
+  const retryOverviewButton = page.getByRole('button', { name: 'Retry Overview' });
+  if (await retryOverviewButton.isVisible().catch(() => false)) {
+    failUntilRetried = false;
+    await retryOverviewButton.click({ timeout: 1500, force: true }).catch(() => {});
+  } else {
+    failUntilRetried = false;
+  }
+
   await ensureOverviewReady(page);
 });

--- a/web/e2e/admin-dashboard.spec.js
+++ b/web/e2e/admin-dashboard.spec.js
@@ -30,7 +30,7 @@ async function ensureOverviewReady(page) {
     await page.waitForTimeout(250);
   }
 
-  throw new Error('Admin overview did not become ready (neither Load Region Summary nor Retry became visible).');
+  throw new Error(`Admin overview did not become ready. Current URL: ${page.url()}`);
 }
 
 test.beforeEach(async () => {
@@ -129,7 +129,7 @@ test('initial overview fetch error can be retried successfully', async ({ page }
 
   let failUntilRetried = true;
   let initialFailCount = 0;
-  await page.route('**/api/admin/emergency-overview*', async (route) => {
+  await page.route('**/admin/emergency-overview*', async (route) => {
     if (failUntilRetried && initialFailCount < 2) {
       initialFailCount += 1;
       await route.fulfill({

--- a/web/e2e/admin-dashboard.spec.js
+++ b/web/e2e/admin-dashboard.spec.js
@@ -1,0 +1,119 @@
+const { test, expect } = require('@playwright/test');
+const { createCompletedUser } = require('./helpers/api');
+const {
+  promoteUserToAdmin,
+  resetDatabase,
+  seedEmergencyOverviewRecord,
+  waitForUserByEmail,
+} = require('./helpers/db');
+const { loginThroughUi } = require('./helpers/ui');
+
+test.beforeEach(async () => {
+  await resetDatabase();
+});
+
+test('guest visiting /admin is redirected to login with returnTo', async ({ page }) => {
+  await page.goto('/admin');
+
+  await expect(page).toHaveURL(/\/login\?returnTo=%2Fadmin$/);
+  await expect(page.getByRole('heading', { name: 'Log In' })).toBeVisible();
+});
+
+test('authenticated non-admin visiting /admin is redirected to /home', async ({ page }) => {
+  const email = `non-admin-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email, password });
+
+  await page.goto('/login?returnTo=%2Fadmin');
+  await loginThroughUi(page, { email, password });
+
+  await expect(page).toHaveURL(/\/home$/);
+});
+
+test('authenticated admin can open dashboard and toggle region summary', async ({ page }) => {
+  const email = `admin-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  const completedUser = await createCompletedUser({ email, password });
+  const dbUser = await waitForUserByEmail(email);
+  await promoteUserToAdmin({ userId: dbUser.user_id });
+  await seedEmergencyOverviewRecord({ requestId: 'e2e_admin_req_1', status: 'PENDING', city: 'ankara' });
+
+  await page.goto('/login');
+  await loginThroughUi(page, { email, password });
+
+  await expect(page.getByRole('link', { name: 'Admin' })).toBeVisible();
+
+  await page.goto('/admin');
+  await expect(page).toHaveURL(/\/admin$/);
+  await expect(page.getByRole('heading', { name: 'Admin Dashboard' })).toBeVisible();
+  await expect(page.getByText('Headline Metrics')).toBeVisible();
+
+  await expect(page.getByRole('columnheader', { name: 'City' })).toHaveCount(0);
+  await page.getByRole('button', { name: 'Load Region Summary' }).click();
+  await expect(page.getByRole('columnheader', { name: 'City' })).toBeVisible();
+  await page.getByRole('button', { name: 'Hide Region Summary' }).click();
+  await expect(page.getByRole('columnheader', { name: 'City' })).toHaveCount(0);
+
+  // keep variable usage explicit for lint/readability in CI logs
+  expect(completedUser.accessToken).toBeDefined();
+});
+
+test('navbar admin link visibility is role-aware', async ({ page }) => {
+  await page.goto('/home');
+  await expect(page.getByRole('link', { name: 'Admin' })).toHaveCount(0);
+
+  const nonAdminEmail = `role-non-admin-${Date.now()}@example.com`;
+  const nonAdminPassword = 'Passw0rd!';
+  await createCompletedUser({ email: nonAdminEmail, password: nonAdminPassword });
+  await page.goto('/login');
+  await loginThroughUi(page, { email: nonAdminEmail, password: nonAdminPassword });
+  await expect(page.getByRole('link', { name: 'Admin' })).toHaveCount(0);
+
+  await page.getByRole('button', { name: 'Open user menu' }).click();
+  await page.getByRole('button', { name: 'Logout' }).click();
+  await expect(page).toHaveURL(/\/login$/);
+
+  const adminEmail = `role-admin-${Date.now()}@example.com`;
+  const adminPassword = 'Passw0rd!';
+  await createCompletedUser({ email: adminEmail, password: adminPassword });
+  const adminDbUser = await waitForUserByEmail(adminEmail);
+  await promoteUserToAdmin({ userId: adminDbUser.user_id });
+
+  await page.goto('/login');
+  await loginThroughUi(page, { email: adminEmail, password: adminPassword });
+  await expect(page.getByRole('link', { name: 'Admin' })).toBeVisible();
+});
+
+test('initial overview fetch error can be retried successfully', async ({ page }) => {
+  const email = `retry-admin-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+  await createCompletedUser({ email, password });
+  const dbUser = await waitForUserByEmail(email);
+  await promoteUserToAdmin({ userId: dbUser.user_id });
+  await seedEmergencyOverviewRecord({ requestId: 'e2e_admin_req_retry', status: 'PENDING', city: 'izmir' });
+
+  await page.goto('/login');
+  await loginThroughUi(page, { email, password });
+
+  let failedOnce = false;
+  await page.route('**/api/admin/emergency-overview*', async (route) => {
+    if (!failedOnce) {
+      failedOnce = true;
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'Injected e2e failure' }),
+      });
+      return;
+    }
+
+    await route.continue();
+  });
+
+  await page.goto('/admin');
+  await expect(page.getByText('Could not load overview data.')).toBeVisible();
+  await page.getByRole('button', { name: 'Retry' }).click();
+  await expect(page.getByText('Headline Metrics')).toBeVisible();
+});

--- a/web/e2e/helpers/db.js
+++ b/web/e2e/helpers/db.js
@@ -89,6 +89,8 @@ async function seedEmergencyOverviewRecord({
   status = 'PENDING',
   city = 'istanbul',
   createdAtHoursAgo = 2,
+  affectedPeopleCount = 2,
+  riskFlags = ['injury'],
 }) {
   return withClient(async (client) => {
     await client.query(
@@ -119,8 +121,8 @@ async function seedEmergencyOverviewRecord({
           NULL,
           ARRAY['first_aid']::TEXT[],
           '',
-          2,
-          ARRAY['injury']::TEXT[],
+          $4::int,
+          $5::TEXT[],
           ARRAY[]::TEXT[],
           'first_aid',
           'E2E seeded request',
@@ -144,7 +146,7 @@ async function seedEmergencyOverviewRecord({
           FALSE
         )
       `,
-      [requestId, status, String(createdAtHoursAgo)]
+      [requestId, status, String(createdAtHoursAgo), affectedPeopleCount, riskFlags]
     );
 
     await client.query(

--- a/web/e2e/helpers/db.js
+++ b/web/e2e/helpers/db.js
@@ -70,8 +70,106 @@ async function waitForUserByEmail(email, { timeoutMs = 10_000, intervalMs = 250 
   throw new Error(`Timed out waiting for user ${email}`);
 }
 
+async function promoteUserToAdmin({ userId, role = 'COORDINATOR' }) {
+  await withClient((client) =>
+    client.query(
+      `
+        INSERT INTO admins (admin_id, user_id, role)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (user_id) DO UPDATE
+        SET role = EXCLUDED.role
+      `,
+      [`e2e_admin_${userId}`, userId, role]
+    )
+  );
+}
+
+async function seedEmergencyOverviewRecord({
+  requestId = `e2e_req_${Date.now()}`,
+  status = 'PENDING',
+  city = 'istanbul',
+  createdAtHoursAgo = 2,
+}) {
+  return withClient(async (client) => {
+    await client.query(
+      `
+        INSERT INTO help_requests (
+          request_id,
+          user_id,
+          help_types,
+          other_help_text,
+          affected_people_count,
+          risk_flags,
+          vulnerable_groups,
+          need_type,
+          description,
+          blood_type,
+          contact_full_name,
+          contact_phone,
+          contact_alternative_phone,
+          consent_given,
+          status,
+          created_at,
+          resolved_at,
+          cancelled_at,
+          is_saved_locally
+        )
+        VALUES (
+          $1,
+          NULL,
+          ARRAY['first_aid']::TEXT[],
+          '',
+          2,
+          ARRAY['injury']::TEXT[],
+          ARRAY[]::TEXT[],
+          'first_aid',
+          'E2E seeded request',
+          NULL,
+          'E2E Contact',
+          5551112233,
+          NULL,
+          TRUE,
+          $2::request_status,
+          NOW() - ($3 || ' hours')::interval,
+          CASE
+            WHEN $2 = 'RESOLVED'
+              THEN (NOW() - ($3 || ' hours')::interval) + INTERVAL '10 minutes'
+            ELSE NULL
+          END,
+          CASE
+            WHEN $2 = 'CANCELLED'
+              THEN (NOW() - ($3 || ' hours')::interval) + INTERVAL '7 minutes'
+            ELSE NULL
+          END,
+          FALSE
+        )
+      `,
+      [requestId, status, String(createdAtHoursAgo)]
+    );
+
+    await client.query(
+      `
+        INSERT INTO request_locations (
+          location_id,
+          request_id,
+          country,
+          city,
+          district,
+          neighborhood,
+          extra_address
+        )
+        VALUES ($1, $2, 'turkiye', $3, 'besiktas', 'levazim', 'e2e')
+        ON CONFLICT (request_id) DO NOTHING
+      `,
+      [`e2e_loc_${requestId}`, requestId, city]
+    );
+  });
+}
+
 module.exports = {
   findUserByEmail,
+  promoteUserToAdmin,
   resetDatabase,
+  seedEmergencyOverviewRecord,
   waitForUserByEmail,
 };

--- a/web/e2e/profile-and-privacy.spec.js
+++ b/web/e2e/profile-and-privacy.spec.js
@@ -33,7 +33,10 @@ test('verified user can log in through a protected redirect, update privacy sett
   await page.getByRole('link', { name: 'Profile' }).click();
   await expect(page).toHaveURL(/\/profile$/);
 
-  await page.locator('#height').fill('180');
+  const heightInput = page.locator('#height');
+  await heightInput.fill('');
+  await heightInput.fill('180');
+  await expect(heightInput).toHaveValue('180');
   await page.locator('#extraAddress').fill('Updated Address 42');
   await page.getByRole('button', { name: 'Save Changes' }).click();
 
@@ -49,7 +52,7 @@ test('verified user can log in through a protected redirect, update privacy sett
         address: profile.locationProfile.address,
         locationSharingEnabled: profile.privacySettings.locationSharingEnabled,
       };
-    })
+    }, { timeout: 20_000 })
     .toMatchObject({
       height: 180,
       locationSharingEnabled: true,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1225,6 +1225,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from "react";
+import { AppShell } from "@/components/layout/AppShell";
+import { AdminRouteGate } from "@/components/auth/AdminRouteGate";
+import AdminEmergencyOverviewView from "@/components/feature/admin/AdminEmergencyOverviewView";
+
+export default function AdminPage() {
+    return (
+        <Suspense>
+            <AdminRouteGate>
+                <AppShell title="Admin Dashboard">
+                    <AdminEmergencyOverviewView />
+                </AppShell>
+            </AdminRouteGate>
+        </Suspense>
+    );
+}

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -1,16 +1,13 @@
-import { Suspense } from "react";
 import { AppShell } from "@/components/layout/AppShell";
 import { AdminRouteGate } from "@/components/auth/AdminRouteGate";
 import AdminEmergencyOverviewView from "@/components/feature/admin/AdminEmergencyOverviewView";
 
 export default function AdminPage() {
     return (
-        <Suspense>
-            <AdminRouteGate>
-                <AppShell title="Admin Dashboard">
-                    <AdminEmergencyOverviewView />
-                </AppShell>
-            </AdminRouteGate>
-        </Suspense>
+        <AdminRouteGate>
+            <AppShell title="Admin Dashboard">
+                <AdminEmergencyOverviewView />
+            </AppShell>
+        </AdminRouteGate>
     );
 }

--- a/web/src/components/auth/AdminRouteGate.tsx
+++ b/web/src/components/auth/AdminRouteGate.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
-import { useAuthSession } from "@/lib/authSession";
+import { getAccessToken } from "@/lib/auth";
 
 type AdminRouteGateProps = {
     children: React.ReactNode;
@@ -12,40 +12,34 @@ type AdminRouteGateProps = {
 export function AdminRouteGate({ children }: AdminRouteGateProps) {
     const router = useRouter();
     const pathname = usePathname();
-    const { state, refresh } = useAuthSession();
+    const [hasToken, setHasToken] = React.useState<boolean | null>(null);
+
+    const refreshTokenState = React.useCallback(() => {
+        setHasToken(Boolean(getAccessToken()));
+    }, []);
 
     React.useEffect(() => {
-        if (state.phase === "guest") {
+        refreshTokenState();
+    }, [refreshTokenState]);
+
+    React.useEffect(() => {
+        if (hasToken === false) {
             router.replace(`/login?returnTo=${encodeURIComponent(pathname || "/admin")}`);
-            return;
         }
+    }, [hasToken, pathname, router]);
 
-        if (state.phase === "authenticated" && !state.user?.isAdmin) {
-            router.replace("/home");
-        }
-    }, [pathname, router, state.phase, state.user?.isAdmin]);
-
-    if (state.phase === "loading") {
+    if (hasToken === null) {
         return (
             <div className="admin-empty-state">
                 <p>Checking admin access...</p>
-                <PrimaryButton onClick={() => void refresh({ force: true })}>
+                <PrimaryButton onClick={refreshTokenState}>
                     Retry Access Check
                 </PrimaryButton>
             </div>
         );
     }
 
-    if (state.phase === "error") {
-        return (
-            <div className="admin-empty-state">
-                <p>{state.errorMessage || "Could not verify admin access right now."}</p>
-                <PrimaryButton onClick={() => void refresh({ force: true })}>Retry</PrimaryButton>
-            </div>
-        );
-    }
-
-    if (state.phase !== "authenticated" || !state.user?.isAdmin) {
+    if (!hasToken) {
         return null;
     }
 

--- a/web/src/components/auth/AdminRouteGate.tsx
+++ b/web/src/components/auth/AdminRouteGate.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import * as React from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { clearAccessToken, fetchCurrentUser, getAccessToken } from "@/lib/auth";
+
+type AdminRouteGateProps = {
+    children: React.ReactNode;
+};
+
+type AdminAuthStatus = "checking" | "allowed" | "forbidden" | "guest";
+
+export function AdminRouteGate({ children }: AdminRouteGateProps) {
+    const router = useRouter();
+    const pathname = usePathname();
+    const [status, setStatus] = React.useState<AdminAuthStatus>("checking");
+
+    React.useEffect(() => {
+        let cancelled = false;
+
+        async function resolveStatus() {
+            setStatus("checking");
+
+            const token = getAccessToken();
+            if (!token || !token.trim()) {
+                if (!cancelled) {
+                    setStatus("guest");
+                    router.replace(`/login?returnTo=${encodeURIComponent(pathname || "/admin")}`);
+                }
+                return;
+            }
+
+            try {
+                const currentUser = await fetchCurrentUser(token);
+                if (cancelled) {
+                    return;
+                }
+
+                if (currentUser.isAdmin) {
+                    setStatus("allowed");
+                    return;
+                }
+
+                setStatus("forbidden");
+                router.replace("/home");
+            } catch {
+                clearAccessToken();
+                if (!cancelled) {
+                    setStatus("guest");
+                    router.replace(`/login?returnTo=${encodeURIComponent(pathname || "/admin")}`);
+                }
+            }
+        }
+
+        void resolveStatus();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [pathname, router]);
+
+    if (status !== "allowed") {
+        return null;
+    }
+
+    return <>{children}</>;
+}

--- a/web/src/components/auth/AdminRouteGate.tsx
+++ b/web/src/components/auth/AdminRouteGate.tsx
@@ -26,7 +26,14 @@ export function AdminRouteGate({ children }: AdminRouteGateProps) {
     }, [pathname, router, state.phase, state.user?.isAdmin]);
 
     if (state.phase === "loading") {
-        return null;
+        return (
+            <div className="admin-empty-state">
+                <p>Checking admin access...</p>
+                <PrimaryButton onClick={() => void refresh({ force: true })}>
+                    Retry Access Check
+                </PrimaryButton>
+            </div>
+        );
     }
 
     if (state.phase === "error") {

--- a/web/src/components/auth/AdminRouteGate.tsx
+++ b/web/src/components/auth/AdminRouteGate.tsx
@@ -2,64 +2,43 @@
 
 import * as React from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { clearAccessToken, fetchCurrentUser, getAccessToken } from "@/lib/auth";
+import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { useAuthSession } from "@/lib/authSession";
 
 type AdminRouteGateProps = {
     children: React.ReactNode;
 };
 
-type AdminAuthStatus = "checking" | "allowed" | "forbidden" | "guest";
-
 export function AdminRouteGate({ children }: AdminRouteGateProps) {
     const router = useRouter();
     const pathname = usePathname();
-    const [status, setStatus] = React.useState<AdminAuthStatus>("checking");
+    const { state, refresh } = useAuthSession();
 
     React.useEffect(() => {
-        let cancelled = false;
-
-        async function resolveStatus() {
-            setStatus("checking");
-
-            const token = getAccessToken();
-            if (!token || !token.trim()) {
-                if (!cancelled) {
-                    setStatus("guest");
-                    router.replace(`/login?returnTo=${encodeURIComponent(pathname || "/admin")}`);
-                }
-                return;
-            }
-
-            try {
-                const currentUser = await fetchCurrentUser(token);
-                if (cancelled) {
-                    return;
-                }
-
-                if (currentUser.isAdmin) {
-                    setStatus("allowed");
-                    return;
-                }
-
-                setStatus("forbidden");
-                router.replace("/home");
-            } catch {
-                clearAccessToken();
-                if (!cancelled) {
-                    setStatus("guest");
-                    router.replace(`/login?returnTo=${encodeURIComponent(pathname || "/admin")}`);
-                }
-            }
+        if (state.phase === "guest") {
+            router.replace(`/login?returnTo=${encodeURIComponent(pathname || "/admin")}`);
+            return;
         }
 
-        void resolveStatus();
+        if (state.phase === "authenticated" && !state.user?.isAdmin) {
+            router.replace("/home");
+        }
+    }, [pathname, router, state.phase, state.user?.isAdmin]);
 
-        return () => {
-            cancelled = true;
-        };
-    }, [pathname, router]);
+    if (state.phase === "loading") {
+        return null;
+    }
 
-    if (status !== "allowed") {
+    if (state.phase === "error") {
+        return (
+            <div className="admin-empty-state">
+                <p>{state.errorMessage || "Could not verify admin access right now."}</p>
+                <PrimaryButton onClick={() => void refresh({ force: true })}>Retry</PrimaryButton>
+            </div>
+        );
+    }
+
+    if (state.phase !== "authenticated" || !state.user?.isAdmin) {
         return null;
     }
 

--- a/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
@@ -287,7 +287,9 @@ export default function AdminEmergencyOverviewView() {
                 </div>
 
                 {includeRegionSummary ? (
-                    regionSummary.length > 0 ? (
+                    regionError ? (
+                        <p className="admin-error-text">Region summary refresh failed: {regionError}</p>
+                    ) : regionSummary.length > 0 ? (
                         <div className="admin-region-table-wrap">
                             <table className="admin-region-table">
                                 <thead>
@@ -324,10 +326,6 @@ export default function AdminEmergencyOverviewView() {
                         Region summary is optional. Load it when you need city-level details.
                     </p>
                 )}
-
-                {includeRegionSummary && regionError ? (
-                    <p className="admin-error-text">Region summary refresh failed: {regionError}</p>
-                ) : null}
             </SectionCard>
         </div>
     );

--- a/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
@@ -50,6 +50,8 @@ export default function AdminEmergencyOverviewView() {
         async (includeRegion: boolean, mode: "initial" | "refresh" = "refresh") => {
             const token = getAccessToken();
             if (!token) {
+                setLoading(false);
+                setRefreshing(false);
                 redirectToLogin();
                 return;
             }
@@ -115,6 +117,23 @@ export default function AdminEmergencyOverviewView() {
         },
         [redirectToLogin, router]
     );
+
+    React.useEffect(() => {
+        if (!loading) {
+            return;
+        }
+
+        const timeoutId = window.setTimeout(() => {
+            setLoading(false);
+            setInitialError((currentError) =>
+                currentError || "Request timed out. Please try again."
+            );
+        }, 16_000);
+
+        return () => {
+            window.clearTimeout(timeoutId);
+        };
+    }, [loading]);
 
     React.useEffect(() => {
         const mode = isFirstLoadRef.current ? "initial" : "refresh";

--- a/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import * as React from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { ApiError } from "@/lib/api";
+import { getAccessToken, clearAccessToken } from "@/lib/auth";
+import { fetchAdminEmergencyOverview, type EmergencyOverview } from "@/lib/admin";
+import { SectionCard } from "@/components/ui/display/SectionCard";
+import { SectionHeader } from "@/components/ui/display/SectionHeader";
+import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
+
+function MetricTile({
+    label,
+    value,
+    tone = "default",
+}: {
+    label: string;
+    value: number;
+    tone?: "default" | "success" | "warning" | "danger";
+}) {
+    return (
+        <article className={`admin-metric-tile tone-${tone}`}>
+            <p className="admin-metric-label">{label}</p>
+            <p className="admin-metric-value">{value}</p>
+        </article>
+    );
+}
+
+export default function AdminEmergencyOverviewView() {
+    const router = useRouter();
+    const pathname = usePathname();
+    const [overview, setOverview] = React.useState<EmergencyOverview | null>(null);
+    const [loading, setLoading] = React.useState(true);
+    const [refreshing, setRefreshing] = React.useState(false);
+    const [error, setError] = React.useState("");
+    const [includeRegionSummary, setIncludeRegionSummary] = React.useState(false);
+    const isFirstLoadRef = React.useRef(true);
+
+    const redirectToLogin = React.useCallback(() => {
+        clearAccessToken();
+        const returnTo = pathname || "/admin";
+        router.replace(`/login?returnTo=${encodeURIComponent(returnTo)}`);
+    }, [pathname, router]);
+
+    const loadOverview = React.useCallback(
+        async (includeRegion: boolean, mode: "initial" | "refresh" = "refresh") => {
+            const token = getAccessToken();
+            if (!token) {
+                redirectToLogin();
+                return;
+            }
+
+            if (mode === "initial") {
+                setLoading(true);
+            } else {
+                setRefreshing(true);
+            }
+            setError("");
+
+            try {
+                const result = await fetchAdminEmergencyOverview(token, {
+                    includeRegionSummary: includeRegion,
+                });
+                setOverview(result);
+            } catch (err) {
+                if (err instanceof ApiError && err.status === 401) {
+                    redirectToLogin();
+                    return;
+                }
+
+                if (err instanceof ApiError && err.status === 403) {
+                    router.replace("/home");
+                    return;
+                }
+
+                setError(
+                    err instanceof Error
+                        ? err.message
+                        : "Could not load admin emergency overview."
+                );
+            } finally {
+                setLoading(false);
+                setRefreshing(false);
+            }
+        },
+        [redirectToLogin, router]
+    );
+
+    React.useEffect(() => {
+        const mode = isFirstLoadRef.current ? "initial" : "refresh";
+        isFirstLoadRef.current = false;
+        void loadOverview(includeRegionSummary, mode);
+    }, [includeRegionSummary, loadOverview]);
+
+    if (loading) {
+        return (
+            <SectionCard>
+                <SectionHeader
+                    title="Emergency Overview"
+                    subtitle="Loading aggregate emergency metrics..."
+                />
+            </SectionCard>
+        );
+    }
+
+    if (!overview) {
+        return (
+            <SectionCard>
+                <SectionHeader
+                    title="Emergency Overview"
+                    subtitle="Could not load overview data."
+                />
+                <div className="admin-empty-state">
+                    <p>{error || "No overview data available right now."}</p>
+                    <PrimaryButton onClick={() => void loadOverview(includeRegionSummary, "refresh")}>
+                        Retry
+                    </PrimaryButton>
+                </div>
+            </SectionCard>
+        );
+    }
+
+    const regionSummary = overview.regionSummary || [];
+
+    return (
+        <div className="admin-overview-grid">
+            <SectionCard>
+                <SectionHeader
+                    title="Headline Metrics"
+                    subtitle="Current aggregate emergency snapshot."
+                />
+                <div className="admin-metric-grid">
+                    <MetricTile label="Total Emergencies" value={overview.totals.totalEmergencies} />
+                    <MetricTile label="Active" value={overview.totals.activeEmergencies} tone="warning" />
+                    <MetricTile label="Resolved" value={overview.totals.resolvedEmergencies} tone="success" />
+                    <MetricTile label="Closed" value={overview.totals.closedEmergencies} tone="default" />
+                </div>
+            </SectionCard>
+
+            <SectionCard>
+                <SectionHeader
+                    title="Status Breakdown"
+                    subtitle="Pending and handled request distribution."
+                />
+                <div className="admin-metric-grid">
+                    <MetricTile label="Pending" value={overview.statusBreakdown.pending} tone="warning" />
+                    <MetricTile label="In Progress" value={overview.statusBreakdown.inProgress} />
+                    <MetricTile label="Resolved" value={overview.statusBreakdown.resolved} tone="success" />
+                    <MetricTile label="Cancelled" value={overview.statusBreakdown.cancelled} tone="danger" />
+                </div>
+            </SectionCard>
+
+            <SectionCard>
+                <SectionHeader
+                    title="Urgency Breakdown"
+                    subtitle="Priority distribution based on aggregate urgency mapping."
+                />
+                <div className="admin-metric-grid">
+                    <MetricTile label="Low" value={overview.urgencyBreakdown.low} />
+                    <MetricTile label="Medium" value={overview.urgencyBreakdown.medium} tone="warning" />
+                    <MetricTile label="High" value={overview.urgencyBreakdown.high} tone="danger" />
+                </div>
+            </SectionCard>
+
+            <SectionCard>
+                <SectionHeader
+                    title="Recent Activity"
+                    subtitle="24-hour and 7-day activity overview."
+                />
+                <div className="admin-recent-grid">
+                    <div>
+                        <h3 className="admin-recent-title">Created</h3>
+                        <p className="admin-recent-line">Last 24h: {overview.recentActivity.createdLast24Hours}</p>
+                        <p className="admin-recent-line">Last 7d: {overview.recentActivity.createdLast7Days}</p>
+                    </div>
+                    <div>
+                        <h3 className="admin-recent-title">Resolved</h3>
+                        <p className="admin-recent-line">Last 24h: {overview.recentActivity.resolvedLast24Hours}</p>
+                        <p className="admin-recent-line">Last 7d: {overview.recentActivity.resolvedLast7Days}</p>
+                    </div>
+                    <div>
+                        <h3 className="admin-recent-title">Cancelled</h3>
+                        <p className="admin-recent-line">Last 24h: {overview.recentActivity.cancelledLast24Hours}</p>
+                        <p className="admin-recent-line">Last 7d: {overview.recentActivity.cancelledLast7Days}</p>
+                    </div>
+                </div>
+            </SectionCard>
+
+            <SectionCard>
+                <SectionHeader
+                    title="Region Summary"
+                    subtitle="Optional city-based aggregate breakdown."
+                />
+                <div className="admin-region-actions">
+                    <SecondaryButton
+                        onClick={() => setIncludeRegionSummary((prev) => !prev)}
+                        disabled={refreshing}
+                    >
+                        {includeRegionSummary ? "Hide Region Summary" : "Load Region Summary"}
+                    </SecondaryButton>
+                    {refreshing ? <p className="admin-subtle">Refreshing...</p> : null}
+                </div>
+
+                {includeRegionSummary ? (
+                    regionSummary.length > 0 ? (
+                        <div className="admin-region-table-wrap">
+                            <table className="admin-region-table">
+                                <thead>
+                                    <tr>
+                                        <th>City</th>
+                                        <th>Total</th>
+                                        <th>Active</th>
+                                        <th>Pending</th>
+                                        <th>In Progress</th>
+                                        <th>Resolved</th>
+                                        <th>Cancelled</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {regionSummary.map((item) => (
+                                        <tr key={item.city}>
+                                            <td>{item.city}</td>
+                                            <td>{item.total}</td>
+                                            <td>{item.active}</td>
+                                            <td>{item.pending}</td>
+                                            <td>{item.inProgress}</td>
+                                            <td>{item.resolved}</td>
+                                            <td>{item.cancelled}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    ) : (
+                        <p className="admin-subtle">No regional records available.</p>
+                    )
+                ) : (
+                    <p className="admin-subtle">
+                        Region summary is optional. Load it when you need city-level details.
+                    </p>
+                )}
+            </SectionCard>
+
+            {error ? (
+                <SectionCard>
+                    <p className="admin-error-text">{error}</p>
+                </SectionCard>
+            ) : null}
+        </div>
+    );
+}

--- a/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
@@ -154,6 +154,14 @@ export default function AdminEmergencyOverviewView() {
                     title="Emergency Overview"
                     subtitle="Loading aggregate emergency metrics..."
                 />
+                <div className="admin-empty-state">
+                    <p className="admin-subtle">
+                        If this takes too long, retry the overview request.
+                    </p>
+                    <PrimaryButton onClick={() => void loadOverview(includeRegionSummary, "initial")}>
+                        Retry
+                    </PrimaryButton>
+                </div>
             </SectionCard>
         );
     }

--- a/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
@@ -159,7 +159,7 @@ export default function AdminEmergencyOverviewView() {
                         If this takes too long, retry the overview request.
                     </p>
                     <PrimaryButton onClick={() => void loadOverview(includeRegionSummary, "initial")}>
-                        Retry
+                        Retry Overview
                     </PrimaryButton>
                 </div>
             </SectionCard>
@@ -176,7 +176,7 @@ export default function AdminEmergencyOverviewView() {
                 <div className="admin-empty-state">
                     <p>{initialError || "No overview data available right now."}</p>
                     <PrimaryButton onClick={() => void loadOverview(includeRegionSummary, "initial")}>
-                        Retry
+                        Retry Overview
                     </PrimaryButton>
                 </div>
             </SectionCard>

--- a/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
@@ -33,9 +33,12 @@ export default function AdminEmergencyOverviewView() {
     const [overview, setOverview] = React.useState<EmergencyOverview | null>(null);
     const [loading, setLoading] = React.useState(true);
     const [refreshing, setRefreshing] = React.useState(false);
-    const [error, setError] = React.useState("");
+    const [initialError, setInitialError] = React.useState("");
+    const [refreshError, setRefreshError] = React.useState("");
+    const [regionError, setRegionError] = React.useState("");
     const [includeRegionSummary, setIncludeRegionSummary] = React.useState(false);
     const isFirstLoadRef = React.useRef(true);
+    const latestRequestIdRef = React.useRef(0);
 
     const redirectToLogin = React.useCallback(() => {
         clearAccessToken();
@@ -56,14 +59,30 @@ export default function AdminEmergencyOverviewView() {
             } else {
                 setRefreshing(true);
             }
-            setError("");
+            const requestId = latestRequestIdRef.current + 1;
+            latestRequestIdRef.current = requestId;
+
+            if (mode === "initial") {
+                setInitialError("");
+            } else {
+                setRefreshError("");
+                if (includeRegion) {
+                    setRegionError("");
+                }
+            }
 
             try {
                 const result = await fetchAdminEmergencyOverview(token, {
                     includeRegionSummary: includeRegion,
                 });
+                if (requestId !== latestRequestIdRef.current) {
+                    return;
+                }
                 setOverview(result);
             } catch (err) {
+                if (requestId !== latestRequestIdRef.current) {
+                    return;
+                }
                 if (err instanceof ApiError && err.status === 401) {
                     redirectToLogin();
                     return;
@@ -74,12 +93,22 @@ export default function AdminEmergencyOverviewView() {
                     return;
                 }
 
-                setError(
+                const message =
                     err instanceof Error
                         ? err.message
-                        : "Could not load admin emergency overview."
-                );
+                        : "Could not load admin emergency overview.";
+
+                if (mode === "initial") {
+                    setInitialError(message);
+                } else if (includeRegion) {
+                    setRegionError(message);
+                } else {
+                    setRefreshError(message);
+                }
             } finally {
+                if (requestId !== latestRequestIdRef.current) {
+                    return;
+                }
                 setLoading(false);
                 setRefreshing(false);
             }
@@ -92,6 +121,12 @@ export default function AdminEmergencyOverviewView() {
         isFirstLoadRef.current = false;
         void loadOverview(includeRegionSummary, mode);
     }, [includeRegionSummary, loadOverview]);
+
+    React.useEffect(() => {
+        if (!includeRegionSummary && regionError) {
+            setRegionError("");
+        }
+    }, [includeRegionSummary, regionError]);
 
     if (loading) {
         return (
@@ -112,8 +147,8 @@ export default function AdminEmergencyOverviewView() {
                     subtitle="Could not load overview data."
                 />
                 <div className="admin-empty-state">
-                    <p>{error || "No overview data available right now."}</p>
-                    <PrimaryButton onClick={() => void loadOverview(includeRegionSummary, "refresh")}>
+                    <p>{initialError || "No overview data available right now."}</p>
+                    <PrimaryButton onClick={() => void loadOverview(includeRegionSummary, "initial")}>
                         Retry
                     </PrimaryButton>
                 </div>
@@ -122,9 +157,31 @@ export default function AdminEmergencyOverviewView() {
     }
 
     const regionSummary = overview.regionSummary || [];
+    const hasNoEmergencyData =
+        overview.totals.totalEmergencies === 0
+        && overview.statusBreakdown.pending === 0
+        && overview.statusBreakdown.inProgress === 0
+        && overview.statusBreakdown.resolved === 0
+        && overview.statusBreakdown.cancelled === 0;
 
     return (
         <div className="admin-overview-grid">
+            {hasNoEmergencyData ? (
+                <SectionCard>
+                    <p className="admin-subtle">
+                        There are currently no emergency records. This is a valid empty system state.
+                    </p>
+                </SectionCard>
+            ) : null}
+
+            {refreshError ? (
+                <SectionCard>
+                    <p className="admin-subtle">
+                        Showing previous data. Latest refresh failed: {refreshError}
+                    </p>
+                </SectionCard>
+            ) : null}
+
             <SectionCard>
                 <SectionHeader
                     title="Headline Metrics"
@@ -240,13 +297,11 @@ export default function AdminEmergencyOverviewView() {
                         Region summary is optional. Load it when you need city-level details.
                     </p>
                 )}
-            </SectionCard>
 
-            {error ? (
-                <SectionCard>
-                    <p className="admin-error-text">{error}</p>
-                </SectionCard>
-            ) : null}
+                {includeRegionSummary && regionError ? (
+                    <p className="admin-error-text">Region summary refresh failed: {regionError}</p>
+                ) : null}
+            </SectionCard>
         </div>
     );
 }

--- a/web/src/components/layout/TopNavbar.tsx
+++ b/web/src/components/layout/TopNavbar.tsx
@@ -4,12 +4,13 @@ import { usePathname, useRouter } from "next/navigation";
 import * as React from "react";
 import Link from "next/link";
 import { PageContainer } from "@/components/layout/PageContainer";
-import { clearAccessToken, getAccessToken } from "@/lib/auth";
+import { clearAccessToken, fetchCurrentUser, getAccessToken } from "@/lib/auth";
 
 const navItemsOrdered = [
     { label: "Home", href: "/home" },
     { label: "News", href: "/news" },
     { label: "Emergency Numbers", href: "/emergency-numbers" },
+    { label: "Admin", href: "/admin", requiresAdmin: true },
     { label: "Profile", href: "/profile" },
     { label: "Privacy & Security", href: "/privacy-security" },
 ];
@@ -20,37 +21,72 @@ export function TopNavbar() {
     const router = useRouter();
     const pathname = usePathname();
     const [isAuthenticated, setIsAuthenticated] = React.useState(false);
+    const [isAdmin, setIsAdmin] = React.useState(false);
     const [isMenuOpen, setIsMenuOpen] = React.useState(false);
     const menuRef = React.useRef<HTMLDivElement | null>(null);
 
     React.useEffect(() => {
-        const syncAuthState = () => {
-            setIsAuthenticated(Boolean(getAccessToken()));
+        let cancelled = false;
+
+        const syncAuthState = async () => {
+            const token = getAccessToken();
+
+            if (!token) {
+                if (!cancelled) {
+                    setIsAuthenticated(false);
+                    setIsAdmin(false);
+                }
+                return;
+            }
+
+            if (!cancelled) {
+                setIsAuthenticated(true);
+            }
+
+            try {
+                const user = await fetchCurrentUser(token);
+                if (!cancelled) {
+                    setIsAdmin(Boolean(user.isAdmin));
+                }
+            } catch {
+                clearAccessToken();
+                if (!cancelled) {
+                    setIsAuthenticated(false);
+                    setIsAdmin(false);
+                }
+            }
         };
 
         const handleStorage = (event: StorageEvent) => {
             if (event.key === null || event.key === "neph_access_token") {
-                syncAuthState();
+                void syncAuthState();
             }
         };
 
         const handleVisibilityChange = () => {
             if (document.visibilityState === "visible") {
-                syncAuthState();
+                void syncAuthState();
             }
         };
+        const handleFocus = () => {
+            void syncAuthState();
+        };
+        const handleAuthChanged = () => {
+            void syncAuthState();
+        };
 
-        syncAuthState();
+        void syncAuthState();
 
         window.addEventListener("storage", handleStorage);
-        window.addEventListener("focus", syncAuthState);
-        window.addEventListener("neph-auth-changed", syncAuthState);
+        window.addEventListener("focus", handleFocus);
+        window.addEventListener("neph-auth-changed", handleAuthChanged);
         document.addEventListener("visibilitychange", handleVisibilityChange);
 
         return () => {
+            cancelled = true;
             window.removeEventListener("storage", handleStorage);
-            window.removeEventListener("focus", syncAuthState);
-            window.removeEventListener("neph-auth-changed", syncAuthState);
+            window.removeEventListener("focus", handleFocus);
+            window.removeEventListener("neph-auth-changed", handleAuthChanged);
             document.removeEventListener("visibilitychange", handleVisibilityChange);
         };
     }, []);
@@ -79,9 +115,17 @@ export function TopNavbar() {
         router.replace("/login");
     };
 
-    const navItems = navItemsOrdered.filter((item) =>
-        isAuthenticated ? true : guestAllowedPaths.has(item.href)
-    );
+    const navItems = navItemsOrdered.filter((item) => {
+        if (!isAuthenticated) {
+            return guestAllowedPaths.has(item.href);
+        }
+
+        if (item.requiresAdmin) {
+            return isAdmin;
+        }
+
+        return true;
+    });
 
     return (
         <header className="top-navbar">

--- a/web/src/components/layout/TopNavbar.tsx
+++ b/web/src/components/layout/TopNavbar.tsx
@@ -11,6 +11,7 @@ const navItemsOrdered = [
     { label: "Home", href: "/home" },
     { label: "News", href: "/news" },
     { label: "Emergency Numbers", href: "/emergency-numbers" },
+    { label: "Gathering Areas", href: "/gathering-areas" },
     { label: "Admin", href: "/admin", requiresAdmin: true },
     { label: "Profile", href: "/profile" },
     { label: "Privacy & Security", href: "/privacy-security" },

--- a/web/src/components/layout/TopNavbar.tsx
+++ b/web/src/components/layout/TopNavbar.tsx
@@ -4,7 +4,8 @@ import { usePathname, useRouter } from "next/navigation";
 import * as React from "react";
 import Link from "next/link";
 import { PageContainer } from "@/components/layout/PageContainer";
-import { clearAccessToken, fetchCurrentUser, getAccessToken } from "@/lib/auth";
+import { clearAccessToken } from "@/lib/auth";
+import { useAuthSession } from "@/lib/authSession";
 
 const navItemsOrdered = [
     { label: "Home", href: "/home" },
@@ -20,62 +21,28 @@ const guestAllowedPaths = new Set(["/home", "/news", "/emergency-numbers"]);
 export function TopNavbar() {
     const router = useRouter();
     const pathname = usePathname();
-    const [isAuthenticated, setIsAuthenticated] = React.useState(false);
-    const [isAdmin, setIsAdmin] = React.useState(false);
+    const { state, refresh } = useAuthSession();
     const [isMenuOpen, setIsMenuOpen] = React.useState(false);
     const menuRef = React.useRef<HTMLDivElement | null>(null);
 
     React.useEffect(() => {
-        let cancelled = false;
-
-        const syncAuthState = async () => {
-            const token = getAccessToken();
-
-            if (!token) {
-                if (!cancelled) {
-                    setIsAuthenticated(false);
-                    setIsAdmin(false);
-                }
-                return;
-            }
-
-            if (!cancelled) {
-                setIsAuthenticated(true);
-            }
-
-            try {
-                const user = await fetchCurrentUser(token);
-                if (!cancelled) {
-                    setIsAdmin(Boolean(user.isAdmin));
-                }
-            } catch {
-                clearAccessToken();
-                if (!cancelled) {
-                    setIsAuthenticated(false);
-                    setIsAdmin(false);
-                }
-            }
-        };
-
         const handleStorage = (event: StorageEvent) => {
             if (event.key === null || event.key === "neph_access_token") {
-                void syncAuthState();
+                void refresh();
             }
         };
 
         const handleVisibilityChange = () => {
             if (document.visibilityState === "visible") {
-                void syncAuthState();
+                void refresh();
             }
         };
         const handleFocus = () => {
-            void syncAuthState();
+            void refresh();
         };
         const handleAuthChanged = () => {
-            void syncAuthState();
+            void refresh();
         };
-
-        void syncAuthState();
 
         window.addEventListener("storage", handleStorage);
         window.addEventListener("focus", handleFocus);
@@ -83,13 +50,12 @@ export function TopNavbar() {
         document.addEventListener("visibilitychange", handleVisibilityChange);
 
         return () => {
-            cancelled = true;
             window.removeEventListener("storage", handleStorage);
             window.removeEventListener("focus", handleFocus);
             window.removeEventListener("neph-auth-changed", handleAuthChanged);
             document.removeEventListener("visibilitychange", handleVisibilityChange);
         };
-    }, []);
+    }, [refresh]);
 
     React.useEffect(() => {
         setIsMenuOpen(false);
@@ -111,9 +77,12 @@ export function TopNavbar() {
 
     const handleLogout = () => {
         clearAccessToken();
-        setIsAuthenticated(false);
+        void refresh({ force: true });
         router.replace("/login");
     };
+
+    const isAuthenticated = state.phase === "authenticated";
+    const isAdmin = Boolean(state.user?.isAdmin);
 
     const navItems = navItemsOrdered.filter((item) => {
         if (!isAuthenticated) {
@@ -191,7 +160,7 @@ export function TopNavbar() {
                                         className="top-navbar-dropdown-item"
                                         onClick={() => {
                                             clearAccessToken();
-                                            setIsAuthenticated(false);
+                                            void refresh({ force: true });
                                             setIsMenuOpen(false);
                                             router.push("/login");
                                         }}

--- a/web/src/lib/admin.ts
+++ b/web/src/lib/admin.ts
@@ -1,0 +1,67 @@
+import { apiRequest } from "@/lib/api";
+
+export type EmergencyOverviewTotals = {
+    totalEmergencies: number;
+    activeEmergencies: number;
+    resolvedEmergencies: number;
+    closedEmergencies: number;
+};
+
+export type EmergencyOverviewStatusBreakdown = {
+    pending: number;
+    inProgress: number;
+    resolved: number;
+    cancelled: number;
+};
+
+export type EmergencyOverviewUrgencyBreakdown = {
+    low: number;
+    medium: number;
+    high: number;
+};
+
+export type EmergencyOverviewRecentActivity = {
+    createdLast24Hours: number;
+    createdLast7Days: number;
+    resolvedLast24Hours: number;
+    resolvedLast7Days: number;
+    cancelledLast24Hours: number;
+    cancelledLast7Days: number;
+};
+
+export type EmergencyOverviewRegionItem = {
+    city: string;
+    total: number;
+    active: number;
+    pending: number;
+    inProgress: number;
+    resolved: number;
+    cancelled: number;
+};
+
+export type EmergencyOverview = {
+    totals: EmergencyOverviewTotals;
+    statusBreakdown: EmergencyOverviewStatusBreakdown;
+    urgencyBreakdown: EmergencyOverviewUrgencyBreakdown;
+    recentActivity: EmergencyOverviewRecentActivity;
+    regionSummary?: EmergencyOverviewRegionItem[];
+};
+
+type EmergencyOverviewResponse = {
+    overview: EmergencyOverview;
+};
+
+export async function fetchAdminEmergencyOverview(
+    token: string,
+    options: { includeRegionSummary?: boolean } = {}
+) {
+    const query = options.includeRegionSummary ? "?includeRegionSummary=true" : "";
+    const response = await apiRequest<EmergencyOverviewResponse>(
+        `/admin/emergency-overview${query}`,
+        {
+            token: token.trim(),
+        }
+    );
+
+    return response.overview;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -19,6 +19,7 @@ type ApiRequestOptions = Omit<RequestInit, "body"> & {
 
 const API_BASE_URL =
     process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, "") || "/api";
+const REQUEST_TIMEOUT_MS = 12_000;
 
 function normalizePath(path: string) {
     return path.startsWith("/") ? path : `/${path}`;
@@ -127,14 +128,31 @@ export async function apiRequest<T>(
     options: ApiRequestOptions = {}
 ): Promise<T> {
     let response: Response;
+    const timeoutController = new AbortController();
+    const timeoutId = setTimeout(() => {
+        timeoutController.abort();
+    }, REQUEST_TIMEOUT_MS);
+    const signal = options.signal || timeoutController.signal;
 
     try {
         response = await fetch(`${API_BASE_URL}${normalizePath(path)}`, {
             ...options,
             headers: buildHeaders(options),
             body: buildBody(options.body),
+            signal,
         });
-    } catch {
+    } catch (error) {
+        clearTimeout(timeoutId);
+        if (error instanceof DOMException && error.name === "AbortError") {
+            throw new ApiError(
+                "Request timed out. Please try again.",
+                {
+                    code: "REQUEST_TIMEOUT",
+                    status: 0,
+                }
+            );
+        }
+
         throw new ApiError(
             "Could not reach the server. Please check your connection and try again.",
             {
@@ -143,6 +161,7 @@ export async function apiRequest<T>(
             }
         );
     }
+    clearTimeout(timeoutId);
 
     if (response.status === 204) {
         return undefined as T;

--- a/web/src/lib/authSession.ts
+++ b/web/src/lib/authSession.ts
@@ -1,0 +1,144 @@
+import * as React from "react";
+import { ApiError } from "@/lib/api";
+import { clearAccessToken, fetchCurrentUser, getAccessToken, type AuthUser } from "@/lib/auth";
+
+type AuthSessionPhase = "loading" | "guest" | "authenticated" | "error";
+
+type AuthSessionSnapshot = {
+    phase: AuthSessionPhase;
+    tokenPresent: boolean;
+    user: AuthUser | null;
+    isStale: boolean;
+    errorMessage: string | null;
+};
+
+type AuthSessionListener = (snapshot: AuthSessionSnapshot) => void;
+
+let snapshot: AuthSessionSnapshot = {
+    phase: "loading",
+    tokenPresent: false,
+    user: null,
+    isStale: false,
+    errorMessage: null,
+};
+
+let inFlightRefresh: Promise<AuthSessionSnapshot> | null = null;
+const listeners = new Set<AuthSessionListener>();
+
+function emitSnapshot() {
+    listeners.forEach((listener) => listener(snapshot));
+}
+
+function setSnapshot(next: AuthSessionSnapshot) {
+    snapshot = next;
+    emitSnapshot();
+}
+
+export function getAuthSessionSnapshot() {
+    return snapshot;
+}
+
+export function subscribeAuthSession(listener: AuthSessionListener) {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+export async function refreshAuthSession(options: { force?: boolean } = {}) {
+    if (inFlightRefresh && !options.force) {
+        return inFlightRefresh;
+    }
+
+    inFlightRefresh = (async () => {
+        const token = getAccessToken();
+        if (!token || !token.trim()) {
+            setSnapshot({
+                phase: "guest",
+                tokenPresent: false,
+                user: null,
+                isStale: false,
+                errorMessage: null,
+            });
+            return snapshot;
+        }
+
+        setSnapshot({
+            ...snapshot,
+            phase: "loading",
+            tokenPresent: true,
+            errorMessage: null,
+        });
+
+        try {
+            const currentUser = await fetchCurrentUser(token);
+            setSnapshot({
+                phase: "authenticated",
+                tokenPresent: true,
+                user: currentUser,
+                isStale: false,
+                errorMessage: null,
+            });
+            return snapshot;
+        } catch (error) {
+            if (error instanceof ApiError && error.status === 401) {
+                clearAccessToken();
+                setSnapshot({
+                    phase: "guest",
+                    tokenPresent: false,
+                    user: null,
+                    isStale: false,
+                    errorMessage: null,
+                });
+                return snapshot;
+            }
+
+            if (snapshot.user) {
+                setSnapshot({
+                    ...snapshot,
+                    phase: "authenticated",
+                    tokenPresent: true,
+                    isStale: true,
+                    errorMessage: error instanceof Error ? error.message : "Could not refresh session.",
+                });
+                return snapshot;
+            }
+
+            setSnapshot({
+                phase: "error",
+                tokenPresent: true,
+                user: null,
+                isStale: true,
+                errorMessage: error instanceof Error ? error.message : "Could not resolve session.",
+            });
+            return snapshot;
+        }
+    })().finally(() => {
+        inFlightRefresh = null;
+    });
+
+    return inFlightRefresh;
+}
+
+export function useAuthSession(options: { resolveOnMount?: boolean } = {}) {
+    const { resolveOnMount = true } = options;
+    const [state, setState] = React.useState<AuthSessionSnapshot>(() => getAuthSessionSnapshot());
+
+    React.useEffect(() => {
+        const unsubscribe = subscribeAuthSession(setState);
+        return unsubscribe;
+    }, []);
+
+    React.useEffect(() => {
+        if (!resolveOnMount) {
+            return;
+        }
+
+        void refreshAuthSession();
+    }, [resolveOnMount]);
+
+    return {
+        state,
+        refresh: refreshAuthSession,
+    };
+}

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -769,6 +769,127 @@ textarea::placeholder {
     color: var(--text-secondary);
 }
 
+.admin-overview-grid {
+    display: grid;
+    gap: 20px;
+}
+
+.admin-metric-grid {
+    margin-top: 16px;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.admin-metric-tile {
+    border: 1px solid var(--border-subtle);
+    border-radius: 12px;
+    background: var(--surface-card);
+    padding: 14px;
+}
+
+.admin-metric-tile.tone-success {
+    border-color: color-mix(in srgb, var(--success) 45%, var(--border-subtle));
+}
+
+.admin-metric-tile.tone-warning {
+    border-color: color-mix(in srgb, var(--warning) 45%, var(--border-subtle));
+}
+
+.admin-metric-tile.tone-danger {
+    border-color: color-mix(in srgb, var(--error) 45%, var(--border-subtle));
+}
+
+.admin-metric-label {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.admin-metric-value {
+    margin: 8px 0 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.admin-recent-grid {
+    margin-top: 16px;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.admin-recent-title {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.admin-recent-line {
+    margin: 8px 0 0;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.admin-region-actions {
+    margin-top: 16px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+}
+
+.admin-region-table-wrap {
+    margin-top: 16px;
+    overflow-x: auto;
+}
+
+.admin-region-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 720px;
+}
+
+.admin-region-table th,
+.admin-region-table td {
+    border-bottom: 1px solid var(--border-subtle);
+    padding: 10px 8px;
+    text-align: left;
+    font-size: 0.85rem;
+}
+
+.admin-region-table th {
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+.admin-region-table td {
+    color: var(--text-primary);
+}
+
+.admin-empty-state {
+    margin-top: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-width: 320px;
+    color: var(--text-secondary);
+}
+
+.admin-subtle {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.admin-error-text {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--error);
+}
+
 .root-layout-body {
     display: flex;
     min-height: 100vh;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -769,6 +769,251 @@ textarea::placeholder {
     color: var(--text-secondary);
 }
 
+.gathering-areas-page-grid {
+    display: grid;
+    gap: 24px;
+}
+
+.gathering-areas-page-container {
+    max-width: 85rem;
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
+.gathering-areas-page-title {
+    font-size: 1.5rem;
+}
+
+.gathering-areas-main-card {
+    padding: 6px;
+}
+
+.gathering-areas-map-wrap {
+    margin-top: 0;
+    position: relative;
+    isolation: isolate;
+}
+
+.gathering-areas-map-note {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    z-index: 25;
+    pointer-events: none;
+    margin: 0;
+    max-width: min(440px, calc(100% - 280px));
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--surface-card) 94%, transparent);
+    backdrop-filter: blur(8px);
+    padding: 8px 10px;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.gathering-areas-map-retry {
+    position: absolute;
+    left: 12px;
+    bottom: 12px;
+    z-index: 35;
+    pointer-events: auto;
+    width: 38px;
+    height: 38px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--surface-card) 94%, transparent);
+    backdrop-filter: blur(8px);
+    box-shadow: var(--shadow-card);
+    color: var(--text-primary);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.gathering-areas-map-retry:hover {
+    border-color: var(--primary-soft-200);
+    background: var(--primary-soft-100);
+}
+
+.gathering-areas-map-retry:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.gathering-areas-overlay-toggle {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 40;
+    pointer-events: auto;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--surface-card) 94%, transparent);
+    backdrop-filter: blur(8px);
+    box-shadow: var(--shadow-card);
+    padding: 7px 10px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.gathering-areas-overlay-toggle:hover {
+    border-color: var(--primary-soft-200);
+    background: var(--primary-soft-100);
+}
+
+.gathering-areas-map-wrap .leaflet-container {
+    z-index: 1;
+}
+
+.gathering-areas-map-wrap .leaflet-top,
+.gathering-areas-map-wrap .leaflet-bottom,
+.gathering-areas-map-wrap .leaflet-pane,
+.gathering-areas-map-wrap .leaflet-control {
+    z-index: 10 !important;
+}
+
+.gathering-areas-map-overlay {
+    position: absolute;
+    top: 48px;
+    right: 12px;
+    bottom: 12px;
+    width: min(240px, calc(100% - 24px));
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: color-mix(in srgb, var(--surface-card) 92%, transparent);
+    backdrop-filter: blur(8px);
+    box-shadow: var(--shadow-card);
+    padding: 12px;
+    display: grid;
+    grid-template-rows: auto auto auto 1fr;
+    gap: 10px;
+    z-index: 20;
+    pointer-events: auto;
+}
+
+.gathering-areas-overlay-title {
+    margin: 0;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+@media (max-width: 1023px) {
+    .gathering-areas-page-container {
+        padding-left: 10px;
+        padding-right: 10px;
+    }
+
+    .gathering-areas-page-title {
+        font-size: 1.3rem;
+    }
+
+    .gathering-areas-overlay-toggle {
+        right: 10px;
+    }
+
+    .gathering-areas-map-overlay {
+        position: static;
+        width: 100%;
+        margin-top: 12px;
+        background: var(--surface-card);
+        backdrop-filter: none;
+    }
+
+    .gathering-areas-map-note {
+        max-width: calc(100% - 24px);
+    }
+}
+
+.gathering-areas-status-box {
+    margin-top: 12px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-soft);
+    padding: 12px;
+    display: grid;
+    gap: 10px;
+    color: var(--text-secondary);
+}
+
+.gathering-areas-status-box.is-error {
+    border-color: var(--primary-soft-200);
+    background: var(--primary-soft-100);
+    color: var(--primary-700);
+}
+
+.gathering-areas-selected-card {
+    margin-top: 0;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--surface-card);
+    padding: 14px;
+    display: grid;
+    gap: 6px;
+}
+
+.gathering-areas-selected-name {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.gathering-areas-selected-meta {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.gathering-areas-empty-detail {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+.gathering-areas-list {
+    margin-top: 0;
+    display: grid;
+    gap: 10px;
+    min-height: 0;
+    overflow: auto;
+}
+
+.gathering-areas-item {
+    width: 100%;
+    text-align: left;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-card);
+    padding: 10px 12px;
+}
+
+.gathering-areas-item:hover {
+    border-color: var(--primary-soft-200);
+    background: var(--primary-soft-100);
+}
+
+.gathering-areas-item.is-active {
+    border-color: var(--primary-500);
+    background: var(--primary-soft-100);
+}
+
+.gathering-areas-item-name {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.gathering-areas-item-meta {
+    margin: 4px 0 0;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
 .admin-overview-grid {
     display: grid;
     gap: 20px;


### PR DESCRIPTION
This PR adds the web-side admin dashboard for aggregate emergency visibility and connects it to the new backend admin overview endpoint.

What was implemented
Added a new admin page at /admin with dashboard cards for:
total / active / resolved / closed emergency counts
status breakdown
urgency breakdown
recent activity summary
optional region summary table
Added a dedicated AdminRouteGate to enforce admin-only access on the client.
Added an admin API client module to fetch overview data from:
/api/admin/emergency-overview
/api/admin/emergency-overview?includeRegionSummary=true
Integrated loading, error, and empty-state handling in the dashboard view.
Updated top navigation to show the Admin link only for authenticated admin users.
UX and behavior details
Non-authenticated users are redirected to login with returnTo=/admin.
Authenticated non-admin users are redirected to /home.
Region summary is fetched only when requested, matching backend optional behavior.
Refresh-loop behavior in the region summary area was fixed by separating initial load and refresh states.
Files added
web/src/app/admin/page.tsx
web/src/components/auth/AdminRouteGate.tsx
web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
web/src/lib/admin.ts
Files updated
web/src/components/layout/TopNavbar.tsx
web/src/styles/globals.css
Notes
This PR assumes admin users already exist in the database and can authenticate via the existing login flow.
The dashboard now reflects real backend aggregate data once emergency records are present.


Important setup note
To access the admin page, the logged-in user must exist in the admins table.
If needed, add the user manually in DB:

INSERT INTO admins (admin_id, user_id, role)
VALUES ('admin_manual_1', '<EXISTING_USER_ID>', 'COORDINATOR');

Closes #269