### PR TITLE
feat:add public active help-requests visibility API for crisis map with filters and tests

### DIFF
--- a/backend/src/modules/help-requests/controller.js
+++ b/backend/src/modules/help-requests/controller.js
@@ -6,11 +6,13 @@ const {
   getGuestHelpRequest,
   updateMyHelpRequestStatus,
   updateGuestHelpRequestStatus,
+  listActiveHelpRequestsForVisibility,
 } = require('./service');
 const {
   readUserId,
   validateCreateHelpRequest,
   validateHelpRequestStatusUpdate,
+  validateActiveHelpRequestListQuery,
 } = require('./validators');
 const { env } = require('../../config/env');
 
@@ -167,9 +169,42 @@ async function patchHelpRequestStatus(request, response) {
   }
 }
 
+async function listActiveHelpRequests(request, response) {
+  const { errors, value } = validateActiveHelpRequestListQuery(request.query || {});
+  if (errors.length > 0) {
+    return sendError(response, 400, 'VALIDATION_FAILED', 'Validation failed', errors);
+  }
+
+  try {
+    const isAdmin = Boolean(request.user?.isAdmin);
+    const payload = await listActiveHelpRequestsForVisibility({
+      ...value,
+      isAdmin,
+    });
+
+    return response.status(200).json({
+      requests: payload.items,
+      total: payload.total,
+      pagination: {
+        limit: value.limit,
+        offset: value.offset,
+      },
+      filters: {
+        type: value.typeFilters,
+        status: value.statusFilters,
+        bbox: value.bbox,
+      },
+    });
+  } catch (error) {
+    console.error('helpRequests.listActiveHelpRequests failed', error);
+    return sendError(response, 500, 'INTERNAL_ERROR', 'Unexpected server error');
+  }
+}
+
 module.exports = {
   createHelpRequest,
   listHelpRequests,
   getHelpRequest,
   patchHelpRequestStatus,
+  listActiveHelpRequests,
 };

--- a/backend/src/modules/help-requests/repository.js
+++ b/backend/src/modules/help-requests/repository.js
@@ -530,6 +530,163 @@ async function markHelpRequestAsCancelledByRequestId(requestId) {
   return findHelpRequestById(requestId);
 }
 
