### PR TITLE
feat(web): introduce reusable Leaflet map canvas across location flows

### DIFF
--- a/web/src/components/feature/location/LeafletGatheringAreasMap.tsx
+++ b/web/src/components/feature/location/LeafletGatheringAreasMap.tsx
@@ -3,11 +3,7 @@
 import * as React from "react";
 import L from "leaflet";
 import { LeafletMapCanvas } from "@/components/feature/location/LeafletMapCanvas";
-
-type LatLng = {
-    latitude: number;
-    longitude: number;
-};
+import type { LatLng } from "@/components/feature/location/LeafletMapCanvas";
 
 type GatheringAreaMapFeature = {
     featureKey: string;
@@ -157,6 +153,7 @@ export function LeafletGatheringAreasMap({
             center={center}
             zoom={zoom}
             heightClassName={heightClassName}
+            ariaLabel="Nearby gathering areas map"
             onMapReady={(map) => {
                 mapRef.current = map;
                 setMapReadyVersion((version) => version + 1);

--- a/web/src/components/feature/location/LeafletGatheringAreasMap.tsx
+++ b/web/src/components/feature/location/LeafletGatheringAreasMap.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import L from "leaflet";
-import "leaflet/dist/leaflet.css";
+import { LeafletMapCanvas } from "@/components/feature/location/LeafletMapCanvas";
 
 type LatLng = {
     latitude: number;
@@ -58,45 +58,34 @@ export function LeafletGatheringAreasMap({
     heightClassName = "h-[380px] md:h-[500px]",
     zoom = 14,
 }: LeafletGatheringAreasMapProps) {
-    const containerRef = React.useRef<HTMLDivElement | null>(null);
     const mapRef = React.useRef<L.Map | null>(null);
     const centerMarkerRef = React.useRef<L.CircleMarker | null>(null);
     const markerLayerRef = React.useRef<L.LayerGroup | null>(null);
     const markerRefs = React.useRef<Map<string, L.CircleMarker>>(new Map());
     const onSelectRef = React.useRef(onSelectFeature);
+    const [mapReadyVersion, setMapReadyVersion] = React.useState(0);
 
     React.useEffect(() => {
         onSelectRef.current = onSelectFeature;
     }, [onSelectFeature]);
 
     React.useEffect(() => {
-        if (!containerRef.current || mapRef.current) {
+        const map = mapRef.current;
+        if (!map || markerLayerRef.current) {
             return;
         }
 
-        const map = L.map(containerRef.current, {
-            center: [center.latitude, center.longitude],
-            zoom,
-            scrollWheelZoom: true,
-        });
-
-        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-            attribution:
-                '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        }).addTo(map);
-
         const markerLayer = L.layerGroup().addTo(map);
         markerLayerRef.current = markerLayer;
+    }, [mapReadyVersion]);
 
-        mapRef.current = map;
-
+    React.useEffect(() => {
         return () => {
             markerRefs.current.clear();
-            markerLayer.clearLayers();
-            map.remove();
-            mapRef.current = null;
+            markerLayerRef.current?.clearLayers();
             markerLayerRef.current = null;
             centerMarkerRef.current = null;
+            mapRef.current = null;
         };
     }, []);
 
@@ -146,7 +135,7 @@ export function LeafletGatheringAreasMap({
             marker.addTo(markerLayer);
             markerRefs.current.set(feature.featureKey, marker);
         }
-    }, [features, selectedFeatureId]);
+    }, [features, selectedFeatureId, mapReadyVersion]);
 
     React.useEffect(() => {
         for (const [featureId, marker] of markerRefs.current.entries()) {
@@ -164,9 +153,15 @@ export function LeafletGatheringAreasMap({
     }, [selectedFeatureId]);
 
     return (
-        <div className={`overflow-hidden rounded-[10px] border border-[#e7e7ea] ${heightClassName}`}>
-            <div ref={containerRef} className="h-full w-full" />
-        </div>
+        <LeafletMapCanvas
+            center={center}
+            zoom={zoom}
+            heightClassName={heightClassName}
+            onMapReady={(map) => {
+                mapRef.current = map;
+                setMapReadyVersion((version) => version + 1);
+            }}
+        />
     );
 }
 

--- a/web/src/components/feature/location/LeafletLocationMap.tsx
+++ b/web/src/components/feature/location/LeafletLocationMap.tsx
@@ -6,11 +6,7 @@ import markerIcon2xAsset from "leaflet/dist/images/marker-icon-2x.png";
 import markerIconAsset from "leaflet/dist/images/marker-icon.png";
 import markerShadowAsset from "leaflet/dist/images/marker-shadow.png";
 import { LeafletMapCanvas } from "@/components/feature/location/LeafletMapCanvas";
-
-type LatLng = {
-    latitude: number;
-    longitude: number;
-};
+import type { LatLng } from "@/components/feature/location/LeafletMapCanvas";
 
 type LeafletLocationMapProps = {
     center: LatLng;
@@ -46,6 +42,7 @@ export function LeafletLocationMap({
     const mapRef = React.useRef<L.Map | null>(null);
     const markerRef = React.useRef<L.Marker | null>(null);
     const onSelectPositionRef = React.useRef(onSelectPosition);
+    const [mapReadyVersion, setMapReadyVersion] = React.useState(0);
 
     React.useEffect(() => {
         onSelectPositionRef.current = onSelectPosition;
@@ -117,15 +114,21 @@ export function LeafletLocationMap({
         }
 
         markerRef.current.setLatLng(latLng);
-    }, [selectedPosition, interactionMode]);
+    }, [selectedPosition, interactionMode, mapReadyVersion]);
 
     return (
         <LeafletMapCanvas
             center={center}
             zoom={zoom}
             heightClassName={heightClassName}
+            ariaLabel={
+                interactionMode === "readonly"
+                    ? "Saved location preview map"
+                    : "Location picker map"
+            }
             onMapReady={(map) => {
                 mapRef.current = map;
+                setMapReadyVersion((version) => version + 1);
             }}
             onMapClick={
                 interactionMode === "selectable"

--- a/web/src/components/feature/location/LeafletLocationMap.tsx
+++ b/web/src/components/feature/location/LeafletLocationMap.tsx
@@ -5,7 +5,7 @@ import L from "leaflet";
 import markerIcon2xAsset from "leaflet/dist/images/marker-icon-2x.png";
 import markerIconAsset from "leaflet/dist/images/marker-icon.png";
 import markerShadowAsset from "leaflet/dist/images/marker-shadow.png";
-import "leaflet/dist/leaflet.css";
+import { LeafletMapCanvas } from "@/components/feature/location/LeafletMapCanvas";
 
 type LatLng = {
     latitude: number;
@@ -17,7 +17,8 @@ type LeafletLocationMapProps = {
     zoom?: number;
     selectedPosition: LatLng | null;
     heightClassName?: string;
-    onSelectPosition: (position: LatLng) => void;
+    interactionMode?: "selectable" | "readonly";
+    onSelectPosition?: (position: LatLng) => void;
 };
 
 function toAssetUrl(asset: string | { src: string }) {
@@ -39,9 +40,9 @@ export function LeafletLocationMap({
     zoom = 12,
     selectedPosition,
     heightClassName = "h-72",
+    interactionMode = "selectable",
     onSelectPosition,
 }: LeafletLocationMapProps) {
-    const mapContainerRef = React.useRef<HTMLDivElement | null>(null);
     const mapRef = React.useRef<L.Map | null>(null);
     const markerRef = React.useRef<L.Marker | null>(null);
     const onSelectPositionRef = React.useRef(onSelectPosition);
@@ -51,59 +52,12 @@ export function LeafletLocationMap({
     }, [onSelectPosition]);
 
     React.useEffect(() => {
-        if (!mapContainerRef.current || mapRef.current) {
-            return;
-        }
-
-        const map = L.map(mapContainerRef.current, {
-            center: [center.latitude, center.longitude],
-            zoom,
-            scrollWheelZoom: true,
-        });
-
-        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-            attribution:
-                '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        }).addTo(map);
-
-        map.on("click", (event: L.LeafletMouseEvent) => {
-            onSelectPositionRef.current({
-                latitude: event.latlng.lat,
-                longitude: event.latlng.lng,
-            });
-        });
-
-        mapRef.current = map;
-
         return () => {
             markerRef.current?.remove();
             markerRef.current = null;
-            map.remove();
             mapRef.current = null;
         };
     }, []);
-
-    React.useEffect(() => {
-        const map = mapRef.current;
-        if (!map) {
-            return;
-        }
-
-        if (map.getZoom() !== zoom) {
-            map.setZoom(zoom);
-        }
-    }, [zoom]);
-
-    React.useEffect(() => {
-        const map = mapRef.current;
-        if (!map) {
-            return;
-        }
-
-        map.setView([center.latitude, center.longitude], map.getZoom(), {
-            animate: true,
-        });
-    }, [center.latitude, center.longitude]);
 
     React.useEffect(() => {
         const map = mapRef.current;
@@ -125,28 +79,61 @@ export function LeafletLocationMap({
         if (!markerRef.current) {
             const marker = L.marker(latLng, {
                 icon: locationMarkerIcon,
-                draggable: true,
+                draggable: interactionMode === "selectable",
             });
 
-            marker.on("dragend", () => {
-                const markerPosition = marker.getLatLng();
-                onSelectPositionRef.current({
-                    latitude: markerPosition.lat,
-                    longitude: markerPosition.lng,
+            if (interactionMode === "selectable") {
+                marker.on("dragend", () => {
+                    const markerPosition = marker.getLatLng();
+                    onSelectPositionRef.current?.({
+                        latitude: markerPosition.lat,
+                        longitude: markerPosition.lng,
+                    });
                 });
-            });
+            }
 
             marker.addTo(map);
             markerRef.current = marker;
             return;
         }
 
+        markerRef.current.off("dragend");
+
+        if (interactionMode === "selectable") {
+            markerRef.current.dragging?.enable();
+            markerRef.current.on("dragend", () => {
+                const markerPosition = markerRef.current?.getLatLng();
+                if (!markerPosition) {
+                    return;
+                }
+
+                onSelectPositionRef.current?.({
+                    latitude: markerPosition.lat,
+                    longitude: markerPosition.lng,
+                });
+            });
+        } else {
+            markerRef.current.dragging?.disable();
+        }
+
         markerRef.current.setLatLng(latLng);
-    }, [selectedPosition]);
+    }, [selectedPosition, interactionMode]);
 
     return (
-        <div className={`overflow-hidden rounded-[10px] border border-[#e7e7ea] ${heightClassName}`}>
-            <div ref={mapContainerRef} className="h-full w-full" />
-        </div>
+        <LeafletMapCanvas
+            center={center}
+            zoom={zoom}
+            heightClassName={heightClassName}
+            onMapReady={(map) => {
+                mapRef.current = map;
+            }}
+            onMapClick={
+                interactionMode === "selectable"
+                    ? (position) => {
+                        onSelectPositionRef.current?.(position);
+                    }
+                    : undefined
+            }
+        />
     );
 }

--- a/web/src/components/feature/location/LeafletMapCanvas.tsx
+++ b/web/src/components/feature/location/LeafletMapCanvas.tsx
@@ -13,6 +13,7 @@ type LeafletMapCanvasProps = {
     center: LatLng;
     zoom?: number;
     heightClassName?: string;
+    ariaLabel?: string;
     onMapReady?: (map: L.Map) => void;
     onMapClick?: (position: LatLng) => void;
 };
@@ -21,6 +22,7 @@ export function LeafletMapCanvas({
     center,
     zoom = 12,
     heightClassName = "h-72",
+    ariaLabel = "Map",
     onMapReady,
     onMapClick,
 }: LeafletMapCanvasProps) {
@@ -92,7 +94,11 @@ export function LeafletMapCanvas({
     }, [center.latitude, center.longitude]);
 
     return (
-        <div className={`overflow-hidden rounded-[10px] border border-[#e7e7ea] ${heightClassName}`}>
+        <div
+            className={`overflow-hidden rounded-[10px] border border-[#e7e7ea] ${heightClassName}`}
+            role="region"
+            aria-label={ariaLabel}
+        >
             <div ref={containerRef} className="h-full w-full" />
         </div>
     );

--- a/web/src/components/feature/location/LeafletMapCanvas.tsx
+++ b/web/src/components/feature/location/LeafletMapCanvas.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import * as React from "react";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+
+type LatLng = {
+    latitude: number;
+    longitude: number;
+};
+
+type LeafletMapCanvasProps = {
+    center: LatLng;
+    zoom?: number;
+    heightClassName?: string;
+    onMapReady?: (map: L.Map) => void;
+    onMapClick?: (position: LatLng) => void;
+};
+
+export function LeafletMapCanvas({
+    center,
+    zoom = 12,
+    heightClassName = "h-72",
+    onMapReady,
+    onMapClick,
+}: LeafletMapCanvasProps) {
+    const containerRef = React.useRef<HTMLDivElement | null>(null);
+    const mapRef = React.useRef<L.Map | null>(null);
+    const onMapReadyRef = React.useRef(onMapReady);
+    const onMapClickRef = React.useRef(onMapClick);
+
+    React.useEffect(() => {
+        onMapReadyRef.current = onMapReady;
+    }, [onMapReady]);
+
+    React.useEffect(() => {
+        onMapClickRef.current = onMapClick;
+    }, [onMapClick]);
+
+    React.useEffect(() => {
+        if (!containerRef.current || mapRef.current) {
+            return;
+        }
+
+        const map = L.map(containerRef.current, {
+            center: [center.latitude, center.longitude],
+            zoom,
+            scrollWheelZoom: true,
+        });
+
+        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+            attribution:
+                '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        }).addTo(map);
+
+        map.on("click", (event: L.LeafletMouseEvent) => {
+            onMapClickRef.current?.({
+                latitude: event.latlng.lat,
+                longitude: event.latlng.lng,
+            });
+        });
+
+        mapRef.current = map;
+        onMapReadyRef.current?.(map);
+
+        return () => {
+            map.remove();
+            mapRef.current = null;
+        };
+    }, []);
+
+    React.useEffect(() => {
+        const map = mapRef.current;
+        if (!map) {
+            return;
+        }
+
+        if (map.getZoom() !== zoom) {
+            map.setZoom(zoom);
+        }
+    }, [zoom]);
+
+    React.useEffect(() => {
+        const map = mapRef.current;
+        if (!map) {
+            return;
+        }
+
+        map.setView([center.latitude, center.longitude], map.getZoom(), {
+            animate: true,
+        });
+    }, [center.latitude, center.longitude]);
+
+    return (
+        <div className={`overflow-hidden rounded-[10px] border border-[#e7e7ea] ${heightClassName}`}>
+            <div ref={containerRef} className="h-full w-full" />
+        </div>
+    );
+}
+
+export type { LatLng };

--- a/web/src/components/feature/location/LocationPreviewMap.tsx
+++ b/web/src/components/feature/location/LocationPreviewMap.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const LeafletLocationMap = dynamic(
+    () => import("@/components/feature/location/LeafletLocationMap").then((mod) => mod.LeafletLocationMap),
+    {
+        ssr: false,
+        loading: () => (
+            <div className="h-56 w-full animate-pulse rounded-[10px] border border-[#e7e7ea] bg-[#f8f8f9]" />
+        ),
+    }
+);
+
+export { LeafletLocationMap as LocationPreviewMap };

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -266,10 +266,16 @@ export default function ProfileView() {
                 void (async () => {
                     try {
                         const treeResponse = await fetchLocationTree("TR");
-                        setLocationTree({
+                        const nextLocationTree = {
                             [treeResponse.countryCode.toLowerCase()]: treeResponse.tree,
-                        });
+                        };
+
+                        setLocationTree(nextLocationTree);
                         setLocationTreeError("");
+
+                        // Rehydrate picker+form location state after the tree is available
+                        // so district/neighborhood keys are resolved consistently.
+                        await refreshProfileFromBackend(token, nextLocationTree);
                     } catch (treeError) {
                         setLocationTree({});
                         setLocationTreeError(

--- a/web/src/components/feature/settings/PrivacySecurityView.tsx
+++ b/web/src/components/feature/settings/PrivacySecurityView.tsx
@@ -165,20 +165,26 @@ export default function PrivacySecurityView() {
                 </div>
 
                 <div className="mt-5 grid gap-2">
-                    <p className="text-sm font-medium text-[color:var(--text-primary)]">
+                    <h3 className="text-sm font-medium text-[color:var(--text-primary)]">
                         Shared Location Preview
-                    </p>
+                    </h3>
                     <p className="text-sm text-[color:var(--text-secondary)]">
-                        This map uses the same shared map infrastructure as profile location screens.
+                        Review the location that may be shared for emergency coordination.
                     </p>
-                    <LocationPreviewMap
-                        center={locationPreview || DEFAULT_MAP_CENTER}
-                        selectedPosition={locationPreview}
-                        interactionMode="readonly"
-                        heightClassName="h-56"
-                        zoom={locationPreview ? 13 : 11}
-                    />
-                    {!locationPreview ? (
+                    {shareLocation ? (
+                        <LocationPreviewMap
+                            center={locationPreview || DEFAULT_MAP_CENTER}
+                            selectedPosition={locationPreview}
+                            interactionMode="readonly"
+                            heightClassName="h-56"
+                            zoom={locationPreview ? 13 : 11}
+                        />
+                    ) : (
+                        <HelperText>
+                            Turn on Share Current Location to show your saved location preview.
+                        </HelperText>
+                    )}
+                    {shareLocation && !locationPreview ? (
                         <HelperText>
                             No saved coordinates yet. Save your profile location to see it here.
                         </HelperText>

--- a/web/src/components/feature/settings/PrivacySecurityView.tsx
+++ b/web/src/components/feature/settings/PrivacySecurityView.tsx
@@ -10,6 +10,12 @@ import { ToggleSwitch } from "@/components/ui/selection/ToggleSwitch";
 import { clearAccessToken, getAccessToken } from "@/lib/auth";
 import { ApiError } from "@/lib/api";
 import { fetchMyProfile, patchMyPrivacy } from "@/lib/profile";
+import { LocationPreviewMap } from "@/components/feature/location/LocationPreviewMap";
+
+const DEFAULT_MAP_CENTER = {
+    latitude: 41.0082,
+    longitude: 28.9784,
+};
 
 export default function PrivacySecurityView() {
     const router = useRouter();
@@ -19,6 +25,10 @@ export default function PrivacySecurityView() {
     const [saving, setSaving] = React.useState(false);
     const [shareLocation, setShareLocation] = React.useState(false);
     const [initialShareLocation, setInitialShareLocation] = React.useState(false);
+    const [locationPreview, setLocationPreview] = React.useState<{
+        latitude: number;
+        longitude: number;
+    } | null>(null);
     const [error, setError] = React.useState("");
     const [info, setInfo] = React.useState("");
 
@@ -41,6 +51,18 @@ export default function PrivacySecurityView() {
                 const profile = await fetchMyProfile(token);
                 setShareLocation(profile.privacySettings.locationSharingEnabled);
                 setInitialShareLocation(profile.privacySettings.locationSharingEnabled);
+
+                if (
+                    typeof profile.locationProfile.latitude === "number" &&
+                    typeof profile.locationProfile.longitude === "number"
+                ) {
+                    setLocationPreview({
+                        latitude: profile.locationProfile.latitude,
+                        longitude: profile.locationProfile.longitude,
+                    });
+                } else {
+                    setLocationPreview(null);
+                }
             } catch (err) {
                 if (err instanceof ApiError && err.status === 401) {
                     redirectToLoginAfterAuthExpiry();
@@ -140,6 +162,27 @@ export default function PrivacySecurityView() {
                     <PrimaryButton onClick={handleSave} loading={saving}>
                         Save Privacy Settings
                     </PrimaryButton>
+                </div>
+
+                <div className="mt-5 grid gap-2">
+                    <p className="text-sm font-medium text-[color:var(--text-primary)]">
+                        Shared Location Preview
+                    </p>
+                    <p className="text-sm text-[color:var(--text-secondary)]">
+                        This map uses the same shared map infrastructure as profile location screens.
+                    </p>
+                    <LocationPreviewMap
+                        center={locationPreview || DEFAULT_MAP_CENTER}
+                        selectedPosition={locationPreview}
+                        interactionMode="readonly"
+                        heightClassName="h-56"
+                        zoom={locationPreview ? 13 : 11}
+                    />
+                    {!locationPreview ? (
+                        <HelperText>
+                            No saved coordinates yet. Save your profile location to see it here.
+                        </HelperText>
+                    ) : null}
                 </div>
             </SectionCard>
 


### PR DESCRIPTION
This PR consolidates Leaflet map logic into a reusable web map infrastructure and integrates it into existing location-related screens.  
The goal is to reduce duplication, keep behavior consistent, and improve maintainability.

## What Changed
- Added a shared Leaflet map canvas component and centralized map init/tile setup behavior.
- Refactored the location picker flow to use the shared map canvas.
- Refactored the gathering areas map to use the shared map canvas.
- Integrated a read-only location preview into Privacy/Security.
- Improved privacy preview copy to be user-facing and clearer.
- Clarified preview behavior when Share Current Location is disabled.
- Added accessibility improvements via meaningful `aria-label` usage on map containers.
- Hardened marker synchronization for StrictMode/remount scenarios.
- Reduced type duplication by reusing a shared `LatLng` type.

## Scope Note
- The “reuse map integration in request help page” item was not implemented in web scope because there is no request-help flow/page currently present in the web app.
- This item should be treated as out of scope for web.

Closes #294 