### PR TITLE
feat(admin): add operational emergency fields to backend and admin dashboard

### DIFF
--- a/backend/migrations/20260425_120000__add_help_request_operational_fields.sql
+++ b/backend/migrations/20260425_120000__add_help_request_operational_fields.sql
@@ -1,0 +1,41 @@
+BEGIN;
+
+ALTER TABLE help_requests
+  ADD COLUMN IF NOT EXISTS urgency_level VARCHAR(20),
+  ADD COLUMN IF NOT EXISTS priority_level VARCHAR(20);
+
+UPDATE help_requests
+SET
+  urgency_level = CASE
+    WHEN COALESCE(array_length(risk_flags, 1), 0) >= 2 OR affected_people_count >= 5 THEN 'HIGH'
+    WHEN COALESCE(array_length(risk_flags, 1), 0) = 1 OR affected_people_count BETWEEN 3 AND 4 THEN 'MEDIUM'
+    ELSE 'LOW'
+  END,
+  priority_level = CASE
+    WHEN COALESCE(array_length(risk_flags, 1), 0) >= 2 OR affected_people_count >= 5 THEN 'HIGH'
+    WHEN COALESCE(array_length(risk_flags, 1), 0) = 1 OR affected_people_count BETWEEN 3 AND 4 THEN 'MEDIUM'
+    ELSE 'LOW'
+  END
+WHERE urgency_level IS NULL OR priority_level IS NULL;
+
+ALTER TABLE help_requests
+  DROP CONSTRAINT IF EXISTS chk_help_request_urgency_level;
+
+ALTER TABLE help_requests
+  ADD CONSTRAINT chk_help_request_urgency_level
+  CHECK (
+    urgency_level IS NULL
+    OR urgency_level IN ('LOW', 'MEDIUM', 'HIGH')
+  );
+
+ALTER TABLE help_requests
+  DROP CONSTRAINT IF EXISTS chk_help_request_priority_level;
+
+ALTER TABLE help_requests
+  ADD CONSTRAINT chk_help_request_priority_level
+  CHECK (
+    priority_level IS NULL
+    OR priority_level IN ('LOW', 'MEDIUM', 'HIGH')
+  );
+
+COMMIT;

--- a/backend/src/modules/admin/repository.js
+++ b/backend/src/modules/admin/repository.js
@@ -1,5 +1,25 @@
 const { query } = require('../../db/pool');
 
+function getDerivedUrgencySql() {
+  return `
+    CASE
+      WHEN COALESCE(array_length(hr.risk_flags, 1), 0) >= 2 OR hr.affected_people_count >= 5 THEN 'HIGH'
+      WHEN COALESCE(array_length(hr.risk_flags, 1), 0) = 1 OR hr.affected_people_count BETWEEN 3 AND 4 THEN 'MEDIUM'
+      ELSE 'LOW'
+    END
+  `;
+}
+
+function getUrgencySql() {
+  const derivedUrgencySql = getDerivedUrgencySql();
+  return `COALESCE(hr.urgency_level, (${derivedUrgencySql}))`;
+}
+
+function getPrioritySql() {
+  const urgencySql = getUrgencySql();
+  return `COALESCE(hr.priority_level, (${urgencySql}))`;
+}
+
 async function listUsers() {
   const result = await query(
     `
@@ -79,6 +99,8 @@ async function getBasicStats() {
 }
 
 async function getEmergencyOverview({ includeRegionSummary = false } = {}) {
+  const urgencySql = getUrgencySql();
+  const prioritySql = getPrioritySql();
   const overviewQueries = [
     query(
       `
@@ -100,12 +122,8 @@ async function getEmergencyOverview({ includeRegionSummary = false } = {}) {
           COUNT(*) FILTER (WHERE urgency_level = 'HIGH')::int AS high_count
         FROM (
           SELECT
-            CASE
-              WHEN COALESCE(array_length(risk_flags, 1), 0) >= 2 OR affected_people_count >= 5 THEN 'HIGH'
-              WHEN COALESCE(array_length(risk_flags, 1), 0) = 1 OR affected_people_count BETWEEN 3 AND 4 THEN 'MEDIUM'
-              ELSE 'LOW'
-            END AS urgency_level
-          FROM help_requests
+            ${urgencySql} AS urgency_level
+          FROM help_requests hr
         ) urgency_map
       `,
     ),
@@ -131,6 +149,41 @@ async function getEmergencyOverview({ includeRegionSummary = false } = {}) {
             AND cancelled_at >= NOW() - INTERVAL '7 days'
           )::int AS cancelled_last_7d
         FROM help_requests
+      `,
+    ),
+    query(
+      `
+        SELECT
+          hr.request_id,
+          hr.need_type,
+          hr.status,
+          ${urgencySql} AS urgency_level,
+          ${prioritySql} AS priority_level,
+          hr.created_at AS opened_at,
+          FLOOR(
+            EXTRACT(
+              EPOCH FROM (COALESCE(hr.cancelled_at, hr.resolved_at, CURRENT_TIMESTAMP) - hr.created_at)
+            ) / 60
+          )::int AS open_duration_minutes,
+          COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown') AS city,
+          COALESCE(NULLIF(TRIM(rl.district), ''), 'unknown') AS district,
+          COALESCE(hr.cancelled_at, hr.resolved_at) AS closed_at,
+          CASE
+            WHEN hr.status = 'RESOLVED' THEN 'RESOLVED'
+            WHEN hr.status = 'CANCELLED' THEN 'CANCELLED'
+            ELSE NULL
+          END AS closed_state
+        FROM help_requests hr
+        LEFT JOIN LATERAL (
+          SELECT city, district
+          FROM request_locations loc
+          WHERE loc.request_id = hr.request_id
+          ORDER BY loc.captured_at DESC, loc.location_id DESC
+          LIMIT 1
+        ) rl ON TRUE
+        WHERE hr.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS')
+        ORDER BY hr.created_at ASC
+        LIMIT 15
       `,
     ),
   ];
@@ -163,7 +216,7 @@ async function getEmergencyOverview({ includeRegionSummary = false } = {}) {
     );
   }
 