+function roundToPrecision(value, digits) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function mapActiveVisibilityItem(row, { isAdmin = false } = {}) {
+  const derivedOperational = deriveOperationalLevels({
+    affectedPeopleCount: row.affected_people_count,
+    riskFlags: row.risk_flags,
+  });
+  const urgencyLevel = row.urgency_level || derivedOperational.urgencyLevel;
+
+  const latitude = row.latitude == null
+    ? null
+    : isAdmin
+      ? Number(row.latitude)
+      : roundToPrecision(Number(row.latitude), 3);
+  const longitude = row.longitude == null
+    ? null
+    : isAdmin
+      ? Number(row.longitude)
+      : roundToPrecision(Number(row.longitude), 3);
+
+  const location = {
+    latitude,
+    longitude,
+    city: row.city || 'unknown',
+    district: row.district || 'unknown',
+  };
+
+  if (isAdmin) {
+    location.neighborhood = row.neighborhood || 'unknown';
+  }
+
+  return {
+    requestId: row.request_id,
+    type: row.need_type,
+    status: row.status,
+    urgencyLevel,
+    createdAt: row.created_at,
+    assignmentState: row.active_assignment_id ? 'ASSIGNED' : 'UNASSIGNED',
+    location,
+  };
+}
+
+async function listActiveHelpRequestsVisibility({
+  typeFilters = [],
+  statusFilters = ['PENDING', 'ASSIGNED', 'IN_PROGRESS'],
+  bbox = null,
+  limit = 100,
+  offset = 0,
+  isAdmin = false,
+} = {}) {
+  const params = [
+    statusFilters,
+    typeFilters.length > 0 ? typeFilters : null,
+    bbox ? bbox.minLng : null,
+    bbox ? bbox.minLat : null,
+    bbox ? bbox.maxLng : null,
+    bbox ? bbox.maxLat : null,
+    limit,
+    offset,
+  ];
+
+  const [countResult, rowsResult] = await Promise.all([
+    query(
+      `
+        SELECT COUNT(*)::int AS total_count
+        FROM help_requests hr
+        LEFT JOIN LATERAL (
+          SELECT
+            loc.latitude,
+            loc.longitude
+          FROM request_locations loc
+          WHERE loc.request_id = hr.request_id
+          ORDER BY loc.captured_at DESC, loc.location_id DESC
+          LIMIT 1
+        ) rl ON TRUE
+        WHERE hr.status = ANY($1::request_status[])
+          AND ($2::text[] IS NULL OR LOWER(hr.need_type) = ANY($2))
+          AND (
+            $3::double precision IS NULL
+            OR (
+              rl.longitude IS NOT NULL
+              AND rl.latitude IS NOT NULL
+              AND rl.longitude BETWEEN $3::double precision AND $5::double precision
+              AND rl.latitude BETWEEN $4::double precision AND $6::double precision
+            )
+          )
+      `,
+      params.slice(0, 6),
+    ),
+    query(
+      `
+        SELECT
+          hr.request_id,
+          LOWER(COALESCE(NULLIF(TRIM(hr.need_type), ''), 'unknown')) AS need_type,
+          hr.status,
+          hr.urgency_level,
+          hr.affected_people_count,
+          hr.risk_flags,
+          hr.created_at,
+          rl.latitude,
+          rl.longitude,
+          COALESCE(NULLIF(TRIM(rl.city), ''), 'unknown') AS city,
+          COALESCE(NULLIF(TRIM(rl.district), ''), 'unknown') AS district,
+          COALESCE(NULLIF(TRIM(rl.neighborhood), ''), 'unknown') AS neighborhood,
+          aa.assignment_id AS active_assignment_id
+        FROM help_requests hr
+        LEFT JOIN LATERAL (
+          SELECT
+            loc.latitude,
+            loc.longitude,
+            loc.city,
+            loc.district,
+            loc.neighborhood
+          FROM request_locations loc
+          WHERE loc.request_id = hr.request_id
+          ORDER BY loc.captured_at DESC, loc.location_id DESC
+          LIMIT 1
+        ) rl ON TRUE
+        LEFT JOIN LATERAL (
+          SELECT a.assignment_id
+          FROM assignments a
+          WHERE a.request_id = hr.request_id
+            AND a.is_cancelled = FALSE
+          ORDER BY a.assigned_at DESC, a.assignment_id DESC
+          LIMIT 1
+        ) aa ON TRUE
+        WHERE hr.status = ANY($1::request_status[])
+          AND ($2::text[] IS NULL OR LOWER(hr.need_type) = ANY($2))
+          AND (
+            $3::double precision IS NULL
+            OR (
+              rl.longitude IS NOT NULL
+              AND rl.latitude IS NOT NULL
+              AND rl.longitude BETWEEN $3::double precision AND $5::double precision
+              AND rl.latitude BETWEEN $4::double precision AND $6::double precision
+            )
+          )
+        ORDER BY hr.created_at DESC
+        LIMIT $7::int
+        OFFSET $8::int
+      `,
+      params,
+    ),
+  ]);
+
+  return {
+    items: rowsResult.rows.map((row) => mapActiveVisibilityItem(row, { isAdmin })),
+    total: countResult.rows[0]?.total_count || 0,
+  };
+}
+
 module.exports = {
   createHelpRequest,
   listHelpRequestsByUserId,
@@ -541,4 +698,5 @@ module.exports = {
   markHelpRequestAsResolvedByRequestId,
   markHelpRequestAsCancelled,
   markHelpRequestAsCancelledByRequestId,
+  listActiveHelpRequestsVisibility,
 };

--- a/backend/src/modules/help-requests/routes.js
+++ b/backend/src/modules/help-requests/routes.js
@@ -5,6 +5,7 @@ const {
   listHelpRequests,
   getHelpRequest,
   patchHelpRequestStatus,
+  listActiveHelpRequests,
 } = require('./controller');
 
 const helpRequestsRouter = express.Router();
@@ -14,6 +15,7 @@ helpRequestsRouter.post('/', optionalAuth, createHelpRequest);
 
 // These routes require authentication
 helpRequestsRouter.get('/', requireAuth, listHelpRequests);
+helpRequestsRouter.get('/active', optionalAuth, listActiveHelpRequests);
 helpRequestsRouter.get('/:requestId', optionalAuth, getHelpRequest);
 helpRequestsRouter.patch('/:requestId/status', optionalAuth, patchHelpRequestStatus);
 

--- a/backend/src/modules/help-requests/service.js
+++ b/backend/src/modules/help-requests/service.js
@@ -12,6 +12,7 @@ const {
   markHelpRequestAsResolvedByRequestId,
   markHelpRequestAsCancelled,
   markHelpRequestAsCancelledByRequestId,
+  listActiveHelpRequestsVisibility,
 } = require('./repository');
 const { tryToAssignRequest, cancelAssignmentByRequestId } = require('../availability/service');
 const { createNotification } = require('../notifications/service');
@@ -269,6 +270,10 @@ async function updateGuestHelpRequestStatus(requestId, nextStatus, guestAccessTo
   return redactGuestRequestDetails(updatedRequest);
 }
 
+async function listActiveHelpRequestsForVisibility(options = {}) {
+  return listActiveHelpRequestsVisibility(options);
+}
+
 module.exports = {
   createMyHelpRequest,
   listMyHelpRequests,
@@ -277,4 +282,5 @@ module.exports = {
   getGuestHelpRequest,
   updateMyHelpRequestStatus,
   updateGuestHelpRequestStatus,
+  listActiveHelpRequestsForVisibility,
 };

--- a/backend/src/modules/help-requests/validators.js
+++ b/backend/src/modules/help-requests/validators.js
@@ -366,8 +366,102 @@ function validateHelpRequestStatusUpdate(payload) {
   };
 }
 
+const ACTIVE_VISIBILITY_STATUSES = new Set(['PENDING', 'ASSIGNED', 'IN_PROGRESS']);
+const BBOX_SEGMENT_COUNT = 4;
+
+function validateActiveHelpRequestListQuery(query = {}) {
+  const errors = [];
+
+  const rawTypes = typeof query.type === 'string' ? query.type : '';
+  const typeFilters = rawTypes
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+
+  const rawStatuses = typeof query.status === 'string' ? query.status : '';
+  const statusFilters = rawStatuses
+    .split(',')
+    .map((value) => value.trim().toUpperCase())
+    .filter(Boolean);
+
+  const invalidStatuses = statusFilters.filter((value) => !ACTIVE_VISIBILITY_STATUSES.has(value));
+  if (invalidStatuses.length > 0) {
+    errors.push(
+      `\`status\` contains invalid values: ${invalidStatuses.join(', ')}. Allowed values: PENDING, ASSIGNED, IN_PROGRESS.`,
+    );
+  }
+
+  let bbox = null;
+  if (typeof query.bbox === 'string' && query.bbox.trim() !== '') {
+    const parts = query.bbox
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+
+    if (parts.length !== BBOX_SEGMENT_COUNT) {
+      errors.push('`bbox` must have 4 comma-separated values: minLng,minLat,maxLng,maxLat.');
+    } else {
+      const [minLngRaw, minLatRaw, maxLngRaw, maxLatRaw] = parts;
+      const minLng = Number(minLngRaw);
+      const minLat = Number(minLatRaw);
+      const maxLng = Number(maxLngRaw);
+      const maxLat = Number(maxLatRaw);
+
+      if (![minLng, minLat, maxLng, maxLat].every((value) => Number.isFinite(value))) {
+        errors.push('`bbox` values must be valid numbers.');
+      } else {
+        if (minLng < -180 || minLng > 180 || maxLng < -180 || maxLng > 180) {
+          errors.push('`bbox` longitude values must be between -180 and 180.');
+        }
+        if (minLat < -90 || minLat > 90 || maxLat < -90 || maxLat > 90) {
+          errors.push('`bbox` latitude values must be between -90 and 90.');
+        }
+        if (minLng > maxLng) {
+          errors.push('`bbox` minLng must be less than or equal to maxLng.');
+        }
+        if (minLat > maxLat) {
+          errors.push('`bbox` minLat must be less than or equal to maxLat.');
+        }
+
+        if (errors.length === 0) {
+          bbox = { minLng, minLat, maxLng, maxLat };
+        }
+      }
+    }
+  }
+
+  const limit =
+    query.limit === undefined
+      ? 100
+      : Number(query.limit);
+  const offset =
+    query.offset === undefined
+      ? 0
+      : Number(query.offset);
+
+  if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+    errors.push('`limit` must be an integer between 1 and 500.');
+  }
+
+  if (!Number.isInteger(offset) || offset < 0 || offset > 100000) {
+    errors.push('`offset` must be an integer between 0 and 100000.');
+  }
+
+  return {
+    errors,
+    value: {
+      typeFilters,
+      statusFilters: statusFilters.length > 0 ? statusFilters : ['PENDING', 'ASSIGNED', 'IN_PROGRESS'],
+      bbox,
+      limit,
+      offset,
+    },
+  };
+}
+
 module.exports = {
   readUserId,
   validateCreateHelpRequest,
   validateHelpRequestStatusUpdate,
+  validateActiveHelpRequestListQuery,
 };

