### PR TITLE
feat: add emergency history tab with filters, pagination, and accessibility improvements

### DIFF
--- a/backend/src/modules/admin/controller.js
+++ b/backend/src/modules/admin/controller.js
@@ -4,7 +4,22 @@ const {
   getAnnouncementsForAdmin,
   getStatsForAdmin,
   getEmergencyOverviewForAdmin,
+  getEmergencyHistoryForAdmin,
 } = require('./service');
+
+const ALLOWED_HISTORY_STATUSES = new Set(['RESOLVED', 'CANCELLED']);
+const ALLOWED_URGENCY_LEVELS = new Set(['LOW', 'MEDIUM', 'HIGH']);
+
+function parseCsvQuery(value) {
+  if (!value) {
+    return [];
+  }
+
+  return String(value)
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
 
 async function getAdminUsers(_req, res) {
   try {
@@ -74,10 +89,81 @@ async function getAdminEmergencyOverview(req, res) {
   }
 }
 
+async function getAdminEmergencyHistory(req, res) {
+  try {
+    const requestedStatuses = parseCsvQuery(req.query?.status).map((item) => item.toUpperCase());
+    const invalidStatuses = requestedStatuses.filter((item) => !ALLOWED_HISTORY_STATUSES.has(item));
+
+    if (invalidStatuses.length > 0) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: `Invalid status filter: ${invalidStatuses.join(', ')}`,
+      });
+    }
+
+    const requestedCities = parseCsvQuery(req.query?.city).map((item) => item.toLowerCase());
+    const requestedNeedTypes = parseCsvQuery(req.query?.type).map((item) => item.toLowerCase());
+    const requestedUrgencies = parseCsvQuery(req.query?.urgency).map((item) => item.toUpperCase());
+    const invalidUrgencies = requestedUrgencies.filter((item) => !ALLOWED_URGENCY_LEVELS.has(item));
+    const limitParam = req.query?.limit;
+    const offsetParam = req.query?.offset;
+    const limit = limitParam === undefined ? 50 : Number(limitParam);
+    const offset = offsetParam === undefined ? 0 : Number(offsetParam);
+
+    if (invalidUrgencies.length > 0) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: `Invalid urgency filter: ${invalidUrgencies.join(', ')}`,
+      });
+    }
+
+    if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: '`limit` must be an integer between 1 and 200.',
+      });
+    }
+    if (!Number.isInteger(offset) || offset < 0 || offset > 100000) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: '`offset` must be an integer between 0 and 100000.',
+      });
+    }
+
+    const historyPayload = await getEmergencyHistoryForAdmin({
+      statuses: requestedStatuses.length > 0 ? requestedStatuses : null,
+      cities: requestedCities.length > 0 ? requestedCities : null,
+      needTypes: requestedNeedTypes.length > 0 ? requestedNeedTypes : null,
+      urgencies: requestedUrgencies.length > 0 ? requestedUrgencies : null,
+      limit,
+      offset,
+    });
+
+    return res.status(200).json({
+      history: historyPayload.history,
+      total: historyPayload.total,
+      filters: {
+        status: requestedStatuses,
+        city: requestedCities,
+        type: requestedNeedTypes,
+        urgency: requestedUrgencies,
+        limit,
+        offset,
+      },
+    });
+  } catch (_error) {
+    return res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      message: 'Something went wrong',
+    });
+  }
+}
+
 module.exports = {
   getAdminUsers,
   getAdminHelpRequests,
   getAdminAnnouncements,
   getAdminStats,
   getAdminEmergencyOverview,
+  getAdminEmergencyHistory,
 };

--- a/backend/src/modules/admin/repository.js
+++ b/backend/src/modules/admin/repository.js
@@ -212,10 +212,109 @@ async function getEmergencyOverview({ includeRegionSummary = false } = {}) {
   return overview;
 }
 
+async function getEmergencyHistory({
+  statuses = null,
+  cities = null,
+  needTypes = null,
+  urgencies = null,
+  limit = 50,
+  offset = 0,
+} = {}) {
+  const urgencySql = `
+    CASE
+      WHEN COALESCE(array_length(hr.risk_flags, 1), 0) >= 2 OR hr.affected_people_count >= 5 THEN 'HIGH'
+      WHEN COALESCE(array_length(hr.risk_flags, 1), 0) = 1 OR hr.affected_people_count BETWEEN 3 AND 4 THEN 'MEDIUM'
+      ELSE 'LOW'
+    END
+  `;
+
+  const [countResult, rowsResult] = await Promise.all([
+    query(
+      `
+        SELECT COUNT(*)::int AS total_count
+        FROM help_requests hr
+        LEFT JOIN LATERAL (
+          SELECT city
+          FROM request_locations loc
+          WHERE loc.request_id = hr.request_id
+          ORDER BY loc.captured_at DESC, loc.location_id DESC
+          LIMIT 1
+        ) rl ON TRUE
+        WHERE hr.status IN ('RESOLVED', 'CANCELLED')
+          AND ($1::request_status[] IS NULL OR hr.status = ANY($1))
+          AND ($2::text[] IS NULL OR LOWER(COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown')) = ANY($2))
+          AND ($3::text[] IS NULL OR LOWER(hr.need_type) = ANY($3))
+          AND ($4::text[] IS NULL OR (${urgencySql}) = ANY($4))
+      `,
+      [statuses, cities, needTypes, urgencies],
+    ),
+    query(
+    `
+      SELECT
+        hr.request_id,
+        hr.need_type,
+        hr.description,
+        hr.status,
+        hr.created_at,
+        hr.resolved_at,
+        hr.cancelled_at,
+        COALESCE(hr.cancelled_at, hr.resolved_at, hr.created_at) AS closed_at,
+        hr.affected_people_count,
+        hr.risk_flags,
+        COALESCE(NULLIF(TRIM(rl.country), ''), 'unknown') AS country,
+        COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown') AS city,
+        COALESCE(NULLIF(TRIM(rl.district), ''), 'unknown') AS district,
+        ${urgencySql} AS urgency_level
+      FROM help_requests hr
+      LEFT JOIN LATERAL (
+        SELECT country, city, district
+        FROM request_locations loc
+        WHERE loc.request_id = hr.request_id
+        ORDER BY loc.captured_at DESC, loc.location_id DESC
+        LIMIT 1
+      ) rl ON TRUE
+      WHERE hr.status IN ('RESOLVED', 'CANCELLED')
+        AND ($1::request_status[] IS NULL OR hr.status = ANY($1))
+        AND ($2::text[] IS NULL OR LOWER(COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown')) = ANY($2))
+        AND ($3::text[] IS NULL OR LOWER(hr.need_type) = ANY($3))
+        AND ($4::text[] IS NULL OR (${urgencySql}) = ANY($4))
+      ORDER BY closed_at DESC, hr.created_at DESC
+      LIMIT $5::int
+      OFFSET $6::int
+    `,
+    [statuses, cities, needTypes, urgencies, limit, offset],
+  )]);
+
+  const history = rowsResult.rows.map((row) => ({
+    requestId: row.request_id,
+    needType: row.need_type,
+    description: row.description,
+    status: row.status,
+    createdAt: row.created_at,
+    resolvedAt: row.resolved_at,
+    cancelledAt: row.cancelled_at,
+    closedAt: row.closed_at,
+    location: {
+      country: row.country,
+      city: row.city,
+      district: row.district,
+    },
+    affectedPeopleCount: row.affected_people_count,
+    urgencyLevel: row.urgency_level,
+    riskFlags: row.risk_flags || [],
+  }));
+
+  return {
+    history,
+    total: countResult.rows[0]?.total_count || 0,
+  };
+}
+
 module.exports = {
   listUsers,
   listHelpRequests,
   listAnnouncements,
   getBasicStats,
   getEmergencyOverview,
+  getEmergencyHistory,
 };

