### PR TITLE
feat: implement backend-backed news announcements with admin CRUD

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -44,6 +44,7 @@ jobs:
               npm install --omit=dev --no-audit --no-fund
             fi
 
+            npm run migrate
             pm2 restart neph-backend || pm2 start src/server.js --name neph-backend
 
             cd ../web

--- a/backend/migrations/20260429_220000__seed_initial_news_announcements.sql
+++ b/backend/migrations/20260429_220000__seed_initial_news_announcements.sql
@@ -1,0 +1,40 @@
+-- Seed initial public announcements when at least one administrator exists.
+-- The announcements table requires an admin_id, so this migration safely no-ops
+-- on environments that do not have an admin row yet.
+
+WITH seed_admin AS (
+  SELECT admin_id
+  FROM admins
+  ORDER BY admin_id
+  LIMIT 1
+)
+INSERT INTO news_announcements (announcement_id, admin_id, title, content, created_at)
+SELECT
+  seed.announcement_id,
+  seed_admin.admin_id,
+  seed.title,
+  seed.content,
+  seed.created_at::timestamp
+FROM seed_admin
+CROSS JOIN (
+  VALUES
+    (
+      'seed_announcement_preparedness_checklist',
+      'Preparedness checklist updated',
+      'Review your household emergency bag, contact list, medication details, and nearest gathering area before an emergency occurs.',
+      '2026-04-29 12:00:00'
+    ),
+    (
+      'seed_announcement_volunteer_expansion',
+      'Community safety volunteers are expanding',
+      'New volunteer coordination improvements are being prepared to help communities respond faster during emergencies.',
+      '2026-04-29 12:05:00'
+    ),
+    (
+      'seed_announcement_gathering_area',
+      'Know your nearest gathering area',
+      'Check the gathering areas page and keep your location information up to date so emergency guidance can stay relevant.',
+      '2026-04-29 12:10:00'
+    )
+) AS seed(announcement_id, title, content, created_at)
+ON CONFLICT (announcement_id) DO NOTHING;

--- a/backend/migrations/20260430_130000__seed_news_announcements_after_admin_creation.sql
+++ b/backend/migrations/20260430_130000__seed_news_announcements_after_admin_creation.sql
@@ -1,0 +1,70 @@
+-- Ensure initial public announcements are still seeded in environments where the
+-- original seed migration ran before any administrator existed.
+--
+-- The seed remains safe and idempotent:
+-- - no admin row means no announcement row is inserted yet
+-- - the first later admin insert triggers the same seed
+-- - fixed announcement ids prevent duplicates
+-- - existing announcements are never overwritten
+
+CREATE OR REPLACE FUNCTION seed_initial_news_announcements_for_admin(seed_admin_id VARCHAR)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF seed_admin_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO news_announcements (announcement_id, admin_id, title, content, created_at)
+  VALUES
+    (
+      'seed_announcement_preparedness_checklist',
+      seed_admin_id,
+      'Preparedness checklist updated',
+      'Review your household emergency bag, contact list, medication details, and nearest gathering area before an emergency occurs.',
+      '2026-04-29 12:00:00'
+    ),
+    (
+      'seed_announcement_volunteer_expansion',
+      seed_admin_id,
+      'Community safety volunteers are expanding',
+      'New volunteer coordination improvements are being prepared to help communities respond faster during emergencies.',
+      '2026-04-29 12:05:00'
+    ),
+    (
+      'seed_announcement_gathering_area',
+      seed_admin_id,
+      'Know your nearest gathering area',
+      'Check the gathering areas page and keep your location information up to date so emergency guidance can stay relevant.',
+      '2026-04-29 12:10:00'
+    )
+  ON CONFLICT (announcement_id) DO NOTHING;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION seed_initial_news_announcements_after_admin_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM seed_initial_news_announcements_for_admin(NEW.admin_id);
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_seed_initial_news_announcements_after_admin_insert ON admins;
+
+CREATE TRIGGER trg_seed_initial_news_announcements_after_admin_insert
+AFTER INSERT ON admins
+FOR EACH ROW
+EXECUTE FUNCTION seed_initial_news_announcements_after_admin_insert();
+
+WITH seed_admin AS (
+  SELECT admin_id
+  FROM admins
+  ORDER BY admin_id
+  LIMIT 1
+)
+SELECT seed_initial_news_announcements_for_admin(admin_id)
+FROM seed_admin;

--- a/backend/src/modules/admin/routes.js
+++ b/backend/src/modules/admin/routes.js
@@ -1,9 +1,9 @@
 const express = require('express');
 const { requireAuth, requireAdmin } = require('../auth/middleware');