--- a/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
+++ b/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
@@ -1629,4 +1629,238 @@ describe('help-requests integration', () => {
 		expect(nearStatus.body.assignment.request_id).toBe(response.body.request.id);
 		expect(farStatus.body.assignment).toBeNull();
 	});
+
+	test('GET /api/help-requests/active allows guest access', async () => {
+		const app = createTestApp();
+
+		const response = await request(app)
+			.get('/api/help-requests/active');
+
+		expect(response.status).toBe(200);
+		expect(response.body.requests).toEqual([]);
+		expect(response.body.total).toBe(0);
+	});
+
+	test('GET /api/help-requests/active returns only active requests with regular-user-safe fields', async () => {
+		const app = createTestApp();
+		const requesterId = 'user_active_visibility_regular_1';
+		await seedActiveUser(requesterId, 'activevisibilityregular1@example.com');
+		const token = buildAuthToken(requesterId);
+
+		const activeCreate = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${token}`)
+			.send(buildCreatePayload({
+				helpTypes: ['first_aid'],
+				location: {
+					country: 'turkiye',
+					city: 'istanbul',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: 'Bina B',
+					latitude: 41.04321,
+					longitude: 29.00987,
+				},
+			}));
+
+		const closedCreate = await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${token}`)
+			.send(buildCreatePayload({
+				helpTypes: ['shelter'],
+				location: {
+					country: 'turkiye',
+					city: 'istanbul',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: 'Bina C',
+					latitude: 41.0435,
+					longitude: 29.01,
+				},
+			}));
+
+		await request(app)
+			.patch(`/api/help-requests/${closedCreate.body.request.id}/status`)
+			.set('Authorization', `Bearer ${token}`)
+			.send({ status: 'RESOLVED' })
+			.expect(200);
+
+		const response = await request(app)
+			.get('/api/help-requests/active')
+			.set('Authorization', `Bearer ${token}`);
+
+		expect(response.status).toBe(200);
+		expect(response.body.requests).toHaveLength(1);
+		expect(response.body.requests[0].requestId).toBe(activeCreate.body.request.id);
+		expect(response.body.requests[0].type).toBe('first_aid');
+		expect(response.body.requests[0].location.latitude).toBeCloseTo(41.043, 3);
+		expect(response.body.requests[0].location.longitude).toBeCloseTo(29.01, 3);
+		expect(response.body.requests[0].location.neighborhood).toBeUndefined();
+		expect(response.body.requests[0].assignmentState).toBe('UNASSIGNED');
+	});
+
+	test('GET /api/help-requests/active supports type and bbox filtering', async () => {
+		const app = createTestApp();
+		const requesterId = 'user_active_visibility_filter_1';
+		await seedActiveUser(requesterId, 'activevisibilityfilter1@example.com');
+		const token = buildAuthToken(requesterId);
+
+		await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${token}`)
+			.send(buildCreatePayload({
+				helpTypes: ['first_aid'],
+				location: {
+					country: 'turkiye',
+					city: 'istanbul',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: 'In bbox',
+					latitude: 41.0432,
+					longitude: 29.0092,
+				},
+			}));
+
+		await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${token}`)
+			.send(buildCreatePayload({
+				helpTypes: ['food'],
+				location: {
+					country: 'turkiye',
+					city: 'ankara',
+					district: 'cankaya',
+					neighborhood: 'kizilay',
+					extraAddress: 'Out of bbox',
+					latitude: 39.9334,
+					longitude: 32.8597,
+				},
+			}));
+
+		const response = await request(app)
+			.get('/api/help-requests/active?type=first_aid&bbox=29.0,41.0,29.1,41.1')
+			.set('Authorization', `Bearer ${token}`);
+
+		expect(response.status).toBe(200);
+		expect(response.body.requests).toHaveLength(1);
+		expect(response.body.requests[0].type).toBe('first_aid');
+	});
+
+	test('GET /api/help-requests/active supports status filtering for active states', async () => {
+		const app = createTestApp();
+		const requesterId = 'user_active_visibility_status_1';
+		const helperId = 'user_active_visibility_status_helper_1';
+		await seedActiveUser(requesterId, 'activevisibilitystatus1@example.com');
+		await seedActiveUser(helperId, 'activevisibilitystatushelper1@example.com');
+		await seedVolunteer({
+			volunteerId: 'vol_active_visibility_status_helper_1',
+			userId: helperId,
+			latitude: 41.043,
+			longitude: 29.009,
+		});
+		const requesterToken = buildAuthToken(requesterId);
+
+		await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${requesterToken}`)
+			.send(buildCreatePayload({
+				helpTypes: ['shelter'],
+				location: {
+					country: 'turkiye',
+					city: 'istanbul',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: 'Pending candidate',
+					latitude: 41.0432,
+					longitude: 29.0092,
+				},
+			}));
+
+		await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${requesterToken}`)
+			.send(buildCreatePayload({
+				helpTypes: ['first_aid'],
+				location: {
+					country: 'turkiye',
+					city: 'istanbul',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: 'Assigned candidate',
+					latitude: 41.043,
+					longitude: 29.009,
+				},
+			}));
+
+		const response = await request(app)
+			.get('/api/help-requests/active?status=PENDING')
+			.set('Authorization', `Bearer ${requesterToken}`);
+
+		expect(response.status).toBe(200);
+		expect(response.body.requests.length).toBeGreaterThanOrEqual(1);
+		expect(response.body.requests.every((item) => item.status === 'PENDING')).toBe(true);
+	});
+
+	test('GET /api/help-requests/active rejects non-active status filters', async () => {
+		const app = createTestApp();
+		const requesterId = 'user_active_visibility_status_2';
+		await seedActiveUser(requesterId, 'activevisibilitystatus2@example.com');
+		const requesterToken = buildAuthToken(requesterId);
+
+		const response = await request(app)
+			.get('/api/help-requests/active?status=RESOLVED')
+			.set('Authorization', `Bearer ${requesterToken}`);
+
+		expect(response.status).toBe(400);
+		expect(response.body.code).toBe('VALIDATION_FAILED');
+		expect(response.body.details).toEqual(expect.arrayContaining([
+			expect.stringContaining('`status` contains invalid values'),
+		]));
+	});
+
+	test('GET /api/help-requests/active includes admin-level location detail for admin users', async () => {
+		const app = createTestApp();
+		const adminUserId = 'user_active_visibility_admin_1';
+		await seedActiveUser(adminUserId, 'activevisibilityadmin1@example.com');
+		await query(
+			`INSERT INTO admins (admin_id, user_id, role) VALUES ('adm_active_visibility_1', $1, 'OPS')`,
+			[adminUserId],
+		);
+		const adminToken = jwt.sign(
+			{
+				userId: adminUserId,
+				email: 'activevisibilityadmin1@example.com',
+				isAdmin: true,
+				adminRole: 'OPS',
+			},
+			process.env.JWT_SECRET || 'dev-secret-123',
+			{ expiresIn: '1h' },
+		);
+
+		await request(app)
+			.post('/api/help-requests')
+			.set('Authorization', `Bearer ${adminToken}`)
+			.send(buildCreatePayload({
+				helpTypes: ['shelter'],
+				location: {
+					country: 'turkiye',
+					city: 'istanbul',
+					district: 'besiktas',
+					neighborhood: 'levazim',
+					extraAddress: 'Admin detail check',
+					latitude: 41.04321,
+					longitude: 29.00987,
+				},
+			}));
+
+		const response = await request(app)
+			.get('/api/help-requests/active')
+			.set('Authorization', `Bearer ${adminToken}`);
+
+		expect(response.status).toBe(200);
+		expect(response.body.requests).toHaveLength(1);
+		expect(response.body.requests[0].location.latitude).toBeCloseTo(41.04321, 5);
+		expect(response.body.requests[0].location.longitude).toBeCloseTo(29.00987, 5);
+		expect(response.body.requests[0].location.neighborhood).toBe('levazim');
+	});
 });

