### PR TITLE
feat: improve requester request overview across current and history

### DIFF
--- a/android/app/src/main/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepository.kt
+++ b/android/app/src/main/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepository.kt
@@ -59,6 +59,24 @@ data class MyHelpRequestUiModel(
         get() = syncStatus == SyncStatus.FAILED || syncStatus == SyncStatus.CONFLICTED
 }
 
+data class MyHelpRequestsOverviewUiModel(
+    val totalRequests: Int,
+    val activeRequests: List<MyHelpRequestUiModel>,
+    val historyRequests: List<MyHelpRequestUiModel>,
+    val resolvedCount: Int,
+    val cancelledCount: Int,
+    val assignedResponderCount: Int
+) {
+    val activeCount: Int
+        get() = activeRequests.size
+
+    val historyCount: Int
+        get() = historyRequests.size
+
+    val hasMultipleRequestContext: Boolean
+        get() = totalRequests > 1 || historyCount > 0
+}
+
 data class AssignedResponderUiModel(
     val firstName: String?,
     val lastName: String?,
@@ -183,6 +201,22 @@ object MyHelpRequestsRepository {
             now = System.currentTimeMillis()
         ).toUiModel()
     }
+}
+
+internal fun buildMyHelpRequestsOverview(
+    requests: List<MyHelpRequestUiModel>
+): MyHelpRequestsOverviewUiModel {
+    val activeRequests = requests.filter { it.isActive }
+    val historyRequests = requests.filterNot { it.isActive }
+
+    return MyHelpRequestsOverviewUiModel(
+        totalRequests = requests.size,
+        activeRequests = activeRequests,
+        historyRequests = historyRequests,
+        resolvedCount = requests.count { it.status.trim().uppercase() == "RESOLVED" },
+        cancelledCount = requests.count { it.status.trim().uppercase() == "CANCELLED" },
+        assignedResponderCount = activeRequests.sumOf { request -> request.responders.size }
+    )
 }
 
 internal fun HelpRequestEntity.toUiModel(): MyHelpRequestUiModel {

--- a/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
@@ -70,8 +70,7 @@ fun MyHelpRequestsScreen(
 
     val requests by MyHelpRequestsRepository.observeHelpRequests(isAuthenticated)
         .collectAsState(initial = emptyList())
-    var actionInProgressRequestId by remember { mutableStateOf<String?>(null) }
-    var actionMessageRequestId by remember { mutableStateOf<String?>(null) }
+    var actionInProgress by remember { mutableStateOf(false) }
     var actionMessage by remember { mutableStateOf("") }
     var initialRefreshInProgress by remember(isAuthenticated, token) { mutableStateOf(true) }
 
@@ -126,7 +125,7 @@ fun MyHelpRequestsScreen(
 
             else -> {
                 val overview = buildMyHelpRequestsOverview(requests)
-                val activeRequests = overview.activeRequests
+                val currentActiveRequest = overview.activeRequests.firstOrNull()
                 val requestHistory = overview.historyRequests
 
                 LazyColumn(
@@ -143,30 +142,18 @@ fun MyHelpRequestsScreen(
                         }
                     }
 
-                    item {
-                        SectionHeader(
-                            title = if (activeRequests.size > 1) {
-                                "Current Requests"
-                            } else {
-                                "Current Request"
-                            },
-                            subtitle = if (isAuthenticated) {
-                                if (activeRequests.size > 1) {
-                                    "Your active help requests are shown together first."
-                                } else {
+                        item {
+                            SectionHeader(
+                                title = "Current Request",
+                                subtitle = if (isAuthenticated) {
                                     "Your latest active help request is shown first."
-                                }
-                            } else {
-                                if (activeRequests.size > 1) {
-                                    "Your active guest help requests are shown together first."
                                 } else {
                                     "Your latest guest help request is shown first."
                                 }
-                            }
-                        )
-                    }
+                            )
+                        }
 
-                    if (activeRequests.isEmpty()) {
+                    if (currentActiveRequest == null) {
                         item {
                             SectionCard {
                                 Text(
@@ -177,59 +164,53 @@ fun MyHelpRequestsScreen(
                             }
                         }
                     } else {
-                        items(activeRequests, key = { it.id }) { activeRequest ->
+                        item(key = currentActiveRequest.id) {
                             MyHelpRequestCard(
-                                request = activeRequest,
-                                titleOverride = activeRequest.helpTypeSummary,
-                                subtitleOverride = activeRequest.createdAt?.let { "Opened: $it" }
+                                request = currentActiveRequest,
+                                titleOverride = currentActiveRequest.helpTypeSummary,
+                                subtitleOverride = currentActiveRequest.createdAt?.let { "Opened: $it" }
                                     ?: "Opened time unavailable",
-                                actionMessage = if (actionMessageRequestId == activeRequest.id) {
-                                    actionMessage
-                                } else {
-                                    ""
-                                },
+                                actionMessage = actionMessage,
                                 onResolve = if (isAuthenticated && token.isNotBlank()) {
                                     {
-                                        actionMessageRequestId = activeRequest.id
                                         actionMessage = ""
-                                        actionInProgressRequestId = activeRequest.id
+                                        actionInProgress = true
                                         scope.launch {
                                             try {
                                                 MyHelpRequestsRepository.markRequestAsResolved(
                                                     token = token,
-                                                    requestId = activeRequest.id
+                                                    requestId = currentActiveRequest.id
                                                 )
                                                 actionMessage = "Request marked resolved locally and queued for sync."
                                             } catch (_: Exception) {
                                                 actionMessage = "Could not save the status change locally."
                                             } finally {
-                                                actionInProgressRequestId = null
+                                                actionInProgress = false
                                             }
                                         }
                                     }
-                                } else if (!isAuthenticated && activeRequest.guestAccessToken != null) {
+                                } else if (!isAuthenticated && currentActiveRequest.guestAccessToken != null) {
                                     {
-                                        actionMessageRequestId = activeRequest.id
                                         actionMessage = ""
-                                        actionInProgressRequestId = activeRequest.id
+                                        actionInProgress = true
                                         scope.launch {
                                             try {
                                                 MyHelpRequestsRepository.markGuestRequestAsResolved(
-                                                    requestId = activeRequest.id,
-                                                    guestAccessToken = activeRequest.guestAccessToken
+                                                    requestId = currentActiveRequest.id,
+                                                    guestAccessToken = currentActiveRequest.guestAccessToken
                                                 )
                                                 actionMessage = "Request marked resolved locally and queued for sync."
                                             } catch (_: Exception) {
                                                 actionMessage = "Could not save the status change locally."
                                             } finally {
-                                                actionInProgressRequestId = null
+                                                actionInProgress = false
                                             }
                                         }
                                     }
                                 } else {
                                     null
                                 },
-                                resolveLoading = actionInProgressRequestId == activeRequest.id
+                                resolveLoading = actionInProgress
                             )
                         }
                     }
@@ -284,8 +265,8 @@ private fun RequestsOverviewCard(
                     modifier = Modifier.weight(1f)
                 )
                 OverviewMetric(
-                    label = "Open Now",
-                    value = overview.activeCount.toString(),
+                    label = "Current",
+                    value = if (overview.activeCount > 0) "Yes" else "No",
                     modifier = Modifier.weight(1f)
                 )
             }
@@ -307,8 +288,8 @@ private fun RequestsOverviewCard(
             }
 
             val responderSummary = when {
-                overview.assignedResponderCount > 0 -> {
-                    "Responders currently assigned across open requests: ${overview.assignedResponderCount}."
+                overview.activeCount > 0 && overview.assignedResponderCount > 0 -> {
+                    "Your current request includes assigned responder details below."
                 }
 
                 overview.historyCount > 0 -> {

--- a/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -29,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.text.style.TextAlign
@@ -36,6 +39,7 @@ import com.neph.core.network.ApiException
 import com.neph.core.sync.OfflineSyncScheduler
 import com.neph.features.auth.data.AuthRepository
 import com.neph.features.auth.data.AuthSessionStore
+import com.neph.features.myhelprequests.data.buildMyHelpRequestsOverview
 import com.neph.features.myhelprequests.data.MyHelpRequestUiModel
 import com.neph.features.myhelprequests.data.MyHelpRequestsRepository
 import com.neph.navigation.Routes
@@ -67,6 +71,7 @@ fun MyHelpRequestsScreen(
     val requests by MyHelpRequestsRepository.observeHelpRequests(isAuthenticated)
         .collectAsState(initial = emptyList())
     var actionInProgressRequestId by remember { mutableStateOf<String?>(null) }
+    var actionMessageRequestId by remember { mutableStateOf<String?>(null) }
     var actionMessage by remember { mutableStateOf("") }
     var initialRefreshInProgress by remember(isAuthenticated, token) { mutableStateOf(true) }
 
@@ -120,26 +125,48 @@ fun MyHelpRequestsScreen(
             }
 
             else -> {
-                val activeRequest = requests.firstOrNull { it.isActive }
-                val requestHistory = requests.filterNot { it.isActive }
+                val overview = buildMyHelpRequestsOverview(requests)
+                val activeRequests = overview.activeRequests
+                val requestHistory = overview.historyRequests
 
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
                     verticalArrangement = Arrangement.spacedBy(spacing.lg),
                     contentPadding = PaddingValues(vertical = spacing.sm)
                 ) {
+                    if (overview.hasMultipleRequestContext) {
+                        item {
+                            RequestsOverviewCard(
+                                overview = overview,
+                                isAuthenticated = isAuthenticated
+                            )
+                        }
+                    }
+
                     item {
                         SectionHeader(
-                            title = "Current Request",
-                            subtitle = if (isAuthenticated) {
-                                "Your latest active help request is shown first."
+                            title = if (activeRequests.size > 1) {
+                                "Current Requests"
                             } else {
-                                "Your latest guest help request is shown first."
+                                "Current Request"
+                            },
+                            subtitle = if (isAuthenticated) {
+                                if (activeRequests.size > 1) {
+                                    "Your active help requests are shown together first."
+                                } else {
+                                    "Your latest active help request is shown first."
+                                }
+                            } else {
+                                if (activeRequests.size > 1) {
+                                    "Your active guest help requests are shown together first."
+                                } else {
+                                    "Your latest guest help request is shown first."
+                                }
                             }
                         )
                     }
 
-                    if (activeRequest == null) {
+                    if (activeRequests.isEmpty()) {
                         item {
                             SectionCard {
                                 Text(
@@ -150,15 +177,20 @@ fun MyHelpRequestsScreen(
                             }
                         }
                     } else {
-                        item {
+                        items(activeRequests, key = { it.id }) { activeRequest ->
                             MyHelpRequestCard(
                                 request = activeRequest,
                                 titleOverride = activeRequest.helpTypeSummary,
                                 subtitleOverride = activeRequest.createdAt?.let { "Opened: $it" }
                                     ?: "Opened time unavailable",
-                                actionMessage = actionMessage,
+                                actionMessage = if (actionMessageRequestId == activeRequest.id) {
+                                    actionMessage
+                                } else {
+                                    ""
+                                },
                                 onResolve = if (isAuthenticated && token.isNotBlank()) {
                                     {
+                                        actionMessageRequestId = activeRequest.id
                                         actionMessage = ""
                                         actionInProgressRequestId = activeRequest.id
                                         scope.launch {
@@ -177,6 +209,7 @@ fun MyHelpRequestsScreen(
                                     }
                                 } else if (!isAuthenticated && activeRequest.guestAccessToken != null) {
                                     {
+                                        actionMessageRequestId = activeRequest.id
                                         actionMessage = ""
                                         actionInProgressRequestId = activeRequest.id
                                         scope.launch {
@@ -220,6 +253,105 @@ fun MyHelpRequestsScreen(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun RequestsOverviewCard(
+    overview: com.neph.features.myhelprequests.data.MyHelpRequestsOverviewUiModel,
+    isAuthenticated: Boolean
+) {
+    val spacing = LocalNephSpacing.current
+
+    SectionCard {
+        Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+            SectionHeader(
+                title = "Overview",
+                subtitle = if (isAuthenticated) {
+                    "See your current and previous requests together."
+                } else {
+                    "See the requests tracked from this device together."
+                }
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm)
+            ) {
+                OverviewMetric(
+                    label = "Tracked",
+                    value = overview.totalRequests.toString(),
+                    modifier = Modifier.weight(1f)
+                )
+                OverviewMetric(
+                    label = "Open Now",
+                    value = overview.activeCount.toString(),
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.sm)
+            ) {
+                OverviewMetric(
+                    label = "Resolved",
+                    value = overview.resolvedCount.toString(),
+                    modifier = Modifier.weight(1f)
+                )
+                OverviewMetric(
+                    label = "Cancelled",
+                    value = overview.cancelledCount.toString(),
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            val responderSummary = when {
+                overview.assignedResponderCount > 0 -> {
+                    "Responders currently assigned across open requests: ${overview.assignedResponderCount}."
+                }
+
+                overview.historyCount > 0 -> {
+                    "${overview.historyCount} previous request${if (overview.historyCount == 1) "" else "s"} kept in history for quick context."
+                }
+
+                else -> {
+                    "Open and closed requests stay grouped so the flow remains easy to scan."
+                }
+            }
+
+            Text(
+                text = responderSummary,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun OverviewMetric(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    val spacing = LocalNephSpacing.current
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(spacing.xs)
+    ) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }
 

--- a/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.layout.RowScope.weight
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items

--- a/android/app/src/test/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepositoryMappingTest.kt
+++ b/android/app/src/test/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepositoryMappingTest.kt
@@ -102,14 +102,45 @@ class MyHelpRequestsRepositoryMappingTest {
             isDeleted = false
         ).toUiModel()
 
-        val matchedModel = cancelledModel.copy(
-            id = "req_matched",
+        val matchedModel = HelpRequestEntity(
+            localId = "local_matched",
+            remoteId = "req_matched",
+            ownerType = LocalOwnerType.AUTHENTICATED,
+            guestAccessToken = null,
+            helpTypesJson = "[\"medical\"]",
+            otherHelpText = "",
+            affectedPeopleCount = 1,
+            riskFlagsJson = "[]",
+            vulnerableGroupsJson = "[]",
+            description = "Need first aid support",
+            bloodType = "",
+            country = "Turkey",
+            city = "Istanbul",
+            district = "Sisli",
+            neighborhood = "Bomonti",
+            extraAddress = "Building D",
+            contactFullName = "Ayse Yilmaz",
+            contactPhone = "5551234567",
+            contactAlternativePhone = null,
             status = "MATCHED",
-            statusLabel = "Responder assigned",
-            isActive = true,
-            closedAtLabel = null,
-            closedStateLabel = null
-        )
+            urgencyLevel = null,
+            priorityLevel = null,
+            resolvedAt = null,
+            cancelledAt = null,
+            helperFirstName = null,
+            helperLastName = null,
+            helperPhone = null,
+            helperProfession = null,
+            helperExpertise = null,
+            helpersJson = "[]",
+            syncStatus = SyncStatus.SYNCED,
+            pendingError = null,
+            createdAtEpochMillis = 0L,
+            updatedAtEpochMillis = 0L,
+            lastSyncedAtEpochMillis = null,
+            serverCreatedAt = "2026-04-26T11:00:00.000Z",
+            isDeleted = false
+        ).toUiModel()
 
         assertFalse(cancelledModel.isActive)
         assertEquals("Cancelled", cancelledModel.statusLabel)
@@ -123,8 +154,8 @@ class MyHelpRequestsRepositoryMappingTest {
     }
 
     @Test
-    fun buildOverviewKeepsAllActiveRequestsAndSummarizesHistory() {
-        val firstActive = HelpRequestEntity(
+    fun buildOverviewSummarizesCurrentAndHistoryContext() {
+        val currentActive = HelpRequestEntity(
             localId = "local_active_1",
             remoteId = "req_active_1",
             ownerType = LocalOwnerType.AUTHENTICATED,
@@ -164,14 +195,7 @@ class MyHelpRequestsRepositoryMappingTest {
             isDeleted = false
         ).toUiModel()
 
-        val secondActive = firstActive.copy(
-            id = "req_active_2",
-            status = "SYNCED",
-            statusLabel = "Awaiting match",
-            responders = emptyList()
-        )
-
-        val cancelled = firstActive.copy(
+        val cancelled = currentActive.copy(
             id = "req_cancelled_2",
             status = "CANCELLED",
             statusLabel = "Cancelled",
@@ -181,14 +205,24 @@ class MyHelpRequestsRepositoryMappingTest {
             closedStateLabel = "Cancelled"
         )
 
-        val overview = buildMyHelpRequestsOverview(listOf(firstActive, secondActive, cancelled))
+        val resolved = currentActive.copy(
+            id = "req_resolved_1",
+            status = "RESOLVED",
+            statusLabel = "Resolved",
+            isActive = false,
+            responders = emptyList(),
+            closedAtLabel = "2026-04-26 13:30:00",
+            closedStateLabel = "Resolved"
+        )
+
+        val overview = buildMyHelpRequestsOverview(listOf(currentActive, cancelled, resolved))
 
         assertEquals(3, overview.totalRequests)
-        assertEquals(2, overview.activeCount)
-        assertEquals(listOf(firstActive.id, secondActive.id), overview.activeRequests.map { it.id })
-        assertEquals(listOf(cancelled.id), overview.historyRequests.map { it.id })
+        assertEquals(1, overview.activeCount)
+        assertEquals(listOf(currentActive.id), overview.activeRequests.map { it.id })
+        assertEquals(listOf(cancelled.id, resolved.id), overview.historyRequests.map { it.id })
         assertEquals(1, overview.cancelledCount)
-        assertEquals(0, overview.resolvedCount)
+        assertEquals(1, overview.resolvedCount)
         assertEquals(1, overview.assignedResponderCount)
         assertTrue(overview.hasMultipleRequestContext)
     }

--- a/android/app/src/test/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepositoryMappingTest.kt
+++ b/android/app/src/test/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepositoryMappingTest.kt
@@ -121,4 +121,75 @@ class MyHelpRequestsRepositoryMappingTest {
         assertTrue(matchedModel.isActive)
         assertEquals("Responder assigned", matchedModel.statusLabel)
     }
+
+    @Test
+    fun buildOverviewKeepsAllActiveRequestsAndSummarizesHistory() {
+        val firstActive = HelpRequestEntity(
+            localId = "local_active_1",
+            remoteId = "req_active_1",
+            ownerType = LocalOwnerType.AUTHENTICATED,
+            guestAccessToken = null,
+            helpTypesJson = "[\"food\"]",
+            otherHelpText = "",
+            affectedPeopleCount = 1,
+            riskFlagsJson = "[]",
+            vulnerableGroupsJson = "[]",
+            description = "Need food support",
+            bloodType = "",
+            country = "Turkey",
+            city = "Istanbul",
+            district = "Kadikoy",
+            neighborhood = "Moda",
+            extraAddress = "Street 1",
+            contactFullName = "Ayse",
+            contactPhone = "5550000001",
+            contactAlternativePhone = null,
+            status = "MATCHED",
+            urgencyLevel = "HIGH",
+            priorityLevel = "HIGH",
+            resolvedAt = null,
+            cancelledAt = null,
+            helperFirstName = null,
+            helperLastName = null,
+            helperPhone = null,
+            helperProfession = null,
+            helperExpertise = null,
+            helpersJson = "[{\"firstName\":\"Ece\"}]",
+            syncStatus = SyncStatus.SYNCED,
+            pendingError = null,
+            createdAtEpochMillis = 1L,
+            updatedAtEpochMillis = 1L,
+            lastSyncedAtEpochMillis = null,
+            serverCreatedAt = "2026-04-26T10:00:00.000Z",
+            isDeleted = false
+        ).toUiModel()
+
+        val secondActive = firstActive.copy(
+            id = "req_active_2",
+            status = "SYNCED",
+            statusLabel = "Awaiting match",
+            responders = emptyList()
+        )
+
+        val cancelled = firstActive.copy(
+            id = "req_cancelled_2",
+            status = "CANCELLED",
+            statusLabel = "Cancelled",
+            isActive = false,
+            responders = emptyList(),
+            closedAtLabel = "2026-04-26 12:30:00",
+            closedStateLabel = "Cancelled"
+        )
+
+        val overview = buildMyHelpRequestsOverview(listOf(firstActive, secondActive, cancelled))
+
+        assertEquals(3, overview.totalRequests)
+        assertEquals(2, overview.activeCount)
+        assertEquals(listOf(firstActive.id, secondActive.id), overview.activeRequests.map { it.id })
+        assertEquals(listOf(cancelled.id), overview.historyRequests.map { it.id })
+        assertEquals(1, overview.cancelledCount)
+        assertEquals(0, overview.resolvedCount)
+        assertEquals(1, overview.assignedResponderCount)
+        assertTrue(overview.hasMultipleRequestContext)
+    }
 }


### PR DESCRIPTION
### Summary
This PR improves requester-side request overview in the Android `My Help Requests` flow by making the screen more informative at a glance across the current request and request history.

### Why this PR exists
Issue #339 is about aggregate request visibility in request-related flows, not admin analytics and not detailed lifecycle/history work by itself.

After reviewing the current implementation, the main requester-side foundations were already present:
- current vs history grouping already existed
- request ordering and metadata were already available
- past requests were already preserved locally

The remaining gap was that the screen still leaned too much toward isolated per-request reading and lacked a lightweight overview layer above the grouped sections.

### What changed
- added a small requester overview builder in `MyHelpRequestsRepository`
- added a lightweight overview card in `MyHelpRequestsScreen`
- improved aggregate visibility across the current request and request history
- preserved the existing current/history structure and styling
- added regression coverage for requester overview behavior

### Important behavior notes
- this PR focuses on requester-side aggregate visibility
- it does **not** introduce support for multiple simultaneous active requests
- it stays compatible with the current business rule that a requester has at most one active request at a time
- the overview value comes from making the current + historical request landscape easier to understand together
- no admin dashboard work was added
- no backend changes were required
- no advanced matching logic was changed

### Scope notes
- no schema changes
- no migration changes
- no history redesign
- no broad lifecycle/priority redesign
- no unrelated UI refactor
- minimal Android-only improvement to the existing requester overview surface

Closes #339