### PR TITLE
feat(admin): add deployment monitoring signals and dashboard tab

### DIFF
--- a/backend/src/modules/admin/controller.js
+++ b/backend/src/modules/admin/controller.js
@@ -6,6 +6,7 @@ const {
   getEmergencyOverviewForAdmin,
   getEmergencyHistoryForAdmin,
   getEmergencyAnalyticsForAdmin,
+  getDeploymentMonitoringForAdmin,
 } = require('./service');
 
 const ALLOWED_HISTORY_STATUSES = new Set(['RESOLVED', 'CANCELLED']);
@@ -224,6 +225,59 @@ async function getAdminEmergencyAnalytics(req, res) {
   }
 }
 
+async function getAdminDeploymentMonitoring(req, res) {
+  try {
+    const waitThresholdHours = parsePositiveIntQuery(req.query?.waitThresholdHours, {
+      min: 1,
+      max: 72,
+      defaultValue: 6,
+    });
+    if (waitThresholdHours.error) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: '`waitThresholdHours` must be an integer between 1 and 72.',
+      });
+    }
+
+    const neglectThresholdHours = parsePositiveIntQuery(req.query?.neglectThresholdHours, {
+      min: 1,
+      max: 168,
+      defaultValue: 12,
+    });
+    if (neglectThresholdHours.error) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: '`neglectThresholdHours` must be an integer between 1 and 168.',
+      });
+    }
+
+    const listLimit = parsePositiveIntQuery(req.query?.listLimit, {
+      min: 1,
+      max: 50,
+      defaultValue: 10,
+    });
+    if (listLimit.error) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: '`listLimit` must be an integer between 1 and 50.',
+      });
+    }
+
+    const monitoring = await getDeploymentMonitoringForAdmin({
+      waitThresholdHours: waitThresholdHours.value,
+      neglectThresholdHours: neglectThresholdHours.value,
+      listLimit: listLimit.value,
+    });
+
+    return res.status(200).json({ monitoring });
+  } catch (_error) {
+    return res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      message: 'Something went wrong',
+    });
+  }
+}
+
 module.exports = {
   getAdminUsers,
   getAdminHelpRequests,
@@ -232,4 +286,5 @@ module.exports = {
   getAdminEmergencyOverview,
   getAdminEmergencyHistory,
   getAdminEmergencyAnalytics,
+  getAdminDeploymentMonitoring,
 };

--- a/backend/src/modules/admin/repository.js
+++ b/backend/src/modules/admin/repository.js
@@ -556,6 +556,272 @@ async function getEmergencyAnalytics({
   };
 }
 
+async function getDeploymentMonitoring({
+  waitThresholdHours = 6,
+  neglectThresholdHours = 12,
+  listLimit = 10,
+} = {}) {
+  const urgencySql = getUrgencySql();
+  const prioritySql = getPrioritySql();
+
+  // Item projection shared across signal lists. `a` is an active (non-cancelled)
+  // assignment LEFT JOIN, so unassigned rows still resolve cleanly.
+  const itemSelect = `
+    SELECT
+      hr.request_id,
+      hr.need_type,
+      hr.status,
+      ${urgencySql} AS urgency_level,
+      ${prioritySql} AS priority_level,
+      hr.created_at AS created_at,
+      FLOOR(EXTRACT(EPOCH FROM (NOW() - hr.created_at)) / 3600)::int AS age_hours,
+      a.assigned_at AS assigned_at,
+      CASE
+        WHEN a.assigned_at IS NULL THEN NULL
+        ELSE FLOOR(EXTRACT(EPOCH FROM (NOW() - a.assigned_at)) / 3600)::int
+      END AS assigned_hours_ago,
+      a.volunteer_id AS volunteer_id,
+      COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown') AS city,
+      COALESCE(NULLIF(TRIM(rl.district), ''), 'unknown') AS district
+    FROM help_requests hr
+    LEFT JOIN LATERAL (
+      SELECT city, district
+      FROM request_locations loc
+      WHERE loc.request_id = hr.request_id
+      ORDER BY loc.captured_at DESC, loc.location_id DESC
+      LIMIT 1
+    ) rl ON TRUE
+    LEFT JOIN assignments a
+      ON a.request_id = hr.request_id
+      AND a.is_cancelled = FALSE
+  `;
+
+  const [
+    unassignedResult,
+    longWaitingResult,
+    inProgressResult,
+    neglectedResult,
+    conflictsResult,
+    summaryResult,
+  ] = await Promise.all([
+    query(
+      `
+        ${itemSelect}
+        WHERE hr.status = 'PENDING'
+          AND a.assignment_id IS NULL
+        ORDER BY hr.created_at ASC
+        LIMIT $1::int
+      `,
+      [listLimit],
+    ),
+    query(
+      `
+        ${itemSelect}
+        WHERE hr.status = 'PENDING'
+          AND hr.created_at < NOW() - ($1::int * INTERVAL '1 hour')
+        ORDER BY hr.created_at ASC
+        LIMIT $2::int
+      `,
+      [waitThresholdHours, listLimit],
+    ),
+    query(
+      `
+        ${itemSelect}
+        WHERE hr.status IN ('ASSIGNED', 'IN_PROGRESS')
+        ORDER BY a.assigned_at ASC NULLS FIRST, hr.created_at ASC
+        LIMIT $1::int
+      `,
+      [listLimit],
+    ),
+    query(
+      `
+        ${itemSelect}
+        WHERE hr.status IN ('ASSIGNED', 'IN_PROGRESS')
+          AND a.assignment_id IS NOT NULL
+          AND a.assigned_at < NOW() - ($1::int * INTERVAL '1 hour')
+        ORDER BY a.assigned_at ASC
+        LIMIT $2::int
+      `,
+      [neglectThresholdHours, listLimit],
+    ),
+    query(
+      `
+        WITH duplicate_groups AS (
+          SELECT
+            LOWER(hr.need_type) AS need_type_key,
+            LOWER(COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown')) AS city_key,
+            hr.contact_phone AS contact_phone,
+            COUNT(*)::int AS dup_count
+          FROM help_requests hr
+          LEFT JOIN LATERAL (
+            SELECT city
+            FROM request_locations loc
+            WHERE loc.request_id = hr.request_id
+            ORDER BY loc.captured_at DESC, loc.location_id DESC
+            LIMIT 1
+          ) rl ON TRUE
+          WHERE hr.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS')
+            AND hr.created_at > NOW() - INTERVAL '24 hours'
+          GROUP BY
+            LOWER(hr.need_type),
+            LOWER(COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown')),
+            hr.contact_phone
+          HAVING COUNT(*) > 1
+          ORDER BY dup_count DESC, city_key ASC, need_type_key ASC
+          LIMIT $1::int
+        )
+        SELECT
+          dg.need_type_key,
+          dg.city_key,
+          dg.dup_count,
+          hr.request_id,
+          hr.need_type,
+          hr.status,
+          ${urgencySql} AS urgency_level,
+          ${prioritySql} AS priority_level,
+          hr.created_at AS created_at,
+          FLOOR(EXTRACT(EPOCH FROM (NOW() - hr.created_at)) / 3600)::int AS age_hours,
+          a.assigned_at AS assigned_at,
+          CASE
+            WHEN a.assigned_at IS NULL THEN NULL
+            ELSE FLOOR(EXTRACT(EPOCH FROM (NOW() - a.assigned_at)) / 3600)::int
+          END AS assigned_hours_ago,
+          a.volunteer_id AS volunteer_id,
+          COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown') AS city,
+          COALESCE(NULLIF(TRIM(rl.district), ''), 'unknown') AS district
+        FROM duplicate_groups dg
+        JOIN help_requests hr
+          ON LOWER(hr.need_type) = dg.need_type_key
+          AND hr.contact_phone = dg.contact_phone
+          AND hr.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS')
+          AND hr.created_at > NOW() - INTERVAL '24 hours'
+        LEFT JOIN LATERAL (
+          SELECT city, district
+          FROM request_locations loc
+          WHERE loc.request_id = hr.request_id
+          ORDER BY loc.captured_at DESC, loc.location_id DESC
+          LIMIT 1
+        ) rl ON TRUE
+        LEFT JOIN assignments a
+          ON a.request_id = hr.request_id AND a.is_cancelled = FALSE
+        WHERE LOWER(COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown')) = dg.city_key
+        ORDER BY dg.dup_count DESC, dg.city_key ASC, dg.need_type_key ASC, hr.created_at ASC
+      `,
+      [listLimit],
+    ),
+    query(
+      `
+        SELECT
+          (
+            SELECT COUNT(*)::int
+            FROM help_requests hr
+            LEFT JOIN assignments a
+              ON a.request_id = hr.request_id AND a.is_cancelled = FALSE
+            WHERE hr.status = 'PENDING' AND a.assignment_id IS NULL
+          ) AS unassigned_count,
+          (
+            SELECT COUNT(*)::int
+            FROM help_requests hr
+            WHERE hr.status = 'PENDING'
+              AND hr.created_at < NOW() - ($1::int * INTERVAL '1 hour')
+          ) AS long_waiting_count,
+          (
+            SELECT COUNT(*)::int
+            FROM help_requests hr
+            WHERE hr.status IN ('ASSIGNED', 'IN_PROGRESS')
+          ) AS in_progress_count,
+          (
+            SELECT COUNT(*)::int
+            FROM help_requests hr
+            JOIN assignments a
+              ON a.request_id = hr.request_id AND a.is_cancelled = FALSE
+            WHERE hr.status IN ('ASSIGNED', 'IN_PROGRESS')
+              AND a.assigned_at < NOW() - ($2::int * INTERVAL '1 hour')
+          ) AS neglected_count,
+          (
+            SELECT COUNT(*)::int
+            FROM (
+              SELECT 1
+              FROM help_requests hr
+              LEFT JOIN LATERAL (
+                SELECT city
+                FROM request_locations loc
+                WHERE loc.request_id = hr.request_id
+                ORDER BY loc.captured_at DESC, loc.location_id DESC
+                LIMIT 1
+              ) rl ON TRUE
+              WHERE hr.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS')
+                AND hr.created_at > NOW() - INTERVAL '24 hours'
+              GROUP BY
+                LOWER(hr.need_type),
+                LOWER(COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown')),
+                hr.contact_phone
+              HAVING COUNT(*) > 1
+            ) duplicate_groups
+          ) AS conflicts_count
+      `,
+      [waitThresholdHours, neglectThresholdHours],
+    ),
+  ]);
+
+  const mapItem = (row) => ({
+    requestId: row.request_id,
+    needType: row.need_type,
+    status: row.status,
+    urgencyLevel: row.urgency_level,
+    priorityLevel: row.priority_level,
+    createdAt: row.created_at,
+    ageHours: row.age_hours,
+    assignedAt: row.assigned_at,
+    assignedHoursAgo: row.assigned_hours_ago,
+    volunteerId: row.volunteer_id || null,
+    location: {
+      city: row.city,
+      district: row.district,
+    },
+  });
+
+  // Group conflicts by (city, needType) duplicate group. The SQL keeps rows
+  // ordered so the first time we see a key it is the highest-priority group.
+  const conflictsByKey = new Map();
+  for (const row of conflictsResult.rows) {
+    const key = `${row.city_key}::${row.need_type_key}`;
+    if (!conflictsByKey.has(key)) {
+      conflictsByKey.set(key, {
+        groupKey: {
+          city: row.city_key,
+          needType: row.need_type_key,
+        },
+        duplicateCount: row.dup_count,
+        items: [],
+      });
+    }
+    conflictsByKey.get(key).items.push(mapItem(row));
+  }
+
+  const summary = summaryResult.rows[0] || {};
+
+  return {
+    thresholds: {
+      waitThresholdHours,
+      neglectThresholdHours,
+      listLimit,
+    },
+    summary: {
+      unassigned: summary.unassigned_count || 0,
+      longWaiting: summary.long_waiting_count || 0,
+      inProgress: summary.in_progress_count || 0,
+      neglected: summary.neglected_count || 0,
+      conflicts: summary.conflicts_count || 0,
+    },
+    unassigned: unassignedResult.rows.map(mapItem),
+    longWaiting: longWaitingResult.rows.map(mapItem),
+    inProgress: inProgressResult.rows.map(mapItem),
+    neglected: neglectedResult.rows.map(mapItem),
+    conflicts: Array.from(conflictsByKey.values()),
+  };
+}
+
 module.exports = {
   listUsers,
   listHelpRequests,
@@ -564,4 +830,5 @@ module.exports = {
   getEmergencyOverview,
   getEmergencyHistory,
   getEmergencyAnalytics,
+  getDeploymentMonitoring,
 };

--- a/backend/src/modules/admin/repository.js
+++ b/backend/src/modules/admin/repository.js
@@ -582,7 +582,8 @@ async function getDeploymentMonitoring({
       END AS assigned_hours_ago,
       a.volunteer_id AS volunteer_id,
       COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown') AS city,
-      COALESCE(NULLIF(TRIM(rl.district), ''), 'unknown') AS district
+      COALESCE(NULLIF(TRIM(rl.district), ''), 'unknown') AS district,
+      hr.contact_phone AS contact_phone
     FROM help_requests hr
     LEFT JOIN LATERAL (
       SELECT city, district
@@ -667,12 +668,13 @@ async function getDeploymentMonitoring({
             LOWER(COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown')),
             hr.contact_phone
           HAVING COUNT(*) > 1
-          ORDER BY dup_count DESC, city_key ASC, need_type_key ASC
+          ORDER BY dup_count DESC, city_key ASC, need_type_key ASC, contact_phone ASC
           LIMIT $1::int
         )
         SELECT
           dg.need_type_key,
           dg.city_key,
+          dg.contact_phone,
           dg.dup_count,
           hr.request_id,
           hr.need_type,
@@ -705,7 +707,12 @@ async function getDeploymentMonitoring({
         LEFT JOIN assignments a
           ON a.request_id = hr.request_id AND a.is_cancelled = FALSE
         WHERE LOWER(COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown')) = dg.city_key
-        ORDER BY dg.dup_count DESC, dg.city_key ASC, dg.need_type_key ASC, hr.created_at ASC
+        ORDER BY
+          dg.dup_count DESC,
+          dg.city_key ASC,
+          dg.need_type_key ASC,
+          dg.contact_phone ASC,
+          hr.created_at ASC
       `,
       [listLimit],
     ),
@@ -781,16 +788,28 @@ async function getDeploymentMonitoring({
     },
   });
 
-  // Group conflicts by (city, needType) duplicate group. The SQL keeps rows
-  // ordered so the first time we see a key it is the highest-priority group.
+  const maskContactKey = (contactPhone) => {
+    const digits = String(contactPhone ?? '').replace(/\D/g, '');
+    if (digits.length >= 4) {
+      return `***${digits.slice(-4)}`;
+    }
+    if (digits.length > 0) {
+      return `***${digits}`;
+    }
+    return 'unknown';
+  };
+
+  // Group conflicts by (city, needType, contact) to avoid merging unrelated
+  // duplicate groups that share only city/type.
   const conflictsByKey = new Map();
   for (const row of conflictsResult.rows) {
-    const key = `${row.city_key}::${row.need_type_key}`;
+    const key = `${row.city_key}::${row.need_type_key}::${String(row.contact_phone ?? '')}`;
     if (!conflictsByKey.has(key)) {
       conflictsByKey.set(key, {
         groupKey: {
           city: row.city_key,
           needType: row.need_type_key,
+          contactKey: maskContactKey(row.contact_phone),
         },
         duplicateCount: row.dup_count,
         items: [],

--- a/backend/src/modules/admin/routes.js
+++ b/backend/src/modules/admin/routes.js
@@ -8,6 +8,7 @@ const {
   getAdminEmergencyOverview,
   getAdminEmergencyHistory,
   getAdminEmergencyAnalytics,
+  getAdminDeploymentMonitoring,
 } = require('./controller');
 
 const adminRouter = express.Router();
@@ -19,6 +20,7 @@ adminRouter.get('/stats', requireAuth, requireAdmin, getAdminStats);
 adminRouter.get('/emergency-overview', requireAuth, requireAdmin, getAdminEmergencyOverview);
 adminRouter.get('/emergency-history', requireAuth, requireAdmin, getAdminEmergencyHistory);
 adminRouter.get('/emergency-analytics', requireAuth, requireAdmin, getAdminEmergencyAnalytics);
+adminRouter.get('/deployment-monitoring', requireAuth, requireAdmin, getAdminDeploymentMonitoring);
 
 module.exports = {
   adminRouter,

--- a/backend/src/modules/admin/service.js
+++ b/backend/src/modules/admin/service.js
@@ -6,6 +6,7 @@ const {
   getEmergencyOverview,
   getEmergencyHistory,
   getEmergencyAnalytics,
+  getDeploymentMonitoring,
 } = require('./repository');
 
 async function getUsersForAdmin() {
@@ -36,6 +37,10 @@ async function getEmergencyAnalyticsForAdmin(options = {}) {
   return getEmergencyAnalytics(options);
 }
 
+async function getDeploymentMonitoringForAdmin(options = {}) {
+  return getDeploymentMonitoring(options);
+}
+
 module.exports = {
   getUsersForAdmin,
   getHelpRequestsForAdmin,
@@ -44,4 +49,5 @@ module.exports = {
   getEmergencyOverviewForAdmin,
   getEmergencyHistoryForAdmin,
   getEmergencyAnalyticsForAdmin,
+  getDeploymentMonitoringForAdmin,
 };

--- a/backend/tests/integration/modules/admin/admin-deployment-monitoring.integration.test.js
+++ b/backend/tests/integration/modules/admin/admin-deployment-monitoring.integration.test.js
@@ -1,0 +1,433 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+const { query } = require('../../../../src/db/pool');
+const { apiRouter } = require('../../../../src/routes');
+
+jest.mock('uuid', () => ({
+  v4: () => require('crypto').randomBytes(16).toString('hex'),
+}));
+
+jest.mock('express-rate-limit', () => () => (_req, _res, next) => next());
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', apiRouter);
+  return app;
+}
+
+function buildAuthToken({ userId, isAdmin }) {
+  return jwt.sign(
+    {
+      userId,
+      email: `${userId}@example.com`,
+      isAdmin,
+      adminRole: isAdmin ? 'COORDINATOR' : null,
+    },
+    process.env.JWT_SECRET || 'dev-secret-123',
+    { expiresIn: '1h' },
+  );
+}
+
+async function seedBaseUsers() {
+  await query(
+    `
+      INSERT INTO users (user_id, email, password_hash, is_email_verified, is_deleted, accepted_terms)
+      VALUES
+        ('admin_user', 'admin@example.com', 'hash', TRUE, FALSE, TRUE),
+        ('normal_user', 'user@example.com', 'hash', TRUE, FALSE, TRUE),
+        ('vol_user_1', 'vol1@example.com', 'hash', TRUE, FALSE, TRUE),
+        ('vol_user_2', 'vol2@example.com', 'hash', TRUE, FALSE, TRUE),
+        ('vol_user_3', 'vol3@example.com', 'hash', TRUE, FALSE, TRUE)
+    `,
+  );
+
+  await query(
+    `
+      INSERT INTO admins (admin_id, user_id, role)
+      VALUES ('admin_record_1', 'admin_user', 'COORDINATOR')
+    `,
+  );
+
+  await query(
+    `
+      INSERT INTO volunteers (volunteer_id, user_id, is_available)
+      VALUES
+        ('vol_overloaded', 'vol_user_1', TRUE),
+        ('vol_normal', 'vol_user_2', TRUE),
+        ('vol_neglect2', 'vol_user_3', TRUE)
+    `,
+  );
+}
+
+async function seedHelpRequests() {
+  await query(
+    `
+      INSERT INTO help_requests (
+        request_id,
+        user_id,
+        help_types,
+        other_help_text,
+        affected_people_count,
+        risk_flags,
+        vulnerable_groups,
+        need_type,
+        description,
+        blood_type,
+        contact_full_name,
+        contact_phone,
+        consent_given,
+        status,
+        created_at,
+        resolved_at,
+        cancelled_at,
+        is_saved_locally
+      )
+      VALUES
+        -- Unassigned + long-waiting (PENDING, 8h old, no assignment)
+        (
+          'req_unassigned_old', 'normal_user', ARRAY['first_aid']::TEXT[], '', 1,
+          ARRAY[]::TEXT[], ARRAY[]::TEXT[],
+          'first_aid', 'Old pending unassigned', NULL, 'A', 5551112233, TRUE,
+          'PENDING', NOW() - INTERVAL '8 hours', NULL, NULL, FALSE
+        ),
+        -- Unassigned + recent (PENDING, 30m old, no assignment) -> only in unassigned
+        (
+          'req_unassigned_new', 'normal_user', ARRAY['water']::TEXT[], '', 1,
+          ARRAY[]::TEXT[], ARRAY[]::TEXT[],
+          'water', 'Fresh pending unassigned', NULL, 'B', 5551112234, TRUE,
+          'PENDING', NOW() - INTERVAL '30 minutes', NULL, NULL, FALSE
+        ),
+        -- Pending but already cancelled-assigned -> still unassigned (active a not present)
+        (
+          'req_pending_with_cancelled_assignment', 'normal_user', ARRAY['shelter']::TEXT[], '', 1,
+          ARRAY[]::TEXT[], ARRAY[]::TEXT[],
+          'shelter', 'Reassigned pending', NULL, 'C', 5551112235, TRUE,
+          'PENDING', NOW() - INTERVAL '7 hours', NULL, NULL, FALSE
+        ),
+        -- In-progress, recently assigned (1h ago) -> only in inProgress
+        (
+          'req_inprogress_fresh', 'normal_user', ARRAY['food']::TEXT[], '', 1,
+          ARRAY[]::TEXT[], ARRAY[]::TEXT[],
+          'food', 'Fresh in-progress', NULL, 'D', 5551112236, TRUE,
+          'IN_PROGRESS', NOW() - INTERVAL '3 hours', NULL, NULL, FALSE
+        ),
+        -- Assigned long ago (24h) -> in inProgress + neglected
+        (
+          'req_neglected_one', 'normal_user', ARRAY['first_aid']::TEXT[], '', 1,
+          ARRAY[]::TEXT[], ARRAY[]::TEXT[],
+          'first_aid', 'Neglected assignment one', NULL, 'E', 5551112237, TRUE,
+          'ASSIGNED', NOW() - INTERVAL '2 days', NULL, NULL, FALSE
+        ),
+        -- Active assignment for a different volunteer, also stale -> neglected
+        (
+          'req_neglected_two', 'normal_user', ARRAY['water']::TEXT[], '', 1,
+          ARRAY[]::TEXT[], ARRAY[]::TEXT[],
+          'water', 'Neglected assignment two', NULL, 'F', 5551112238, TRUE,
+          'IN_PROGRESS', NOW() - INTERVAL '2 days', NULL, NULL, FALSE
+        ),
+        -- Duplicate active reports (same contact phone + same need_type + same city, last 24h)
+        (
+          'req_dup_a', 'normal_user', ARRAY['first_aid']::TEXT[], '', 1,
+          ARRAY[]::TEXT[], ARRAY[]::TEXT[],
+          'first_aid', 'Duplicate report A', NULL, 'Dup', 5559998877, TRUE,
+          'PENDING', NOW() - INTERVAL '90 minutes', NULL, NULL, FALSE
+        ),
+        (
+          'req_dup_b', 'normal_user', ARRAY['first_aid']::TEXT[], '', 1,
+          ARRAY[]::TEXT[], ARRAY[]::TEXT[],
+          'first_aid', 'Duplicate report B', NULL, 'Dup', 5559998877, TRUE,
+          'PENDING', NOW() - INTERVAL '30 minutes', NULL, NULL, FALSE
+        ),
+        -- Resolved (must be ignored everywhere)
+        (
+          'req_resolved', 'normal_user', ARRAY['food']::TEXT[], '', 1,
+          ARRAY[]::TEXT[], ARRAY[]::TEXT[],
+          'food', 'Already resolved', NULL, 'G', 5551112239, TRUE,
+          'RESOLVED', NOW() - INTERVAL '5 days', NOW() - INTERVAL '1 day', NULL, FALSE
+        )
+    `,
+  );
+
+  await query(
+    `
+      INSERT INTO request_locations (
+        location_id, request_id, country, city, district, neighborhood, extra_address
+      )
+      VALUES
+        ('loc_u1', 'req_unassigned_old', 'turkiye', 'ankara', 'cankaya', 'kizilay', ''),
+        ('loc_u2', 'req_unassigned_new', 'turkiye', 'ankara', 'cankaya', 'kizilay', ''),
+        ('loc_u3', 'req_pending_with_cancelled_assignment', 'turkiye', 'istanbul', 'kadikoy', 'fenerbahce', ''),
+        ('loc_p1', 'req_inprogress_fresh', 'turkiye', 'istanbul', 'besiktas', 'levazim', ''),
+        ('loc_n1', 'req_neglected_one', 'turkiye', 'izmir', 'konak', 'alsancak', ''),
+        ('loc_n2', 'req_neglected_two', 'turkiye', 'izmir', 'konak', 'alsancak', ''),
+        ('loc_dup_a', 'req_dup_a', 'turkiye', 'ankara', 'cankaya', 'kizilay', ''),
+        ('loc_dup_b', 'req_dup_b', 'turkiye', 'ankara', 'cankaya', 'kizilay', ''),
+        ('loc_r1', 'req_resolved', 'turkiye', 'bursa', 'osmangazi', 'kukurtlu', '')
+    `,
+  );
+
+  await query(
+    `
+      INSERT INTO assignments (assignment_id, volunteer_id, request_id, assigned_at, is_cancelled)
+      VALUES
+        -- Cancelled assignment for the still-pending request -> request remains unassigned
+        ('asg_cancelled', 'vol_normal', 'req_pending_with_cancelled_assignment', NOW() - INTERVAL '6 hours', TRUE),
+        -- Fresh active assignment
+        ('asg_fresh', 'vol_normal', 'req_inprogress_fresh', NOW() - INTERVAL '1 hour', FALSE),
+        -- Two active assignments to two distinct volunteers (partial unique index forbids same volunteer twice)
+        ('asg_neglected_one', 'vol_overloaded', 'req_neglected_one', NOW() - INTERVAL '24 hours', FALSE),
+        ('asg_neglected_two', 'vol_neglect2', 'req_neglected_two', NOW() - INTERVAL '20 hours', FALSE)
+    `,
+  );
+}
+
+beforeEach(async () => {
+  await query(`
+    TRUNCATE TABLE
+      messages,
+      assignments,
+      availability_records,
+      resources,
+      volunteers,
+      request_locations,
+      help_requests,
+      news_announcements,
+      reports,
+      expertise,
+      privacy_settings,
+      location_profiles,
+      health_info,
+      physical_info,
+      user_profiles,
+      admins,
+      users
+    RESTART IDENTITY CASCADE;
+  `);
+});
+
+describe('GET /api/admin/deployment-monitoring', () => {
+  test('returns 401 without token', async () => {
+    const app = createTestApp();
+    const response = await request(app).get('/api/admin/deployment-monitoring');
+    expect(response.status).toBe(401);
+    expect(response.body.code).toBe('UNAUTHORIZED');
+  });
+
+  test('returns 403 for non-admin users', async () => {
+    await seedBaseUsers();
+    const app = createTestApp();
+    const userToken = buildAuthToken({ userId: 'normal_user', isAdmin: false });
+
+    const response = await request(app)
+      .get('/api/admin/deployment-monitoring')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe('FORBIDDEN');
+  });
+
+  test('returns deployment monitoring buckets for admins', async () => {
+    await seedBaseUsers();
+    await seedHelpRequests();
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/deployment-monitoring')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.monitoring).toBeTruthy();
+
+    const { thresholds, summary, unassigned, longWaiting, inProgress, neglected, conflicts } =
+      response.body.monitoring;
+
+    // Thresholds echo defaults
+    expect(thresholds).toEqual({
+      waitThresholdHours: 6,
+      neglectThresholdHours: 12,
+      listLimit: 10,
+    });
+
+    // Summary counts
+    expect(summary.unassigned).toBe(5); // old + new + cancelled-assignment-only + dup_a + dup_b
+    expect(summary.longWaiting).toBe(2); // old (8h) + cancelled-assignment-only (7h)
+    expect(summary.inProgress).toBe(3); // fresh + neglected_one + neglected_two
+    expect(summary.neglected).toBe(2); // both neglected ones (>12h)
+    expect(summary.conflicts).toBe(1); // duplicate group: ankara + first_aid + same phone
+
+    // Unassigned items only contain pending requests with no active assignment
+    const unassignedIds = unassigned.map((row) => row.requestId);
+    expect(unassignedIds).toEqual(
+      expect.arrayContaining([
+        'req_unassigned_old',
+        'req_unassigned_new',
+        'req_pending_with_cancelled_assignment',
+        'req_dup_a',
+        'req_dup_b',
+      ]),
+    );
+    unassigned.forEach((row) => {
+      expect(row.status).toBe('PENDING');
+      expect(row.volunteerId).toBeNull();
+      expect(row.assignedAt).toBeNull();
+    });
+
+    // Long-waiting omits the recent pending rows
+    const longWaitingIds = longWaiting.map((row) => row.requestId);
+    expect(longWaitingIds).toEqual(
+      expect.arrayContaining(['req_unassigned_old', 'req_pending_with_cancelled_assignment']),
+    );
+    expect(longWaitingIds).not.toContain('req_unassigned_new');
+    expect(longWaitingIds).not.toContain('req_dup_a');
+
+    // In-progress contains active assignments only
+    const inProgressIds = inProgress.map((row) => row.requestId);
+    expect(inProgressIds).toEqual(
+      expect.arrayContaining(['req_inprogress_fresh', 'req_neglected_one', 'req_neglected_two']),
+    );
+    inProgress.forEach((row) => {
+      expect(['ASSIGNED', 'IN_PROGRESS']).toContain(row.status);
+      expect(row.volunteerId).toBeTruthy();
+      expect(row.assignedAt).toBeTruthy();
+    });
+
+    // Neglected contains only the >=12h ones
+    const neglectedIds = neglected.map((row) => row.requestId);
+    expect(neglectedIds).toEqual(
+      expect.arrayContaining(['req_neglected_one', 'req_neglected_two']),
+    );
+    expect(neglectedIds).not.toContain('req_inprogress_fresh');
+    neglected.forEach((row) => {
+      expect(row.assignedHoursAgo).toBeGreaterThanOrEqual(12);
+    });
+
+    // Conflicts grouped by (city, needType) duplicate group
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].groupKey).toEqual({ city: 'ankara', needType: 'first_aid' });
+    expect(conflicts[0].duplicateCount).toBe(2);
+    const conflictRequestIds = conflicts[0].items.map((row) => row.requestId);
+    expect(conflictRequestIds).toEqual(
+      expect.arrayContaining(['req_dup_a', 'req_dup_b']),
+    );
+  });
+
+  test('respects waitThresholdHours and neglectThresholdHours query params', async () => {
+    await seedBaseUsers();
+    await seedHelpRequests();
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/deployment-monitoring?waitThresholdHours=1&neglectThresholdHours=48')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    const { summary, longWaiting, neglected, thresholds } = response.body.monitoring;
+    expect(thresholds.waitThresholdHours).toBe(1);
+    expect(thresholds.neglectThresholdHours).toBe(48);
+    // With 1h threshold, all PENDING rows older than 1h count as long-waiting:
+    // req_unassigned_old (8h), req_pending_with_cancelled_assignment (7h),
+    // req_dup_a (1.5h). Excludes req_unassigned_new (1h) and req_dup_b (30m).
+    expect(summary.longWaiting).toBe(3);
+    expect(longWaiting.map((row) => row.requestId)).toEqual(
+      expect.arrayContaining([
+        'req_unassigned_old',
+        'req_pending_with_cancelled_assignment',
+        'req_dup_a',
+      ]),
+    );
+    // With 48h threshold none of the assignments are neglected
+    expect(summary.neglected).toBe(0);
+    expect(neglected).toEqual([]);
+  });
+
+  test('respects listLimit', async () => {
+    await seedBaseUsers();
+    await seedHelpRequests();
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/deployment-monitoring?listLimit=1')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    const { summary, unassigned } = response.body.monitoring;
+    // Summary still reflects full counts
+    expect(summary.unassigned).toBe(5);
+    // List capped to 1
+    expect(unassigned).toHaveLength(1);
+  });
+
+  test('returns 400 for invalid waitThresholdHours', async () => {
+    await seedBaseUsers();
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/deployment-monitoring?waitThresholdHours=0')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('returns 400 for invalid neglectThresholdHours', async () => {
+    await seedBaseUsers();
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/deployment-monitoring?neglectThresholdHours=999')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('returns 400 for invalid listLimit', async () => {
+    await seedBaseUsers();
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/deployment-monitoring?listLimit=0')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('returns zeroed summary and empty lists when there is no data', async () => {
+    await seedBaseUsers();
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/deployment-monitoring')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.monitoring.summary).toEqual({
+      unassigned: 0,
+      longWaiting: 0,
+      inProgress: 0,
+      neglected: 0,
+      conflicts: 0,
+    });
+    expect(response.body.monitoring.unassigned).toEqual([]);
+    expect(response.body.monitoring.longWaiting).toEqual([]);
+    expect(response.body.monitoring.inProgress).toEqual([]);
+    expect(response.body.monitoring.neglected).toEqual([]);
+    expect(response.body.monitoring.conflicts).toEqual([]);
+  });
+});

--- a/backend/tests/integration/modules/admin/admin-deployment-monitoring.integration.test.js
+++ b/backend/tests/integration/modules/admin/admin-deployment-monitoring.integration.test.js
@@ -307,14 +307,102 @@ describe('GET /api/admin/deployment-monitoring', () => {
       expect(row.assignedHoursAgo).toBeGreaterThanOrEqual(12);
     });
 
-    // Conflicts grouped by (city, needType) duplicate group
+    // Conflicts grouped by (city, needType, contact) duplicate group
     expect(conflicts).toHaveLength(1);
-    expect(conflicts[0].groupKey).toEqual({ city: 'ankara', needType: 'first_aid' });
+    expect(conflicts[0].groupKey).toEqual({
+      city: 'ankara',
+      needType: 'first_aid',
+      contactKey: '***8877',
+    });
     expect(conflicts[0].duplicateCount).toBe(2);
     const conflictRequestIds = conflicts[0].items.map((row) => row.requestId);
     expect(conflictRequestIds).toEqual(
       expect.arrayContaining(['req_dup_a', 'req_dup_b']),
     );
+  });
+
+  test('does not merge conflict groups with same city/type but different contacts', async () => {
+    await seedBaseUsers();
+    await seedHelpRequests();
+
+    await query(
+      `
+        INSERT INTO help_requests (
+          request_id,
+          user_id,
+          help_types,
+          other_help_text,
+          affected_people_count,
+          risk_flags,
+          vulnerable_groups,
+          need_type,
+          description,
+          blood_type,
+          contact_full_name,
+          contact_phone,
+          consent_given,
+          status,
+          created_at,
+          resolved_at,
+          cancelled_at,
+          is_saved_locally
+        )
+        VALUES
+          (
+            'req_dup_c', 'normal_user', ARRAY['first_aid']::TEXT[], '', 1,
+            ARRAY[]::TEXT[], ARRAY[]::TEXT[],
+            'first_aid', 'Duplicate report C', NULL, 'Dup2', 5554441100, TRUE,
+            'PENDING', NOW() - INTERVAL '80 minutes', NULL, NULL, FALSE
+          ),
+          (
+            'req_dup_d', 'normal_user', ARRAY['first_aid']::TEXT[], '', 1,
+            ARRAY[]::TEXT[], ARRAY[]::TEXT[],
+            'first_aid', 'Duplicate report D', NULL, 'Dup2', 5554441100, TRUE,
+            'PENDING', NOW() - INTERVAL '20 minutes', NULL, NULL, FALSE
+          )
+      `,
+    );
+
+    await query(
+      `
+        INSERT INTO request_locations (
+          location_id,
+          request_id,
+          country,
+          city,
+          district,
+          neighborhood,
+          extra_address
+        )
+        VALUES
+          ('loc_dup_c', 'req_dup_c', 'turkiye', 'ankara', 'cankaya', 'kizilay', ''),
+          ('loc_dup_d', 'req_dup_d', 'turkiye', 'ankara', 'cankaya', 'kizilay', '')
+      `,
+    );
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/deployment-monitoring')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+
+    const { summary, conflicts } = response.body.monitoring;
+    expect(summary.conflicts).toBe(2);
+    expect(conflicts).toHaveLength(2);
+
+    const groupKeys = conflicts.map((group) => `${group.groupKey.city}:${group.groupKey.needType}:${group.groupKey.contactKey}`);
+    expect(groupKeys).toEqual(expect.arrayContaining([
+      'ankara:first_aid:***8877',
+      'ankara:first_aid:***1100',
+    ]));
+
+    conflicts.forEach((group) => {
+      expect(group.duplicateCount).toBe(2);
+      expect(group.items).toHaveLength(2);
+    });
   });
 
   test('respects waitThresholdHours and neglectThresholdHours query params', async () => {

--- a/web/e2e/admin-deployment-monitoring.spec.js
+++ b/web/e2e/admin-deployment-monitoring.spec.js
@@ -1,0 +1,174 @@
+const { test, expect } = require('@playwright/test');
+const { createCompletedUser } = require('./helpers/api');
+const {
+  promoteUserToAdmin,
+  resetDatabase,
+  seedEmergencyOverviewRecord,
+  waitForUserByEmail,
+} = require('./helpers/db');
+const { loginThroughUi } = require('./helpers/ui');
+
+async function openMonitoringTab(page) {
+  await expect(page).toHaveURL(/\/admin(\?|$)/, { timeout: 20_000 });
+
+  if (/\/login(\?|$)/.test(page.url())) {
+    throw new Error(`Admin page redirected to login unexpectedly. URL: ${page.url()}`);
+  }
+  if (/\/home(\?|$)/.test(page.url())) {
+    throw new Error(`Admin page redirected to home unexpectedly. URL: ${page.url()}`);
+  }
+
+  await expect(page.getByRole('tablist', { name: 'Admin dashboard sections' })).toBeVisible({
+    timeout: 20_000,
+  });
+
+  const monitoringTab = page.getByRole('tab', { name: 'Deployment Monitoring' });
+  await expect(monitoringTab).toBeVisible({ timeout: 20_000 });
+  await monitoringTab.click();
+}
+
+async function ensureMonitoringReady(page) {
+  const retryButton = page.getByRole('button', { name: 'Retry Monitoring' });
+  const errorSubtitle = page.getByText('Could not load deployment monitoring data.', {
+    exact: false,
+  });
+  const controlsHeading = page.getByRole('heading', {
+    name: /Monitoring Controls/i,
+  });
+
+  const deadline = Date.now() + 45_000;
+  let lastClickAt = 0;
+
+  while (Date.now() < deadline) {
+    if (/\/login(\?|$)/.test(page.url())) {
+      throw new Error(`Monitoring redirected to login. URL: ${page.url()}`);
+    }
+    if (/\/home(\?|$)/.test(page.url())) {
+      throw new Error(`Monitoring redirected to home. URL: ${page.url()}`);
+    }
+
+    if (await controlsHeading.isVisible().catch(() => false)) {
+      return;
+    }
+
+    const inErrorState = await errorSubtitle.isVisible().catch(() => false);
+    if (inErrorState && Date.now() - lastClickAt > 2_000) {
+      if (await retryButton.isVisible().catch(() => false)) {
+        lastClickAt = Date.now();
+        await retryButton.click({ timeout: 1500, force: true }).catch(() => {});
+      }
+    }
+
+    await page.waitForTimeout(250);
+  }
+
+  throw new Error(`Monitoring tab did not become ready. URL: ${page.url()}`);
+}
+
+test.beforeEach(async () => {
+  await resetDatabase();
+});
+
+test('admin can open Deployment Monitoring tab and see signal sections', async ({ page }) => {
+  const email = `admin-monitoring-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email, password });
+  const dbUser = await waitForUserByEmail(email);
+  await promoteUserToAdmin({ userId: dbUser.user_id });
+
+  // Old pending in istanbul/first_aid — unassigned + long-waiting + duplicate.
+  await seedEmergencyOverviewRecord({
+    requestId: 'e2e_dm_old_istanbul',
+    status: 'PENDING',
+    city: 'istanbul',
+    needType: 'first_aid',
+    createdAtHoursAgo: 8,
+  });
+  // Recent pending in istanbul/first_aid — unassigned + duplicate (shared phone).
+  await seedEmergencyOverviewRecord({
+    requestId: 'e2e_dm_dupe_istanbul',
+    status: 'PENDING',
+    city: 'istanbul',
+    needType: 'first_aid',
+    createdAtHoursAgo: 2,
+  });
+  // Old pending in ankara/water — unassigned + long-waiting.
+  await seedEmergencyOverviewRecord({
+    requestId: 'e2e_dm_old_ankara',
+    status: 'PENDING',
+    city: 'ankara',
+    needType: 'water',
+    createdAtHoursAgo: 8,
+  });
+
+  await page.goto('/login');
+  await loginThroughUi(page, { email, password });
+  await expect(page.getByRole('link', { name: 'Admin' })).toBeVisible({ timeout: 20_000 });
+
+  await page.goto('/admin');
+  await openMonitoringTab(page);
+
+  await ensureMonitoringReady(page);
+
+  await expect(
+    page.getByRole('heading', { name: /Signal Summary/i })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: /Unassigned Emergencies/i })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: /Long-waiting Emergencies/i })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: /Conflicting \/ Duplicate Reports/i })
+  ).toBeVisible();
+
+  // Seeded request IDs should be visible somewhere in the tables.
+  await expect(page.getByText('e2e_dm_old_istanbul', { exact: false }).first()).toBeVisible();
+  await expect(page.getByText('e2e_dm_old_ankara', { exact: false }).first()).toBeVisible();
+});
+
+test('admin sees retry state on monitoring failure and recovers', async ({ page }) => {
+  const email = `admin-monitoring-fail-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email, password });
+  const dbUser = await waitForUserByEmail(email);
+  await promoteUserToAdmin({ userId: dbUser.user_id });
+
+  await seedEmergencyOverviewRecord({
+    requestId: 'e2e_dm_retry_seed',
+    status: 'PENDING',
+    city: 'istanbul',
+    needType: 'first_aid',
+    createdAtHoursAgo: 8,
+  });
+
+  let failNext = true;
+  await page.route('**/api/admin/deployment-monitoring**', async (route) => {
+    if (failNext) {
+      failNext = false;
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 'INTERNAL_ERROR', message: 'boom' }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto('/login');
+  await loginThroughUi(page, { email, password });
+  await expect(page.getByRole('link', { name: 'Admin' })).toBeVisible({ timeout: 20_000 });
+
+  await page.goto('/admin');
+  await openMonitoringTab(page);
+
+  await ensureMonitoringReady(page);
+
+  await expect(
+    page.getByRole('heading', { name: /Monitoring Controls/i })
+  ).toBeVisible({ timeout: 20_000 });
+});

--- a/web/e2e/profile-and-privacy.spec.js
+++ b/web/e2e/profile-and-privacy.spec.js
@@ -103,7 +103,7 @@ test('profile save blocks first-time share enable until Use Current Location is 
 
   const locationToggle = page.getByRole('button', { name: 'Share Current Location' });
   await locationToggle.click();
-  await expect(locationToggle).toHaveAttribute('aria-pressed', 'true');
+  await expect.poll(async () => locationToggle.getAttribute('aria-pressed')).toBe('true');
 
   await page.locator('#height').fill('180');
   await page.locator('#extraAddress').fill('Updated Address 42');

--- a/web/src/components/feature/admin/AdminDashboardSwitcher.tsx
+++ b/web/src/components/feature/admin/AdminDashboardSwitcher.tsx
@@ -4,13 +4,15 @@ import * as React from "react";
 import AdminEmergencyOverviewView from "@/components/feature/admin/AdminEmergencyOverviewView";
 import AdminEmergencyHistoryView from "@/components/feature/admin/AdminEmergencyHistoryView";
 import AdminEmergencyInsightsView from "@/components/feature/admin/AdminEmergencyInsightsView";
+import AdminDeploymentMonitoringView from "@/components/feature/admin/AdminDeploymentMonitoringView";
 
-type AdminSectionKey = "overview" | "history" | "insights";
+type AdminSectionKey = "overview" | "history" | "insights" | "monitoring";
 
 const SECTIONS: Array<{ key: AdminSectionKey; label: string }> = [
     { key: "overview", label: "Emergency Overview" },
     { key: "history", label: "Emergency History" },
     { key: "insights", label: "Emergency Insights" },
+    { key: "monitoring", label: "Deployment Monitoring" },
 ];
 
 export default function AdminDashboardSwitcher() {
@@ -70,13 +72,21 @@ export default function AdminDashboardSwitcher() {
                 >
                     <AdminEmergencyHistoryView />
                 </div>
-            ) : (
+            ) : activeSection === "insights" ? (
                 <div
                     id="admin-panel-insights"
                     role="tabpanel"
                     aria-labelledby="admin-tab-insights"
                 >
                     <AdminEmergencyInsightsView />
+                </div>
+            ) : (
+                <div
+                    id="admin-panel-monitoring"
+                    role="tabpanel"
+                    aria-labelledby="admin-tab-monitoring"
+                >
+                    <AdminDeploymentMonitoringView />
                 </div>
             )}
         </div>

--- a/web/src/components/feature/admin/AdminDeploymentMonitoringView.tsx
+++ b/web/src/components/feature/admin/AdminDeploymentMonitoringView.tsx
@@ -1,0 +1,493 @@
+"use client";
+
+import * as React from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { ApiError } from "@/lib/api";
+import { getAccessToken, clearAccessToken } from "@/lib/auth";
+import {
+    fetchAdminDeploymentMonitoring,
+    type DeploymentMonitoring,
+    type DeploymentMonitoringConflictGroup,
+    type DeploymentMonitoringItem,
+} from "@/lib/admin";
+import { formatOperationalLabel } from "@/lib/formatters";
+import { SectionCard } from "@/components/ui/display/SectionCard";
+import { SectionHeader } from "@/components/ui/display/SectionHeader";
+import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
+
+type MonitoringControls = {
+    waitThresholdHours: number;
+    neglectThresholdHours: number;
+    listLimit: number;
+};
+
+const DEFAULT_MONITORING_CONTROLS: MonitoringControls = {
+    waitThresholdHours: 6,
+    neglectThresholdHours: 12,
+    listLimit: 10,
+};
+
+function formatHours(value: number | null | undefined) {
+    if (value === null || value === undefined) {
+        return "-";
+    }
+    if (value < 1) {
+        return "<1h";
+    }
+    return `${value}h`;
+}
+
+function formatCity(value: string) {
+    if (!value) return "Unknown";
+    return formatOperationalLabel(value);
+}
+
+function ItemRow({ item }: { item: DeploymentMonitoringItem }) {
+    return (
+        <tr>
+            <td>{item.requestId}</td>
+            <td>{formatOperationalLabel(item.needType || "-")}</td>
+            <td>{formatCity(item.location.city)}</td>
+            <td>{formatOperationalLabel(item.location.district)}</td>
+            <td>{item.urgencyLevel}</td>
+            <td>{item.status}</td>
+            <td>{formatHours(item.ageHours)}</td>
+            <td>{formatHours(item.assignedHoursAgo)}</td>
+            <td>{item.volunteerId || "-"}</td>
+        </tr>
+    );
+}
+
+function ItemsTable({
+    items,
+    emptyText,
+}: {
+    items: DeploymentMonitoringItem[];
+    emptyText: string;
+}) {
+    if (items.length === 0) {
+        return <p className="admin-subtle">{emptyText}</p>;
+    }
+
+    return (
+        <div className="admin-region-table-wrap">
+            <table className="admin-region-table admin-history-table">
+                <thead>
+                    <tr>
+                        <th>Request</th>
+                        <th>Type</th>
+                        <th>City</th>
+                        <th>District</th>
+                        <th>Urgency</th>
+                        <th>Status</th>
+                        <th>Open</th>
+                        <th>Assigned</th>
+                        <th>Volunteer</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {items.map((item) => (
+                        <ItemRow key={item.requestId} item={item} />
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+function ConflictGroupCard({ group }: { group: DeploymentMonitoringConflictGroup }) {
+    return (
+        <div className="admin-conflict-group">
+            <p className="admin-recent-line">
+                <strong>
+                    {formatCity(group.groupKey.city)} ·{" "}
+                    {formatOperationalLabel(group.groupKey.needType)}
+                </strong>{" "}
+                · {group.duplicateCount} duplicate reports
+            </p>
+            <ItemsTable
+                items={group.items}
+                emptyText="No duplicate reports for this group."
+            />
+        </div>
+    );
+}
+
+function SummaryTile({
+    label,
+    value,
+    tone,
+    description,
+}: {
+    label: string;
+    value: number;
+    tone: "default" | "warning" | "danger" | "success";
+    description: string;
+}) {
+    return (
+        <article className={`admin-metric-tile tone-${tone}`}>
+            <p className="admin-metric-label">{label}</p>
+            <p className="admin-metric-value">{value}</p>
+            <p className="admin-recent-line">{description}</p>
+        </article>
+    );
+}
+
+export default function AdminDeploymentMonitoringView() {
+    const router = useRouter();
+    const pathname = usePathname();
+    const [monitoring, setMonitoring] = React.useState<DeploymentMonitoring | null>(null);
+    const [loading, setLoading] = React.useState(true);
+    const [error, setError] = React.useState("");
+    const [controls, setControls] = React.useState<MonitoringControls>(
+        DEFAULT_MONITORING_CONTROLS
+    );
+    const [pendingControls, setPendingControls] = React.useState<MonitoringControls>(
+        DEFAULT_MONITORING_CONTROLS
+    );
+    const latestRequestIdRef = React.useRef(0);
+
+    const redirectToLogin = React.useCallback(() => {
+        clearAccessToken();
+        const returnTo = pathname || "/admin";
+        router.replace(`/login?returnTo=${encodeURIComponent(returnTo)}`);
+    }, [pathname, router]);
+
+    const loadMonitoring = React.useCallback(
+        async (options: MonitoringControls) => {
+            const token = getAccessToken();
+            if (!token) {
+                setLoading(false);
+                redirectToLogin();
+                return;
+            }
+
+            setLoading(true);
+            setError("");
+            const requestId = latestRequestIdRef.current + 1;
+            latestRequestIdRef.current = requestId;
+
+            try {
+                const result = await fetchAdminDeploymentMonitoring(token, options);
+                if (requestId !== latestRequestIdRef.current) {
+                    return;
+                }
+                setMonitoring(result);
+            } catch (err) {
+                if (requestId !== latestRequestIdRef.current) {
+                    return;
+                }
+                if (err instanceof ApiError && err.status === 401) {
+                    redirectToLogin();
+                    return;
+                }
+                if (err instanceof ApiError && err.status === 403) {
+                    router.replace("/home");
+                    return;
+                }
+                const message =
+                    err instanceof Error
+                        ? err.message
+                        : "Could not load deployment monitoring.";
+                setError(message);
+            } finally {
+                if (requestId === latestRequestIdRef.current) {
+                    setLoading(false);
+                }
+            }
+        },
+        [redirectToLogin, router]
+    );
+
+    React.useEffect(() => {
+        void loadMonitoring(controls);
+    }, [controls, loadMonitoring]);
+
+    React.useEffect(() => {
+        if (!loading) {
+            return;
+        }
+
+        const timeoutId = window.setTimeout(() => {
+            setLoading(false);
+            setError((current) => current || "Request timed out. Please try again.");
+        }, 16_000);
+
+        return () => {
+            window.clearTimeout(timeoutId);
+        };
+    }, [loading]);
+
+    if (loading) {
+        return (
+            <SectionCard>
+                <SectionHeader
+                    title="Deployment Monitoring"
+                    subtitle="Loading deployment monitoring signals..."
+                />
+                <div className="admin-empty-state">
+                    <p className="admin-subtle">
+                        If this takes too long, retry the monitoring request.
+                    </p>
+                    <PrimaryButton onClick={() => void loadMonitoring(controls)}>
+                        Retry Monitoring
+                    </PrimaryButton>
+                </div>
+            </SectionCard>
+        );
+    }
+
+    if (!monitoring) {
+        return (
+            <SectionCard>
+                <SectionHeader
+                    title="Deployment Monitoring"
+                    subtitle="Could not load deployment monitoring data."
+                />
+                <div className="admin-empty-state">
+                    <p>{error || "No deployment monitoring data available right now."}</p>
+                    <PrimaryButton onClick={() => void loadMonitoring(controls)}>
+                        Retry Monitoring
+                    </PrimaryButton>
+                </div>
+            </SectionCard>
+        );
+    }
+
+    const { summary, unassigned, longWaiting, inProgress, neglected, conflicts } =
+        monitoring;
+
+    const hasAnySignal =
+        summary.unassigned > 0 ||
+        summary.longWaiting > 0 ||
+        summary.inProgress > 0 ||
+        summary.neglected > 0 ||
+        summary.conflicts > 0;
+
+    const applyControls = () => {
+        setControls(pendingControls);
+    };
+
+    const resetControls = () => {
+        setPendingControls(DEFAULT_MONITORING_CONTROLS);
+        setControls(DEFAULT_MONITORING_CONTROLS);
+    };
+
+    return (
+        <div className="admin-overview-grid">
+            {error ? (
+                <SectionCard>
+                    <p className="admin-error-text">
+                        Showing previous data. Latest refresh failed: {error}
+                    </p>
+                </SectionCard>
+            ) : null}
+
+            <SectionCard>
+                <SectionHeader
+                    title="Monitoring Controls"
+                    subtitle="Tune the wait and neglect thresholds used to flag deployment issues."
+                />
+                <div className="admin-history-filter-grid">
+                    <label
+                        className="admin-history-filter-label"
+                        htmlFor="monitoring-wait-threshold"
+                    >
+                        Long-waiting threshold
+                        <select
+                            id="monitoring-wait-threshold"
+                            className="admin-history-filter-input"
+                            value={pendingControls.waitThresholdHours}
+                            onChange={(event) =>
+                                setPendingControls((current) => ({
+                                    ...current,
+                                    waitThresholdHours: Number(event.target.value),
+                                }))
+                            }
+                        >
+                            <option value={1}>1 hour</option>
+                            <option value={3}>3 hours</option>
+                            <option value={6}>6 hours</option>
+                            <option value={12}>12 hours</option>
+                            <option value={24}>24 hours</option>
+                        </select>
+                    </label>
+
+                    <label
+                        className="admin-history-filter-label"
+                        htmlFor="monitoring-neglect-threshold"
+                    >
+                        Neglect threshold
+                        <select
+                            id="monitoring-neglect-threshold"
+                            className="admin-history-filter-input"
+                            value={pendingControls.neglectThresholdHours}
+                            onChange={(event) =>
+                                setPendingControls((current) => ({
+                                    ...current,
+                                    neglectThresholdHours: Number(event.target.value),
+                                }))
+                            }
+                        >
+                            <option value={6}>6 hours</option>
+                            <option value={12}>12 hours</option>
+                            <option value={24}>24 hours</option>
+                            <option value={48}>48 hours</option>
+                            <option value={72}>72 hours</option>
+                        </select>
+                    </label>
+
+                    <label
+                        className="admin-history-filter-label"
+                        htmlFor="monitoring-list-limit"
+                    >
+                        List size
+                        <select
+                            id="monitoring-list-limit"
+                            className="admin-history-filter-input"
+                            value={pendingControls.listLimit}
+                            onChange={(event) =>
+                                setPendingControls((current) => ({
+                                    ...current,
+                                    listLimit: Number(event.target.value),
+                                }))
+                            }
+                        >
+                            <option value={5}>Top 5</option>
+                            <option value={10}>Top 10</option>
+                            <option value={20}>Top 20</option>
+                        </select>
+                    </label>
+                </div>
+
+                <div className="admin-history-actions">
+                    <PrimaryButton onClick={applyControls} loading={loading}>
+                        Apply Controls
+                    </PrimaryButton>
+                    <SecondaryButton onClick={resetControls} disabled={loading}>
+                        Reset Defaults
+                    </SecondaryButton>
+                </div>
+            </SectionCard>
+
+            {!hasAnySignal ? (
+                <SectionCard>
+                    <SectionHeader
+                        title="Deployment Monitoring"
+                        subtitle="No deployment issues detected for the selected thresholds."
+                    />
+                    <p className="admin-subtle">
+                        All active emergencies appear assigned within healthy time bounds.
+                    </p>
+                </SectionCard>
+            ) : (
+                <>
+                    <SectionCard>
+                        <SectionHeader
+                            title="Signal Summary"
+                            subtitle="Counts use the thresholds above. Lists below show the top items."
+                        />
+                        <div className="admin-metric-grid">
+                            <SummaryTile
+                                label="Unassigned"
+                                value={summary.unassigned}
+                                tone={summary.unassigned > 0 ? "warning" : "default"}
+                                description="Pending without an active assignment"
+                            />
+                            <SummaryTile
+                                label="Long-waiting"
+                                value={summary.longWaiting}
+                                tone={summary.longWaiting > 0 ? "danger" : "default"}
+                                description={`Pending older than ${monitoring.thresholds.waitThresholdHours}h`}
+                            />
+                            <SummaryTile
+                                label="In progress"
+                                value={summary.inProgress}
+                                tone="default"
+                                description="Active assignments right now"
+                            />
+                            <SummaryTile
+                                label="Neglected"
+                                value={summary.neglected}
+                                tone={summary.neglected > 0 ? "danger" : "default"}
+                                description={`Assigned more than ${monitoring.thresholds.neglectThresholdHours}h ago`}
+                            />
+                            <SummaryTile
+                                label="Possible duplicates"
+                                value={summary.conflicts}
+                                tone={summary.conflicts > 0 ? "warning" : "default"}
+                                description="Conflicting / duplicate active reports"
+                            />
+                        </div>
+                    </SectionCard>
+
+                    <SectionCard>
+                        <SectionHeader
+                            title="Unassigned Emergencies"
+                            subtitle="Pending requests that have not been assigned to a volunteer yet."
+                        />
+                        <ItemsTable
+                            items={unassigned}
+                            emptyText="No unassigned pending emergencies."
+                        />
+                    </SectionCard>
+
+                    <SectionCard>
+                        <SectionHeader
+                            title="Long-waiting Emergencies"
+                            subtitle={`Pending emergencies older than ${monitoring.thresholds.waitThresholdHours} hours.`}
+                        />
+                        <ItemsTable
+                            items={longWaiting}
+                            emptyText="No long-waiting emergencies for this threshold."
+                        />
+                    </SectionCard>
+
+                    <SectionCard>
+                        <SectionHeader
+                            title="Assigned / In-progress Emergencies"
+                            subtitle="Active assignments ordered by oldest assignment first."
+                        />
+                        <ItemsTable
+                            items={inProgress}
+                            emptyText="No active assignments right now."
+                        />
+                    </SectionCard>
+
+                    <SectionCard>
+                        <SectionHeader
+                            title="Potentially Neglected Emergencies"
+                            subtitle={`Active assignments untouched for more than ${monitoring.thresholds.neglectThresholdHours} hours.`}
+                        />
+                        <ItemsTable
+                            items={neglected}
+                            emptyText="No neglected assignments for this threshold."
+                        />
+                    </SectionCard>
+
+                    <SectionCard>
+                        <SectionHeader
+                            title="Conflicting / Duplicate Reports"
+                            subtitle="Active emergencies grouped by city, type and contact within the last 24 hours."
+                        />
+                        {conflicts.length === 0 ? (
+                            <p className="admin-subtle">
+                                No conflicting or duplicate reports detected.
+                            </p>
+                        ) : (
+                            <div className="admin-conflict-list">
+                                {conflicts.map((group) => (
+                                    <ConflictGroupCard
+                                        key={`${group.groupKey.city}-${group.groupKey.needType}`}
+                                        group={group}
+                                    />
+                                ))}
+                            </div>
+                        )}
+                    </SectionCard>
+                </>
+            )}
+        </div>
+    );
+}

--- a/web/src/components/feature/admin/AdminDeploymentMonitoringView.tsx
+++ b/web/src/components/feature/admin/AdminDeploymentMonitoringView.tsx
@@ -104,6 +104,7 @@ function ConflictGroupCard({ group }: { group: DeploymentMonitoringConflictGroup
                     {formatCity(group.groupKey.city)} ·{" "}
                     {formatOperationalLabel(group.groupKey.needType)}
                 </strong>{" "}
+                · Contact {group.groupKey.contactKey}{" "}
                 · {group.duplicateCount} duplicate reports
             </p>
             <ItemsTable
@@ -479,7 +480,7 @@ export default function AdminDeploymentMonitoringView() {
                             <div className="admin-conflict-list">
                                 {conflicts.map((group) => (
                                     <ConflictGroupCard
-                                        key={`${group.groupKey.city}-${group.groupKey.needType}`}
+                                        key={`${group.groupKey.city}-${group.groupKey.needType}-${group.groupKey.contactKey}`}
                                         group={group}
                                     />
                                 ))}

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -263,28 +263,26 @@ export default function ProfileView() {
 
                 setEmptyStateAction(null);
 
-                void (async () => {
-                    try {
-                        const treeResponse = await fetchLocationTree("TR");
-                        const nextLocationTree = {
-                            [treeResponse.countryCode.toLowerCase()]: treeResponse.tree,
-                        };
+                try {
+                    const treeResponse = await fetchLocationTree("TR");
+                    const nextLocationTree = {
+                        [treeResponse.countryCode.toLowerCase()]: treeResponse.tree,
+                    };
 
-                        setLocationTree(nextLocationTree);
-                        setLocationTreeError("");
+                    setLocationTree(nextLocationTree);
+                    setLocationTreeError("");
 
-                        // Rehydrate picker+form location state after the tree is available
-                        // so district/neighborhood keys are resolved consistently.
-                        await refreshProfileFromBackend(token, nextLocationTree);
-                    } catch (treeError) {
-                        setLocationTree({});
-                        setLocationTreeError(
-                            treeError instanceof Error
-                                ? treeError.message
-                                : "Could not load location tree."
-                        );
-                    }
-                })();
+                    // Rehydrate picker+form location state after the tree is available
+                    // so district/neighborhood keys are resolved consistently.
+                    await refreshProfileFromBackend(token, nextLocationTree);
+                } catch (treeError) {
+                    setLocationTree({});
+                    setLocationTreeError(
+                        treeError instanceof Error
+                            ? treeError.message
+                            : "Could not load location tree."
+                    );
+                }
             } catch (err) {
                 if (err instanceof ApiError && err.status === 401) {
                     clearAccessToken();

--- a/web/src/lib/admin.ts
+++ b/web/src/lib/admin.ts
@@ -235,3 +235,94 @@ export async function fetchAdminEmergencyAnalytics(
 
     return response.analytics;
 }
+
+export type DeploymentMonitoringStatus =
+    | "PENDING"
+    | "ASSIGNED"
+    | "IN_PROGRESS"
+    | "RESOLVED"
+    | "CANCELLED";
+
+export type DeploymentMonitoringItem = {
+    requestId: string;
+    needType: string | null;
+    status: DeploymentMonitoringStatus;
+    urgencyLevel: "LOW" | "MEDIUM" | "HIGH";
+    priorityLevel: "LOW" | "MEDIUM" | "HIGH";
+    createdAt: string;
+    ageHours: number;
+    assignedAt: string | null;
+    assignedHoursAgo: number | null;
+    volunteerId: string | null;
+    location: {
+        city: string;
+        district: string;
+    };
+};
+
+export type DeploymentMonitoringConflictGroup = {
+    groupKey: {
+        city: string;
+        needType: string;
+    };
+    duplicateCount: number;
+    items: DeploymentMonitoringItem[];
+};
+
+export type DeploymentMonitoringSummary = {
+    unassigned: number;
+    longWaiting: number;
+    inProgress: number;
+    neglected: number;
+    conflicts: number;
+};
+
+export type DeploymentMonitoringThresholds = {
+    waitThresholdHours: number;
+    neglectThresholdHours: number;
+    listLimit: number;
+};
+
+export type DeploymentMonitoring = {
+    thresholds: DeploymentMonitoringThresholds;
+    summary: DeploymentMonitoringSummary;
+    unassigned: DeploymentMonitoringItem[];
+    longWaiting: DeploymentMonitoringItem[];
+    inProgress: DeploymentMonitoringItem[];
+    neglected: DeploymentMonitoringItem[];
+    conflicts: DeploymentMonitoringConflictGroup[];
+};
+
+type DeploymentMonitoringResponse = {
+    monitoring: DeploymentMonitoring;
+};
+
+export async function fetchAdminDeploymentMonitoring(
+    token: string,
+    options: {
+        waitThresholdHours?: number;
+        neglectThresholdHours?: number;
+        listLimit?: number;
+    } = {}
+) {
+    const params = new URLSearchParams();
+    if (typeof options.waitThresholdHours === "number") {
+        params.set("waitThresholdHours", String(options.waitThresholdHours));
+    }
+    if (typeof options.neglectThresholdHours === "number") {
+        params.set("neglectThresholdHours", String(options.neglectThresholdHours));
+    }
+    if (typeof options.listLimit === "number") {
+        params.set("listLimit", String(options.listLimit));
+    }
+
+    const query = params.toString() ? `?${params.toString()}` : "";
+    const response = await apiRequest<DeploymentMonitoringResponse>(
+        `/admin/deployment-monitoring${query}`,
+        {
+            token: token.trim(),
+        }
+    );
+
+    return response.monitoring;
+}

--- a/web/src/lib/admin.ts
+++ b/web/src/lib/admin.ts
@@ -264,6 +264,7 @@ export type DeploymentMonitoringConflictGroup = {
     groupKey: {
         city: string;
         needType: string;
+        contactKey: string;
     };
     duplicateCount: number;
     items: DeploymentMonitoringItem[];


### PR DESCRIPTION
This PR adds an end-to-end Deployment Monitoring feature for admin users.

It introduces a new admin API and a new Admin dashboard tab to surface problematic emergency assignment situations with configurable thresholds.

## What’s Added
- New backend endpoint: `GET /admin/deployment-monitoring`
- New monitoring signals:
  - Unassigned emergencies
  - Long-waiting emergencies
  - In-progress emergencies
  - Potentially neglected emergencies
  - Conflicting / duplicate active reports
- Threshold/query controls:
  - `waitThresholdHours`
  - `neglectThresholdHours`
  - `listLimit`
- New web admin view with:
  - Monitoring controls
  - Signal summary tiles
  - Per-signal tables
  - Conflict grouping cards
- Admin dashboard switcher integration with new **Deployment Monitoring** tab
- Test coverage:
  - Backend integration tests for deployment monitoring
  - E2E Playwright spec for admin monitoring tab + retry/recovery flow

## Important Design Note
Conflict detection is implemented as **duplicate active reports** (grouped by city + need type + contact within recent window), instead of volunteer-overload, because the schema already enforces one active assignment per volunteer via partial unique index.