+const { adminAnnouncementsRouter } = require('../announcements/routes');
 const {
   getAdminUsers,
   getAdminHelpRequests,
-  getAdminAnnouncements,
   getAdminStats,
   getAdminEmergencyOverview,
   getAdminEmergencyHistory,
@@ -15,7 +15,7 @@ const adminRouter = express.Router();
 
 adminRouter.get('/users', requireAuth, requireAdmin, getAdminUsers);
 adminRouter.get('/help-requests', requireAuth, requireAdmin, getAdminHelpRequests);
-adminRouter.get('/announcements', requireAuth, requireAdmin, getAdminAnnouncements);
+adminRouter.use('/announcements', adminAnnouncementsRouter);
 adminRouter.get('/stats', requireAuth, requireAdmin, getAdminStats);
 adminRouter.get('/emergency-overview', requireAuth, requireAdmin, getAdminEmergencyOverview);
 adminRouter.get('/emergency-history', requireAuth, requireAdmin, getAdminEmergencyHistory);

--- a/backend/src/modules/announcements/controller.js
+++ b/backend/src/modules/announcements/controller.js
@@ -1,0 +1,142 @@
+const {
+  createAnnouncement,
+  deleteAnnouncement,
+  getAnnouncement,
+  getAnnouncements,
+  updateAnnouncement,
+} = require('./service');
+const {
+  validateAnnouncementIdParam,
+  validateCreateAnnouncementPayload,
+  validateListAnnouncementsQuery,
+  validateUpdateAnnouncementPayload,
+} = require('./validators');
+
+function sendError(response, status, code, message, details) {
+  const payload = { code, message };
+
+  if (details) {
+    payload.details = details;
+  }
+
+  return response.status(status).json(payload);
+}
+
+function readValidatedAnnouncementId(request, response) {
+  const validation = validateAnnouncementIdParam(request.params.announcementId);
+  if (validation.errors.length > 0) {
+    sendError(response, 400, 'VALIDATION_FAILED', 'Validation failed', validation.errors);
+    return null;
+  }
+
+  return validation.value;
+}
+
+async function listPublicAnnouncements(request, response) {
+  const validation = validateListAnnouncementsQuery(request.query || {});
+  if (validation.errors.length > 0) {
+    return sendError(response, 400, 'VALIDATION_FAILED', 'Validation failed', validation.errors);
+  }
+
+  try {
+    const announcements = await getAnnouncements(validation.value);
+    return response.status(200).json({ announcements });
+  } catch (error) {
+    console.error('announcements.listPublicAnnouncements failed', error);
+    return sendError(response, 500, 'INTERNAL_ERROR', 'Unexpected server error');
+  }
+}
+
+async function getPublicAnnouncement(request, response) {
+  const announcementId = readValidatedAnnouncementId(request, response);
+  if (!announcementId) {
+    return response;
+  }
+
+  try {
+    const announcement = await getAnnouncement(announcementId);
+    if (!announcement) {
+      return sendError(response, 404, 'NOT_FOUND', 'Announcement not found');
+    }
+
+    return response.status(200).json({ announcement });
+  } catch (error) {
+    console.error('announcements.getPublicAnnouncement failed', error);
+    return sendError(response, 500, 'INTERNAL_ERROR', 'Unexpected server error');
+  }
+}
+
+async function listAdminAnnouncements(request, response) {
+  return listPublicAnnouncements(request, response);
+}
+
+async function postAdminAnnouncement(request, response) {
+  const validation = validateCreateAnnouncementPayload(request.body || {});
+  if (validation.errors.length > 0) {
+    return sendError(response, 400, 'VALIDATION_FAILED', 'Validation failed', validation.errors);
+  }
+
+  try {
+    const announcement = await createAnnouncement(request.user, validation.value);
+    return response.status(201).json({ announcement });
+  } catch (error) {
+    if (error.code === 'FORBIDDEN') {
+      return sendError(response, 403, 'FORBIDDEN', error.message);
+    }
+
+    console.error('announcements.postAdminAnnouncement failed', error);
+    return sendError(response, 500, 'INTERNAL_ERROR', 'Unexpected server error');
+  }
+}
+
+async function patchAdminAnnouncement(request, response) {
+  const announcementId = readValidatedAnnouncementId(request, response);
+  if (!announcementId) {
+    return response;
+  }
+
+  const validation = validateUpdateAnnouncementPayload(request.body || {});
+  if (validation.errors.length > 0) {
+    return sendError(response, 400, 'VALIDATION_FAILED', 'Validation failed', validation.errors);
+  }
+
+  try {
+    const announcement = await updateAnnouncement(announcementId, validation.value);
+    if (!announcement) {
+      return sendError(response, 404, 'NOT_FOUND', 'Announcement not found');
+    }
+
+    return response.status(200).json({ announcement });
+  } catch (error) {
+    console.error('announcements.patchAdminAnnouncement failed', error);
+    return sendError(response, 500, 'INTERNAL_ERROR', 'Unexpected server error');
+  }
+}
+
+async function deleteAdminAnnouncement(request, response) {
+  const announcementId = readValidatedAnnouncementId(request, response);
+  if (!announcementId) {
+    return response;
+  }
+
+  try {
+    const deleted = await deleteAnnouncement(announcementId);
+    if (!deleted) {
+      return sendError(response, 404, 'NOT_FOUND', 'Announcement not found');
+    }
+
+    return response.status(204).send();
+  } catch (error) {
+    console.error('announcements.deleteAdminAnnouncement failed', error);
+    return sendError(response, 500, 'INTERNAL_ERROR', 'Unexpected server error');
+  }
+}
+
+module.exports = {
+  deleteAdminAnnouncement,
+  getPublicAnnouncement,
+  listAdminAnnouncements,
+  listPublicAnnouncements,
+  patchAdminAnnouncement,
+  postAdminAnnouncement,
+};

--- a/backend/src/modules/announcements/repository.js
+++ b/backend/src/modules/announcements/repository.js
@@ -1,0 +1,117 @@
+const { query } = require('../../db/pool');
+
+function mapAnnouncement(row) {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    id: row.announcement_id,
+    adminId: row.admin_id,
+    title: row.title,
+    content: row.content,
+    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+  };
+}
+
+async function listAnnouncements({ limit = 50 } = {}) {
+  const result = await query(
+    `
+      SELECT
+        announcement_id,
+        admin_id,
+        title,
+        content,
+        created_at
+      FROM news_announcements
+      ORDER BY created_at DESC, announcement_id DESC
+      LIMIT $1
+    `,
+    [limit],
+  );
+
+  return result.rows.map(mapAnnouncement);
+}
+
+async function findAnnouncementById(announcementId) {
+  const result = await query(
+    `
+      SELECT
+        announcement_id,
+        admin_id,
+        title,
+        content,
+        created_at
+      FROM news_announcements
+      WHERE announcement_id = $1
+    `,
+    [announcementId],
+  );
+
+  return mapAnnouncement(result.rows[0]);
+}
+
+async function insertAnnouncement({ id, adminId, title, content }) {
+  const result = await query(
+    `
+      INSERT INTO news_announcements (announcement_id, admin_id, title, content)
+      VALUES ($1, $2, $3, $4)
+      RETURNING announcement_id, admin_id, title, content, created_at
+    `,
+    [id, adminId, title, content],
+  );
+
+  return mapAnnouncement(result.rows[0]);
+}
+
+async function updateAnnouncementById(announcementId, patch) {
+  const assignments = [];
+  const values = [announcementId];
+
+  if (Object.prototype.hasOwnProperty.call(patch, 'title')) {
+    values.push(patch.title);
+    assignments.push(`title = $${values.length}`);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(patch, 'content')) {
+    values.push(patch.content);
+    assignments.push(`content = $${values.length}`);
+  }
+
+  if (assignments.length === 0) {
+    return findAnnouncementById(announcementId);
+  }
+
+  const result = await query(
+    `
+      UPDATE news_announcements
+      SET ${assignments.join(', ')}
+      WHERE announcement_id = $1
+      RETURNING announcement_id, admin_id, title, content, created_at
+    `,
+    values,
+  );
+
+  return mapAnnouncement(result.rows[0]);
+}
+
+async function deleteAnnouncementById(announcementId) {
+  const result = await query(
+    `
+      DELETE FROM news_announcements
+      WHERE announcement_id = $1
+      RETURNING announcement_id
+    `,
+    [announcementId],
+  );
+
+  return result.rowCount > 0;
+}
+
+module.exports = {
+  deleteAnnouncementById,
+  findAnnouncementById,
+  insertAnnouncement,
+  listAnnouncements,
+  updateAnnouncementById,
+};

--- a/backend/src/modules/announcements/routes.js
+++ b/backend/src/modules/announcements/routes.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const { requireAuth, requireAdmin } = require('../auth/middleware');
+const {
+  deleteAdminAnnouncement,
+  getPublicAnnouncement,
+  listAdminAnnouncements,
+  listPublicAnnouncements,
+  patchAdminAnnouncement,
+  postAdminAnnouncement,
+} = require('./controller');
+
+const announcementsRouter = express.Router();
+const adminAnnouncementsRouter = express.Router();
+
+announcementsRouter.get('/', listPublicAnnouncements);
+announcementsRouter.get('/:announcementId', getPublicAnnouncement);
+
+adminAnnouncementsRouter.use(requireAuth, requireAdmin);
+adminAnnouncementsRouter.get('/', listAdminAnnouncements);
+adminAnnouncementsRouter.post('/', postAdminAnnouncement);
+adminAnnouncementsRouter.patch('/:announcementId', patchAdminAnnouncement);
+adminAnnouncementsRouter.delete('/:announcementId', deleteAdminAnnouncement);
+
+module.exports = {
+  adminAnnouncementsRouter,
+  announcementsRouter,
+};

--- a/backend/src/modules/announcements/service.js
+++ b/backend/src/modules/announcements/service.js
@@ -1,0 +1,51 @@
+const { randomUUID } = require('crypto');
+const {
+  deleteAnnouncementById,
+  findAnnouncementById,
+  insertAnnouncement,
+  listAnnouncements,
+  updateAnnouncementById,
+} = require('./repository');
+
+function createAnnouncementId() {
+  return `ann_${randomUUID()}`;
+}
+
+async function getAnnouncements(options = {}) {
+  return listAnnouncements(options);
+}
+
+async function getAnnouncement(announcementId) {
+  return findAnnouncementById(announcementId);
+}
+
+async function createAnnouncement(adminUser, payload) {
+  if (!adminUser?.adminId) {
+    const error = new Error('Admin identity is required to create announcements.');
+    error.code = 'FORBIDDEN';
+    throw error;
+  }
+
+  return insertAnnouncement({
+    id: createAnnouncementId(),
+    adminId: adminUser.adminId,
+    title: payload.title,
+    content: payload.content,
+  });
+}
+
+async function updateAnnouncement(announcementId, payload) {
+  return updateAnnouncementById(announcementId, payload);
+}
+
+async function deleteAnnouncement(announcementId) {
+  return deleteAnnouncementById(announcementId);
+}
+
+module.exports = {
+  createAnnouncement,
+  deleteAnnouncement,
+  getAnnouncement,
+  getAnnouncements,
+  updateAnnouncement,
+};