--- a/backend/tests/unit/modules/help-requests/controller.test.js
+++ b/backend/tests/unit/modules/help-requests/controller.test.js
@@ -8,12 +8,14 @@ jest.mock('../../../../src/modules/help-requests/service', () => ({
 	getGuestHelpRequest: jest.fn(),
 	updateMyHelpRequestStatus: jest.fn(),
 	updateGuestHelpRequestStatus: jest.fn(),
+	listActiveHelpRequestsForVisibility: jest.fn(),
 }));
 
 jest.mock('../../../../src/modules/help-requests/validators', () => ({
 	readUserId: jest.fn(),
 	validateCreateHelpRequest: jest.fn(),
 	validateHelpRequestStatusUpdate: jest.fn(),
+	validateActiveHelpRequestListQuery: jest.fn(),
 }));
 
 const service = require('../../../../src/modules/help-requests/service');
@@ -24,6 +26,7 @@ const {
 	listHelpRequests,
 	getHelpRequest,
 	patchHelpRequestStatus,
+	listActiveHelpRequests,
 } = require('../../../../src/modules/help-requests/controller');
 
 function buildResponse() {
@@ -480,6 +483,105 @@ describe('help-requests controller', () => {
 			await patchHelpRequestStatus({ body: {}, params: { requestId: 'req_1' } }, response);
 
 			expect(response.status).toHaveBeenCalledWith(500);
+		});
+	});
+
+	describe('listActiveHelpRequests', () => {
+		test('allows guest access when user is missing', async () => {
+			validators.readUserId.mockReturnValueOnce(null);
+			validators.validateActiveHelpRequestListQuery.mockReturnValueOnce({
+				errors: [],
+				value: {
+					typeFilters: [],
+					statusFilters: ['PENDING', 'ASSIGNED', 'IN_PROGRESS'],
+					bbox: null,
+					limit: 100,
+					offset: 0,
+				},
+			});
+			service.listActiveHelpRequestsForVisibility.mockResolvedValueOnce({
+				items: [],
+				total: 0,
+			});
+			const response = buildResponse();
+
+			await listActiveHelpRequests({ query: {} }, response);
+
+			expect(response.status).toHaveBeenCalledWith(200);
+		});
+
+		test('returns 400 on query validation failure', async () => {
+			validators.readUserId.mockReturnValueOnce('u1');
+			validators.validateActiveHelpRequestListQuery.mockReturnValueOnce({
+				errors: ['`limit` must be an integer between 1 and 500.'],
+				value: null,
+			});
+			const response = buildResponse();
+
+			await listActiveHelpRequests({ query: {} }, response);
+
+			expect(response.status).toHaveBeenCalledWith(400);
+			expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+				code: 'VALIDATION_FAILED',
+			}));
+		});
+
+		test('returns 200 with payload for regular user', async () => {
+			validators.readUserId.mockReturnValueOnce('u1');
+			validators.validateActiveHelpRequestListQuery.mockReturnValueOnce({
+				errors: [],
+				value: {
+					typeFilters: ['first_aid'],
+					statusFilters: ['PENDING'],
+					bbox: null,
+					limit: 50,
+					offset: 0,
+				},
+			});
+			service.listActiveHelpRequestsForVisibility.mockResolvedValueOnce({
+				items: [{ requestId: 'req_1' }],
+				total: 1,
+			});
+			const response = buildResponse();
+
+			await listActiveHelpRequests({
+				query: { type: 'first_aid' },
+				user: { isAdmin: false },
+			}, response);
+
+			expect(service.listActiveHelpRequestsForVisibility).toHaveBeenCalledWith(expect.objectContaining({
+				isAdmin: false,
+			}));
+			expect(response.status).toHaveBeenCalledWith(200);
+		});
+
+		test('passes isAdmin=true when authenticated user is admin', async () => {
+			validators.readUserId.mockReturnValueOnce('admin_1');
+			validators.validateActiveHelpRequestListQuery.mockReturnValueOnce({
+				errors: [],
+				value: {
+					typeFilters: [],
+					statusFilters: ['PENDING', 'ASSIGNED', 'IN_PROGRESS'],
+					bbox: null,
+					limit: 100,
+					offset: 0,
+				},
+			});
+			service.listActiveHelpRequestsForVisibility.mockResolvedValueOnce({
+				items: [],
+				total: 0,
+			});
+			const response = buildResponse();
+
+			await listActiveHelpRequests({
+				query: {},
+				user: { isAdmin: true },
+			}, response);
+
+			expect(service.listActiveHelpRequestsForVisibility).toHaveBeenCalledWith(expect.objectContaining({
+				isAdmin: true,
+			}));
+			expect(response.status).toHaveBeenCalledWith(200);
 		});
 	});
 });

