### PR TITLE
feat: represent multi-responder assignments consistently in request flows

### DIFF
--- a/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
+++ b/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.neph.BuildConfig
 
 @Database(
@@ -14,7 +16,7 @@ import com.neph.BuildConfig
         SyncOperationEntity::class,
         SyncMetadataEntity::class
     ],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 abstract class NephDatabase : RoomDatabase() {
@@ -28,6 +30,13 @@ abstract class NephDatabase : RoomDatabase() {
 object NephDatabaseProvider {
     @Volatile private var instance: NephDatabase? = null
     private const val DatabaseName = "neph-offline.db"
+    private val Migration1To2 = object : Migration(1, 2) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL(
+                "ALTER TABLE help_requests ADD COLUMN helpersJson TEXT NOT NULL DEFAULT '[]'"
+            )
+        }
+    }
 
     fun initialize(context: Context) {
         getInstance(context)
@@ -39,7 +48,9 @@ object NephDatabaseProvider {
                 context.applicationContext,
                 NephDatabase::class.java,
                 DatabaseName
-            ).build().also { instance = it }
+            ).addMigrations(Migration1To2)
+                .build()
+                .also { instance = it }
         }
     }
 

--- a/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
@@ -41,6 +41,7 @@ data class HelpRequestEntity(
     val helperPhone: String?,
     val helperProfession: String?,
     val helperExpertise: String?,
+    val helpersJson: String,
     val syncStatus: String = SyncStatus.SYNCED,
     val pendingError: String? = null,
     val createdAtEpochMillis: Long,

--- a/android/app/src/main/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepository.kt
+++ b/android/app/src/main/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepository.kt
@@ -32,6 +32,7 @@ data class MyHelpRequestUiModel(
     val contactName: String?,
     val contactPhone: String?,
     val alternativePhone: String?,
+    val responders: List<AssignedResponderUiModel>,
     val helperFirstName: String?,
     val helperLastName: String?,
     val helperPhone: String?,
@@ -48,6 +49,20 @@ data class MyHelpRequestUiModel(
 
     val isFailedSync: Boolean
         get() = syncStatus == SyncStatus.FAILED || syncStatus == SyncStatus.CONFLICTED
+}
+
+data class AssignedResponderUiModel(
+    val firstName: String?,
+    val lastName: String?,
+    val phone: String?,
+    val profession: String?,
+    val expertise: String?
+) {
+    val fullName: String?
+        get() = listOfNotNull(firstName, lastName).joinToString(" ").trim().takeIf { it.isNotBlank() }
+
+    val hasVisibleDetails: Boolean
+        get() = fullName != null || phone != null || profession != null || expertise != null
 }
 
 object MyHelpRequestsRepository {
@@ -174,6 +189,29 @@ internal fun HelpRequestEntity.toUiModel(): MyHelpRequestUiModel {
     val displayId = remoteId ?: localId
     val created = serverCreatedAt?.let(::formatTimestamp)
         ?: formatEpochMillis(createdAtEpochMillis)
+    val responders = helpersJson.jsonArrayToAssignedResponderList()
+        .ifEmpty {
+            buildList {
+                if (
+                    helperFirstName != null ||
+                    helperLastName != null ||
+                    helperPhone != null ||
+                    helperProfession != null ||
+                    helperExpertise != null
+                ) {
+                    add(
+                        AssignedResponderUiModel(
+                            firstName = helperFirstName,
+                            lastName = helperLastName,
+                            phone = helperPhone,
+                            profession = helperProfession,
+                            expertise = helperExpertise
+                        )
+                    )
+                }
+            }
+        }
+    val primaryResponder = responders.firstOrNull()
 
     return MyHelpRequestUiModel(
         id = displayId,
@@ -189,19 +227,41 @@ internal fun HelpRequestEntity.toUiModel(): MyHelpRequestUiModel {
         contactName = contactFullName.takeIf { it.isNotBlank() },
         contactPhone = contactPhone.takeIf { it.isNotBlank() },
         alternativePhone = contactAlternativePhone,
-        helperFirstName = helperFirstName,
-        helperLastName = helperLastName,
-        helperPhone = helperPhone,
-        helperProfession = helperProfession,
-        helperExpertise = helperExpertise,
-        helperFullName = listOfNotNull(helperFirstName, helperLastName)
-            .joinToString(" ")
-            .trim()
-            .takeIf { it.isNotBlank() },
+        responders = responders,
+        helperFirstName = primaryResponder?.firstName,
+        helperLastName = primaryResponder?.lastName,
+        helperPhone = primaryResponder?.phone,
+        helperProfession = primaryResponder?.profession,
+        helperExpertise = primaryResponder?.expertise,
+        helperFullName = primaryResponder?.fullName,
         createdAt = created,
         syncStatus = syncStatus,
         pendingError = pendingError,
         lastSyncedAt = lastSyncedAtEpochMillis?.let(::formatEpochMillis)
+    )
+}
+
+private fun String.jsonArrayToAssignedResponderList(): List<AssignedResponderUiModel> {
+    return runCatching { JSONArray(this) }
+        .getOrNull()
+        ?.let { json ->
+            buildList {
+                for (index in 0 until json.length()) {
+                    val value = json.optJSONObject(index)?.toAssignedResponderUiModel() ?: continue
+                    add(value)
+                }
+            }
+        }
+        ?: emptyList()
+}
+
+private fun org.json.JSONObject.toAssignedResponderUiModel(): AssignedResponderUiModel {
+    return AssignedResponderUiModel(
+        firstName = optString("firstName").trim().takeIf { it.isNotBlank() },
+        lastName = optString("lastName").trim().takeIf { it.isNotBlank() },
+        phone = opt("phone")?.toString()?.takeIf { it.isNotBlank() && it != "null" },
+        profession = optString("profession").trim().takeIf { it.isNotBlank() },
+        expertise = optString("expertise").trim().takeIf { it.isNotBlank() }
     )
 }
 

--- a/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
@@ -363,48 +363,69 @@ private fun MyHelpRequestCard(
                 )
             }
 
-            if (
-                request.helperFullName != null ||
-                request.helperPhone != null ||
-                request.helperProfession != null ||
-                request.helperExpertise != null
-            ) {
+            if (request.responders.isNotEmpty()) {
                 SectionHeader(
-                    title = "Assigned Helper Details",
-                    subtitle = "Name, phone, profession, and expertise of your assigned helper."
+                    title = if (request.responders.size == 1) "Assigned Helper Details" else "Assigned Responders",
+                    subtitle = if (request.responders.size == 1) {
+                        "Name, phone, profession, and expertise of your assigned helper."
+                    } else {
+                        "Name, phone, profession, and expertise of active responders assigned to this request."
+                    }
                 )
 
-                request.helperFullName?.let {
-                    Text(
-                        text = "Name: $it",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                    request.responders.forEachIndexed { index, responder ->
+                        Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+                            if (request.responders.size > 1) {
+                                Text(
+                                    text = "Responder ${index + 1}",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                            }
 
-                request.helperPhone?.let {
-                    Text(
-                        text = "Phone: $it",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.clickable { openDialer(it) }
-                    )
-                }
+                            responder.fullName?.let {
+                                Text(
+                                    text = "Name: $it",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
 
-                request.helperProfession?.let {
-                    Text(
-                        text = "Profession: $it",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+                            responder.phone?.let {
+                                Text(
+                                    text = "Phone: $it",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.clickable { openDialer(it) }
+                                )
+                            }
 
-                request.helperExpertise?.let {
-                    Text(
-                        text = "Expertise: $it",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                            responder.profession?.let {
+                                Text(
+                                    text = "Profession: $it",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+
+                            responder.expertise?.let {
+                                Text(
+                                    text = "Expertise: $it",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+
+                            if (!responder.hasVisibleDetails) {
+                                Text(
+                                    text = "Responder details unavailable.",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
                 }
             }
 

--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
@@ -23,6 +23,14 @@ import java.net.URLEncoder
 import java.util.Locale
 import java.util.UUID
 
+internal data class AssignedResponderSnapshot(
+    val firstName: String?,
+    val lastName: String?,
+    val phone: String?,
+    val profession: String?,
+    val expertise: String?
+)
+
 private const val PendingHelpRequestStatus = "PENDING_SYNC"
 private const val ReverseGeocodeTimeoutMillis = 7000L
 
@@ -482,6 +490,7 @@ internal fun RequestHelpSubmission.toEntity(
         helperPhone = null,
         helperProfession = null,
         helperExpertise = null,
+        helpersJson = JSONArray().toString(),
         syncStatus = syncStatus,
         pendingError = null,
         createdAtEpochMillis = now,
@@ -501,7 +510,14 @@ internal fun JSONObject.toHelpRequestEntity(
     val remoteId = optString("id").takeIf { it.isNotBlank() }
     val location = optJSONObject("location") ?: JSONObject()
     val contact = optJSONObject("contact") ?: JSONObject()
-    val helper = optJSONObject("helper")
+    val helpers = optJSONArray("helpers")
+        ?.toAssignedResponderSnapshots()
+        ?.takeIf { it.isNotEmpty() }
+        ?: optJSONObject("helper")
+            ?.toAssignedResponderSnapshot()
+            ?.let(::listOf)
+        ?: emptyList()
+    val primaryHelper = helpers.firstOrNull()
 
     return HelpRequestEntity(
         localId = existing?.localId ?: remoteId ?: "remote_${UUID.randomUUID()}",
@@ -524,11 +540,12 @@ internal fun JSONObject.toHelpRequestEntity(
         contactPhone = contact.opt("phone")?.toString().orEmpty(),
         contactAlternativePhone = contact.opt("alternativePhone")?.toString()?.takeIf { it.isNotBlank() && it != "null" },
         status = optString("status").ifBlank { existing?.status ?: "SYNCED" },
-        helperFirstName = helper?.optString("firstName")?.takeIf { it.isNotBlank() },
-        helperLastName = helper?.optString("lastName")?.takeIf { it.isNotBlank() },
-        helperPhone = helper?.opt("phone")?.toString()?.takeIf { it.isNotBlank() && it != "null" },
-        helperProfession = helper?.optString("profession")?.takeIf { it.isNotBlank() },
-        helperExpertise = helper?.optString("expertise")?.takeIf { it.isNotBlank() },
+        helperFirstName = primaryHelper?.firstName,
+        helperLastName = primaryHelper?.lastName,
+        helperPhone = primaryHelper?.phone,
+        helperProfession = primaryHelper?.profession,
+        helperExpertise = primaryHelper?.expertise,
+        helpersJson = helpers.toJsonArrayString(),
         syncStatus = SyncStatus.SYNCED,
         pendingError = null,
         createdAtEpochMillis = existing?.createdAtEpochMillis ?: now,
@@ -540,6 +557,42 @@ internal fun JSONObject.toHelpRequestEntity(
 }
 
 internal fun JSONArray?.orEmptyJsonArrayString(): String = (this ?: JSONArray()).toString()
+
+internal fun JSONArray.toAssignedResponderSnapshots(): List<AssignedResponderSnapshot> {
+    return buildList {
+        for (index in 0 until length()) {
+            optJSONObject(index)
+                ?.toAssignedResponderSnapshot()
+                ?.let(::add)
+        }
+    }
+}
+
+internal fun JSONObject.toAssignedResponderSnapshot(): AssignedResponderSnapshot {
+    return AssignedResponderSnapshot(
+        firstName = optString("firstName").trim().takeIf { it.isNotBlank() },
+        lastName = optString("lastName").trim().takeIf { it.isNotBlank() },
+        phone = opt("phone")?.toString()?.takeIf { it.isNotBlank() && it != "null" },
+        profession = optString("profession").trim().takeIf { it.isNotBlank() },
+        expertise = optString("expertise").trim().takeIf { it.isNotBlank() }
+    )
+}
+
+internal fun List<AssignedResponderSnapshot>.toJsonArrayString(): String {
+    return JSONArray().apply {
+        this@toJsonArrayString.forEach { helper ->
+            put(
+                JSONObject().apply {
+                    put("firstName", helper.firstName)
+                    put("lastName", helper.lastName)
+                    put("phone", helper.phone)
+                    put("profession", helper.profession)
+                    put("expertise", helper.expertise)
+                }
+            )
+        }
+    }.toString()
+}
 
 internal fun String.jsonArrayToStringList(): List<String> {
     val json = runCatching { JSONArray(this) }.getOrNull() ?: return emptyList()

--- a/backend/src/modules/help-requests/repository.js
+++ b/backend/src/modules/help-requests/repository.js
@@ -61,21 +61,41 @@ function mapContact(row) {
   };
 }
 
-function mapHelper(row) {
-  if (!row.helper_first_name && !row.helper_last_name && !row.helper_phone_number) {
+function parseHelpers(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+
+  return [];
+}
+
+function mapHelperValue(value) {
+  if (!value || typeof value !== 'object') {
     return null;
   }
 
   return {
-    firstName: row.helper_first_name || null,
-    lastName: row.helper_last_name || null,
-    phone: row.helper_phone_number ? Number(row.helper_phone_number) : null,
-    profession: row.helper_profession || null,
-    expertise: row.helper_expertise_area || null,
+    firstName: value.firstName || null,
+    lastName: value.lastName || null,
+    phone: value.phone ? Number(value.phone) : null,
+    profession: value.profession || null,
+    expertise: value.expertise || null,
   };
 }
 
 function mapHelpRequest(row) {
+  const helpers = parseHelpers(row.helpers)
+    .map(mapHelperValue)
+    .filter(Boolean);
   const derivedOperational = deriveOperationalLevels({
     affectedPeopleCount: row.affected_people_count,
     riskFlags: row.risk_flags,
@@ -115,7 +135,8 @@ function mapHelpRequest(row) {
     resolvedAt: row.resolved_at,
     cancelledAt: row.cancelled_at,
     isSavedLocally: row.is_saved_locally,
-    helper: mapHelper(row),
+    helper: helpers[0] || null,
+    helpers,
   };
 }
 
@@ -160,31 +181,39 @@ function buildSelectQuery() {
       rl.is_gps_location,
       rl.is_last_known,
       rl.captured_at,
-      helper_profile.first_name AS helper_first_name,
-      helper_profile.last_name AS helper_last_name,
-      helper_profile.phone_number AS helper_phone_number,
-      helper_expertise.profession AS helper_profession,
-      helper_expertise.expertise_area AS helper_expertise_area
+      helper_assignments.helpers AS helpers
     FROM help_requests hr
     LEFT JOIN request_locations rl ON rl.request_id = hr.request_id
     LEFT JOIN LATERAL (
-      SELECT a.volunteer_id
-      FROM assignments a
-      WHERE a.request_id = hr.request_id
-        AND a.is_cancelled = FALSE
-      ORDER BY a.assigned_at ASC, a.assignment_id ASC
-      LIMIT 1
-    ) primary_assignment ON TRUE
-    LEFT JOIN volunteers vol ON vol.volunteer_id = primary_assignment.volunteer_id
-    LEFT JOIN users helper_user ON helper_user.user_id = vol.user_id
-    LEFT JOIN user_profiles helper_profile ON helper_profile.user_id = vol.user_id
-    LEFT JOIN LATERAL (
-      SELECT e.profession, e.expertise_area
-      FROM expertise e
-      WHERE e.profile_id = helper_profile.profile_id
-      ORDER BY e.is_verified DESC, e.expertise_id ASC
-      LIMIT 1
-    ) helper_expertise ON TRUE
+      SELECT COALESCE(
+        json_agg(
+          json_build_object(
+            'firstName', helper_profile.first_name,
+            'lastName', helper_profile.last_name,
+            'phone', helper_profile.phone_number,
+            'profession', helper_expertise.profession,
+            'expertise', helper_expertise.expertise_area
+          )
+          ORDER BY assignment_rows.assigned_at ASC, assignment_rows.assignment_id ASC
+        ) FILTER (WHERE assignment_rows.assignment_id IS NOT NULL),
+        '[]'::json
+      ) AS helpers
+      FROM (
+        SELECT a.assignment_id, a.assigned_at, vol.user_id
+        FROM assignments a
+        JOIN volunteers vol ON vol.volunteer_id = a.volunteer_id
+        WHERE a.request_id = hr.request_id
+          AND a.is_cancelled = FALSE
+      ) assignment_rows
+      LEFT JOIN user_profiles helper_profile ON helper_profile.user_id = assignment_rows.user_id
+      LEFT JOIN LATERAL (
+        SELECT e.profession, e.expertise_area
+        FROM expertise e
+        WHERE e.profile_id = helper_profile.profile_id
+        ORDER BY e.is_verified DESC, e.expertise_id ASC
+        LIMIT 1
+      ) helper_expertise ON TRUE
+    ) helper_assignments ON TRUE
   `;
 }
 

--- a/backend/src/modules/help-requests/repository.js
+++ b/backend/src/modules/help-requests/repository.js
@@ -78,24 +78,47 @@ function parseHelpers(value) {
   return [];
 }
 
+function normalizeHelperText(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized || null;
+}
+
 function mapHelperValue(value) {
   if (!value || typeof value !== 'object') {
     return null;
   }
 
   return {
-    firstName: value.firstName || null,
-    lastName: value.lastName || null,
+    firstName: normalizeHelperText(value.firstName),
+    lastName: normalizeHelperText(value.lastName),
     phone: value.phone ? Number(value.phone) : null,
-    profession: value.profession || null,
-    expertise: value.expertise || null,
+    profession: normalizeHelperText(value.profession),
+    expertise: normalizeHelperText(value.expertise),
   };
+}
+
+function hasVisibleHelperField(helper) {
+  return Boolean(
+    helper
+    && (
+      helper.firstName
+      || helper.lastName
+      || helper.phone != null
+      || helper.profession
+      || helper.expertise
+    )
+  );
 }
 
 function mapHelpRequest(row) {
   const helpers = parseHelpers(row.helpers)
     .map(mapHelperValue)
     .filter(Boolean);
+  const helper = helpers.find(hasVisibleHelperField) || null;
   const derivedOperational = deriveOperationalLevels({
     affectedPeopleCount: row.affected_people_count,
     riskFlags: row.risk_flags,
@@ -135,7 +158,7 @@ function mapHelpRequest(row) {
     resolvedAt: row.resolved_at,
     cancelledAt: row.cancelled_at,
     isSavedLocally: row.is_saved_locally,
-    helper: helpers[0] || null,
+    helper,
     helpers,
   };
 }

--- a/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
+++ b/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
@@ -1178,6 +1178,72 @@ describe('help-requests integration', () => {
 		expect(listRes.body.requests[0].helpers[1].firstName).toBe('Kerem');
 	});
 
+	test('request reads keep blank helper entries out of legacy helper compatibility field', async () => {
+		const app = createTestApp();
+		const requesterId = 'user_hr_blank_helper_requester';
+		const blankHelperId = 'user_hr_blank_helper_responder';
+
+		await seedActiveUser(requesterId, 'blank-helper-requester@example.com');
+		await seedActiveUser(blankHelperId, 'blank-helper-responder@example.com');
+
+		const requesterToken = buildAuthToken(requesterId);
+
+		await query(
+			`INSERT INTO user_profiles (profile_id, user_id, first_name, last_name, phone_number)
+			 VALUES ('prf_blank_helper', $1, '   ', '', NULL)`,
+			[blankHelperId],
+		);
+		await query(
+			`INSERT INTO expertise (expertise_id, profile_id, profession, expertise_area, is_verified)
+			 VALUES ('exp_blank_helper', 'prf_blank_helper', '   ', '', FALSE)`,
+		);
+
+		const createRes = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${requesterToken}`)
+			.send(buildCreatePayload({ helpTypes: ['food'], needType: 'food' }));
+
+		const requestId = createRes.body.request.id;
+
+		await seedVolunteer({ volunteerId: 'vol_blank_helper', userId: blankHelperId });
+
+		await query(
+			`UPDATE help_requests SET status = 'ASSIGNED' WHERE request_id = $1`,
+			[requestId],
+		);
+
+		await query(
+			`INSERT INTO assignments (assignment_id, volunteer_id, request_id, assigned_at, is_cancelled)
+			 VALUES ('asg_blank_helper', 'vol_blank_helper', $1, '2026-04-23T08:00:00.000Z', FALSE)`,
+			[requestId],
+		);
+
+		const detailRes = await request(app)
+			.get(`/api/help-requests/${requestId}`)
+			.set('Authorization', `Bearer ${requesterToken}`);
+
+		expect(detailRes.status).toBe(200);
+		expect(detailRes.body.request.status).toBe('MATCHED');
+		expect(detailRes.body.request.helpers).toHaveLength(1);
+		expect(detailRes.body.request.helpers[0]).toEqual({
+			firstName: null,
+			lastName: null,
+			phone: null,
+			profession: null,
+			expertise: null,
+		});
+		expect(detailRes.body.request.helper).toBeNull();
+
+		const listRes = await request(app)
+			.get('/api/help-requests')
+			.set('Authorization', `Bearer ${requesterToken}`);
+
+		expect(listRes.status).toBe(200);
+		expect(listRes.body.requests).toHaveLength(1);
+		expect(listRes.body.requests[0].helpers).toHaveLength(1);
+		expect(listRes.body.requests[0].helper).toBeNull();
+	});
+
 	test('help request without assignment has null helper', async () => {
 		const app = createTestApp();
 		const requesterId = 'user_hr_nohelper';

--- a/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
+++ b/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
@@ -1019,6 +1019,7 @@ describe('help-requests integration', () => {
 
 		// Initially, no helper assigned
 		expect(createRes.body.request.helper).toBeNull();
+		expect(createRes.body.request.helpers).toEqual([]);
 
 		// Helper toggles availability → gets assigned
 		const toggleRes = await request(app)
@@ -1036,6 +1037,8 @@ describe('help-requests integration', () => {
 
 		expect(getRes.status).toBe(200);
 		expect(getRes.body.request.helper).toBeTruthy();
+		expect(getRes.body.request.helpers).toHaveLength(1);
+		expect(getRes.body.request.helpers[0].firstName).toBe('Mehmet');
 		expect(getRes.body.request.helper.firstName).toBe('Mehmet');
 		expect(getRes.body.request.helper.lastName).toBe('Kaya');
 		expect(getRes.body.request.helper.phone).toBe(5301234567);
@@ -1090,10 +1093,11 @@ describe('help-requests integration', () => {
 		expect(listRes.body.requests).toHaveLength(1);
 		expect(listRes.body.requests[0].id).toBe(requestId);
 		expect(listRes.body.requests[0].helper).toBeTruthy();
+		expect(listRes.body.requests[0].helpers).toHaveLength(1);
 		expect(listRes.body.requests[0].helper.expertise).toBe('Medical');
 	});
 
-	test('request reads keep a single deterministic helper when multiple active assignments exist', async () => {
+	test('request reads expose deterministic ordered helpers while preserving single-helper compatibility', async () => {
 		const app = createTestApp();
 		const requesterId = 'user_hr_multi_helper_requester';
 		const firstHelperId = 'user_hr_multi_helper_first';
@@ -1154,8 +1158,13 @@ describe('help-requests integration', () => {
 		expect(detailRes.status).toBe(200);
 		expect(detailRes.body.request.status).toBe('MATCHED');
 		expect(detailRes.body.request.helper).toBeTruthy();
+		expect(detailRes.body.request.helpers).toHaveLength(2);
 		expect(detailRes.body.request.helper.firstName).toBe('Ece');
 		expect(detailRes.body.request.helper.phone).toBe(5301111111);
+		expect(detailRes.body.request.helpers[0].firstName).toBe('Ece');
+		expect(detailRes.body.request.helpers[0].phone).toBe(5301111111);
+		expect(detailRes.body.request.helpers[1].firstName).toBe('Kerem');
+		expect(detailRes.body.request.helpers[1].phone).toBe(5302222222);
 
 		const listRes = await request(app)
 			.get('/api/help-requests')
@@ -1164,7 +1173,9 @@ describe('help-requests integration', () => {
 		expect(listRes.status).toBe(200);
 		expect(listRes.body.requests).toHaveLength(1);
 		expect(listRes.body.requests[0].id).toBe(requestId);
+		expect(listRes.body.requests[0].helpers).toHaveLength(2);
 		expect(listRes.body.requests[0].helper.firstName).toBe('Ece');
+		expect(listRes.body.requests[0].helpers[1].firstName).toBe('Kerem');
 	});
 
 	test('help request without assignment has null helper', async () => {
@@ -1186,6 +1197,7 @@ describe('help-requests integration', () => {
 
 		expect(getRes.status).toBe(200);
 		expect(getRes.body.request.helper).toBeNull();
+		expect(getRes.body.request.helpers).toEqual([]);
 	});
 
 	test('POST /api/help-requests auto-assigns to already available volunteer', async () => {


### PR DESCRIPTION
### Summary
This PR improves request-related response and page consistency after the advanced matching update by representing multi-responder assignments more clearly in requester-facing flows.

### What changed
- updated request-related response mapping to support multi-responder visibility
- preserved compatibility with the existing single-helper behavior where needed
- improved requester-facing request flows/pages so multiple assigned responders are not hidden behind a single-helper assumption
- kept the implementation aligned with the current advanced matching model without reworking the matcher itself
- added/updated focused tests for multi-responder response and UI behavior

### Important behavior notes
- requests can now be represented with multiple assigned responders in request-related flows
- existing compatibility expectations around the current helper representation are preserved where reasonable
- the change is focused on response/page consistency, not on changing assignment logic itself

### Scope notes
- this PR does not redesign the advanced matching algorithm
- this PR does not expand into aggregated overview, lifecycle metadata, or history work
- this PR focuses only on request-related response/page consistency for multi-responder assignments

Closes #338 