### PR TITLE
fix(auth): scope login rate-limit per email+ip

### DIFF
--- a/backend/src/modules/auth/routes.js
+++ b/backend/src/modules/auth/routes.js
@@ -3,13 +3,41 @@ const rateLimit = require('express-rate-limit');
 const { env } = require('../../config/env');
 const { adminRouter } = require('../admin/routes');
 
+function shouldSkipAuthRateLimit() {
+  return env.nodeEnv === 'test' && process.env.ENABLE_RATE_LIMIT_IN_TEST !== 'true';
+}
+
+function buildLoginRateLimitKey(request) {
+  const normalizedIp = typeof rateLimit.ipKeyGenerator === 'function'
+    ? rateLimit.ipKeyGenerator(request.ip)
+    : request.ip;
+  const email = typeof request.body?.email === 'string'
+    ? request.body.email.trim().toLowerCase()
+    : '';
+  const safeEmail = email || 'unknown-email';
+
+  return `${normalizedIp}|${safeEmail}`;
+}
+
 const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 10, // max 10 requests
-  skip: () => env.nodeEnv === 'test',
+  skip: shouldSkipAuthRateLimit,
   message: {
     code: 'TOO_MANY_REQUESTS',
     message: 'Too many requests, please try again later',
+  },
+});
+
+const loginLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 5, // max 5 failed attempts per email+ip per minute
+  skipSuccessfulRequests: true,
+  keyGenerator: buildLoginRateLimitKey,
+  skip: shouldSkipAuthRateLimit,
+  message: {
+    code: 'TOO_MANY_REQUESTS',
+    message: 'Too many login attempts, please try again in a minute',
   },
 });
 
@@ -30,7 +58,7 @@ const authRouter = express.Router();
 
 authRouter.get('/', getAuthInfo);
 authRouter.post('/signup', authLimiter, signup);
-authRouter.post('/login', authLimiter, login);
+authRouter.post('/login', loginLimiter, login);
 authRouter.get('/verify-email', verifyEmail);
 authRouter.post('/resend-verification', authLimiter, resendVerification);
 authRouter.post('/forgot-password', authLimiter, forgotPassword);
@@ -43,4 +71,6 @@ authRouter.use('/admin', adminRouter);
 
 module.exports = {
   authRouter,
+  buildLoginRateLimitKey,
+  loginLimiter,
 };

--- a/backend/tests/unit/modules/auth/routes.rate-limit.test.js
+++ b/backend/tests/unit/modules/auth/routes.rate-limit.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+
+function loadAuthRouteExportsWithLimiterEnabled() {
+  jest.resetModules();
+  process.env.ENABLE_RATE_LIMIT_IN_TEST = 'true';
+  jest.doMock('../../../../src/modules/auth/controller', () => ({
+    getAuthInfo: (_req, res) => res.status(200).json({ ok: true }),
+    signup: (_req, res) => res.status(200).json({ ok: true }),
+    login: (_req, res) => res.status(200).json({ ok: true }),
+    verifyEmail: (_req, res) => res.status(200).json({ ok: true }),
+    getMe: (_req, res) => res.status(200).json({ ok: true }),
+    resendVerification: (_req, res) => res.status(200).json({ ok: true }),
+    forgotPassword: (_req, res) => res.status(200).json({ ok: true }),
+    resetPasswordHandler: (_req, res) => res.status(200).json({ ok: true }),
+    logout: (_req, res) => res.status(200).json({ ok: true }),
+  }));
+  jest.doMock('../../../../src/modules/admin/routes', () => {
+    const mockExpress = require('express');
+    return { adminRouter: mockExpress.Router() };
+  });
+  jest.doMock('../../../../src/modules/auth/middleware', () => ({
+    requireAuth: (_req, _res, next) => next(),
+  }));
+  // eslint-disable-next-line global-require
+  return require('../../../../src/modules/auth/routes');
+}
+
+describe('auth login rate limiter', () => {
+  afterEach(() => {
+    delete process.env.ENABLE_RATE_LIMIT_IN_TEST;
+  });
+
+  test('uses ip+email key for login limiter', () => {
+    const { buildLoginRateLimitKey } = loadAuthRouteExportsWithLimiterEnabled();
+
+    const key = buildLoginRateLimitKey({
+      ip: '127.0.0.1',
+      body: { email: '  Test@Example.com ' },
+    });
+
+    expect(key).toContain('|test@example.com');
+  });
+
+  test('blocks repeated failed attempts per email but does not block different email', async () => {
+    const { loginLimiter } = loadAuthRouteExportsWithLimiterEnabled();
+
+    const app = express();
+    app.use(express.json());
+    app.post('/login', loginLimiter, (_req, res) => {
+      res.status(401).json({
+        code: 'INVALID_CREDENTIALS',
+        message: 'Invalid email or password',
+      });
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      const response = await request(app)
+        .post('/login')
+        .send({ email: 'locked@example.com', password: 'wrong-pass' });
+      expect(response.status).toBe(401);
+    }
+
+    const blockedResponse = await request(app)
+      .post('/login')
+      .send({ email: 'locked@example.com', password: 'wrong-pass' });
+    expect(blockedResponse.status).toBe(429);
+    expect(blockedResponse.body.code).toBe('TOO_MANY_REQUESTS');
+
+    const otherEmailResponse = await request(app)
+      .post('/login')
+      .send({ email: 'other@example.com', password: 'wrong-pass' });
+    expect(otherEmailResponse.status).toBe(401);
+  });
+});


### PR DESCRIPTION
Fixes #189

## What changed
- Scoped login rate limit key to `ip + normalized email` instead of global IP-only blocking.
- Added a dedicated login limiter with:
  - `windowMs: 1 minute`
  - `max: 5`
  - `skipSuccessfulRequests: true`
- Kept existing auth limiter behavior for other auth endpoints.
- Made key generation IPv6-safe with express-rate-limit helper.

## Why
Previously, after too many failed attempts, users could remain blocked in a way that affected subsequent login attempts broadly.  
Now lockout is isolated per email+IP, so one account’s failures don’t effectively freeze all login attempts from that client.

## Tests
- Added unit test: `backend/tests/unit/modules/auth/routes.rate-limit.test.js`
  - verifies key format behavior
  - verifies 6th failed attempt is blocked for same email
  - verifies different email is not blocked
- Auth unit tests passed locally.