--- a/backend/tests/unit/modules/help-requests/service.test.js
+++ b/backend/tests/unit/modules/help-requests/service.test.js
@@ -13,6 +13,7 @@ jest.mock('../../../../src/modules/help-requests/repository', () => ({
 	markHelpRequestAsResolvedByRequestId: jest.fn(),
 	markHelpRequestAsCancelled: jest.fn(),
 	markHelpRequestAsCancelledByRequestId: jest.fn(),
+	listActiveHelpRequestsVisibility: jest.fn(),
 }));
 
 const repository = require('../../../../src/modules/help-requests/repository');
@@ -31,6 +32,7 @@ const {
 	getGuestHelpRequest,
 	updateMyHelpRequestStatus,
 	updateGuestHelpRequestStatus,
+	listActiveHelpRequestsForVisibility,
 } = require('../../../../src/modules/help-requests/service');
 
 describe('help-requests service', () => {
@@ -488,6 +490,25 @@ describe('help-requests service', () => {
 			await expect(updateGuestHelpRequestStatus('req_guest_locked', 'SYNCED', token))
 				.rejects
 				.toMatchObject({ code: 'INVALID_STATUS_TRANSITION' });
+		});
+	});
+
+	describe('listActiveHelpRequestsForVisibility', () => {
+		test('delegates visibility listing to repository', async () => {
+			const payload = {
+				typeFilters: ['first_aid'],
+				statusFilters: ['PENDING'],
+				limit: 10,
+				offset: 0,
+				isAdmin: false,
+			};
+			const expected = { items: [{ requestId: 'req_1' }], total: 1 };
+			repository.listActiveHelpRequestsVisibility.mockResolvedValueOnce(expected);
+
+			const result = await listActiveHelpRequestsForVisibility(payload);
+
+			expect(repository.listActiveHelpRequestsVisibility).toHaveBeenCalledWith(payload);
+			expect(result).toEqual(expected);
 		});
 	});
 });