-  const [statusResult, urgencyResult, recentActivityResult, regionResult] = await Promise.all(overviewQueries);
+  const [statusResult, urgencyResult, recentActivityResult, activeOperationalResult, regionResult] = await Promise.all(overviewQueries);
 
   const status = statusResult.rows[0];
   const urgency = urgencyResult.rows[0];
@@ -195,6 +248,21 @@ async function getEmergencyOverview({ includeRegionSummary = false } = {}) {
       cancelledLast24Hours: recent.cancelled_last_24h,
       cancelledLast7Days: recent.cancelled_last_7d,
     },
+    activeOperational: activeOperationalResult.rows.map((row) => ({
+      requestId: row.request_id,
+      needType: row.need_type,
+      status: row.status,
+      urgencyLevel: row.urgency_level,
+      priorityLevel: row.priority_level,
+      openedAt: row.opened_at,
+      openDurationMinutes: row.open_duration_minutes,
+      closedAt: row.closed_at,
+      closedState: row.closed_state,
+      location: {
+        city: row.city,
+        district: row.district,
+      },
+    })),
   };
 
   if (includeRegionSummary) {
@@ -220,13 +288,8 @@ async function getEmergencyHistory({
   limit = 50,
   offset = 0,
 } = {}) {
-  const urgencySql = `
-    CASE
-      WHEN COALESCE(array_length(hr.risk_flags, 1), 0) >= 2 OR hr.affected_people_count >= 5 THEN 'HIGH'
-      WHEN COALESCE(array_length(hr.risk_flags, 1), 0) = 1 OR hr.affected_people_count BETWEEN 3 AND 4 THEN 'MEDIUM'
-      ELSE 'LOW'
-    END
-  `;
+  const urgencySql = getUrgencySql();
+  const prioritySql = getPrioritySql();
 
   const [countResult, rowsResult] = await Promise.all([
     query(
@@ -259,12 +322,24 @@ async function getEmergencyHistory({
         hr.resolved_at,
         hr.cancelled_at,
         COALESCE(hr.cancelled_at, hr.resolved_at, hr.created_at) AS closed_at,
+        hr.created_at AS opened_at,
+        FLOOR(
+          EXTRACT(
+            EPOCH FROM (COALESCE(hr.cancelled_at, hr.resolved_at, CURRENT_TIMESTAMP) - hr.created_at)
+          ) / 60
+        )::int AS open_duration_minutes,
+        CASE
+          WHEN hr.status = 'RESOLVED' THEN 'RESOLVED'
+          WHEN hr.status = 'CANCELLED' THEN 'CANCELLED'
+          ELSE NULL
+        END AS closed_state,
         hr.affected_people_count,
         hr.risk_flags,
         COALESCE(NULLIF(TRIM(rl.country), ''), 'unknown') AS country,
         COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown') AS city,
         COALESCE(NULLIF(TRIM(rl.district), ''), 'unknown') AS district,
-        ${urgencySql} AS urgency_level
+        ${urgencySql} AS urgency_level,
+        ${prioritySql} AS priority_level
       FROM help_requests hr
       LEFT JOIN LATERAL (
         SELECT country, city, district
@@ -294,6 +369,9 @@ async function getEmergencyHistory({
     resolvedAt: row.resolved_at,
     cancelledAt: row.cancelled_at,
     closedAt: row.closed_at,
+    openedAt: row.opened_at,
+    openDurationMinutes: row.open_duration_minutes,
+    closedState: row.closed_state,
     location: {
       country: row.country,
       city: row.city,
@@ -301,6 +379,7 @@ async function getEmergencyHistory({
     },
     affectedPeopleCount: row.affected_people_count,
     urgencyLevel: row.urgency_level,
+    priorityLevel: row.priority_level,
     riskFlags: row.risk_flags || [],
   }));
 

--- a/backend/src/modules/admin/repository.js
+++ b/backend/src/modules/admin/repository.js
@@ -182,7 +182,19 @@ async function getEmergencyOverview({ includeRegionSummary = false } = {}) {
           LIMIT 1
         ) rl ON TRUE
         WHERE hr.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS')
-        ORDER BY hr.created_at ASC
+        ORDER BY
+          CASE ${prioritySql}
+            WHEN 'HIGH' THEN 3
+            WHEN 'MEDIUM' THEN 2
+            ELSE 1
+          END DESC,
+          CASE ${urgencySql}
+            WHEN 'HIGH' THEN 3
+            WHEN 'MEDIUM' THEN 2
+            ELSE 1
+          END DESC,
+          open_duration_minutes DESC,
+          hr.created_at ASC
         LIMIT 15
       `,
     ),
@@ -325,7 +337,7 @@ async function getEmergencyHistory({
         hr.created_at AS opened_at,
         FLOOR(
           EXTRACT(
-            EPOCH FROM (COALESCE(hr.cancelled_at, hr.resolved_at, CURRENT_TIMESTAMP) - hr.created_at)
+            EPOCH FROM (COALESCE(hr.cancelled_at, hr.resolved_at, hr.created_at) - hr.created_at)
           ) / 60
         )::int AS open_duration_minutes,
         CASE

--- a/backend/src/modules/help-requests/operational.js
+++ b/backend/src/modules/help-requests/operational.js
@@ -1,0 +1,44 @@
+function normalizeRiskFlags(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item) => typeof item === 'string' && item.trim() !== '');
+}
+
+function deriveUrgencyLevel({ affectedPeopleCount, riskFlags }) {
+  const normalizedRiskFlags = normalizeRiskFlags(riskFlags);
+  const safeAffectedPeople = Number.isInteger(affectedPeopleCount) ? affectedPeopleCount : 0;
+
+  if (normalizedRiskFlags.length >= 2 || safeAffectedPeople >= 5) {
+    return 'HIGH';
+  }
+
+  if (normalizedRiskFlags.length === 1 || (safeAffectedPeople >= 3 && safeAffectedPeople <= 4)) {
+    return 'MEDIUM';
+  }
+
+  return 'LOW';
+}
+
+function derivePriorityLevel({ urgencyLevel }) {
+  if (urgencyLevel === 'HIGH' || urgencyLevel === 'MEDIUM') {
+    return urgencyLevel;
+  }
+
+  return 'LOW';
+}
+
+function deriveOperationalLevels(input) {
+  const urgencyLevel = deriveUrgencyLevel(input);
+  const priorityLevel = derivePriorityLevel({ urgencyLevel });
+
+  return {
+    urgencyLevel,
+    priorityLevel,
+  };
+}
+
+module.exports = {
+  deriveOperationalLevels,
+};

--- a/backend/src/modules/help-requests/repository.js
+++ b/backend/src/modules/help-requests/repository.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 
 const { pool, query } = require('../../db/pool');
+const { deriveOperationalLevels } = require('./operational');
 
 function mapStatus(row) {
   if (row.status === 'RESOLVED') {
@@ -75,6 +76,14 @@ function mapHelper(row) {
 }
 
 function mapHelpRequest(row) {
+  const derivedOperational = deriveOperationalLevels({
+    affectedPeopleCount: row.affected_people_count,
+    riskFlags: row.risk_flags,
+  });
+  const urgencyLevel = row.urgency_level || derivedOperational.urgencyLevel;
+  const priorityLevel = row.priority_level || derivedOperational.priorityLevel;
+  const closedAt = row.closed_at || row.cancelled_at || row.resolved_at || null;
+
   return {
     id: row.request_id,
     userId: row.user_id,
@@ -91,6 +100,17 @@ function mapHelpRequest(row) {
     needType: row.need_type,
     status: mapStatus(row),
     internalStatus: row.status,
+    urgencyLevel,
+    priorityLevel,
+    openedAt: row.created_at,
+    closedAt,
+    openDurationMinutes: row.open_duration_minutes,
+    closedState:
+      row.status === 'RESOLVED'
+        ? 'RESOLVED'
+        : row.status === 'CANCELLED'
+          ? 'CANCELLED'
+          : null,
     createdAt: row.created_at,
     resolvedAt: row.resolved_at,
     cancelledAt: row.cancelled_at,
@@ -117,9 +137,17 @@ function buildSelectQuery() {
       hr.contact_alternative_phone,
       hr.consent_given,
       hr.status,
+      hr.urgency_level,
+      hr.priority_level,
       hr.created_at,
       hr.resolved_at,
       hr.cancelled_at,
+      COALESCE(hr.cancelled_at, hr.resolved_at) AS closed_at,
+      FLOOR(
+        EXTRACT(
+          EPOCH FROM (COALESCE(hr.cancelled_at, hr.resolved_at, CURRENT_TIMESTAMP) - hr.created_at)
+        ) / 60
+      )::int AS open_duration_minutes,
       hr.is_saved_locally,
       rl.location_id,
       rl.country,
@@ -162,6 +190,10 @@ async function createHelpRequest(input) {
     await client.query('BEGIN');
 
     const requestId = crypto.randomUUID();
+    const operationalLevels = deriveOperationalLevels({
+      affectedPeopleCount: input.affectedPeopleCount,
+      riskFlags: input.riskFlags,
+    });
 
     const requestResult = await client.query(
       `
@@ -180,9 +212,11 @@ async function createHelpRequest(input) {
           contact_phone,
           contact_alternative_phone,
           consent_given,
+          urgency_level,
+          priority_level,
           is_saved_locally
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
         RETURNING
           request_id,
           user_id,
@@ -199,9 +233,17 @@ async function createHelpRequest(input) {
           contact_alternative_phone,
           consent_given,
           status,
+          urgency_level,
+          priority_level,
           created_at,
           resolved_at,
           cancelled_at,
+          COALESCE(cancelled_at, resolved_at) AS closed_at,
+          FLOOR(
+            EXTRACT(
+              EPOCH FROM (COALESCE(cancelled_at, resolved_at, CURRENT_TIMESTAMP) - created_at)
+            ) / 60
+          )::int AS open_duration_minutes,
           is_saved_locally
       `,
       [
@@ -219,6 +261,8 @@ async function createHelpRequest(input) {
         input.contact.phone,
         input.contact.alternativePhone ?? null,
         input.consentGiven,
+        operationalLevels.urgencyLevel,
+        operationalLevels.priorityLevel,
         input.isSavedLocally,
       ],
     );

--- a/backend/tests/integration/modules/admin/admin-emergency-history.integration.test.js
+++ b/backend/tests/integration/modules/admin/admin-emergency-history.integration.test.js
@@ -268,6 +268,36 @@ describe('GET /api/admin/emergency-history', () => {
       'CANCELLED',
       'RESOLVED',
     ]);
+    expect(response.body.history[0]).toEqual(
+      expect.objectContaining({
+        requestId: 'req_resolved_new',
+        closedState: 'RESOLVED',
+        urgencyLevel: 'LOW',
+        priorityLevel: 'LOW',
+      }),
+    );
+    expect(response.body.history[0].openedAt).toEqual(expect.any(String));
+    expect(response.body.history[0].openDurationMinutes).toEqual(expect.any(Number));
+
+    expect(response.body.history[1]).toEqual(
+      expect.objectContaining({
+        requestId: 'req_cancelled_mid',
+        closedState: 'CANCELLED',
+        urgencyLevel: 'MEDIUM',
+        priorityLevel: 'MEDIUM',
+      }),
+    );
+    expect(response.body.history[1].openedAt).toEqual(expect.any(String));
+    expect(response.body.history[1].openDurationMinutes).toEqual(expect.any(Number));
+
+    expect(response.body.history[3]).toEqual(
+      expect.objectContaining({
+        requestId: 'req_resolved_old',
+        closedState: 'RESOLVED',
+        urgencyLevel: 'HIGH',
+        priorityLevel: 'HIGH',
+      }),
+    );
     expect(response.body.history.some((item) => item.requestId === 'req_pending_active')).toBe(false);
   });
 

--- a/backend/tests/integration/modules/admin/admin-emergency-history.integration.test.js
+++ b/backend/tests/integration/modules/admin/admin-emergency-history.integration.test.js
@@ -243,6 +243,77 @@ describe('GET /api/admin/emergency-history', () => {
     expect(response.body.code).toBe('FORBIDDEN');
   });
 
+    test('uses consistent fallback for closedAt and openDurationMinutes on dirty closed rows', async () => {
+      await seedBaseUsers();
+
+      await query(
+        `
+          INSERT INTO help_requests (
+            request_id,
+            user_id,
+            help_types,
+            other_help_text,
+            affected_people_count,
+            risk_flags,
+            vulnerable_groups,
+            need_type,
+            description,
+            blood_type,
+            contact_full_name,
+            contact_phone,
+            consent_given,
+            status,
+            created_at,
+            resolved_at,
+            cancelled_at,
+            is_saved_locally
+          )
+          VALUES (
+            'req_dirty_closed',
+            'normal_user',
+            ARRAY['first_aid']::TEXT[],
+            '',
+            1,
+            ARRAY[]::TEXT[],
+            ARRAY[]::TEXT[],
+            'first_aid',
+            'Dirty closed row',
+            NULL,
+            'Z User',
+            5556667788,
+            TRUE,
+            'RESOLVED',
+            NOW() - INTERVAL '8 hours',
+            NULL,
+            NULL,
+            FALSE
+          )
+        `,
+      );
+
+      const app = createTestApp();
+      const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+      const response = await request(app)
+        .get('/api/admin/emergency-history?status=resolved&type=first_aid')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.history).toHaveLength(1);
+      expect(response.body.history[0]).toEqual(
+        expect.objectContaining({
+          requestId: 'req_dirty_closed',
+          status: 'RESOLVED',
+          closedState: 'RESOLVED',
+          openDurationMinutes: 0,
+        }),
+      );
+
+      const openedAt = new Date(response.body.history[0].openedAt).getTime();
+      const closedAt = new Date(response.body.history[0].closedAt).getTime();
+      expect(closedAt).toBe(openedAt);
+    });
+
   test('returns only resolved/cancelled history sorted by closed time', async () => {
     await seedBaseUsers();
     await seedHelpRequests();

--- a/backend/tests/integration/modules/admin/admin-emergency-overview.integration.test.js
+++ b/backend/tests/integration/modules/admin/admin-emergency-overview.integration.test.js
@@ -259,6 +259,39 @@ describe('GET /api/admin/emergency-overview', () => {
     expect(response.body.overview.recentActivity.resolvedLast7Days).toBe(1);
     expect(response.body.overview.recentActivity.cancelledLast24Hours).toBe(1);
     expect(response.body.overview.recentActivity.cancelledLast7Days).toBe(1);
+    expect(response.body.overview.activeOperational).toHaveLength(2);
+    expect(response.body.overview.activeOperational[0]).toEqual(
+      expect.objectContaining({
+        requestId: 'req_in_progress',
+        status: 'IN_PROGRESS',
+        urgencyLevel: 'MEDIUM',
+        priorityLevel: 'MEDIUM',
+        closedAt: null,
+        closedState: null,
+        location: {
+          city: 'istanbul',
+          district: 'besiktas',
+        },
+      }),
+    );
+    expect(response.body.overview.activeOperational[0].openedAt).toEqual(expect.any(String));
+    expect(response.body.overview.activeOperational[0].openDurationMinutes).toEqual(expect.any(Number));
+    expect(response.body.overview.activeOperational[1]).toEqual(
+      expect.objectContaining({
+        requestId: 'req_pending',
+        status: 'PENDING',
+        urgencyLevel: 'HIGH',
+        priorityLevel: 'HIGH',
+        closedAt: null,
+        closedState: null,
+        location: {
+          city: 'ankara',
+          district: 'cankaya',
+        },
+      }),
+    );
+    expect(response.body.overview.activeOperational[1].openedAt).toEqual(expect.any(String));
+    expect(response.body.overview.activeOperational[1].openDurationMinutes).toEqual(expect.any(Number));
     expect(response.body.overview.regionSummary).toBeUndefined();
   });
 

--- a/backend/tests/integration/modules/admin/admin-emergency-overview.integration.test.js
+++ b/backend/tests/integration/modules/admin/admin-emergency-overview.integration.test.js
@@ -262,22 +262,6 @@ describe('GET /api/admin/emergency-overview', () => {
     expect(response.body.overview.activeOperational).toHaveLength(2);
     expect(response.body.overview.activeOperational[0]).toEqual(
       expect.objectContaining({
-        requestId: 'req_in_progress',
-        status: 'IN_PROGRESS',
-        urgencyLevel: 'MEDIUM',
-        priorityLevel: 'MEDIUM',
-        closedAt: null,
-        closedState: null,
-        location: {
-          city: 'istanbul',
-          district: 'besiktas',
-        },
-      }),
-    );
-    expect(response.body.overview.activeOperational[0].openedAt).toEqual(expect.any(String));
-    expect(response.body.overview.activeOperational[0].openDurationMinutes).toEqual(expect.any(Number));
-    expect(response.body.overview.activeOperational[1]).toEqual(
-      expect.objectContaining({
         requestId: 'req_pending',
         status: 'PENDING',
         urgencyLevel: 'HIGH',
@@ -287,6 +271,22 @@ describe('GET /api/admin/emergency-overview', () => {
         location: {
           city: 'ankara',
           district: 'cankaya',
+        },
+      }),
+    );
+    expect(response.body.overview.activeOperational[0].openedAt).toEqual(expect.any(String));
+    expect(response.body.overview.activeOperational[0].openDurationMinutes).toEqual(expect.any(Number));
+    expect(response.body.overview.activeOperational[1]).toEqual(
+      expect.objectContaining({
+        requestId: 'req_in_progress',
+        status: 'IN_PROGRESS',
+        urgencyLevel: 'MEDIUM',
+        priorityLevel: 'MEDIUM',
+        closedAt: null,
+        closedState: null,
+        location: {
+          city: 'istanbul',
+          district: 'besiktas',
         },
       }),
     );

--- a/web/e2e/admin-dashboard.spec.js
+++ b/web/e2e/admin-dashboard.spec.js
@@ -205,6 +205,25 @@ test('aggregate metrics reflect mixed status and urgency records', async ({ page
     urgencyMedium: 2,
     urgencyHigh: 1,
   });
+
+  const activeOperationalTable = page
+    .locator('section', {
+      has: page.getByRole('heading', { name: 'Active Operational Snapshot' }),
+    })
+    .locator('table');
+
+  await expect(activeOperationalTable).toContainText('In Progress');
+  await expect(activeOperationalTable).toContainText('First Aid');
+  await expect(activeOperationalTable).not.toContainText('IN_PROGRESS');
+  await expect(activeOperationalTable).not.toContainText('In_progress');
+  await expect(activeOperationalTable).not.toContainText('first_aid');
+  await expect(activeOperationalTable).not.toContainText('First_aid');
+
+  const activeRows = activeOperationalTable.locator('tbody tr');
+  await expect(activeRows.first()).toContainText('In Progress');
+  await expect(activeRows.first()).toContainText('High');
+  await expect(activeRows.nth(1)).toContainText('Pending');
+  await expect(activeRows.nth(1)).toContainText('Low');
 });
 
 test('navbar admin link visibility is role-aware', async ({ page }) => {

--- a/web/e2e/admin-history.spec.js
+++ b/web/e2e/admin-history.spec.js
@@ -32,7 +32,7 @@ test('admin can review closed emergency history records', async ({ page }) => {
     requestId: 'e2e_hist_resolved_recent',
     status: 'RESOLVED',
     city: 'ankara',
-    needType: 'water',
+    needType: 'first_aid',
     description: 'History resolved recent',
     createdAtHoursAgo: 2,
   });
@@ -68,6 +68,12 @@ test('admin can review closed emergency history records', async ({ page }) => {
   await expect(historyTable).toContainText('History resolved recent');
   await expect(historyTable).toContainText('History cancelled old');
   await expect(historyTable).not.toContainText('History pending should not show');
+  await expect(historyTable).toContainText('First Aid');
+  await expect(historyTable).not.toContainText('first_aid');
+  await expect(historyTable).not.toContainText('First_aid');
+  await expect(historyTable).toContainText('Resolved');
+  await expect(historyTable).toContainText('Cancelled');
+  await expect(historyTable.locator('tbody tr').first().locator('td').nth(6)).toHaveText(/^[0-9]+$/);
   await expect(page.getByText('Showing 2 of 2 closed emergencies.')).toBeVisible();
 });
 

--- a/web/src/components/feature/admin/AdminEmergencyHistoryView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyHistoryView.tsx
@@ -306,10 +306,13 @@ export default function AdminEmergencyHistoryView() {
                         <table className="admin-region-table admin-history-table">
                             <thead>
                                 <tr>
+                                    <th>Opened At</th>
                                     <th>Closed At</th>
-                                    <th>Status</th>
+                                    <th>Closed State</th>
                                     <th>Type</th>
                                     <th>Urgency</th>
+                                    <th>Priority</th>
+                                    <th>Open (min)</th>
                                     <th>Region</th>
                                     <th>Description</th>
                                 </tr>
@@ -317,10 +320,13 @@ export default function AdminEmergencyHistoryView() {
                             <tbody>
                                 {items.map((item) => (
                                     <tr key={item.requestId}>
+                                        <td>{formatDateTime(item.openedAt)}</td>
                                         <td>{formatDateTime(item.closedAt)}</td>
-                                        <td>{formatTitleCase(item.status)}</td>
+                                        <td>{formatTitleCase(item.closedState || item.status)}</td>
                                         <td>{formatTitleCase(item.needType)}</td>
                                         <td>{formatTitleCase(item.urgencyLevel)}</td>
+                                        <td>{formatTitleCase(item.priorityLevel)}</td>
+                                        <td>{item.openDurationMinutes}</td>
                                         <td>{formatTitleCase(item.location.city)}</td>
                                         <td>{item.description}</td>
                                     </tr>

--- a/web/src/components/feature/admin/AdminEmergencyHistoryView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyHistoryView.tsx
@@ -8,6 +8,7 @@ import {
     fetchAdminEmergencyHistory,
     type EmergencyHistoryItem,
 } from "@/lib/admin";
+import { formatOperationalLabel } from "@/lib/formatters";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { SectionHeader } from "@/components/ui/display/SectionHeader";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
@@ -39,19 +40,6 @@ function formatDateTime(value: string | null) {
     }
 
     return date.toLocaleString();
-}
-
-function formatTitleCase(value: string | null | undefined) {
-    if (!value) {
-        return "-";
-    }
-
-    return String(value)
-        .trim()
-        .toLocaleLowerCase("tr-TR")
-        .split(/\s+/)
-        .map((word) => (word ? word[0].toLocaleUpperCase("tr-TR") + word.slice(1) : word))
-        .join(" ");
 }
 
 export default function AdminEmergencyHistoryView() {
@@ -322,12 +310,12 @@ export default function AdminEmergencyHistoryView() {
                                     <tr key={item.requestId}>
                                         <td>{formatDateTime(item.openedAt)}</td>
                                         <td>{formatDateTime(item.closedAt)}</td>
-                                        <td>{formatTitleCase(item.closedState || item.status)}</td>
-                                        <td>{formatTitleCase(item.needType)}</td>
-                                        <td>{formatTitleCase(item.urgencyLevel)}</td>
-                                        <td>{formatTitleCase(item.priorityLevel)}</td>
+                                        <td>{formatOperationalLabel(item.closedState || item.status)}</td>
+                                        <td>{formatOperationalLabel(item.needType)}</td>
+                                        <td>{formatOperationalLabel(item.urgencyLevel)}</td>
+                                        <td>{formatOperationalLabel(item.priorityLevel)}</td>
                                         <td>{item.openDurationMinutes}</td>
-                                        <td>{formatTitleCase(item.location.city)}</td>
+                                        <td>{formatOperationalLabel(item.location.city)}</td>
                                         <td>{item.description}</td>
                                     </tr>
                                 ))}

--- a/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
@@ -27,6 +27,32 @@ function MetricTile({
     );
 }
 
+function formatDateTime(value: string | null) {
+    if (!value) {
+        return "-";
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return date.toLocaleString();
+}
+
+function formatTitleCase(value: string | null | undefined) {
+    if (!value) {
+        return "-";
+    }
+
+    return String(value)
+        .trim()
+        .toLocaleLowerCase("tr-TR")
+        .split(/\s+/)
+        .map((word) => (word ? word[0].toLocaleUpperCase("tr-TR") + word.slice(1) : word))
+        .join(" ");
+}
+
 export default function AdminEmergencyOverviewView() {
     const router = useRouter();
     const pathname = usePathname();
@@ -269,6 +295,45 @@ export default function AdminEmergencyOverviewView() {
                         <p className="admin-recent-line">Last 7d: {overview.recentActivity.cancelledLast7Days}</p>
                     </div>
                 </div>
+            </SectionCard>
+
+            <SectionCard>
+                <SectionHeader
+                    title="Active Operational Snapshot"
+                    subtitle="Live operational details for active emergencies."
+                />
+                {overview.activeOperational.length > 0 ? (
+                    <div className="admin-region-table-wrap">
+                        <table className="admin-region-table admin-history-table">
+                            <thead>
+                                <tr>
+                                    <th>Opened At</th>
+                                    <th>Status</th>
+                                    <th>Type</th>
+                                    <th>Urgency</th>
+                                    <th>Priority</th>
+                                    <th>Open (min)</th>
+                                    <th>Region</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {overview.activeOperational.map((item) => (
+                                    <tr key={item.requestId}>
+                                        <td>{formatDateTime(item.openedAt)}</td>
+                                        <td>{formatTitleCase(item.status)}</td>
+                                        <td>{formatTitleCase(item.needType)}</td>
+                                        <td>{formatTitleCase(item.urgencyLevel)}</td>
+                                        <td>{formatTitleCase(item.priorityLevel)}</td>
+                                        <td>{item.openDurationMinutes}</td>
+                                        <td>{formatTitleCase(item.location.city)}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                ) : (
+                    <p className="admin-subtle">No active emergencies to display.</p>
+                )}
             </SectionCard>
 
             <SectionCard>

--- a/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { ApiError } from "@/lib/api";
 import { getAccessToken, clearAccessToken } from "@/lib/auth";
 import { fetchAdminEmergencyOverview, type EmergencyOverview } from "@/lib/admin";
+import { formatOperationalLabel } from "@/lib/formatters";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { SectionHeader } from "@/components/ui/display/SectionHeader";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
@@ -38,19 +39,6 @@ function formatDateTime(value: string | null) {
     }
 
     return date.toLocaleString();
-}
-
-function formatTitleCase(value: string | null | undefined) {
-    if (!value) {
-        return "-";
-    }
-
-    return String(value)
-        .trim()
-        .toLocaleLowerCase("tr-TR")
-        .split(/\s+/)
-        .map((word) => (word ? word[0].toLocaleUpperCase("tr-TR") + word.slice(1) : word))
-        .join(" ");
 }
 
 export default function AdminEmergencyOverviewView() {
@@ -320,12 +308,12 @@ export default function AdminEmergencyOverviewView() {
                                 {overview.activeOperational.map((item) => (
                                     <tr key={item.requestId}>
                                         <td>{formatDateTime(item.openedAt)}</td>
-                                        <td>{formatTitleCase(item.status)}</td>
-                                        <td>{formatTitleCase(item.needType)}</td>
-                                        <td>{formatTitleCase(item.urgencyLevel)}</td>
-                                        <td>{formatTitleCase(item.priorityLevel)}</td>
+                                        <td>{formatOperationalLabel(item.status)}</td>
+                                        <td>{formatOperationalLabel(item.needType)}</td>
+                                        <td>{formatOperationalLabel(item.urgencyLevel)}</td>
+                                        <td>{formatOperationalLabel(item.priorityLevel)}</td>
                                         <td>{item.openDurationMinutes}</td>
-                                        <td>{formatTitleCase(item.location.city)}</td>
+                                        <td>{formatOperationalLabel(item.location.city)}</td>
                                     </tr>
                                 ))}
                             </tbody>

--- a/web/src/lib/admin.ts
+++ b/web/src/lib/admin.ts
@@ -39,11 +39,28 @@ export type EmergencyOverviewRegionItem = {
     cancelled: number;
 };
 
+export type EmergencyOperationalItem = {
+    requestId: string;
+    needType: string | null;
+    status: "PENDING" | "ASSIGNED" | "IN_PROGRESS" | "RESOLVED" | "CANCELLED";
+    urgencyLevel: "LOW" | "MEDIUM" | "HIGH";
+    priorityLevel: "LOW" | "MEDIUM" | "HIGH";
+    openedAt: string;
+    openDurationMinutes: number;
+    closedAt: string | null;
+    closedState: "RESOLVED" | "CANCELLED" | null;
+    location: {
+        city: string;
+        district: string;
+    };
+};
+
 export type EmergencyOverview = {
     totals: EmergencyOverviewTotals;
     statusBreakdown: EmergencyOverviewStatusBreakdown;
     urgencyBreakdown: EmergencyOverviewUrgencyBreakdown;
     recentActivity: EmergencyOverviewRecentActivity;
+    activeOperational: EmergencyOperationalItem[];
     regionSummary?: EmergencyOverviewRegionItem[];
 };
 
@@ -57,6 +74,9 @@ export type EmergencyHistoryItem = {
     description: string;
     status: "RESOLVED" | "CANCELLED";
     createdAt: string;
+    openedAt: string;
+    openDurationMinutes: number;
+    closedState: "RESOLVED" | "CANCELLED" | null;
     resolvedAt: string | null;
     cancelledAt: string | null;
     closedAt: string;
@@ -67,6 +87,7 @@ export type EmergencyHistoryItem = {
     };
     affectedPeopleCount: number;
     urgencyLevel: "LOW" | "MEDIUM" | "HIGH";
+    priorityLevel: "LOW" | "MEDIUM" | "HIGH";
     riskFlags: string[];
 };
 

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -1,0 +1,14 @@
+export function formatOperationalLabel(value: string | null | undefined) {
+    if (!value) {
+        return "-";
+    }
+
+    return String(value)
+        .trim()
+        .replace(/[_-]+/g, " ")
+        .replace(/\s+/g, " ")
+        .toLocaleLowerCase("tr-TR")
+        .split(" ")
+        .map((word) => (word ? word[0].toLocaleUpperCase("tr-TR") + word.slice(1) : word))
+        .join(" ");
+}

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -7,8 +7,8 @@ export function formatOperationalLabel(value: string | null | undefined) {
         .trim()
         .replace(/[_-]+/g, " ")
         .replace(/\s+/g, " ")
-        .toLocaleLowerCase("tr-TR")
+        .toLocaleLowerCase("en-US")
         .split(" ")
-        .map((word) => (word ? word[0].toLocaleUpperCase("tr-TR") + word.slice(1) : word))
+        .map((word) => (word ? word[0].toLocaleUpperCase("en-US") + word.slice(1) : word))
         .join(" ");
 }


### PR DESCRIPTION
This PR adds operational emergency fields end-to-end for admin visibility and consistent prioritization.

## What Changed
1. Added database migration for operational fields on help requests:
- `urgency_level`
- `priority_level`
- Backfill for existing rows
- Validation constraints for allowed values (`LOW`, `MEDIUM`, `HIGH`)

2. Added centralized operational derivation logic in backend:
- Derives urgency/priority from existing risk and affected-people signals
- Reused in help request creation and read mappings

3. Extended admin backend responses:
- Emergency overview now includes `activeOperational` snapshot for active requests
- Emergency history now includes:
- `openedAt`
- `openDurationMinutes`
- `closedState`
- `priorityLevel`
- Urgency/priority derivation uses consistent fallback logic

4. Updated web admin contract and UI:
- Extended admin API types for new operational/lifecycle fields
- Overview page shows active operational table
- History page shows lifecycle and priority columns

5. Strengthened integration tests:
- Added assertions for newly introduced operational and lifecycle fields in admin integration tests

## Why
Admin users need a clearer operational picture (urgency, priority, lifecycle duration) to triage and monitor emergencies consistently.

## Validation
1. Backend admin integration tests passed.
2. Backend help-requests integration tests passed.
3. Web build passed successfully.

Closes #272 