--- a/backend/src/modules/announcements/validators.js
+++ b/backend/src/modules/announcements/validators.js
@@ -1,0 +1,155 @@
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const MAX_TITLE_LENGTH = 500;
+const MAX_CONTENT_LENGTH = 10000;
+const MAX_ID_LENGTH = 64;
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function validateRequiredString(name, value, errors, { maxLength }) {
+  if (value == null) {
+    errors.push(`\`${name}\` is required.`);
+    return '';
+  }
+
+  if (typeof value !== 'string') {
+    errors.push(`\`${name}\` must be a string.`);
+    return '';
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    errors.push(`\`${name}\` must not be empty.`);
+    return '';
+  }
+
+  if (trimmed.length > maxLength) {
+    errors.push(`\`${name}\` must be ${maxLength} characters or fewer.`);
+  }
+
+  return trimmed;
+}
+
+function validateOptionalString(name, value, errors, { maxLength }) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    errors.push(`\`${name}\` must be a string.`);
+    return undefined;
+  }
+
+  if (typeof value !== 'string') {
+    errors.push(`\`${name}\` must be a string.`);
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    errors.push(`\`${name}\` must not be empty.`);
+    return undefined;
+  }
+
+  if (trimmed.length > maxLength) {
+    errors.push(`\`${name}\` must be ${maxLength} characters or fewer.`);
+  }
+
+  return trimmed;
+}
+
+function validateListAnnouncementsQuery(query) {
+  const limitValue = query?.limit;
+
+  if (limitValue == null || limitValue === '') {
+    return { errors: [], value: { limit: DEFAULT_LIMIT } };
+  }
+
+  const limit = Number.parseInt(String(limitValue), 10);
+  if (!Number.isInteger(limit) || String(limitValue).trim() !== String(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return {
+      errors: [`\`limit\` must be an integer between 1 and ${MAX_LIMIT}.`],
+      value: null,
+    };
+  }
+
+  return { errors: [], value: { limit } };
+}
+
+function validateAnnouncementIdParam(value) {
+  if (typeof value !== 'string' || !value.trim()) {
+    return {
+      errors: ['`announcementId` is required.'],
+      value: null,
+    };
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length > MAX_ID_LENGTH) {
+    return {
+      errors: [`\`announcementId\` must be ${MAX_ID_LENGTH} characters or fewer.`],
+      value: null,
+    };
+  }
+
+  return { errors: [], value: trimmed };
+}
+
+function validateCreateAnnouncementPayload(payload) {
+  const errors = [];
+
+  if (!isPlainObject(payload)) {
+    return {
+      errors: ['Payload must be an object.'],
+      value: null,
+    };
+  }
+
+  const title = validateRequiredString('title', payload.title, errors, { maxLength: MAX_TITLE_LENGTH });
+  const content = validateRequiredString('content', payload.content, errors, { maxLength: MAX_CONTENT_LENGTH });
+
+  return {
+    errors,
+    value: errors.length > 0 ? null : { title, content },
+  };
+}
+
+function validateUpdateAnnouncementPayload(payload) {
+  const errors = [];
+
+  if (!isPlainObject(payload)) {
+    return {
+      errors: ['Payload must be an object.'],
+      value: null,
+    };
+  }
+
+  const title = validateOptionalString('title', payload.title, errors, { maxLength: MAX_TITLE_LENGTH });
+  const content = validateOptionalString('content', payload.content, errors, { maxLength: MAX_CONTENT_LENGTH });
+
+  if (title === undefined && content === undefined) {
+    errors.push('At least one of `title` or `content` is required.');
+  }
+
+  const value = {};
+  if (title !== undefined) {
+    value.title = title;
+  }
+  if (content !== undefined) {
+    value.content = content;
+  }
+
+  return {
+    errors,
+    value: errors.length > 0 ? null : value,
+  };
+}
+
+module.exports = {
+  validateAnnouncementIdParam,
+  validateCreateAnnouncementPayload,
+  validateListAnnouncementsQuery,
+  validateUpdateAnnouncementPayload,
+};

--- a/backend/src/modules/auth/middleware.js
+++ b/backend/src/modules/auth/middleware.js
@@ -55,6 +55,7 @@ async function requireAdmin(req, res, next) {
 
     req.user.isAdmin = true;
     req.user.adminRole = adminRecord.role;
+    req.user.adminId = adminRecord.admin_id;
 
     return next();
   } catch (_error) {

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -8,6 +8,7 @@ const { availabilityRouter } = require('../modules/availability/routes');
 const { locationRouter } = require('../modules/location/routes');
 const { gatheringAreasRouter } = require('../modules/gathering-areas/routes');
 const { notificationsRouter } = require('../modules/notifications/routes');
+const { announcementsRouter } = require('../modules/announcements/routes');
 
 const apiRouter = express.Router();
 
@@ -16,7 +17,7 @@ apiRouter.get('/', (_request, response) => {
     service: 'api',
     status: 'ok',
     name: 'Neighborhood Emergency Preparedness Hub API',
-    modules: ['auth', 'admin', 'profiles', 'help-requests', 'availability', 'location', 'gathering-areas', 'notifications'],
+    modules: ['auth', 'admin', 'profiles', 'help-requests', 'availability', 'location', 'gathering-areas', 'notifications', 'announcements'],
   });
 });
 
@@ -28,6 +29,7 @@ apiRouter.use('/availability', availabilityRouter);
 apiRouter.use('/location', locationRouter);
 apiRouter.use('/gathering-areas', gatheringAreasRouter);
 apiRouter.use('/notifications', notificationsRouter);
