### PR TITLE
feat: build privacy & security page

### DIFF
--- a/android/app/src/main/java/com/neph/features/privacysecurity/presentation/PrivacySecurityScreen.kt
+++ b/android/app/src/main/java/com/neph/features/privacysecurity/presentation/PrivacySecurityScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.neph.core.network.ApiException
 import com.neph.features.profile.data.ProfileRepository
 import com.neph.ui.components.buttons.PrimaryButton
+import com.neph.ui.components.buttons.SecondaryButton
 import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
@@ -43,7 +44,8 @@ private val visibilityOptions = listOf(
 
 @Composable
 fun PrivacySecurityScreen(
-    onNavigateBack: () -> Unit
+    onNavigateBack: () -> Unit,
+    onResetPassword: () -> Unit
 ) {
     val spacing = LocalNephSpacing.current
     val scope = rememberCoroutineScope()
@@ -192,6 +194,12 @@ fun PrivacySecurityScreen(
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
+
+                        SecondaryButton(
+                            text = "Reset your password",
+                            onClick = onResetPassword,
+                            modifier = Modifier.fillMaxWidth()
+                        )
                     }
                 }
 
@@ -222,6 +230,9 @@ fun PrivacySecurityScreen(
 @Composable
 private fun PrivacySecurityScreenPreview() {
     NephTheme {
-        PrivacySecurityScreen(onNavigateBack = {})
+        PrivacySecurityScreen(
+            onNavigateBack = {},
+            onResetPassword = {}
+        )
     }
 }

--- a/android/app/src/main/java/com/neph/features/privacysecurity/presentation/PrivacySecurityScreen.kt
+++ b/android/app/src/main/java/com/neph/features/privacysecurity/presentation/PrivacySecurityScreen.kt
@@ -3,47 +3,215 @@ package com.neph.features.privacysecurity.presentation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.neph.core.network.ApiException
+import com.neph.features.profile.data.ProfileRepository
+import com.neph.ui.components.buttons.PrimaryButton
+import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
+import com.neph.ui.components.selection.AppRadioGroup
+import com.neph.ui.components.selection.AppToggleSwitch
+import com.neph.ui.components.selection.RadioOption
 import com.neph.ui.layout.AppScaffold
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+
+private const val PrivateVisibility = "PRIVATE"
+private const val EmergencyVisibility = "EMERGENCY_ONLY"
+private const val PublicVisibility = "PUBLIC"
+
+private val visibilityOptions = listOf(
+    RadioOption("Private", PrivateVisibility),
+    RadioOption("Emergency only", EmergencyVisibility),
+    RadioOption("Public", PublicVisibility)
+)
 
 @Composable
 fun PrivacySecurityScreen(
     onNavigateBack: () -> Unit
 ) {
     val spacing = LocalNephSpacing.current
+    val scope = rememberCoroutineScope()
+
+    var loading by remember { mutableStateOf(true) }
+    var saving by remember { mutableStateOf(false) }
+    var profileVisibility by remember { mutableStateOf(PrivateVisibility) }
+    var healthInfoVisibility by remember { mutableStateOf(PrivateVisibility) }
+    var locationVisibility by remember { mutableStateOf(PrivateVisibility) }
+    var shareLocation by remember { mutableStateOf(false) }
+    var initialShareLocation by remember { mutableStateOf(false) }
+    var hasSavedCoordinates by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf("") }
+    var info by remember { mutableStateOf("") }
+
+    LaunchedEffect(Unit) {
+        try {
+            val profile = ProfileRepository.fetchAndCacheRemoteProfile()
+            profileVisibility = profile.profileVisibility ?: PrivateVisibility
+            healthInfoVisibility = profile.healthInfoVisibility ?: PrivateVisibility
+            locationVisibility = profile.locationVisibility ?: PrivateVisibility
+            shareLocation = profile.shareLocation == true
+            initialShareLocation = profile.shareLocation == true
+            hasSavedCoordinates = profile.sharedLatitude != null && profile.sharedLongitude != null
+            error = ""
+        } catch (cancellationException: CancellationException) {
+            throw cancellationException
+        } catch (apiError: ApiException) {
+            error = if (apiError.status == 401) {
+                "Your session expired. Please log in again."
+            } else {
+                apiError.message.ifBlank { "Could not load privacy settings." }
+            }
+        } catch (_: Exception) {
+            error = "Could not load privacy settings."
+        } finally {
+            loading = false
+        }
+    }
+
+    fun savePrivacySettings() {
+        if (!initialShareLocation && shareLocation && !hasSavedCoordinates) {
+            error = ProfileRepository.LocationSharingInitializationMessage
+            info = ""
+            return
+        }
+
+        scope.launch {
+            try {
+                saving = true
+                error = ""
+                info = ""
+
+                val profile = ProfileRepository.syncPrivacySettings(
+                    profileVisibility = profileVisibility,
+                    healthInfoVisibility = healthInfoVisibility,
+                    locationVisibility = locationVisibility,
+                    locationSharingEnabled = shareLocation
+                )
+
+                initialShareLocation = profile.shareLocation == true
+                hasSavedCoordinates = profile.sharedLatitude != null && profile.sharedLongitude != null
+                info = "Privacy settings updated successfully."
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (apiError: ApiException) {
+                error = if (apiError.status == 401) {
+                    "Your session expired. Please log in again."
+                } else {
+                    apiError.message.ifBlank { "Could not save privacy settings." }
+                }
+            } catch (_: Exception) {
+                error = "Could not save privacy settings."
+            } finally {
+                saving = false
+            }
+        }
+    }
 
     AppScaffold(
         title = "Privacy & Security",
         onNavigateBack = onNavigateBack
     ) {
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(spacing.lg)
-        ) {
-            SectionCard {
-                SectionHeader(
-                    title = "Privacy & Security",
-                    subtitle = "Configure privacy safely from your profile flow."
-                )
+        if (loading) {
+            HelperText(text = "Loading privacy settings...")
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(spacing.lg)
+            ) {
+                SectionCard {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(spacing.md)
+                    ) {
+                        SectionHeader(
+                            title = "Privacy",
+                            subtitle = "Choose who can see profile, health, and location details."
+                        )
 
-                Text(
-                    text = "To enable Share Current Location, go to Profile, grant location permission, and save a valid current location first.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                        AppRadioGroup(
+                            value = profileVisibility,
+                            onValueChange = { profileVisibility = it },
+                            label = "Profile visibility",
+                            options = visibilityOptions,
+                            vertical = true
+                        )
 
-                Text(
-                    text = "If there are no saved or fresh coordinates, Android will keep location sharing disabled for safety.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                        AppRadioGroup(
+                            value = healthInfoVisibility,
+                            onValueChange = { healthInfoVisibility = it },
+                            label = "Health information visibility",
+                            options = visibilityOptions,
+                            vertical = true
+                        )
+
+                        AppRadioGroup(
+                            value = locationVisibility,
+                            onValueChange = { locationVisibility = it },
+                            label = "Saved location visibility",
+                            options = visibilityOptions,
+                            vertical = true
+                        )
+
+                        AppToggleSwitch(
+                            checked = shareLocation,
+                            onCheckedChange = { shareLocation = it },
+                            label = "Share Current Location",
+                            description = "Allow emergency coordination flows to use your saved current-location status."
+                        )
+                    }
+                }
+
+                SectionCard {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(spacing.md)
+                    ) {
+                        SectionHeader(
+                            title = "Security",
+                            subtitle = "Password recovery and email verification use the existing account flows."
+                        )
+
+                        Text(
+                            text = "Use Forgot Password from the login screen to reset your password securely.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+
+                if (error.isNotBlank()) {
+                    Text(
+                        text = error,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+
+                if (info.isNotBlank()) {
+                    HelperText(text = info)
+                }
+
+                PrimaryButton(
+                    text = "Save Privacy Settings",
+                    onClick = ::savePrivacySettings,
+                    loading = saving,
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
         }

--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileData.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileData.kt
@@ -27,6 +27,9 @@ data class ProfileData(
     val neighborhood: String? = null,
     val extraAddress: String? = null,
 
+    val profileVisibility: String? = null,
+    val healthInfoVisibility: String? = null,
+    val locationVisibility: String? = null,
     val shareLocation: Boolean? = null,
     val sharedLatitude: Double? = null,
     val sharedLongitude: Double? = null

--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
@@ -201,6 +201,9 @@ object ProfileRepository {
                 method = "PATCH",
                 token = token,
                 body = JSONObject().apply {
+                    put("profileVisibility", normalizedProfile.profileVisibility ?: "PRIVATE")
+                    put("healthInfoVisibility", normalizedProfile.healthInfoVisibility ?: "PRIVATE")
+                    put("locationVisibility", normalizedProfile.locationVisibility ?: "PRIVATE")
                     put("locationSharingEnabled", profile.shareLocation ?: false)
                 }
             )
@@ -255,6 +258,38 @@ object ProfileRepository {
         val hasFreshCurrentCoordinates = currentDeviceLocation != null
 
         return !hasTrustedSavedCoordinates && !hasFreshCurrentCoordinates
+    }
+
+    suspend fun syncPrivacySettings(
+        profileVisibility: String,
+        healthInfoVisibility: String,
+        locationVisibility: String,
+        locationSharingEnabled: Boolean
+    ): ProfileData {
+        ensureInitialized()
+
+        val token = AuthSessionStore.getAccessToken().orEmpty()
+        check(token.isNotBlank()) { "Access token is required before saving privacy settings." }
+
+        val response = JsonHttpClient.request(
+            path = "/profiles/me/privacy",
+            method = "PATCH",
+            token = token,
+            body = JSONObject().apply {
+                put("profileVisibility", normalizeVisibility(profileVisibility))
+                put("healthInfoVisibility", normalizeVisibility(healthInfoVisibility))
+                put("locationVisibility", normalizeVisibility(locationVisibility))
+                put("locationSharingEnabled", locationSharingEnabled)
+            }
+        )
+
+        val updated = mapBackendProfile(
+            profileJson = response,
+            email = cachedProfile.email.orEmpty(),
+            cachedProfileSnapshot = cachedProfile
+        )
+        saveProfile(updated)
+        return updated
     }
 
     private suspend fun hasTrustedRemoteSharedCoordinates(token: String): Boolean {
@@ -417,6 +452,9 @@ object ProfileRepository {
             putString("district", profile.district)
             putString("neighborhood", profile.neighborhood)
             putString("extraAddress", profile.extraAddress)
+            putString("profileVisibility", normalizeVisibility(profile.profileVisibility))
+            putString("healthInfoVisibility", normalizeVisibility(profile.healthInfoVisibility))
+            putString("locationVisibility", normalizeVisibility(profile.locationVisibility))
             putBoolean("shareLocation", profile.shareLocation ?: false)
             putString("sharedLatitude", profile.sharedLatitude?.toString())
             putString("sharedLongitude", profile.sharedLongitude?.toString())
@@ -462,6 +500,9 @@ object ProfileRepository {
             district = prefs.getString("district", null),
             neighborhood = prefs.getString("neighborhood", null),
             extraAddress = prefs.getString("extraAddress", null),
+            profileVisibility = normalizeVisibility(prefs.getString("profileVisibility", null)),
+            healthInfoVisibility = normalizeVisibility(prefs.getString("healthInfoVisibility", null)),
+            locationVisibility = normalizeVisibility(prefs.getString("locationVisibility", null)),
             shareLocation = if (prefs.contains("shareLocation")) prefs.getBoolean("shareLocation", false) else null,
             sharedLatitude = prefs.getString("sharedLatitude", null)?.toDoubleOrNull(),
             sharedLongitude = prefs.getString("sharedLongitude", null)?.toDoubleOrNull()
@@ -546,6 +587,9 @@ object ProfileRepository {
                 .takeIf { it.isNotBlank() },
             extraAddress = extraAddressFromBackend
                 ?: cachedProfileSnapshot.extraAddress,
+            profileVisibility = normalizeVisibility(privacySettings.optStringOrNull("profileVisibility")),
+            healthInfoVisibility = normalizeVisibility(privacySettings.optStringOrNull("healthInfoVisibility")),
+            locationVisibility = normalizeVisibility(privacySettings.optStringOrNull("locationVisibility")),
             shareLocation = privacySettings.optNullableBoolean("locationSharingEnabled"),
             sharedLatitude = sharedLatitude,
             sharedLongitude = sharedLongitude
@@ -658,6 +702,14 @@ object ProfileRepository {
 
     private fun JSONObject.optNullableDouble(key: String): Double? {
         return if (has(key) && !isNull(key)) optDouble(key) else null
+    }
+
+    private fun normalizeVisibility(value: String?): String {
+        return when (value?.uppercase(Locale.ROOT)) {
+            "PUBLIC" -> "PUBLIC"
+            "EMERGENCY_ONLY" -> "EMERGENCY_ONLY"
+            else -> "PRIVATE"
+        }
     }
 
     private fun ensureInitialized() {

--- a/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
@@ -385,6 +385,9 @@ fun AppNavGraph(
             PrivacySecurityScreen(
                 onNavigateBack = {
                     navController.popBackStack()
+                },
+                onResetPassword = {
+                    navController.navigate(Routes.ForgotPassword.route)
                 }
             )
         }

--- a/web/src/components/feature/settings/PrivacySecurityView.tsx
+++ b/web/src/components/feature/settings/PrivacySecurityView.tsx
@@ -108,7 +108,7 @@ export default function PrivacySecurityView() {
             setError("");
             setInfo("");
 
-            if (!initialShareLocation && shareLocation && !locationPreview) {
+            if (!initialShareLocation && shareLocation) {
                 setError(
                     "To enable Share Current Location, go to Profile, click Use Current Location, and save there first."
                 );

--- a/web/src/components/feature/settings/PrivacySecurityView.tsx
+++ b/web/src/components/feature/settings/PrivacySecurityView.tsx
@@ -6,6 +6,7 @@ import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
 import { HelperText } from "@/components/ui/display/HelperText";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { SectionHeader } from "@/components/ui/display/SectionHeader";
+import { RadioGroup } from "@/components/ui/selection/RadioGroup";
 import { ToggleSwitch } from "@/components/ui/selection/ToggleSwitch";
 import { clearAccessToken, getAccessToken } from "@/lib/auth";
 import { ApiError } from "@/lib/api";
@@ -17,12 +18,21 @@ const DEFAULT_MAP_CENTER = {
     longitude: 28.9784,
 };
 
+const visibilityOptions = [
+    { label: "Private", value: "PRIVATE" },
+    { label: "Emergency only", value: "EMERGENCY_ONLY" },
+    { label: "Public", value: "PUBLIC" },
+];
+
 export default function PrivacySecurityView() {
     const router = useRouter();
     const pathname = usePathname();
 
     const [loading, setLoading] = React.useState(true);
     const [saving, setSaving] = React.useState(false);
+    const [profileVisibility, setProfileVisibility] = React.useState("PRIVATE");
+    const [healthInfoVisibility, setHealthInfoVisibility] = React.useState("PRIVATE");
+    const [locationVisibility, setLocationVisibility] = React.useState("PRIVATE");
     const [shareLocation, setShareLocation] = React.useState(false);
     const [initialShareLocation, setInitialShareLocation] = React.useState(false);
     const [locationPreview, setLocationPreview] = React.useState<{
@@ -49,6 +59,9 @@ export default function PrivacySecurityView() {
 
             try {
                 const profile = await fetchMyProfile(token);
+                setProfileVisibility(profile.privacySettings.profileVisibility || "PRIVATE");
+                setHealthInfoVisibility(profile.privacySettings.healthInfoVisibility || "PRIVATE");
+                setLocationVisibility(profile.privacySettings.locationVisibility || "PRIVATE");
                 setShareLocation(profile.privacySettings.locationSharingEnabled);
                 setInitialShareLocation(profile.privacySettings.locationSharingEnabled);
 
@@ -95,7 +108,7 @@ export default function PrivacySecurityView() {
             setError("");
             setInfo("");
 
-            if (!initialShareLocation && shareLocation) {
+            if (!initialShareLocation && shareLocation && !locationPreview) {
                 setError(
                     "To enable Share Current Location, go to Profile, click Use Current Location, and save there first."
                 );
@@ -103,9 +116,13 @@ export default function PrivacySecurityView() {
             }
 
             await patchMyPrivacy(token, {
+                profileVisibility,
+                healthInfoVisibility,
+                locationVisibility,
                 locationSharingEnabled: shareLocation,
             });
 
+            setInitialShareLocation(shareLocation);
             setInfo("Privacy settings updated successfully.");
         } catch (err) {
             if (err instanceof ApiError && err.status === 401) {
@@ -137,10 +154,39 @@ export default function PrivacySecurityView() {
             <SectionCard>
                 <SectionHeader
                     title="Privacy"
-                    subtitle="Control the account settings the backend currently supports."
+                    subtitle="Choose who can see profile, health, and location details."
                 />
 
-                <div className="mt-4 flex items-center justify-between gap-4">
+                <div className="mt-4 grid gap-5">
+                    <RadioGroup
+                        label="Profile visibility"
+                        name="profileVisibility"
+                        value={profileVisibility}
+                        options={visibilityOptions}
+                        onValueChange={setProfileVisibility}
+                        direction="column"
+                    />
+
+                    <RadioGroup
+                        label="Health information visibility"
+                        name="healthInfoVisibility"
+                        value={healthInfoVisibility}
+                        options={visibilityOptions}
+                        onValueChange={setHealthInfoVisibility}
+                        direction="column"
+                    />
+
+                    <RadioGroup
+                        label="Saved location visibility"
+                        name="locationVisibility"
+                        value={locationVisibility}
+                        options={visibilityOptions}
+                        onValueChange={setLocationVisibility}
+                        direction="column"
+                    />
+                </div>
+
+                <div className="mt-5 flex items-center justify-between gap-4 border-t border-gray-100 pt-5">
                     <div>
                         <p className="text-sm font-medium text-[color:var(--text-primary)]">
                             Share Current Location
@@ -159,7 +205,7 @@ export default function PrivacySecurityView() {
                 </div>
 
                 <div className="mt-5 flex justify-end">
-                    <PrimaryButton onClick={handleSave} loading={saving}>
+                    <PrimaryButton className="w-auto" onClick={handleSave} loading={saving}>
                         Save Privacy Settings
                     </PrimaryButton>
                 </div>

--- a/web/src/lib/profile.ts
+++ b/web/src/lib/profile.ts
@@ -320,7 +320,12 @@ export async function patchMyLocation(
 
 export async function patchMyPrivacy(
     token: string,
-    payload: { locationSharingEnabled?: boolean }
+    payload: {
+        profileVisibility?: string;
+        healthInfoVisibility?: string;
+        locationVisibility?: string;
+        locationSharingEnabled?: boolean;
+    }
 ) {
     return apiRequest<BackendProfileResponse>("/profiles/me/privacy", {
         method: "PATCH",


### PR DESCRIPTION
Related to [#285](https://github.com/bounswe/bounswe2026group6/issues/285).

I have implemented the Privacy & Security settings page on both web and mobile platforms, ensuring full
  parity with the backend's privacy model.

  ### Key Changes

  **1. Data Model & Backend Integration**
   - Web: Updated BackendProfileResponse and EditableProfileData in web/src/lib/profile.ts to include
     profileVisibility, healthInfoVisibility, and locationVisibility.
   - Mobile: Updated ProfileData.kt and ProfileRepository.kt to support the three visibility fields and
     ensure they are persisted to SharedPreferences and synced with the backend.

  **2. Web Implementation**
   - UI Enhancement: Updated PrivacySecurityView.tsx to include RadioGroup controls for Profile, Health, and
     Location visibility (Public, Emergency Only, Private).
   - Styling: Migrated hardcoded colors to project-specific CSS tokens (--primary-500) for the ToggleSwitch
     and RadioGroup components.
   - Persistence: Wired the new visibility states to the patchMyPrivacy API call.

  **3. Mobile (Android) Implementation**
   - Feature Completion: Replaced the placeholder PrivacySecurityScreen.kt with a fully functional
     implementation using Jetpack Compose.
   - Controls: Added AppRadioGroup for visibility levels and AppToggleSwitch for location sharing.
   - Security: Integrated a "Reset your password" action that navigates to the ForgotPassword route.
   - Navigation: Updated AppNavGraph.kt to correctly wire the new screen and its dependencies.

  ### Acceptance Criteria Verified
   - [x] Privacy & security page exists on web and mobile: Both platforms now have a dedicated settings
     view.
   - [x] Relevant settings are saved and retrieved correctly: All four privacy fields (3 visibility levels +
     1 sharing toggle) are synced across platforms via the backend.
   - [x] Location/privacy-related controls behave consistently: Both platforms use identical visibility
     options and share a common persistence logic.