--- a/backend/tests/unit/modules/help-requests/validators.test.js
+++ b/backend/tests/unit/modules/help-requests/validators.test.js
@@ -4,6 +4,7 @@ const {
 	readUserId,
 	validateCreateHelpRequest,
 	validateHelpRequestStatusUpdate,
+	validateActiveHelpRequestListQuery,
 } = require('../../../../src/modules/help-requests/validators');
 
 describe('help-requests validators', () => {
@@ -287,6 +288,78 @@ describe('help-requests validators', () => {
 			const { errors } = validateHelpRequestStatusUpdate({ status: 123 });
 
 			expect(errors.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('validateActiveHelpRequestListQuery', () => {
+		test('uses defaults when optional query params are absent', () => {
+			const { errors, value } = validateActiveHelpRequestListQuery({});
+
+			expect(errors).toHaveLength(0);
+			expect(value.typeFilters).toEqual([]);
+			expect(value.statusFilters).toEqual(['PENDING', 'ASSIGNED', 'IN_PROGRESS']);
+			expect(value.limit).toBe(100);
+			expect(value.offset).toBe(0);
+			expect(value.bbox).toBeNull();
+		});
+
+		test('parses type and status filters', () => {
+			const { errors, value } = validateActiveHelpRequestListQuery({
+				type: 'first_aid, shelter ',
+				status: 'pending,assigned',
+				limit: '20',
+				offset: '5',
+			});
+
+			expect(errors).toHaveLength(0);
+			expect(value.typeFilters).toEqual(['first_aid', 'shelter']);
+			expect(value.statusFilters).toEqual(['PENDING', 'ASSIGNED']);
+			expect(value.limit).toBe(20);
+			expect(value.offset).toBe(5);
+		});
+
+		test('parses bbox values', () => {
+			const { errors, value } = validateActiveHelpRequestListQuery({
+				bbox: '28.9,40.9,29.2,41.2',
+			});
+
+			expect(errors).toHaveLength(0);
+			expect(value.bbox).toEqual({
+				minLng: 28.9,
+				minLat: 40.9,
+				maxLng: 29.2,
+				maxLat: 41.2,
+			});
+		});
+
+		test('rejects unsupported statuses', () => {
+			const { errors } = validateActiveHelpRequestListQuery({
+				status: 'resolved',
+			});
+
+			expect(errors).toEqual(expect.arrayContaining([
+				expect.stringContaining('`status` contains invalid values'),
+			]));
+		});
+
+		test('rejects malformed bbox', () => {
+			const { errors } = validateActiveHelpRequestListQuery({
+				bbox: '29.1,41.1,29.2',
+			});
+
+			expect(errors).toContain('`bbox` must have 4 comma-separated values: minLng,minLat,maxLng,maxLat.');
+		});
+
+		test('rejects invalid pagination values', () => {
+			const { errors } = validateActiveHelpRequestListQuery({
+				limit: '0',
+				offset: '-1',
+			});
+
+			expect(errors).toEqual(expect.arrayContaining([
+				'`limit` must be an integer between 1 and 500.',
+				'`offset` must be an integer between 0 and 100000.',
+			]));
 		});
 	});
 });


### PR DESCRIPTION
## Summary
This PR adds backend support for crisis visibility screens by introducing an active help-requests listing API and full test coverage.

## What’s Included
- Added `GET /api/help-requests/active`
- Enabled access for both authenticated users and guests (`optionalAuth`)
- Returns only active requests by default (`PENDING`, `ASSIGNED`, `IN_PROGRESS`)
- Added query support:
  - `type` (csv)
  - `status` (active statuses only)
  - `bbox=minLng,minLat,maxLng,maxLat`
  - `limit`, `offset`
- Added role-based response shaping:
  - Regular/guest: approximate coordinates
  - Admin: more detailed location fields
- Included assignment state in response (`ASSIGNED` / `UNASSIGNED`)
- Ensured requester identity/sensitive profile fields are not exposed

## Response Shape (high level)
Each item includes:
- `requestId`
- `type`
- `status`
- `urgencyLevel`
- `createdAt`
- `assignmentState`
- `location` (role-dependent precision/details)

## Tests
Added/updated unit and integration coverage for:
- Authorization/access behavior (including guest access)
- Query validation (`status`, `bbox`, pagination)
- Filtering (`type`, `status`, `bbox`)
- Response shape and visibility behavior (regular vs admin)
- Invalid active-status filter case (`?status=RESOLVED` -> `400 VALIDATION_FAILED`)

## Notes
- This PR is focused only on backend API support and does not include web/android UI implementation.

Closes #385