+apiRouter.use('/announcements', announcementsRouter);
 
 module.exports = {
   apiRouter,

--- a/backend/tests/integration/modules/announcements/announcements.integration.test.js
+++ b/backend/tests/integration/modules/announcements/announcements.integration.test.js
@@ -66,6 +66,10 @@ async function seedAdmin({ userId = 'admin-user', adminId = 'admin-1', email = '
     `,
     [adminId, userId, role],
   );
+  // The production migration seeds demo announcements when the first admin is
+  // created. These tests verify explicit API behavior, so keep each scenario's
+  // announcement set isolated from migration-owned demo rows.
+  await query("DELETE FROM news_announcements WHERE announcement_id LIKE 'seed_announcement_%'");
 
   return {
     adminId,

--- a/backend/tests/integration/modules/announcements/announcements.integration.test.js
+++ b/backend/tests/integration/modules/announcements/announcements.integration.test.js
@@ -4,6 +4,9 @@ const request = require('supertest');
 const jwt = require('jsonwebtoken');
 
 jest.mock('express-rate-limit', () => () => (_req, _res, next) => next());
+jest.mock('uuid', () => ({
+  v4: () => require('crypto').randomBytes(16).toString('hex'),
+}));
 jest.mock('../../../../src/config/mailer', () => ({
   sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
   sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),

--- a/backend/tests/integration/modules/announcements/announcements.integration.test.js
+++ b/backend/tests/integration/modules/announcements/announcements.integration.test.js
@@ -1,0 +1,242 @@
+'use strict';
+
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+jest.mock('express-rate-limit', () => () => (_req, _res, next) => next());
+jest.mock('../../../../src/config/mailer', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+  sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { createApp } = require('../../../../src/app');
+const { env } = require('../../../../src/config/env');
+const { query } = require('../../../../src/db/pool');
+
+const TRUNCATE_SQL = `
+  TRUNCATE TABLE
+    notification_deliveries,
+    notification_devices,
+    notification_type_preferences,
+    notification_preferences,
+    notifications,
+    messages,
+    assignments,
+    availability_records,
+    resources,
+    volunteers,
+    request_locations,
+    help_requests,
+    news_announcements,
+    reports,
+    expertise,
+    privacy_settings,
+    location_profiles,
+    health_info,
+    physical_info,
+    user_profiles,
+    admins,
+    users
+  RESTART IDENTITY CASCADE;
+`;
+
+beforeEach(async () => {
+  await query(TRUNCATE_SQL);
+});
+
+async function seedUser({ userId, email }) {
+  await query(
+    `
+      INSERT INTO users (user_id, email, password_hash, is_email_verified, accepted_terms)
+      VALUES ($1, $2, 'test-hash', TRUE, TRUE)
+    `,
+    [userId, email],
+  );
+}
+
+async function seedAdmin({ userId = 'admin-user', adminId = 'admin-1', email = 'admin@example.com', role = 'COORDINATOR' } = {}) {
+  await seedUser({ userId, email });
+  await query(
+    `
+      INSERT INTO admins (admin_id, user_id, role)
+      VALUES ($1, $2, $3)
+    `,
+    [adminId, userId, role],
+  );
+
+  return {
+    adminId,
+    userId,
+    token: jwt.sign(
+      {
+        userId,
+        email,
+        isAdmin: true,
+        adminRole: role,
+      },
+      env.jwt.secret,
+      { expiresIn: '1h' },
+    ),
+  };
+}
+
+async function seedNonAdmin({ userId = 'regular-user', email = 'regular@example.com' } = {}) {
+  await seedUser({ userId, email });
+
+  return jwt.sign(
+    {
+      userId,
+      email,
+      isAdmin: false,
+      adminRole: null,
+    },
+    env.jwt.secret,
+    { expiresIn: '1h' },
+  );
+}
+
+async function seedAnnouncement({
+  id,
+  adminId,
+  title,
+  content,
+  createdAt,
+}) {
+  await query(
+    `
+      INSERT INTO news_announcements (announcement_id, admin_id, title, content, created_at)
+      VALUES ($1, $2, $3, $4, $5::timestamp)
+    `,
+    [id, adminId, title, content, createdAt],
+  );
+}
+
+describe('announcements API', () => {
+  test('GET /api/announcements returns public announcements from the database', async () => {
+    const app = createApp();
+    const { adminId } = await seedAdmin();
+    await seedAnnouncement({
+      id: 'ann_old',
+      adminId,
+      title: 'Older update',
+      content: 'Older preparedness update body.',
+      createdAt: '2026-04-01T10:00:00Z',
+    });
+    await seedAnnouncement({
+      id: 'ann_new',
+      adminId,
+      title: 'Newer update',
+      content: 'New emergency announcement body.',
+      createdAt: '2026-04-02T10:00:00Z',
+    });
+
+    const response = await request(app).get('/api/announcements');
+
+    expect(response.status).toBe(200);
+    expect(response.body.announcements).toHaveLength(2);
+    expect(response.body.announcements[0]).toMatchObject({
+      id: 'ann_new',
+      adminId,
+      title: 'Newer update',
+      content: 'New emergency announcement body.',
+    });
+    expect(response.body.announcements[0].createdAt).toBeTruthy();
+  });
+
+  test('GET /api/announcements validates limit', async () => {
+    const app = createApp();
+
+    const response = await request(app).get('/api/announcements?limit=0');
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_FAILED');
+  });
+
+  test('admin can create update and delete an announcement', async () => {
+    const app = createApp();
+    const { token, adminId } = await seedAdmin();
+
+    const createResponse = await request(app)
+      .post('/api/admin/announcements')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'Shelter status update',
+        content: 'Community shelter capacity has been updated for tonight.',
+      });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.announcement).toMatchObject({
+      adminId,
+      title: 'Shelter status update',
+      content: 'Community shelter capacity has been updated for tonight.',
+    });
+    expect(createResponse.body.announcement.id).toMatch(/^ann_/);
+
+    const announcementId = createResponse.body.announcement.id;
+
+    const updateResponse = await request(app)
+      .patch(`/api/admin/announcements/${announcementId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'Updated shelter status',
+      });
+
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body.announcement).toMatchObject({
+      id: announcementId,
+      title: 'Updated shelter status',
+      content: 'Community shelter capacity has been updated for tonight.',
+    });
+
+    const deleteResponse = await request(app)
+      .delete(`/api/admin/announcements/${announcementId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(deleteResponse.status).toBe(204);
+
+    const publicResponse = await request(app).get('/api/announcements');
+    expect(publicResponse.status).toBe(200);
+    expect(publicResponse.body.announcements).toEqual([]);
+  });
+
+  test('admin mutations reject unauthenticated and non-admin users', async () => {
+    const app = createApp();
+    const nonAdminToken = await seedNonAdmin();
+
+    const unauthenticatedResponse = await request(app)
+      .post('/api/admin/announcements')
+      .send({ title: 'Blocked', content: 'No token.' });
+
+    expect(unauthenticatedResponse.status).toBe(401);
+    expect(unauthenticatedResponse.body.code).toBe('UNAUTHORIZED');
+
+    const forbiddenResponse = await request(app)
+      .post('/api/admin/announcements')
+      .set('Authorization', `Bearer ${nonAdminToken}`)
+      .send({ title: 'Blocked', content: 'Not an admin.' });
+
+    expect(forbiddenResponse.status).toBe(403);
+    expect(forbiddenResponse.body.code).toBe('FORBIDDEN');
+  });
+
+  test('admin mutations validate payload and return not found for missing announcements', async () => {
+    const app = createApp();
+    const { token } = await seedAdmin();
+
+    const invalidCreate = await request(app)
+      .post('/api/admin/announcements')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'Missing content' });
+
+    expect(invalidCreate.status).toBe(400);
+    expect(invalidCreate.body.code).toBe('VALIDATION_FAILED');
+
+    const missingPatch = await request(app)
+      .patch('/api/admin/announcements/missing-announcement')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ content: 'Updated body.' });
+
+    expect(missingPatch.status).toBe(404);
+    expect(missingPatch.body.code).toBe('NOT_FOUND');
+  });
+});

--- a/backend/tests/unit/modules/announcements/routes.test.js
+++ b/backend/tests/unit/modules/announcements/routes.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+jest.mock('../../../../src/modules/auth/repository', () => ({
+  findAdminByUserId: jest.fn(),
+}));
+
+jest.mock('../../../../src/modules/announcements/service', () => ({
+  createAnnouncement: jest.fn(),
+  deleteAnnouncement: jest.fn(),
+  getAnnouncement: jest.fn(),
+  getAnnouncements: jest.fn(),
+  updateAnnouncement: jest.fn(),
+}));
+
+const { env } = require('../../../../src/config/env');
+const { findAdminByUserId } = require('../../../../src/modules/auth/repository');
+const announcementService = require('../../../../src/modules/announcements/service');
+const {
+  adminAnnouncementsRouter,
+  announcementsRouter,
+} = require('../../../../src/modules/announcements/routes');
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/announcements', announcementsRouter);
+  app.use('/api/admin/announcements', adminAnnouncementsRouter);
+  return app;
+}
+
+function signToken(payload = {}) {
+  return jwt.sign(
+    {
+      userId: 'user-1',
+      email: 'user@example.com',
+      isAdmin: false,
+      adminRole: null,
+      ...payload,
+    },
+    env.jwt.secret,
+    { expiresIn: '1h' },
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('announcements routes', () => {
+  test('GET /api/announcements lists public announcements without auth', async () => {
+    announcementService.getAnnouncements.mockResolvedValue([
+      {
+        id: 'ann-1',
+        adminId: 'admin-1',
+        title: 'Preparedness update',
+        content: 'Public body',
+        createdAt: '2026-04-01T10:00:00.000Z',
+      },
+    ]);
+
+    const response = await request(createTestApp()).get('/api/announcements?limit=10');
+
+    expect(response.status).toBe(200);
+    expect(announcementService.getAnnouncements).toHaveBeenCalledWith({ limit: 10 });
+    expect(response.body.announcements).toHaveLength(1);
+  });
+
+  test('POST /api/admin/announcements rejects missing token', async () => {
+    const response = await request(createTestApp())
+      .post('/api/admin/announcements')
+      .send({ title: 'Blocked', content: 'Missing token' });
+
+    expect(response.status).toBe(401);
+    expect(response.body.code).toBe('UNAUTHORIZED');
+    expect(announcementService.createAnnouncement).not.toHaveBeenCalled();
+  });
+
+  test('POST /api/admin/announcements rejects authenticated non-admin', async () => {
+    findAdminByUserId.mockResolvedValue(null);
+
+    const response = await request(createTestApp())
+      .post('/api/admin/announcements')
+      .set('Authorization', `Bearer ${signToken()}`)
+      .send({ title: 'Blocked', content: 'Not admin' });
+
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe('FORBIDDEN');
+    expect(findAdminByUserId).toHaveBeenCalledWith('user-1');
+    expect(announcementService.createAnnouncement).not.toHaveBeenCalled();
+  });
+
+  test('POST /api/admin/announcements allows admins to create', async () => {
+    findAdminByUserId.mockResolvedValue({
+      admin_id: 'admin-1',
+      user_id: 'admin-user',
+      role: 'COORDINATOR',
+    });
+    announcementService.createAnnouncement.mockResolvedValue({
+      id: 'ann-1',
+      adminId: 'admin-1',
+      title: 'Shelter update',
+      content: 'Shelter capacity changed.',
+      createdAt: '2026-04-01T10:00:00.000Z',
+    });
+
+    const response = await request(createTestApp())
+      .post('/api/admin/announcements')
+      .set('Authorization', `Bearer ${signToken({ userId: 'admin-user', isAdmin: true, adminRole: 'COORDINATOR' })}`)
+      .send({ title: ' Shelter update ', content: ' Shelter capacity changed. ' });
+
+    expect(response.status).toBe(201);
+    expect(announcementService.createAnnouncement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'admin-user',
+        adminId: 'admin-1',
+        isAdmin: true,
+        adminRole: 'COORDINATOR',
+      }),
+      {
+        title: 'Shelter update',
+        content: 'Shelter capacity changed.',
+      },
+    );
+    expect(response.body.announcement.id).toBe('ann-1');
+  });
+
+  test('PATCH and DELETE /api/admin/announcements/:id handle not found', async () => {
+    findAdminByUserId.mockResolvedValue({
+      admin_id: 'admin-1',
+      user_id: 'admin-user',
+      role: 'COORDINATOR',
+    });
+    announcementService.updateAnnouncement.mockResolvedValue(null);
+    announcementService.deleteAnnouncement.mockResolvedValue(false);
+    const token = signToken({ userId: 'admin-user', isAdmin: true, adminRole: 'COORDINATOR' });
+
+    const patchResponse = await request(createTestApp())
+      .patch('/api/admin/announcements/missing')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'Updated' });
+
+    expect(patchResponse.status).toBe(404);
+    expect(patchResponse.body.code).toBe('NOT_FOUND');
+
+    const deleteResponse = await request(createTestApp())
+      .delete('/api/admin/announcements/missing')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(deleteResponse.status).toBe(404);
+    expect(deleteResponse.body.code).toBe('NOT_FOUND');
+  });
+});

--- a/web/src/app/home/page.tsx
+++ b/web/src/app/home/page.tsx
@@ -11,7 +11,7 @@ import {
     defaultEmergencyContacts,
     type EmergencyContact,
 } from "../../lib/emergencyNumbers";
-import { mockNews } from "@/lib/news";
+import { announcementToNewsItem, fetchAnnouncements, type NewsItem } from "@/lib/news";
 
 type HeroSlide = {
     title: string;
@@ -62,6 +62,9 @@ const heroSlides: HeroSlide[] = [
 export default function HomePage() {
     const router = useRouter();
     const [activeSlide, setActiveSlide] = React.useState(0);
+    const [previewNews, setPreviewNews] = React.useState<NewsItem[]>([]);
+    const [newsLoading, setNewsLoading] = React.useState(true);
+    const [newsError, setNewsError] = React.useState("");
 
     React.useEffect(() => {
         const timer = setInterval(() => {
@@ -71,8 +74,40 @@ export default function HomePage() {
         return () => clearInterval(timer);
     }, []);
 
+    React.useEffect(() => {
+        let isMounted = true;
+
+        async function loadPreviewNews() {
+            setNewsLoading(true);
+            setNewsError("");
+
+            try {
+                const announcements = await fetchAnnouncements({ limit: 3 });
+                if (!isMounted) {
+                    return;
+                }
+                setPreviewNews(announcements.map(announcementToNewsItem));
+            } catch (err) {
+                if (!isMounted) {
+                    return;
+                }
+                setPreviewNews([]);
+                setNewsError(err instanceof Error ? err.message : "Could not load latest announcements.");
+            } finally {
+                if (isMounted) {
+                    setNewsLoading(false);
+                }
+            }
+        }
+
+        void loadPreviewNews();
+
+        return () => {
+            isMounted = false;
+        };
+    }, []);
+
     const currentSlide = heroSlides[activeSlide];
-    const previewNews = mockNews.slice(0, 3);
     const previewContacts = defaultEmergencyContacts.slice(0, 3);
 
     return (
@@ -131,15 +166,29 @@ export default function HomePage() {
                             subtitle="A short preview from announcements and community updates."
                         />
 
-                        <div className="home-news-list">
-                            {previewNews.map((item) => (
-                                <article key={item.id} className="home-news-card">
-                                    <p className="home-news-category">{item.category}</p>
-                                    <h3 className="home-news-title">{item.title}</h3>
-                                    <p className="home-news-summary">{item.summary}</p>
-                                </article>
-                            ))}
-                        </div>
+                        {newsLoading ? (
+                            <div className="admin-empty-state">
+                                <p>Loading latest announcements...</p>
+                            </div>
+                        ) : newsError ? (
+                            <div className="admin-empty-state">
+                                <p className="admin-error-text">{newsError}</p>
+                            </div>
+                        ) : previewNews.length === 0 ? (
+                            <div className="admin-empty-state">
+                                <p>No announcements have been published yet.</p>
+                            </div>
+                        ) : (
+                            <div className="home-news-list">
+                                {previewNews.map((item) => (
+                                    <article key={item.id} className="home-news-card">
+                                        <p className="home-news-category">{item.category}</p>
+                                        <h3 className="home-news-title">{item.title}</h3>
+                                        <p className="home-news-summary">{item.summary}</p>
+                                    </article>
+                                ))}
+                            </div>
+                        )}
 
                         <div className="home-news-action-wrap">
                             <SecondaryButton onClick={() => router.push("/news")}>View All News</SecondaryButton>

--- a/web/src/app/news/[announcementId]/page.tsx
+++ b/web/src/app/news/[announcementId]/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { AppShell } from "@/components/layout/AppShell";
+import { SectionCard } from "@/components/ui/display/SectionCard";
+import { SectionHeader } from "@/components/ui/display/SectionHeader";
+import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { fetchAnnouncement, formatAnnouncementDate, type Announcement } from "@/lib/news";
+
+function readAnnouncementId(param: string | string[] | undefined) {
+    if (Array.isArray(param)) {
+        return param[0] || "";
+    }
+
+    return param || "";
+}
+
+export default function NewsDetailPage() {
+    const params = useParams<{ announcementId?: string | string[] }>();
+    const announcementId = readAnnouncementId(params.announcementId);
+    const [announcement, setAnnouncement] = React.useState<Announcement | null>(null);
+    const [loading, setLoading] = React.useState(true);
+    const [error, setError] = React.useState("");
+
+    const loadAnnouncement = React.useCallback(async () => {
+        if (!announcementId) {
+            setAnnouncement(null);
+            setError("Announcement id is missing.");
+            setLoading(false);
+            return;
+        }
+
+        setLoading(true);
+        setError("");
+
+        try {
+            const nextAnnouncement = await fetchAnnouncement(announcementId);
+            setAnnouncement(nextAnnouncement);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Could not load announcement.");
+            setAnnouncement(null);
+        } finally {
+            setLoading(false);
+        }
+    }, [announcementId]);
+
+    React.useEffect(() => {
+        void loadAnnouncement();
+    }, [loadAnnouncement]);
+
+    return (
+        <AppShell title="News">
+            <div className="news-page-grid">
+                <SectionCard>
+                    <Link className="news-back-link" href="/news">
+                        ← Back to all news
+                    </Link>
+
+                    {loading ? (
+                        <div className="admin-empty-state">
+                            <p>Loading announcement...</p>
+                        </div>
+                    ) : error ? (
+                        <div className="admin-empty-state">
+                            <p className="admin-error-text">{error}</p>
+                            <PrimaryButton className="w-auto" onClick={() => void loadAnnouncement()}>
+                                Retry
+                            </PrimaryButton>
+                        </div>
+                    ) : announcement ? (
+                        <article className="news-detail-card">
+                            <div className="news-item-meta-row">
+                                <span className="news-item-category-chip">Announcement</span>
+                                <span className="news-item-date">
+                                    {formatAnnouncementDate(announcement.createdAt)}
+                                </span>
+                            </div>
+
+                            <SectionHeader
+                                className="news-detail-header"
+                                title={announcement.title}
+                                subtitle="Official public announcement from the emergency coordination team."
+                            />
+
+                            <p className="news-detail-content">{announcement.content}</p>
+                        </article>
+                    ) : (
+                        <div className="admin-empty-state">
+                            <p>Announcement not found.</p>
+                        </div>
+                    )}
+                </SectionCard>
+            </div>
+        </AppShell>
+    );
+}

--- a/web/src/app/news/page.tsx
+++ b/web/src/app/news/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import Link from "next/link";
 import { AppShell } from "@/components/layout/AppShell";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { SectionHeader } from "@/components/ui/display/SectionHeader";
@@ -68,6 +69,12 @@ export default function NewsPage() {
 
                                     <h2 className="news-item-title">{item.title}</h2>
                                     <p className="news-item-summary">{item.summary}</p>
+                                    <Link
+                                        className="news-read-more-link"
+                                        href={`/news/${encodeURIComponent(item.id)}`}
+                                    >
+                                        {item.hasMore ? "Read full announcement" : "Open announcement"}
+                                    </Link>
                                 </article>
                             ))}
                         </div>

--- a/web/src/app/news/page.tsx
+++ b/web/src/app/news/page.tsx
@@ -1,9 +1,36 @@
+"use client";
+
+import * as React from "react";
 import { AppShell } from "@/components/layout/AppShell";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { SectionHeader } from "@/components/ui/display/SectionHeader";
-import { mockNews } from "@/lib/news";
+import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { announcementToNewsItem, fetchAnnouncements, type NewsItem } from "@/lib/news";
 
 export default function NewsPage() {
+    const [items, setItems] = React.useState<NewsItem[]>([]);
+    const [loading, setLoading] = React.useState(true);
+    const [error, setError] = React.useState("");
+
+    const loadAnnouncements = React.useCallback(async () => {
+        setLoading(true);
+        setError("");
+
+        try {
+            const announcements = await fetchAnnouncements({ limit: 100 });
+            setItems(announcements.map(announcementToNewsItem));
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Could not load announcements.");
+            setItems([]);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    React.useEffect(() => {
+        void loadAnnouncements();
+    }, [loadAnnouncements]);
+
     return (
         <AppShell title="News">
             <div className="news-page-grid">
@@ -13,21 +40,38 @@ export default function NewsPage() {
                         subtitle="Announcements, preparedness updates, and community coordination notes."
                     />
 
-                    <div className="news-list">
-                        {mockNews.map((item) => (
-                            <article key={item.id} className="news-item-card">
-                                <div className="news-item-meta-row">
-                                    <span className="news-item-category-chip">
-                                        {item.category}
-                                    </span>
-                                    <span className="news-item-date">{item.publishedAt}</span>
-                                </div>
+                    {loading ? (
+                        <div className="admin-empty-state">
+                            <p>Loading announcements...</p>
+                        </div>
+                    ) : error ? (
+                        <div className="admin-empty-state">
+                            <p className="admin-error-text">{error}</p>
+                            <PrimaryButton className="w-auto" onClick={() => void loadAnnouncements()}>
+                                Retry
+                            </PrimaryButton>
+                        </div>
+                    ) : items.length === 0 ? (
+                        <div className="admin-empty-state">
+                            <p>No announcements have been published yet.</p>
+                        </div>
+                    ) : (
+                        <div className="news-list">
+                            {items.map((item) => (
+                                <article key={item.id} className="news-item-card">
+                                    <div className="news-item-meta-row">
+                                        <span className="news-item-category-chip">
+                                            {item.category}
+                                        </span>
+                                        <span className="news-item-date">{item.publishedAt}</span>
+                                    </div>
 
-                                <h2 className="news-item-title">{item.title}</h2>
-                                <p className="news-item-summary">{item.summary}</p>
-                            </article>
-                        ))}
-                    </div>
+                                    <h2 className="news-item-title">{item.title}</h2>
+                                    <p className="news-item-summary">{item.summary}</p>
+                                </article>
+                            ))}
+                        </div>
+                    )}
                 </SectionCard>
             </div>
         </AppShell>

--- a/web/src/components/feature/admin/AdminAnnouncementsView.tsx
+++ b/web/src/components/feature/admin/AdminAnnouncementsView.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import * as React from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { ApiError } from "@/lib/api";
+import { clearAccessToken, getAccessToken } from "@/lib/auth";
+import {
+    createAdminAnnouncement,
+    deleteAdminAnnouncement,
+    fetchAdminAnnouncements,
+    updateAdminAnnouncement,
+    type AdminAnnouncement,
+} from "@/lib/admin";
+import { formatAnnouncementDate, summarizeAnnouncementContent } from "@/lib/news";
+import { SectionCard } from "@/components/ui/display/SectionCard";
+import { SectionHeader } from "@/components/ui/display/SectionHeader";
+import { TextInput } from "@/components/ui/inputs/TextInput";
+import { TextArea } from "@/components/ui/inputs/TextArea";
+import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
+
+type AnnouncementFormState = {
+    title: string;
+    content: string;
+};
+
+const EMPTY_FORM: AnnouncementFormState = {
+    title: "",
+    content: "",
+};
+
+function sortAnnouncements(items: AdminAnnouncement[]) {
+    return [...items].sort((a, b) => {
+        const aDate = new Date(a.createdAt).getTime();
+        const bDate = new Date(b.createdAt).getTime();
+        return (Number.isNaN(bDate) ? 0 : bDate) - (Number.isNaN(aDate) ? 0 : aDate);
+    });
+}
+
+export default function AdminAnnouncementsView() {
+    const router = useRouter();
+    const pathname = usePathname();
+    const [announcements, setAnnouncements] = React.useState<AdminAnnouncement[]>([]);
+    const [loading, setLoading] = React.useState(true);
+    const [refreshing, setRefreshing] = React.useState(false);
+    const [saving, setSaving] = React.useState(false);
+    const [deletingId, setDeletingId] = React.useState<string | null>(null);
+    const [editingId, setEditingId] = React.useState<string | null>(null);
+    const [form, setForm] = React.useState<AnnouncementFormState>(EMPTY_FORM);
+    const [error, setError] = React.useState("");
+    const [formError, setFormError] = React.useState("");
+    const [statusMessage, setStatusMessage] = React.useState("");
+
+    const redirectToLogin = React.useCallback(() => {
+        clearAccessToken();
+        const returnTo = pathname || "/admin";
+        router.replace(`/login?returnTo=${encodeURIComponent(returnTo)}`);
+    }, [pathname, router]);
+
+    const handleAdminApiError = React.useCallback(
+        (err: unknown, fallback: string) => {
+            if (err instanceof ApiError && err.status === 401) {
+                redirectToLogin();
+                return null;
+            }
+
+            if (err instanceof ApiError && err.status === 403) {
+                router.replace("/home");
+                return null;
+            }
+
+            return err instanceof Error ? err.message : fallback;
+        },
+        [redirectToLogin, router]
+    );
+
+    const loadAnnouncements = React.useCallback(
+        async (mode: "initial" | "refresh" = "refresh") => {
+            const token = getAccessToken();
+            if (!token) {
+                setLoading(false);
+                setRefreshing(false);
+                redirectToLogin();
+                return;
+            }
+
+            if (mode === "initial") {
+                setLoading(true);
+            } else {
+                setRefreshing(true);
+            }
+            setError("");
+
+            try {
+                const result = await fetchAdminAnnouncements(token, { limit: 100 });
+                setAnnouncements(sortAnnouncements(result));
+            } catch (err) {
+                const message = handleAdminApiError(err, "Could not load announcements.");
+                if (message) {
+                    setError(message);
+                }
+            } finally {
+                setLoading(false);
+                setRefreshing(false);
+            }
+        },
+        [handleAdminApiError, redirectToLogin]
+    );
+
+    React.useEffect(() => {
+        void loadAnnouncements("initial");
+    }, [loadAnnouncements]);
+
+    const resetForm = () => {
+        setForm(EMPTY_FORM);
+        setEditingId(null);
+        setFormError("");
+    };
+
+    const handleEdit = (announcement: AdminAnnouncement) => {
+        setEditingId(announcement.id);
+        setForm({
+            title: announcement.title,
+            content: announcement.content,
+        });
+        setFormError("");
+        setStatusMessage("");
+    };
+
+    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        setFormError("");
+        setStatusMessage("");
+
+        const title = form.title.trim();
+        const content = form.content.trim();
+
+        if (!title || !content) {
+            setFormError("Title and content are required.");
+            return;
+        }
+
+        const token = getAccessToken();
+        if (!token) {
+            redirectToLogin();
+            return;
+        }
+
+        try {
+            setSaving(true);
+            if (editingId) {
+                const updated = await updateAdminAnnouncement(token, editingId, { title, content });
+                setAnnouncements((current) => sortAnnouncements(
+                    current.map((item) => (item.id === updated.id ? updated : item))
+                ));
+                setStatusMessage("Announcement updated.");
+            } else {
+                const created = await createAdminAnnouncement(token, { title, content });
+                setAnnouncements((current) => sortAnnouncements([created, ...current]));
+                setStatusMessage("Announcement created.");
+            }
+            resetForm();
+        } catch (err) {
+            const message = handleAdminApiError(
+                err,
+                editingId ? "Could not update announcement." : "Could not create announcement."
+            );
+            if (message) {
+                setFormError(message);
+            }
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleDelete = async (announcement: AdminAnnouncement) => {
+        const confirmed = window.confirm(`Delete announcement "${announcement.title}"?`);
+        if (!confirmed) {
+            return;
+        }
+
+        const token = getAccessToken();
+        if (!token) {
+            redirectToLogin();
+            return;
+        }
+
+        setDeletingId(announcement.id);
+        setStatusMessage("");
+        setError("");
+
+        try {
+            await deleteAdminAnnouncement(token, announcement.id);
+            setAnnouncements((current) => current.filter((item) => item.id !== announcement.id));
+            if (editingId === announcement.id) {
+                resetForm();
+            }
+            setStatusMessage("Announcement deleted.");
+        } catch (err) {
+            const message = handleAdminApiError(err, "Could not delete announcement.");
+            if (message) {
+                setError(message);
+            }
+        } finally {
+            setDeletingId(null);
+        }
+    };
+
+    if (loading) {
+        return (
+            <SectionCard>
+                <SectionHeader
+                    title="Announcements"
+                    subtitle="Loading announcement management..."
+                />
+                <div className="admin-empty-state">
+                    <p className="admin-subtle">Checking the latest announcement data.</p>
+                </div>
+            </SectionCard>
+        );
+    }
+
+    return (
+        <div className="admin-overview-grid">
+            <SectionCard>
+                <SectionHeader
+                    title={editingId ? "Edit Announcement" : "Create Announcement"}
+                    subtitle="Publish emergency notices, preparedness updates, and community announcements."
+                />
+
+                <form className="admin-announcements-form" onSubmit={handleSubmit}>
+                    <TextInput
+                        id="announcement-title"
+                        label="Title"
+                        value={form.title}
+                        maxLength={500}
+                        placeholder="Preparedness workshop schedule"
+                        onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))}
+                    />
+                    <TextArea
+                        id="announcement-content"
+                        label="Content"
+                        value={form.content}
+                        maxLength={10000}
+                        placeholder="Share the update users should see in the news feed."
+                        onChange={(event) => setForm((current) => ({ ...current, content: event.target.value }))}
+                    />
+
+                    {formError ? <p className="admin-error-text">{formError}</p> : null}
+                    {statusMessage ? <p className="admin-subtle">{statusMessage}</p> : null}
+
+                    <div className="admin-history-actions">
+                        <PrimaryButton className="w-auto" type="submit" loading={saving}>
+                            {editingId ? "Save Changes" : "Create Announcement"}
+                        </PrimaryButton>
+                        {editingId ? (
+                            <SecondaryButton className="w-auto" type="button" onClick={resetForm} disabled={saving}>
+                                Cancel Edit
+                            </SecondaryButton>
+                        ) : null}
+                    </div>
+                </form>
+            </SectionCard>
+
+            <SectionCard>
+                <SectionHeader
+                    title="Published Announcements"
+                    subtitle="Manage live announcements shown on the public news page."
+                />
+
+                <div className="admin-region-actions">
+                    <SecondaryButton className="w-auto" onClick={() => void loadAnnouncements("refresh")} disabled={refreshing}>
+                        {refreshing ? "Refreshing..." : "Refresh"}
+                    </SecondaryButton>
+                </div>
+
+                {error ? <p className="admin-error-text">{error}</p> : null}
+
+                {announcements.length === 0 ? (
+                    <div className="admin-empty-state">
+                        <p>No announcements have been published yet.</p>
+                    </div>
+                ) : (
+                    <div className="admin-announcements-list">
+                        {announcements.map((announcement) => (
+                            <article key={announcement.id} className="admin-announcements-card">
+                                <div className="admin-announcements-card-header">
+                                    <div>
+                                        <p className="admin-metric-label">
+                                            {formatAnnouncementDate(announcement.createdAt)}
+                                        </p>
+                                        <h3 className="admin-recent-title">{announcement.title}</h3>
+                                    </div>
+                                    <div className="admin-announcements-actions">
+                                        <SecondaryButton
+                                            className="w-auto"
+                                            type="button"
+                                            onClick={() => handleEdit(announcement)}
+                                            disabled={saving || deletingId === announcement.id}
+                                        >
+                                            Edit
+                                        </SecondaryButton>
+                                        <SecondaryButton
+                                            className="w-auto"
+                                            type="button"
+                                            onClick={() => void handleDelete(announcement)}
+                                            disabled={saving || deletingId === announcement.id}
+                                        >
+                                            {deletingId === announcement.id ? "Deleting..." : "Delete"}
+                                        </SecondaryButton>
+                                    </div>
+                                </div>
+                                <p className="admin-recent-line">
+                                    {summarizeAnnouncementContent(announcement.content, 260)}
+                                </p>
+                            </article>
+                        ))}
+                    </div>
+                )}
+            </SectionCard>
+        </div>
+    );
+}

--- a/web/src/components/feature/admin/AdminDashboardSwitcher.tsx
+++ b/web/src/components/feature/admin/AdminDashboardSwitcher.tsx
@@ -5,11 +5,13 @@ import AdminEmergencyOverviewView from "@/components/feature/admin/AdminEmergenc
 import AdminEmergencyHistoryView from "@/components/feature/admin/AdminEmergencyHistoryView";
 import AdminEmergencyInsightsView from "@/components/feature/admin/AdminEmergencyInsightsView";
 import AdminDeploymentMonitoringView from "@/components/feature/admin/AdminDeploymentMonitoringView";
+import AdminAnnouncementsView from "@/components/feature/admin/AdminAnnouncementsView";
 
-type AdminSectionKey = "overview" | "history" | "insights" | "monitoring";
+type AdminSectionKey = "overview" | "announcements" | "history" | "insights" | "monitoring";
 
 const SECTIONS: Array<{ key: AdminSectionKey; label: string }> = [
     { key: "overview", label: "Emergency Overview" },
+    { key: "announcements", label: "Announcements" },
     { key: "history", label: "Emergency History" },
     { key: "insights", label: "Emergency Insights" },
     { key: "monitoring", label: "Deployment Monitoring" },
@@ -63,6 +65,14 @@ export default function AdminDashboardSwitcher() {
                     aria-labelledby="admin-tab-overview"
                 >
                     <AdminEmergencyOverviewView />
+                </div>
+            ) : activeSection === "announcements" ? (
+                <div
+                    id="admin-panel-announcements"
+                    role="tabpanel"
+                    aria-labelledby="admin-tab-announcements"
+                >
+                    <AdminAnnouncementsView />
                 </div>
             ) : activeSection === "history" ? (
                 <div

--- a/web/src/lib/admin.ts
+++ b/web/src/lib/admin.ts
@@ -327,3 +327,80 @@ export async function fetchAdminDeploymentMonitoring(
 
     return response.monitoring;
 }
+
+export type AdminAnnouncement = {
+    id: string;
+    adminId: string;
+    title: string;
+    content: string;
+    createdAt: string;
+};
+
+type AdminAnnouncementsResponse = {
+    announcements: AdminAnnouncement[];
+};
+
+type AdminAnnouncementResponse = {
+    announcement: AdminAnnouncement;
+};
+
+export type AnnouncementMutationPayload = {
+    title: string;
+    content: string;
+};
+
+export async function fetchAdminAnnouncements(token: string, options: { limit?: number } = {}) {
+    const params = new URLSearchParams();
+    if (typeof options.limit === "number") {
+        params.set("limit", String(options.limit));
+    }
+
+    const query = params.toString() ? `?${params.toString()}` : "";
+    const response = await apiRequest<AdminAnnouncementsResponse>(`/admin/announcements${query}`, {
+        token: token.trim(),
+    });
+
+    return response.announcements;
+}
+
+export async function createAdminAnnouncement(token: string, payload: AnnouncementMutationPayload) {
+    const response = await apiRequest<AdminAnnouncementResponse>("/admin/announcements", {
+        method: "POST",
+        token: token.trim(),
+        body: {
+            title: payload.title.trim(),
+            content: payload.content.trim(),
+        },
+    });
+
+    return response.announcement;
+}
+
+export async function updateAdminAnnouncement(
+    token: string,
+    announcementId: string,
+    payload: Partial<AnnouncementMutationPayload>
+) {
+    const body: Record<string, string> = {};
+    if (payload.title !== undefined) {
+        body.title = payload.title.trim();
+    }
+    if (payload.content !== undefined) {
+        body.content = payload.content.trim();
+    }
+
+    const response = await apiRequest<AdminAnnouncementResponse>(`/admin/announcements/${encodeURIComponent(announcementId)}`, {
+        method: "PATCH",
+        token: token.trim(),
+        body,
+    });
+
+    return response.announcement;
+}
+
+export async function deleteAdminAnnouncement(token: string, announcementId: string) {
+    await apiRequest<void>(`/admin/announcements/${encodeURIComponent(announcementId)}`, {
+        method: "DELETE",
+        token: token.trim(),
+    });
+}

--- a/web/src/lib/news.ts
+++ b/web/src/lib/news.ts
@@ -11,13 +11,19 @@ export type Announcement = {
 export type NewsItem = {
     id: string;
     title: string;
+    content: string;
     summary: string;
+    hasMore: boolean;
     publishedAt: string;
     category: "Announcement";
 };
 
 type AnnouncementsResponse = {
     announcements: Announcement[];
+};
+
+type AnnouncementResponse = {
+    announcement: Announcement;
 };
 
 function buildAnnouncementsPath(options: { limit?: number } = {}) {
@@ -53,10 +59,14 @@ export function summarizeAnnouncementContent(content: string, maxLength = 180) {
 }
 
 export function announcementToNewsItem(announcement: Announcement): NewsItem {
+    const summary = summarizeAnnouncementContent(announcement.content);
+
     return {
         id: announcement.id,
         title: announcement.title,
-        summary: summarizeAnnouncementContent(announcement.content),
+        content: announcement.content,
+        summary,
+        hasMore: summary !== announcement.content.replace(/\s+/g, " ").trim(),
         publishedAt: formatAnnouncementDate(announcement.createdAt),
         category: "Announcement",
     };
@@ -65,4 +75,12 @@ export function announcementToNewsItem(announcement: Announcement): NewsItem {
 export async function fetchAnnouncements(options: { limit?: number } = {}) {
     const response = await apiRequest<AnnouncementsResponse>(buildAnnouncementsPath(options));
     return response.announcements;
+}
+
+export async function fetchAnnouncement(announcementId: string) {
+    const response = await apiRequest<AnnouncementResponse>(
+        `/announcements/${encodeURIComponent(announcementId)}`
+    );
+
+    return response.announcement;
 }

--- a/web/src/lib/news.ts
+++ b/web/src/lib/news.ts
@@ -1,42 +1,68 @@
+import { apiRequest } from "@/lib/api";
+
+export type Announcement = {
+    id: string;
+    adminId: string;
+    title: string;
+    content: string;
+    createdAt: string;
+};
+
 export type NewsItem = {
     id: string;
     title: string;
     summary: string;
     publishedAt: string;
-    category: "Preparedness" | "Community" | "Announcement";
+    category: "Announcement";
 };
 
-export const mockNews: NewsItem[] = [
-    {
-        id: "n-001",
-        title: "Neighborhood Preparedness Workshops Start Next Week",
-        summary:
-            "Local volunteer teams will host practical first-response workshops for households in participating districts.",
-        publishedAt: "2026-03-20",
-        category: "Preparedness",
-    },
-    {
-        id: "n-002",
-        title: "Mobile App Pilot Open for Early Access",
-        summary:
-            "NEPH mobile pilot is available for selected users to test incident reporting and emergency support requests.",
-        publishedAt: "2026-03-18",
+type AnnouncementsResponse = {
+    announcements: Announcement[];
+};
+
+function buildAnnouncementsPath(options: { limit?: number } = {}) {
+    const params = new URLSearchParams();
+    if (typeof options.limit === "number") {
+        params.set("limit", String(options.limit));
+    }
+
+    const query = params.toString();
+    return `/announcements${query ? `?${query}` : ""}`;
+}
+
+export function formatAnnouncementDate(value: string) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return date.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+    });
+}
+
+export function summarizeAnnouncementContent(content: string, maxLength = 180) {
+    const normalized = content.replace(/\s+/g, " ").trim();
+    if (normalized.length <= maxLength) {
+        return normalized;
+    }
+
+    return `${normalized.slice(0, maxLength - 1).trim()}…`;
+}
+
+export function announcementToNewsItem(announcement: Announcement): NewsItem {
+    return {
+        id: announcement.id,
+        title: announcement.title,
+        summary: summarizeAnnouncementContent(announcement.content),
+        publishedAt: formatAnnouncementDate(announcement.createdAt),
         category: "Announcement",
-    },
-    {
-        id: "n-003",
-        title: "Community Safety Volunteers Expanded",
-        summary:
-            "New volunteers have joined the response network, improving local coverage for urgent coordination.",
-        publishedAt: "2026-03-13",
-        category: "Community",
-    },
-    {
-        id: "n-004",
-        title: "Medical Information Checklist Updated",
-        summary:
-            "The profile health checklist now includes clearer guidance for medications and chronic conditions.",
-        publishedAt: "2026-03-09",
-        category: "Preparedness",
-    },
-];
+    };
+}
+
+export async function fetchAnnouncements(options: { limit?: number } = {}) {
+    const response = await apiRequest<AnnouncementsResponse>(buildAnnouncementsPath(options));
+    return response.announcements;
+}

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -641,6 +641,43 @@ textarea::placeholder {
     color: var(--text-secondary);
 }
 
+.news-read-more-link,
+.news-back-link {
+    display: inline-flex;
+    margin-top: 14px;
+    color: var(--primary-600);
+    font-size: 0.875rem;
+    font-weight: 700;
+    text-decoration: none;
+}
+
+.news-read-more-link:hover,
+.news-back-link:hover {
+    text-decoration: underline;
+}
+
+.news-back-link {
+    margin-top: 0;
+    margin-bottom: 18px;
+}
+
+.news-detail-card {
+    display: grid;
+    gap: 16px;
+}
+
+.news-detail-header {
+    margin-bottom: 0;
+}
+
+.news-detail-content {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.75;
+    white-space: pre-wrap;
+}
+
 .emergency-page-grid {
     display: grid;
     gap: 24px;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1226,6 +1226,39 @@ textarea::placeholder {
     gap: 10px;
 }
 
+.admin-announcements-form {
+    margin-top: 16px;
+    display: grid;
+    gap: 14px;
+}
+
+.admin-announcements-list {
+    margin-top: 16px;
+    display: grid;
+    gap: 12px;
+}
+
+.admin-announcements-card {
+    border: 1px solid var(--border-subtle);
+    border-radius: 12px;
+    background: var(--surface-card);
+    padding: 14px;
+}
+
+.admin-announcements-card-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.admin-announcements-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 8px;
+}
+
 .root-layout-body {
     display: flex;
     min-height: 100vh;


### PR DESCRIPTION
  ## Description:
 - Implements production-backed announcements across backend and web.
 - Adds public announcement APIs, admin-only create/update/delete endpoints, replaces mock
  news data on /news and home preview, and adds an admin dashboard tab for
  managing announcements.
- Includes backend unit/integration test coverage and verified web build.

Resolves #332 