--- a/backend/src/modules/admin/routes.js
+++ b/backend/src/modules/admin/routes.js
@@ -6,6 +6,7 @@ const {
   getAdminAnnouncements,
   getAdminStats,
   getAdminEmergencyOverview,
+  getAdminEmergencyHistory,
 } = require('./controller');
 
 const adminRouter = express.Router();
@@ -15,6 +16,7 @@ adminRouter.get('/help-requests', requireAuth, requireAdmin, getAdminHelpRequest
 adminRouter.get('/announcements', requireAuth, requireAdmin, getAdminAnnouncements);
 adminRouter.get('/stats', requireAuth, requireAdmin, getAdminStats);
 adminRouter.get('/emergency-overview', requireAuth, requireAdmin, getAdminEmergencyOverview);
+adminRouter.get('/emergency-history', requireAuth, requireAdmin, getAdminEmergencyHistory);
 
 module.exports = {
   adminRouter,

--- a/backend/src/modules/admin/service.js
+++ b/backend/src/modules/admin/service.js
@@ -4,6 +4,7 @@ const {
   listAnnouncements,
   getBasicStats,
   getEmergencyOverview,
+  getEmergencyHistory,
 } = require('./repository');
 
 async function getUsersForAdmin() {
@@ -26,10 +27,15 @@ async function getEmergencyOverviewForAdmin(options = {}) {
   return getEmergencyOverview(options);
 }
 
+async function getEmergencyHistoryForAdmin(options = {}) {
+  return getEmergencyHistory(options);
+}
+
 module.exports = {
   getUsersForAdmin,
   getHelpRequestsForAdmin,
   getAnnouncementsForAdmin,
   getStatsForAdmin,
   getEmergencyOverviewForAdmin,
+  getEmergencyHistoryForAdmin,
 };

--- a/backend/src/modules/auth/middleware.js
+++ b/backend/src/modules/auth/middleware.js
@@ -1,4 +1,5 @@
 const jwt = require('jsonwebtoken');
+const { findAdminByUserId } = require('./repository');
 
 const { env } = require('../../config/env');
 const JWT_SECRET = env.jwt.secret;
@@ -34,15 +35,34 @@ function requireAuth(req, res, next) {
   }
 }
 
-function requireAdmin(req, res, next) {
-  if (!req.user || !req.user.isAdmin) {
+async function requireAdmin(req, res, next) {
+  if (!req.user || !req.user.userId) {
     return res.status(403).json({
       code: 'FORBIDDEN',
       message: 'Admin access required',
     });
   }
 
-  return next();
+  try {
+    const adminRecord = await findAdminByUserId(req.user.userId);
+
+    if (!adminRecord) {
+      return res.status(403).json({
+        code: 'FORBIDDEN',
+        message: 'Admin access required',
+      });
+    }
+
+    req.user.isAdmin = true;
+    req.user.adminRole = adminRecord.role;
+
+    return next();
+  } catch (_error) {
+    return res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      message: 'Something went wrong',
+    });
+  }
 }
 
 function optionalAuth(req, _res, next) {

--- a/backend/tests/integration/modules/admin/admin-emergency-history.integration.test.js
+++ b/backend/tests/integration/modules/admin/admin-emergency-history.integration.test.js
@@ -1,0 +1,447 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+const { query } = require('../../../../src/db/pool');
+const { apiRouter } = require('../../../../src/routes');
+
+jest.mock('uuid', () => ({
+  v4: () => require('crypto').randomBytes(16).toString('hex'),
+}));
+
+jest.mock('express-rate-limit', () => () => (_req, _res, next) => next());
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', apiRouter);
+  return app;
+}
+
+function buildAuthToken({ userId, isAdmin }) {
+  return jwt.sign(
+    {
+      userId,
+      email: `${userId}@example.com`,
+      isAdmin,
+      adminRole: isAdmin ? 'COORDINATOR' : null,
+    },
+    process.env.JWT_SECRET || 'dev-secret-123',
+    { expiresIn: '1h' },
+  );
+}
+
+async function seedBaseUsers() {
+  await query(
+    `
+      INSERT INTO users (user_id, email, password_hash, is_email_verified, is_deleted, accepted_terms)
+      VALUES
+        ('admin_user', 'admin@example.com', 'hash', TRUE, FALSE, TRUE),
+        ('normal_user', 'user@example.com', 'hash', TRUE, FALSE, TRUE)
+    `,
+  );
+
+  await query(
+    `
+      INSERT INTO admins (admin_id, user_id, role)
+      VALUES ('admin_record_1', 'admin_user', 'COORDINATOR')
+    `,
+  );
+}
+
+async function seedHelpRequests() {
+  await query(
+    `
+      INSERT INTO help_requests (
+        request_id,
+        user_id,
+        help_types,
+        other_help_text,
+        affected_people_count,
+        risk_flags,
+        vulnerable_groups,
+        need_type,
+        description,
+        blood_type,
+        contact_full_name,
+        contact_phone,
+        consent_given,
+        status,
+        created_at,
+        resolved_at,
+        cancelled_at,
+        is_saved_locally
+      )
+      VALUES
+        (
+          'req_pending_active',
+          'normal_user',
+          ARRAY['first_aid']::TEXT[],
+          '',
+          2,
+          ARRAY['injury']::TEXT[],
+          ARRAY[]::TEXT[],
+          'first_aid',
+          'Pending emergency',
+          NULL,
+          'A User',
+          5551112233,
+          TRUE,
+          'PENDING',
+          NOW() - INTERVAL '1 hour',
+          NULL,
+          NULL,
+          FALSE
+        ),
+        (
+          'req_resolved_new',
+          'normal_user',
+          ARRAY['water']::TEXT[],
+          '',
+          1,
+          ARRAY[]::TEXT[],
+          ARRAY[]::TEXT[],
+          'water',
+          'Resolved recently',
+          NULL,
+          'B User',
+          5552223344,
+          TRUE,
+          'RESOLVED',
+          NOW() - INTERVAL '2 days',
+          NOW() - INTERVAL '1 hour',
+          NULL,
+          FALSE
+        ),
+        (
+          'req_cancelled_mid',
+          'normal_user',
+          ARRAY['shelter']::TEXT[],
+          '',
+          4,
+          ARRAY['injury']::TEXT[],
+          ARRAY[]::TEXT[],
+          'shelter',
+          'Cancelled recently',
+          NULL,
+          'C User',
+          5553334455,
+          TRUE,
+          'CANCELLED',
+          NOW() - INTERVAL '3 days',
+          NULL,
+          NOW() - INTERVAL '2 hours',
+          FALSE
+        ),
+        (
+          'req_resolved_old',
+          'normal_user',
+          ARRAY['food']::TEXT[],
+          '',
+          6,
+          ARRAY['fire', 'injury']::TEXT[],
+          ARRAY[]::TEXT[],
+          'food',
+          'Resolved older',
+          NULL,
+          'D User',
+          5554445566,
+          TRUE,
+          'RESOLVED',
+          NOW() - INTERVAL '10 days',
+          NOW() - INTERVAL '5 days',
+          NULL,
+          FALSE
+        ),
+        (
+          'req_cancelled_unknown_city',
+          'normal_user',
+          ARRAY['food']::TEXT[],
+          '',
+          1,
+          ARRAY[]::TEXT[],
+          ARRAY[]::TEXT[],
+          'food',
+          'Cancelled unknown city',
+          NULL,
+          'E User',
+          5555556677,
+          TRUE,
+          'CANCELLED',
+          NOW() - INTERVAL '6 days',
+          NULL,
+          NOW() - INTERVAL '4 days',
+          FALSE
+        )
+    `,
+  );
+
+  await query(
+    `
+      INSERT INTO request_locations (
+        location_id,
+        request_id,
+        country,
+        city,
+        district,
+        neighborhood,
+        extra_address
+      )
+      VALUES
+        ('loc_resolved_new', 'req_resolved_new', 'turkiye', ' ankara ', 'cankaya', 'kizilay', 'blok a'),
+        ('loc_cancelled_mid', 'req_cancelled_mid', 'turkiye', 'izmir', 'konak', 'alsancak', 'blok b'),
+        ('loc_resolved_old', 'req_resolved_old', 'turkiye', 'ankara', 'etimesgut', 'goksu', 'blok c'),
+        ('loc_unknown_city', 'req_cancelled_unknown_city', 'turkiye', '', 'kecioren', 'etlik', 'blok d')
+    `,
+  );
+}
+
+beforeEach(async () => {
+  await query(`
+    TRUNCATE TABLE
+      messages,
+      assignments,
+      availability_records,
+      resources,
+      volunteers,
+      request_locations,
+      help_requests,
+      news_announcements,
+      reports,
+      expertise,
+      privacy_settings,
+      location_profiles,
+      health_info,
+      physical_info,
+      user_profiles,
+      admins,
+      users
+    RESTART IDENTITY CASCADE;
+  `);
+});
+
+describe('GET /api/admin/emergency-history', () => {
+  test('returns 401 without token', async () => {
+    const app = createTestApp();
+    const response = await request(app).get('/api/admin/emergency-history');
+
+    expect(response.status).toBe(401);
+    expect(response.body.code).toBe('UNAUTHORIZED');
+  });
+
+  test('returns 403 for non-admin users', async () => {
+    await seedBaseUsers();
+    const app = createTestApp();
+    const userToken = buildAuthToken({ userId: 'normal_user', isAdmin: false });
+
+    const response = await request(app)
+      .get('/api/admin/emergency-history')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe('FORBIDDEN');
+  });
+
+  test('returns only resolved/cancelled history sorted by closed time', async () => {
+    await seedBaseUsers();
+    await seedHelpRequests();
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/emergency-history')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.total).toBe(4);
+    expect(response.body.history.map((item) => item.requestId)).toEqual([
+      'req_resolved_new',
+      'req_cancelled_mid',
+      'req_cancelled_unknown_city',
+      'req_resolved_old',
+    ]);
+    expect(response.body.history.map((item) => item.status)).toEqual([
+      'RESOLVED',
+      'CANCELLED',
+      'CANCELLED',
+      'RESOLVED',
+    ]);
+    expect(response.body.history.some((item) => item.requestId === 'req_pending_active')).toBe(false);
+  });
+
+  test('applies status/city/type filters', async () => {
+    await seedBaseUsers();
+    await seedHelpRequests();
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/emergency-history?status=resolved&city=ankara&type=water')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.total).toBe(1);
+    expect(response.body.history).toHaveLength(1);
+    expect(response.body.history[0]).toEqual(
+      expect.objectContaining({
+        requestId: 'req_resolved_new',
+        status: 'RESOLVED',
+        needType: 'water',
+      }),
+    );
+    expect(response.body.filters).toEqual({
+      status: ['RESOLVED'],
+      city: ['ankara'],
+      type: ['water'],
+      urgency: [],
+      limit: 50,
+      offset: 0,
+    });
+  });
+
+  test('returns 400 for invalid status filter', async () => {
+    await seedBaseUsers();
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/emergency-history?status=pending')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('returns 400 for invalid urgency filter', async () => {
+    await seedBaseUsers();
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/emergency-history?urgency=critical')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('applies limit and returns newest closed records first', async () => {
+    await seedBaseUsers();
+    await seedHelpRequests();
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/emergency-history?limit=2')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.total).toBe(4);
+    expect(response.body.history).toHaveLength(2);
+    expect(response.body.history.map((item) => item.requestId)).toEqual([
+      'req_resolved_new',
+      'req_cancelled_mid',
+    ]);
+  });
+
+  test('applies offset for pagination', async () => {
+    await seedBaseUsers();
+    await seedHelpRequests();
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/emergency-history?limit=1&offset=1')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.total).toBe(4);
+    expect(response.body.history).toHaveLength(1);
+    expect(response.body.history[0].requestId).toBe('req_cancelled_mid');
+    expect(response.body.filters).toEqual({
+      status: [],
+      city: [],
+      type: [],
+      urgency: [],
+      limit: 1,
+      offset: 1,
+    });
+  });
+
+  test('keeps total stable when offset exceeds available rows', async () => {
+    await seedBaseUsers();
+    await seedHelpRequests();
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/emergency-history?limit=10&offset=999')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.total).toBe(4);
+    expect(response.body.history).toEqual([]);
+  });
+
+  test('filters by urgency and unknown city', async () => {
+    await seedBaseUsers();
+    await seedHelpRequests();
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const urgencyResponse = await request(app)
+      .get('/api/admin/emergency-history?urgency=high')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(urgencyResponse.status).toBe(200);
+    expect(urgencyResponse.body.history).toHaveLength(1);
+    expect(urgencyResponse.body.history[0].requestId).toBe('req_resolved_old');
+
+    const unknownCityResponse = await request(app)
+      .get('/api/admin/emergency-history?city=unknown')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(unknownCityResponse.status).toBe(200);
+    expect(unknownCityResponse.body.history).toHaveLength(1);
+    expect(unknownCityResponse.body.history[0].requestId).toBe('req_cancelled_unknown_city');
+  });
+
+  test('returns successful empty state when filters do not match any closed request', async () => {
+    await seedBaseUsers();
+    await seedHelpRequests();
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/emergency-history?city=trabzon&type=food')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.total).toBe(0);
+    expect(response.body.history).toEqual([]);
+  });
+
+  test('supports legacy /api/auth/admin route for history endpoint', async () => {
+    await seedBaseUsers();
+    await seedHelpRequests();
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/auth/admin/emergency-history?status=cancelled')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.history).toHaveLength(2);
+    expect(response.body.history.every((item) => item.status === 'CANCELLED')).toBe(true);
+  });
+});

--- a/backend/tests/unit/modules/admin/controller.test.js
+++ b/backend/tests/unit/modules/admin/controller.test.js
@@ -4,10 +4,12 @@ jest.mock('../../../../src/modules/admin/service');
 
 const {
   getAdminEmergencyOverview,
+  getAdminEmergencyHistory,
 } = require('../../../../src/modules/admin/controller');
 
 const {
   getEmergencyOverviewForAdmin,
+  getEmergencyHistoryForAdmin,
 } = require('../../../../src/modules/admin/service');
 
 function mockRes() {
@@ -115,6 +117,144 @@ describe('getAdminEmergencyOverview', () => {
     const res = mockRes();
 
     await getAdminEmergencyOverview(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'INTERNAL_ERROR',
+      }),
+    );
+  });
+});
+
+describe('getAdminEmergencyHistory', () => {
+  test('200 - success with default filters', async () => {
+    getEmergencyHistoryForAdmin.mockResolvedValue({
+      history: [],
+      total: 0,
+    });
+
+    const req = { query: {} };
+    const res = mockRes();
+
+    await getAdminEmergencyHistory(req, res);
+
+    expect(getEmergencyHistoryForAdmin).toHaveBeenCalledWith({
+      statuses: null,
+      cities: null,
+      needTypes: null,
+      urgencies: null,
+      limit: 50,
+      offset: 0,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      history: [],
+      total: 0,
+      filters: {
+        status: [],
+        city: [],
+        type: [],
+        urgency: [],
+        limit: 50,
+        offset: 0,
+      },
+    });
+  });
+
+  test('200 - parses comma filters', async () => {
+    getEmergencyHistoryForAdmin.mockResolvedValue({
+      history: [{ requestId: 'r1' }],
+      total: 1,
+    });
+
+    const req = {
+      query: {
+        status: 'resolved,cancelled',
+        city: 'Ankara, Izmir',
+        type: 'water, shelter',
+        urgency: 'high,medium',
+        limit: '25',
+        offset: '10',
+      },
+    };
+    const res = mockRes();
+
+    await getAdminEmergencyHistory(req, res);
+
+    expect(getEmergencyHistoryForAdmin).toHaveBeenCalledWith({
+      statuses: ['RESOLVED', 'CANCELLED'],
+      cities: ['ankara', 'izmir'],
+      needTypes: ['water', 'shelter'],
+      urgencies: ['HIGH', 'MEDIUM'],
+      limit: 25,
+      offset: 10,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test('400 - rejects invalid status filter', async () => {
+    const req = { query: { status: 'pending' } };
+    const res = mockRes();
+
+    await getAdminEmergencyHistory(req, res);
+
+    expect(getEmergencyHistoryForAdmin).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'VALIDATION_ERROR',
+      }),
+    );
+  });
+
+  test('400 - rejects invalid limit', async () => {
+    const req = { query: { limit: '0' } };
+    const res = mockRes();
+
+    await getAdminEmergencyHistory(req, res);
+
+    expect(getEmergencyHistoryForAdmin).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  test('400 - rejects invalid offset', async () => {
+    const req = { query: { offset: '-1' } };
+    const res = mockRes();
+
+    await getAdminEmergencyHistory(req, res);
+
+    expect(getEmergencyHistoryForAdmin).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'VALIDATION_ERROR',
+      }),
+    );
+  });
+
+  test('400 - rejects invalid urgency', async () => {
+    const req = { query: { urgency: 'critical' } };
+    const res = mockRes();
+
+    await getAdminEmergencyHistory(req, res);
+
+    expect(getEmergencyHistoryForAdmin).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'VALIDATION_ERROR',
+      }),
+    );
+  });
+
+  test('500 - internal error', async () => {
+    getEmergencyHistoryForAdmin.mockRejectedValue(new Error('unexpected'));
+
+    const req = { query: {} };
+    const res = mockRes();
+
+    await getAdminEmergencyHistory(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith(

--- a/backend/tests/unit/modules/admin/service.test.js
+++ b/backend/tests/unit/modules/admin/service.test.js
@@ -8,6 +8,7 @@ const {
   getAnnouncementsForAdmin,
   getStatsForAdmin,
   getEmergencyOverviewForAdmin,
+  getEmergencyHistoryForAdmin,
 } = require('../../../../src/modules/admin/service');
 
 const {
@@ -16,6 +17,7 @@ const {
   listAnnouncements,
   getBasicStats,
   getEmergencyOverview,
+  getEmergencyHistory,
 } = require('../../../../src/modules/admin/repository');
 
 beforeEach(() => {
@@ -67,5 +69,27 @@ describe('admin service', () => {
     expect(getEmergencyOverview).toHaveBeenCalledTimes(1);
     expect(getEmergencyOverview).toHaveBeenCalledWith({ includeRegionSummary: true });
     expect(result).toEqual({ totals: { totalEmergencies: 3 } });
+  });
+
+  test('getEmergencyHistoryForAdmin delegates to repository', async () => {
+    getEmergencyHistory.mockResolvedValue({ history: [], total: 0 });
+
+    const result = await getEmergencyHistoryForAdmin({
+      statuses: ['RESOLVED'],
+      cities: ['ankara'],
+      needTypes: ['water'],
+      urgencies: ['HIGH'],
+      limit: 20,
+    });
+
+    expect(getEmergencyHistory).toHaveBeenCalledTimes(1);
+    expect(getEmergencyHistory).toHaveBeenCalledWith({
+      statuses: ['RESOLVED'],
+      cities: ['ankara'],
+      needTypes: ['water'],
+      urgencies: ['HIGH'],
+      limit: 20,
+    });
+    expect(result).toEqual({ history: [], total: 0 });
   });
 });

--- a/web/e2e/admin-history.spec.js
+++ b/web/e2e/admin-history.spec.js
@@ -1,0 +1,124 @@
+const { test, expect } = require('@playwright/test');
+const { createCompletedUser } = require('./helpers/api');
+const {
+  promoteUserToAdmin,
+  resetDatabase,
+  seedEmergencyOverviewRecord,
+  waitForUserByEmail,
+} = require('./helpers/db');
+const { loginThroughUi } = require('./helpers/ui');
+
+async function createAdminUserAndLogin(page, { email, password }) {
+  await createCompletedUser({ email, password });
+  const dbUser = await waitForUserByEmail(email);
+  await promoteUserToAdmin({ userId: dbUser.user_id });
+
+  await page.goto('/login');
+  await loginThroughUi(page, { email, password });
+  await expect(page.getByRole('link', { name: 'Admin' })).toBeVisible();
+}
+
+test.beforeEach(async () => {
+  await resetDatabase();
+});
+
+test('admin can review closed emergency history records', async ({ page }) => {
+  const email = `history-admin-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createAdminUserAndLogin(page, { email, password });
+
+  await seedEmergencyOverviewRecord({
+    requestId: 'e2e_hist_resolved_recent',
+    status: 'RESOLVED',
+    city: 'ankara',
+    needType: 'water',
+    description: 'History resolved recent',
+    createdAtHoursAgo: 2,
+  });
+  await seedEmergencyOverviewRecord({
+    requestId: 'e2e_hist_cancelled_old',
+    status: 'CANCELLED',
+    city: 'izmir',
+    needType: 'shelter',
+    description: 'History cancelled old',
+    createdAtHoursAgo: 5,
+  });
+  await seedEmergencyOverviewRecord({
+    requestId: 'e2e_hist_pending',
+    status: 'PENDING',
+    city: 'ankara',
+    needType: 'food',
+    description: 'History pending should not show',
+    createdAtHoursAgo: 1,
+  });
+
+  await page.goto('/admin');
+  await expect(page).toHaveURL(/\/admin$/);
+  await page.getByRole('tab', { name: 'Emergency History' }).click();
+  await expect(page.getByRole('heading', { name: 'Emergency History' })).toBeVisible();
+
+  const historyTable = page
+    .locator('section', {
+      has: page.getByRole('heading', { name: 'Emergency History' }),
+    })
+    .locator('table');
+
+  await expect(historyTable).toBeVisible();
+  await expect(historyTable).toContainText('History resolved recent');
+  await expect(historyTable).toContainText('History cancelled old');
+  await expect(historyTable).not.toContainText('History pending should not show');
+  await expect(page.getByText('Showing 2 of 2 closed emergencies.')).toBeVisible();
+});
+
+test('admin history filters by status city type and handles empty result state', async ({ page }) => {
+  const email = `history-filter-admin-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createAdminUserAndLogin(page, { email, password });
+
+  await seedEmergencyOverviewRecord({
+    requestId: 'e2e_hist_filter_resolved',
+    status: 'RESOLVED',
+    city: 'ankara',
+    needType: 'water',
+    description: 'History filter resolved',
+    createdAtHoursAgo: 4,
+    affectedPeopleCount: 1,
+    riskFlags: [],
+  });
+  await seedEmergencyOverviewRecord({
+    requestId: 'e2e_hist_filter_cancelled',
+    status: 'CANCELLED',
+    city: 'izmir',
+    needType: 'shelter',
+    description: 'History filter cancelled',
+    createdAtHoursAgo: 3,
+    affectedPeopleCount: 6,
+    riskFlags: ['injury', 'flood'],
+  });
+
+  await page.goto('/admin');
+  await page.getByRole('tab', { name: 'Emergency History' }).click();
+  await expect(page.getByRole('heading', { name: 'Emergency History' })).toBeVisible();
+
+  await page.selectOption('#history-status', 'CANCELLED');
+  await page.selectOption('#history-urgency', 'HIGH');
+  await page.fill('#history-city', 'izmir');
+  await page.fill('#history-type', 'shelter');
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+
+  const historyTable = page
+    .locator('section', {
+      has: page.getByRole('heading', { name: 'Emergency History' }),
+    })
+    .locator('table');
+
+  await expect(historyTable).toContainText('History filter cancelled');
+  await expect(historyTable).not.toContainText('History filter resolved');
+  await expect(page.getByText('Showing 1 of 1 closed emergencies.')).toBeVisible();
+
+  await page.fill('#history-city', 'trabzon');
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+  await expect(page.getByText('No past emergencies matched the current filters.')).toBeVisible();
+});

--- a/web/e2e/helpers/db.js
+++ b/web/e2e/helpers/db.js
@@ -88,6 +88,8 @@ async function seedEmergencyOverviewRecord({
   requestId = `e2e_req_${Date.now()}`,
   status = 'PENDING',
   city = 'istanbul',
+  needType = 'first_aid',
+  description = 'E2E seeded request',
   createdAtHoursAgo = 2,
   affectedPeopleCount = 2,
   riskFlags = ['injury'],
@@ -119,13 +121,13 @@ async function seedEmergencyOverviewRecord({
         VALUES (
           $1,
           NULL,
-          ARRAY['first_aid']::TEXT[],
+          ARRAY[$6]::TEXT[],
           '',
           $4::int,
           $5::TEXT[],
           ARRAY[]::TEXT[],
-          'first_aid',
-          'E2E seeded request',
+          $6,
+          $7,
           NULL,
           'E2E Contact',
           5551112233,
@@ -146,7 +148,7 @@ async function seedEmergencyOverviewRecord({
           FALSE
         )
       `,
-      [requestId, status, String(createdAtHoursAgo), affectedPeopleCount, riskFlags]
+      [requestId, status, String(createdAtHoursAgo), affectedPeopleCount, riskFlags, needType, description]
     );
 
     await client.query(

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -1,12 +1,12 @@
 import { AppShell } from "@/components/layout/AppShell";
 import { AdminRouteGate } from "@/components/auth/AdminRouteGate";
-import AdminEmergencyOverviewView from "@/components/feature/admin/AdminEmergencyOverviewView";
+import AdminDashboardSwitcher from "@/components/feature/admin/AdminDashboardSwitcher";
 
 export default function AdminPage() {
     return (
         <AdminRouteGate>
             <AppShell title="Admin Dashboard">
-                <AdminEmergencyOverviewView />
+                <AdminDashboardSwitcher />
             </AppShell>
         </AdminRouteGate>
     );

--- a/web/src/components/feature/admin/AdminDashboardSwitcher.tsx
+++ b/web/src/components/feature/admin/AdminDashboardSwitcher.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import * as React from "react";
+import AdminEmergencyOverviewView from "@/components/feature/admin/AdminEmergencyOverviewView";
+import AdminEmergencyHistoryView from "@/components/feature/admin/AdminEmergencyHistoryView";
+
+type AdminSectionKey = "overview" | "history";
+
+const SECTIONS: Array<{ key: AdminSectionKey; label: string }> = [
+    { key: "overview", label: "Emergency Overview" },
+    { key: "history", label: "Emergency History" },
+];
+
+export default function AdminDashboardSwitcher() {
+    const [activeSection, setActiveSection] = React.useState<AdminSectionKey>("overview");
+    const tabRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
+
+    const handleTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+        if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") {
+            return;
+        }
+
+        event.preventDefault();
+        const delta = event.key === "ArrowRight" ? 1 : -1;
+        const nextIndex = (index + delta + SECTIONS.length) % SECTIONS.length;
+        const nextSection = SECTIONS[nextIndex];
+        setActiveSection(nextSection.key);
+        tabRefs.current[nextIndex]?.focus();
+    };
+
+    return (
+        <div className="grid gap-5">
+            <div className="admin-dashboard-nav" role="tablist" aria-label="Admin dashboard sections">
+                {SECTIONS.map((section, index) => (
+                    <button
+                        key={section.key}
+                        type="button"
+                        id={`admin-tab-${section.key}`}
+                        role="tab"
+                        aria-controls={`admin-panel-${section.key}`}
+                        aria-selected={activeSection === section.key}
+                        tabIndex={activeSection === section.key ? 0 : -1}
+                        ref={(node) => {
+                            tabRefs.current[index] = node;
+                        }}
+                        className={`admin-dashboard-tab${activeSection === section.key ? " is-active" : ""}`}
+                        onClick={() => setActiveSection(section.key)}
+                        onKeyDown={(event) => handleTabKeyDown(event, index)}
+                    >
+                        {section.label}
+                    </button>
+                ))}
+            </div>
+
+            {activeSection === "overview" ? (
+                <div
+                    id="admin-panel-overview"
+                    role="tabpanel"
+                    aria-labelledby="admin-tab-overview"
+                >
+                    <AdminEmergencyOverviewView />
+                </div>
+            ) : (
+                <div
+                    id="admin-panel-history"
+                    role="tabpanel"
+                    aria-labelledby="admin-tab-history"
+                >
+                    <AdminEmergencyHistoryView />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/web/src/components/feature/admin/AdminEmergencyHistoryView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyHistoryView.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import * as React from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { ApiError } from "@/lib/api";
+import { clearAccessToken, getAccessToken } from "@/lib/auth";
+import {
+    fetchAdminEmergencyHistory,
+    type EmergencyHistoryItem,
+} from "@/lib/admin";
+import { SectionCard } from "@/components/ui/display/SectionCard";
+import { SectionHeader } from "@/components/ui/display/SectionHeader";
+import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
+
+type HistoryFilters = {
+    status: "ALL" | "RESOLVED" | "CANCELLED";
+    urgency: "ALL" | "LOW" | "MEDIUM" | "HIGH";
+    city: string;
+    type: string;
+};
+
+const DEFAULT_FILTERS: HistoryFilters = {
+    status: "ALL",
+    urgency: "ALL",
+    city: "",
+    type: "",
+};
+const HISTORY_PAGE_SIZE = 100;
+
+function formatDateTime(value: string | null) {
+    if (!value) {
+        return "-";
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return date.toLocaleString();
+}
+
+function formatTitleCase(value: string | null | undefined) {
+    if (!value) {
+        return "-";
+    }
+
+    return String(value)
+        .trim()
+        .toLocaleLowerCase("tr-TR")
+        .split(/\s+/)
+        .map((word) => (word ? word[0].toLocaleUpperCase("tr-TR") + word.slice(1) : word))
+        .join(" ");
+}
+
+export default function AdminEmergencyHistoryView() {
+    const router = useRouter();
+    const pathname = usePathname();
+    const [items, setItems] = React.useState<EmergencyHistoryItem[]>([]);
+    const [total, setTotal] = React.useState(0);
+    const [filters, setFilters] = React.useState<HistoryFilters>(DEFAULT_FILTERS);
+    const [loading, setLoading] = React.useState(true);
+    const [refreshing, setRefreshing] = React.useState(false);
+    const [loadingMore, setLoadingMore] = React.useState(false);
+    const [error, setError] = React.useState("");
+    const [loadedOnce, setLoadedOnce] = React.useState(false);
+    const latestRequestIdRef = React.useRef(0);
+
+    const redirectToLogin = React.useCallback(() => {
+        clearAccessToken();
+        const returnTo = pathname || "/admin";
+        router.replace(`/login?returnTo=${encodeURIComponent(returnTo)}`);
+    }, [pathname, router]);
+
+    const loadHistory = React.useCallback(
+        async (
+            nextFilters: HistoryFilters,
+            options: {
+                mode?: "initial" | "refresh";
+                offset?: number;
+                append?: boolean;
+            } = {}
+        ) => {
+            const mode = options.mode || "refresh";
+            const offset = options.offset ?? 0;
+            const append = options.append ?? false;
+            const token = getAccessToken();
+            if (!token) {
+                setLoading(false);
+                setRefreshing(false);
+                setLoadingMore(false);
+                redirectToLogin();
+                return;
+            }
+
+            if (mode === "initial") {
+                setLoading(true);
+            } else if (append) {
+                setLoadingMore(true);
+            } else {
+                setRefreshing(true);
+            }
+            const requestId = latestRequestIdRef.current + 1;
+            latestRequestIdRef.current = requestId;
+            setError("");
+
+            try {
+                const response = await fetchAdminEmergencyHistory(token, {
+                    status: nextFilters.status === "ALL" ? "" : nextFilters.status,
+                    urgency: nextFilters.urgency === "ALL" ? "" : nextFilters.urgency,
+                    city: nextFilters.city,
+                    type: nextFilters.type,
+                    limit: HISTORY_PAGE_SIZE,
+                    offset,
+                });
+                if (requestId !== latestRequestIdRef.current) {
+                    return;
+                }
+
+                setItems((current) => (append ? [...current, ...response.history] : response.history));
+                setTotal(response.total);
+                setLoadedOnce(true);
+            } catch (err) {
+                if (requestId !== latestRequestIdRef.current) {
+                    return;
+                }
+                if (err instanceof ApiError && err.status === 401) {
+                    redirectToLogin();
+                    return;
+                }
+
+                if (err instanceof ApiError && err.status === 403) {
+                    router.replace("/home");
+                    return;
+                }
+
+                setError(
+                    err instanceof Error
+                        ? err.message
+                        : "Could not load emergency history."
+                );
+            } finally {
+                if (requestId !== latestRequestIdRef.current) {
+                    return;
+                }
+                setLoading(false);
+                setRefreshing(false);
+                setLoadingMore(false);
+            }
+        },
+        [redirectToLogin, router]
+    );
+
+    React.useEffect(() => {
+        void loadHistory(DEFAULT_FILTERS, { mode: "initial", offset: 0 });
+    }, [loadHistory]);
+
+    const applyFilters = async () => {
+        await loadHistory(filters, {
+            mode: loadedOnce ? "refresh" : "initial",
+            offset: 0,
+        });
+    };
+
+    const clearFilters = async () => {
+        setFilters(DEFAULT_FILTERS);
+        await loadHistory(DEFAULT_FILTERS, {
+            mode: loadedOnce ? "refresh" : "initial",
+            offset: 0,
+        });
+    };
+
+    if (loading) {
+        return (
+            <SectionCard>
+                <SectionHeader
+                    title="Emergency History"
+                    subtitle="Loading resolved and closed emergencies..."
+                />
+            </SectionCard>
+        );
+    }
+
+    if (error && items.length === 0) {
+        return (
+            <SectionCard>
+                <SectionHeader
+                    title="Emergency History"
+                    subtitle="Could not load emergency history."
+                />
+                <div className="admin-empty-state">
+                    <p>{error}</p>
+                    <PrimaryButton onClick={() => void loadHistory(filters, { mode: "initial", offset: 0 })}>
+                        Retry History Load
+                    </PrimaryButton>
+                </div>
+            </SectionCard>
+        );
+    }
+
+    return (
+        <SectionCard>
+            <SectionHeader
+                title="Emergency History"
+                subtitle="Resolved and cancelled emergencies for operational review."
+            />
+
+            <div className="admin-history-filter-grid">
+                <label className="admin-history-filter-label" htmlFor="history-status">
+                    Status
+                    <select
+                        id="history-status"
+                        className="admin-history-filter-input"
+                        value={filters.status}
+                        onChange={(event) =>
+                            setFilters((current) => ({
+                                ...current,
+                                status: event.target.value as HistoryFilters["status"],
+                            }))
+                        }
+                    >
+                        <option value="ALL">All Closed</option>
+                        <option value="RESOLVED">Resolved</option>
+                        <option value="CANCELLED">Cancelled</option>
+                    </select>
+                </label>
+
+                <label className="admin-history-filter-label" htmlFor="history-urgency">
+                    Urgency
+                    <select
+                        id="history-urgency"
+                        className="admin-history-filter-input"
+                        value={filters.urgency}
+                        onChange={(event) =>
+                            setFilters((current) => ({
+                                ...current,
+                                urgency: event.target.value as HistoryFilters["urgency"],
+                            }))
+                        }
+                    >
+                        <option value="ALL">All Urgency Levels</option>
+                        <option value="LOW">Low</option>
+                        <option value="MEDIUM">Medium</option>
+                        <option value="HIGH">High</option>
+                    </select>
+                </label>
+
+                <label className="admin-history-filter-label" htmlFor="history-city">
+                    Region (City)
+                    <input
+                        id="history-city"
+                        className="admin-history-filter-input"
+                        value={filters.city}
+                        onChange={(event) =>
+                            setFilters((current) => ({
+                                ...current,
+                                city: event.target.value,
+                            }))
+                        }
+                        placeholder="e.g. Ankara"
+                    />
+                </label>
+
+                <label className="admin-history-filter-label" htmlFor="history-type">
+                    Type
+                    <input
+                        id="history-type"
+                        className="admin-history-filter-input"
+                        value={filters.type}
+                        onChange={(event) =>
+                            setFilters((current) => ({
+                                ...current,
+                                type: event.target.value,
+                            }))
+                        }
+                        placeholder="e.g. Water"
+                    />
+                </label>
+            </div>
+
+            <div className="admin-history-actions">
+                <PrimaryButton onClick={applyFilters} disabled={refreshing || loadingMore}>
+                    Apply Filters
+                </PrimaryButton>
+                <SecondaryButton onClick={clearFilters} disabled={refreshing || loadingMore}>
+                    Clear Filters
+                </SecondaryButton>
+                {refreshing ? <p className="admin-subtle">Refreshing history...</p> : null}
+                {loadingMore ? <p className="admin-subtle">Loading more history...</p> : null}
+            </div>
+
+            <p className="admin-subtle">Showing {items.length} of {total} closed emergencies.</p>
+
+            {error ? (
+                <p className="admin-error-text">Latest refresh failed: {error}</p>
+            ) : null}
+
+            {items.length === 0 ? (
+                <div className="admin-empty-state">
+                    <p>No past emergencies matched the current filters.</p>
+                </div>
+            ) : (
+                <div>
+                    <div className="admin-region-table-wrap">
+                        <table className="admin-region-table admin-history-table">
+                            <thead>
+                                <tr>
+                                    <th>Closed At</th>
+                                    <th>Status</th>
+                                    <th>Type</th>
+                                    <th>Urgency</th>
+                                    <th>Region</th>
+                                    <th>Description</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {items.map((item) => (
+                                    <tr key={item.requestId}>
+                                        <td>{formatDateTime(item.closedAt)}</td>
+                                        <td>{formatTitleCase(item.status)}</td>
+                                        <td>{formatTitleCase(item.needType)}</td>
+                                        <td>{formatTitleCase(item.urgencyLevel)}</td>
+                                        <td>{formatTitleCase(item.location.city)}</td>
+                                        <td>{item.description}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                    {items.length < total ? (
+                        <div className="admin-history-actions">
+                            <SecondaryButton
+                                onClick={() =>
+                                    void loadHistory(filters, {
+                                        mode: "refresh",
+                                        offset: items.length,
+                                        append: true,
+                                    })
+                                }
+                                disabled={refreshing || loadingMore}
+                            >
+                                Load More
+                            </SecondaryButton>
+                        </div>
+                    ) : null}
+                </div>
+            )}
+        </SectionCard>
+    );
+}

--- a/web/src/lib/admin.ts
+++ b/web/src/lib/admin.ts
@@ -51,6 +51,37 @@ type EmergencyOverviewResponse = {
     overview: EmergencyOverview;
 };
 
+export type EmergencyHistoryItem = {
+    requestId: string;
+    needType: string | null;
+    description: string;
+    status: "RESOLVED" | "CANCELLED";
+    createdAt: string;
+    resolvedAt: string | null;
+    cancelledAt: string | null;
+    closedAt: string;
+    location: {
+        country: string;
+        city: string;
+        district: string;
+    };
+    affectedPeopleCount: number;
+    urgencyLevel: "LOW" | "MEDIUM" | "HIGH";
+    riskFlags: string[];
+};
+
+export type EmergencyHistoryResponse = {
+    history: EmergencyHistoryItem[];
+    total: number;
+    filters: {
+        status: string[];
+        city: string[];
+        type: string[];
+        limit: number;
+        offset: number;
+    };
+};
+
 export async function fetchAdminEmergencyOverview(
     token: string,
     options: { includeRegionSummary?: boolean } = {}
@@ -64,4 +95,41 @@ export async function fetchAdminEmergencyOverview(
     );
 
     return response.overview;
+}
+
+export async function fetchAdminEmergencyHistory(
+    token: string,
+    options: {
+        status?: string;
+        city?: string;
+        type?: string;
+        urgency?: string;
+        limit?: number;
+        offset?: number;
+    } = {}
+) {
+    const params = new URLSearchParams();
+    if (options.status && options.status.trim()) {
+        params.set("status", options.status.trim());
+    }
+    if (options.city && options.city.trim()) {
+        params.set("city", options.city.trim());
+    }
+    if (options.type && options.type.trim()) {
+        params.set("type", options.type.trim());
+    }
+    if (options.urgency && options.urgency.trim()) {
+        params.set("urgency", options.urgency.trim());
+    }
+    if (typeof options.limit === "number") {
+        params.set("limit", String(options.limit));
+    }
+    if (typeof options.offset === "number") {
+        params.set("offset", String(options.offset));
+    }
+
+    const query = params.toString() ? `?${params.toString()}` : "";
+    return apiRequest<EmergencyHistoryResponse>(`/admin/emergency-history${query}`, {
+        token: token.trim(),
+    });
 }

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1019,6 +1019,39 @@ textarea::placeholder {
     gap: 20px;
 }
 
+.admin-dashboard-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 12px;
+    background: var(--surface-card);
+    padding: 8px;
+}
+
+.admin-dashboard-tab {
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
+    background: var(--surface-card);
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    font-weight: 600;
+    padding: 9px 14px;
+    transition: background-color 180ms ease, color 180ms ease, border-color 180ms ease;
+}
+
+.admin-dashboard-tab:hover {
+    border-color: var(--primary-soft-200);
+    background: var(--primary-soft-100);
+    color: var(--primary-700);
+}
+
+.admin-dashboard-tab.is-active {
+    border-color: var(--primary-500);
+    background: var(--primary-500);
+    color: var(--text-on-primary);
+}
+
 .admin-metric-grid {
     margin-top: 16px;
     display: grid;
@@ -1133,6 +1166,47 @@ textarea::placeholder {
     margin: 0;
     font-size: 0.9rem;
     color: var(--error);
+}
+
+.admin-history-filter-grid {
+    margin-top: 16px;
+    display: grid;
+    gap: 12px;
+}
+
+@media (min-width: 768px) {
+    .admin-history-filter-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+}
+
+.admin-history-filter-label {
+    display: grid;
+    gap: 8px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.admin-history-filter-input {
+    width: 100%;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-card);
+    padding: 10px 12px;
+    color: var(--text-primary);
+}
+
+.admin-history-filter-input:focus {
+    border-color: var(--primary-500);
+}
+
+.admin-history-actions {
+    margin-top: 14px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
 }
 
 .root-layout-body {


### PR DESCRIPTION
This PR extends the admin dashboard with a dedicated Emergency History flow so admins can review resolved/cancelled cases more effectively.

Backend changes:

Adds GET /api/admin/emergency-history
Supports filtering by status, city, type, and urgency
Adds pagination support via limit and offset
Improves city normalization to handle empty/null values consistently as unknown
Keeps legacy admin route compatibility intact
Web changes:

Introduces a tabbed admin dashboard experience (Overview / Emergency History), defaulting to Overview
Adds a full Emergency History view with filters, loading/error/empty states, and retry behavior
Adds Load More pagination on the history table using limit+offset
Improves table readability by displaying values like city/type/urgency/status in title case
Accessibility/UX:

Implements proper tab semantics (tablist, tab, tabpanel) with ARIA linking
Adds keyboard navigation support for tabs (left/right arrow keys)
Testing:

Updates unit and integration tests for the new history endpoint behavior
Adds/updates E2E coverage for history tab navigation and filtering scenarios

Closes #275 