### PR TITLE
Fix Gathering Areas provider resilience, 406 handling, and map UX/address fallback

### DIFF
--- a/backend/src/modules/gathering-areas/service.js
+++ b/backend/src/modules/gathering-areas/service.js
@@ -2,6 +2,7 @@ const DEFAULT_OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
 const DEFAULT_TIMEOUT_MS = 6000;
 const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_CACHE_MAX_ENTRIES = 500;
+const DEFAULT_OVERPASS_USER_AGENT = 'NEPH-Backend/1.0 (+https://github.com/bounswe/bounswe2026group6)';
 const CACHE_COORDINATE_DECIMALS = 4;
 
 const nearbyCache = new Map();
@@ -17,6 +18,11 @@ function readPositiveNumberEnv(value, fallback, { integer = false } = {}) {
 
 function getOverpassUrl() {
   return process.env.GATHERING_AREAS_OVERPASS_URL || DEFAULT_OVERPASS_URL;
+}
+
+function getOverpassUserAgent() {
+  const configured = (process.env.GATHERING_AREAS_USER_AGENT || '').trim();
+  return configured || DEFAULT_OVERPASS_USER_AGENT;
 }
 
 function getTimeoutMs() {
@@ -87,6 +93,17 @@ function buildOverpassQuery({ lat, lon, radius }) {
     `  relation(around:${radius},${lat},${lon})["amenity"="shelter"];`,
     ');',
     'out center tags;',
+  ].join('\n');
+}
+
+function buildOverpassLightweightQuery({ lat, lon, radius }) {
+  return [
+    '[out:json][timeout:25];',
+    '(',
+      `  node(around:${radius},${lat},${lon})["emergency"="assembly_point"];`,
+      `  node(around:${radius},${lat},${lon})["amenity"="shelter"];`,
+    ');',
+    'out tags;',
   ].join('\n');
 }
 
@@ -182,7 +199,7 @@ function toFeatureCollection(elements, limit, center) {
   };
 }
 
-async function fetchNearbyFromOverpass(params) {
+async function fetchNearbyFromOverpassWithQuery(params, queryText) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), getTimeoutMs());
 
@@ -191,15 +208,16 @@ async function fetchNearbyFromOverpass(params) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-        Accept: 'application/json',
+        'User-Agent': getOverpassUserAgent(),
       },
-      body: new URLSearchParams({ data: buildOverpassQuery(params) }),
+      body: new URLSearchParams({ data: queryText }),
       signal: controller.signal,
     });
 
     if (!response.ok) {
       const error = new Error(`Overpass request failed with status ${response.status}`);
       error.code = 'OVERPASS_UNAVAILABLE';
+      error.status = response.status;
       throw error;
     }
 
@@ -228,6 +246,22 @@ async function fetchNearbyFromOverpass(params) {
     throw wrappedError;
   } finally {
     clearTimeout(timeout);
+  }
+}
+
+async function fetchNearbyFromOverpass(params) {
+  try {
+    return await fetchNearbyFromOverpassWithQuery(params, buildOverpassQuery(params));
+  } catch (error) {
+    const shouldRetryWithLightweightQuery =
+      error &&
+      (error.code === 'OVERPASS_UNAVAILABLE' || error.code === 'OVERPASS_TIMEOUT');
+
+    if (!shouldRetryWithLightweightQuery) {
+      throw error;
+    }
+
+    return fetchNearbyFromOverpassWithQuery(params, buildOverpassLightweightQuery(params));
   }
 }
 

--- a/backend/tests/integration/modules/gathering-areas/gathering-areas.integration.test.js
+++ b/backend/tests/integration/modules/gathering-areas/gathering-areas.integration.test.js
@@ -144,6 +144,42 @@ describe('gathering-areas integration', () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
+  test('GET /api/gathering-areas/nearby retries with lightweight query after provider 406', async () => {
+    const app = createApp();
+
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 406,
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          elements: [
+            {
+              type: 'node',
+              id: 11003,
+              lat: 41.0153,
+              lon: 28.9799,
+              tags: {
+                name: 'Fallback Area 406',
+                emergency: 'assembly_point',
+              },
+            },
+          ],
+        }),
+      });
+
+    const response = await request(app)
+      .get('/api/gathering-areas/nearby?lat=41.015137&lon=28.97953&radius=1500&limit=10');
+
+    expect(response.status).toBe(200);
+    expect(response.body.collection.type).toBe('FeatureCollection');
+    expect(response.body.collection.features).toHaveLength(1);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
   test('GET /api/gathering-areas/nearby validates query params', async () => {
     const app = createApp();
 

--- a/backend/tests/integration/modules/gathering-areas/gathering-areas.integration.test.js
+++ b/backend/tests/integration/modules/gathering-areas/gathering-areas.integration.test.js
@@ -72,6 +72,78 @@ describe('gathering-areas integration', () => {
     expect(response.body.collection.features[0].properties.distanceMeters).toBeGreaterThanOrEqual(0);
   });
 
+  test('GET /api/gathering-areas/nearby retries with lightweight query after provider 504', async () => {
+    const app = createApp();
+
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 504,
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          elements: [
+            {
+              type: 'node',
+              id: 11001,
+              lat: 41.0152,
+              lon: 28.9798,
+              tags: {
+                name: 'Fallback Area',
+                amenity: 'shelter',
+              },
+            },
+          ],
+        }),
+      });
+
+    const response = await request(app)
+      .get('/api/gathering-areas/nearby?lat=41.015137&lon=28.97953&radius=1500&limit=10');
+
+    expect(response.status).toBe(200);
+    expect(response.body.collection.type).toBe('FeatureCollection');
+    expect(response.body.collection.features).toHaveLength(1);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('GET /api/gathering-areas/nearby retries with lightweight query after provider 503', async () => {
+    const app = createApp();
+
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          elements: [
+            {
+              type: 'node',
+              id: 11002,
+              lat: 41.0151,
+              lon: 28.9796,
+              tags: {
+                name: 'Fallback Area 503',
+                emergency: 'assembly_point',
+              },
+            },
+          ],
+        }),
+      });
+
+    const response = await request(app)
+      .get('/api/gathering-areas/nearby?lat=41.015137&lon=28.97953&radius=1500&limit=10');
+
+    expect(response.status).toBe(200);
+    expect(response.body.collection.type).toBe('FeatureCollection');
+    expect(response.body.collection.features).toHaveLength(1);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
   test('GET /api/gathering-areas/nearby validates query params', async () => {
     const app = createApp();
 

--- a/backend/tests/integration/modules/gathering-areas/gathering-areas.provider-failures.integration.test.js
+++ b/backend/tests/integration/modules/gathering-areas/gathering-areas.provider-failures.integration.test.js
@@ -49,6 +49,29 @@ describe('gathering-areas integration - provider failures', () => {
     expect(response.body.code).toBe('OVERPASS_UNAVAILABLE');
   });
 
+  test('GET /api/gathering-areas/nearby returns 503 when provider keeps returning 406', async () => {
+    const app = createApp();
+
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 406,
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 406,
+        json: async () => ({}),
+      });
+
+    const response = await request(app)
+      .get('/api/gathering-areas/nearby?lat=41.01&lon=29.01&radius=1500&limit=10');
+
+    expect(response.status).toBe(503);
+    expect(response.body.code).toBe('OVERPASS_UNAVAILABLE');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
   test('GET /api/gathering-areas/nearby returns 504 when provider times out', async () => {
     const app = createApp();
 

--- a/backend/tests/integration/modules/gathering-areas/gathering-areas.provider-failures.integration.test.js
+++ b/backend/tests/integration/modules/gathering-areas/gathering-areas.provider-failures.integration.test.js
@@ -54,7 +54,9 @@ describe('gathering-areas integration - provider failures', () => {
 
     const timeoutError = new Error('timeout');
     timeoutError.name = 'AbortError';
-    global.fetch.mockRejectedValueOnce(timeoutError);
+    global.fetch
+      .mockRejectedValueOnce(timeoutError)
+      .mockRejectedValueOnce(timeoutError);
 
     const response = await request(app)
       .get('/api/gathering-areas/nearby?lat=41.01&lon=29.01&radius=1500&limit=10');

--- a/web/e2e/gathering-areas.spec.js
+++ b/web/e2e/gathering-areas.spec.js
@@ -112,7 +112,7 @@ test('keeps map/list selection stable when features share same id but different 
   await page.getByRole('button', { name: /City Hall Shelter/i }).click();
 
   await expect(page.locator('.gathering-areas-selected-name')).toHaveText('City Hall Shelter');
-  await expect(page.locator('.gathering-areas-selected-meta').first()).toContainText('shelter');
+  await expect(page.locator('.gathering-areas-selected-meta').first()).toContainText('Shelter');
 });
 
 test('shows empty and error states for gathering areas retrieval', async ({ page }) => {

--- a/web/src/app/gathering-areas/page.tsx
+++ b/web/src/app/gathering-areas/page.tsx
@@ -5,6 +5,7 @@ import { AppShell } from "@/components/layout/AppShell";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { GatheringAreasMap } from "@/components/feature/location/GatheringAreasMap";
 import { fetchNearbyGatheringAreas } from "@/lib/gatheringAreas";
+import { reverseLocation } from "@/lib/location";
 import type { GatheringAreaFeature } from "@/types/location";
 import type { GatheringAreaMapFeature } from "@/components/feature/location/LeafletGatheringAreasMap";
 
@@ -15,7 +16,103 @@ const DEFAULT_CENTER = {
 
 const DEFAULT_RADIUS = 2000;
 const DEFAULT_LIMIT = 20;
+const SEARCH_RADIUS_KM = DEFAULT_RADIUS / 1000;
+const ADDRESS_UNAVAILABLE = "Address unavailable";
 type FetchState = "idle" | "loading" | "success" | "empty" | "error";
+
+function formatCategoryLabel(category: string) {
+    const normalized = (category || "").trim().toLowerCase();
+
+    if (!normalized || normalized === "unknown") {
+        return "Gathering area";
+    }
+
+    if (normalized === "assembly_point") {
+        return "Assembly area";
+    }
+
+    if (normalized === "shelter") {
+        return "Shelter";
+    }
+
+    return normalized
+        .split("_")
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(" ");
+}
+
+function formatDistanceLabel(distanceMeters: number) {
+    if (distanceMeters >= 1000) {
+        return `${(distanceMeters / 1000).toFixed(1)} km`;
+    }
+
+    return `${distanceMeters} m`;
+}
+
+function readTagValue(rawTags: Record<string, unknown>, key: string) {
+    const value = rawTags[key];
+    return typeof value === "string" ? value.trim() : "";
+}
+
+function buildAddressFromRawTags(rawTags: Record<string, unknown>) {
+    const direct =
+        readTagValue(rawTags, "addr:full") ||
+        readTagValue(rawTags, "address") ||
+        readTagValue(rawTags, "description");
+
+    if (direct) {
+        return direct;
+    }
+
+    const street = readTagValue(rawTags, "addr:street");
+    const houseNumber = readTagValue(rawTags, "addr:housenumber");
+    const neighborhood = readTagValue(rawTags, "addr:suburb") || readTagValue(rawTags, "addr:neighbourhood");
+    const district = readTagValue(rawTags, "addr:district");
+    const city = readTagValue(rawTags, "addr:city") || readTagValue(rawTags, "is_in:city");
+
+    const streetLine = [street, houseNumber].filter(Boolean).join(" ");
+    const localityLine = [neighborhood, district, city].filter(Boolean).join(", ");
+    const address = [streetLine, localityLine].filter(Boolean).join(", ");
+
+    return address || ADDRESS_UNAVAILABLE;
+}
+
+function buildAddressFromReverseLookup(item: {
+    displayName?: string;
+    administrative?: {
+        neighborhood?: string | null;
+        district?: string | null;
+        city?: string | null;
+        extraAddress?: string | null;
+        country?: string | null;
+    };
+}) {
+    const displayName = (item.displayName || "").trim();
+    if (displayName) {
+        return displayName;
+    }
+
+    const admin = item.administrative || {};
+    const locality = [admin.neighborhood, admin.district, admin.city]
+        .map((part) => (part || "").trim())
+        .filter(Boolean)
+        .join(", ");
+
+    const address = [admin.extraAddress, locality, admin.country]
+        .map((part) => (part || "").trim())
+        .filter(Boolean)
+        .join(", ");
+
+    return address || ADDRESS_UNAVAILABLE;
+}
+
+function isAddressUnavailable(address: string) {
+    return !address || address === ADDRESS_UNAVAILABLE;
+}
+
+function getCoordinateCacheKey(latitude: number, longitude: number) {
+    return `${latitude.toFixed(6)},${longitude.toFixed(6)}`;
+}
 
 function mapFeature(feature: GatheringAreaFeature): GatheringAreaMapFeature | null {
     const [longitude, latitude] = feature.geometry.coordinates;
@@ -32,6 +129,7 @@ function mapFeature(feature: GatheringAreaFeature): GatheringAreaMapFeature | nu
         id: baseId,
         osmType,
         name: feature.properties.name || "Unnamed gathering area",
+        address: buildAddressFromRawTags(feature.properties.rawTags || {}),
         category: feature.properties.category || "unknown",
         distanceMeters: feature.properties.distanceMeters,
         latitude,
@@ -49,6 +147,73 @@ export default function GatheringAreasPage() {
     const [error, setError] = React.useState("");
     const [locationNote, setLocationNote] = React.useState("Resolving your current location...");
     const requestIdRef = React.useRef(0);
+    const reverseAddressCacheRef = React.useRef<Map<string, string>>(new Map());
+
+    const hydrateMissingAddresses = React.useCallback(
+        async (items: GatheringAreaMapFeature[], requestId: number) => {
+            const unresolved = items.filter((item) => isAddressUnavailable(item.address));
+            if (!unresolved.length) {
+                return;
+            }
+
+            const updates = await Promise.all(
+                unresolved.map(async (item) => {
+                    const cacheKey = getCoordinateCacheKey(item.latitude, item.longitude);
+                    const cached = reverseAddressCacheRef.current.get(cacheKey);
+
+                    if (cached) {
+                        return { featureKey: item.featureKey, address: cached };
+                    }
+
+                    try {
+                        const response = await reverseLocation({
+                            latitude: item.latitude,
+                            longitude: item.longitude,
+                        });
+                        const address = buildAddressFromReverseLookup(response.item || {});
+
+                        if (isAddressUnavailable(address)) {
+                            return null;
+                        }
+
+                        reverseAddressCacheRef.current.set(cacheKey, address);
+                        return { featureKey: item.featureKey, address };
+                    } catch {
+                        return null;
+                    }
+                })
+            );
+
+            if (requestId !== requestIdRef.current) {
+                return;
+            }
+
+            const resolvedAddressByFeature = new Map(
+                updates
+                    .filter((entry): entry is { featureKey: string; address: string } => Boolean(entry))
+                    .map((entry) => [entry.featureKey, entry.address])
+            );
+
+            if (!resolvedAddressByFeature.size) {
+                return;
+            }
+
+            setAreas((current) =>
+                current.map((item) => {
+                    const resolvedAddress = resolvedAddressByFeature.get(item.featureKey);
+                    if (!resolvedAddress || !isAddressUnavailable(item.address)) {
+                        return item;
+                    }
+
+                    return {
+                        ...item,
+                        address: resolvedAddress,
+                    };
+                })
+            );
+        },
+        []
+    );
 
     const handleSelectArea = React.useCallback((featureId: string) => {
         setSelectedAreaId(featureId);
@@ -79,6 +244,7 @@ export default function GatheringAreasPage() {
                     .filter((item): item is GatheringAreaMapFeature => item !== null);
 
                 setAreas(mapped);
+                void hydrateMissingAddresses(mapped, currentRequestId);
                 setFetchState(mapped.length ? "success" : "empty");
                 setSelectedAreaId((current) => {
                     if (!mapped.length) {
@@ -116,7 +282,7 @@ export default function GatheringAreasPage() {
                 }
             }
         },
-        []
+        [hydrateMissingAddresses]
     );
 
     const resolveCurrentLocationAndLoad = React.useCallback(() => {
@@ -188,12 +354,8 @@ export default function GatheringAreasPage() {
                             features={areas}
                             selectedFeatureId={selectedAreaId}
                             onSelectFeature={handleSelectArea}
-                            heightClassName="h-[380px] md:h-[500px]"
+                            heightClassName="h-[460px] md:h-[620px]"
                         />
-
-                        {locationNote ? (
-                            <p className="gathering-areas-map-note">{locationNote}</p>
-                        ) : null}
 
                         <button
                             type="button"
@@ -201,7 +363,7 @@ export default function GatheringAreasPage() {
                             title="Retry Results"
                             className="gathering-areas-map-retry"
                             onClick={resolveCurrentLocationAndLoad}
-                                                        disabled={isLoading || resolvingLocation}
+                            disabled={isLoading || resolvingLocation}
                         >
                             <svg
                                 width="16"
@@ -237,13 +399,13 @@ export default function GatheringAreasPage() {
                                     <article className="gathering-areas-selected-card">
                                         <p className="gathering-areas-selected-name">{selectedArea.name}</p>
                                         <p className="gathering-areas-selected-meta">
-                                            Category: {selectedArea.category}
+                                            Type: {formatCategoryLabel(selectedArea.category)}
                                         </p>
                                         <p className="gathering-areas-selected-meta">
-                                            Distance: {selectedArea.distanceMeters} m
+                                            Distance: {formatDistanceLabel(selectedArea.distanceMeters)}
                                         </p>
                                         <p className="gathering-areas-selected-meta">
-                                            Coordinates: {selectedArea.latitude.toFixed(5)}, {selectedArea.longitude.toFixed(5)}
+                                            Address: {selectedArea.address}
                                         </p>
                                     </article>
                                 ) : (
@@ -269,7 +431,7 @@ export default function GatheringAreasPage() {
                                             >
                                                 <p className="gathering-areas-item-name">{area.name}</p>
                                                 <p className="gathering-areas-item-meta">
-                                                    {area.category} • {area.distanceMeters} m • {area.osmType}
+                                                    {formatCategoryLabel(area.category)} • {formatDistanceLabel(area.distanceMeters)}
                                                 </p>
                                             </button>
                                         ))
@@ -285,6 +447,13 @@ export default function GatheringAreasPage() {
                                 </div>
                             </aside>
                         ) : null}
+                    </div>
+
+                    <div className="gathering-areas-context-note">
+                        <p className="gathering-areas-context-line">{locationNote}</p>
+                        <p className="gathering-areas-context-line">
+                            Searching within {SEARCH_RADIUS_KM} km of your current location.
+                        </p>
                     </div>
 
                     {isLoading ? (

--- a/web/src/components/feature/location/LeafletGatheringAreasMap.tsx
+++ b/web/src/components/feature/location/LeafletGatheringAreasMap.tsx
@@ -2,6 +2,9 @@
 
 import * as React from "react";
 import L from "leaflet";
+import markerIcon2xAsset from "leaflet/dist/images/marker-icon-2x.png";
+import markerIconAsset from "leaflet/dist/images/marker-icon.png";
+import markerShadowAsset from "leaflet/dist/images/marker-shadow.png";
 import { LeafletMapCanvas } from "@/components/feature/location/LeafletMapCanvas";
 import type { LatLng } from "@/components/feature/location/LeafletMapCanvas";
 
@@ -10,6 +13,7 @@ type GatheringAreaMapFeature = {
     id: string;
     osmType: string;
     name: string;
+    address: string;
     category: string;
     distanceMeters: number;
     latitude: number;
@@ -25,6 +29,58 @@ type LeafletGatheringAreasMapProps = {
     zoom?: number;
 };
 
+function toAssetUrl(asset: string | { src: string }) {
+    return typeof asset === "string" ? asset : asset.src;
+}
+
+const gatheringAreaMarkerIcon = L.icon({
+    iconUrl: toAssetUrl(markerIconAsset),
+    iconRetinaUrl: toAssetUrl(markerIcon2xAsset),
+    shadowUrl: toAssetUrl(markerShadowAsset),
+    iconSize: [25, 41],
+    iconAnchor: [12, 41],
+    popupAnchor: [1, -34],
+    shadowSize: [41, 41],
+});
+
+function formatCategoryLabel(category: string) {
+    const normalized = (category || "").trim().toLowerCase();
+
+    if (!normalized || normalized === "unknown") {
+        return "Gathering area";
+    }
+
+    if (normalized === "assembly_point") {
+        return "Assembly area";
+    }
+
+    if (normalized === "shelter") {
+        return "Shelter";
+    }
+
+    return normalized
+        .split("_")
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(" ");
+}
+
+function formatDistanceLabel(distanceMeters: number) {
+    if (distanceMeters >= 1000) {
+        return `${(distanceMeters / 1000).toFixed(1)} km`;
+    }
+
+    return `${distanceMeters} m`;
+}
+
+function createLiveLocationIcon(): L.DivIcon {
+    return L.divIcon({
+        className: "gathering-areas-live-dot",
+        html: '<span class="gathering-areas-live-dot-core" aria-hidden="true"></span>',
+        iconSize: [20, 20],
+        iconAnchor: [10, 10],
+    });
+}
+
 function createPopupContent(feature: GatheringAreaMapFeature) {
     const wrapper = document.createElement("div");
     wrapper.style.display = "grid";
@@ -34,10 +90,10 @@ function createPopupContent(feature: GatheringAreaMapFeature) {
     title.textContent = feature.name || "Unnamed gathering area";
 
     const category = document.createElement("span");
-    category.textContent = `Category: ${feature.category || "unknown"}`;
+    category.textContent = `Type: ${formatCategoryLabel(feature.category)}`;
 
     const distance = document.createElement("span");
-    distance.textContent = `Distance: ${feature.distanceMeters} m`;
+    distance.textContent = `Distance: ${formatDistanceLabel(feature.distanceMeters)}`;
 
     wrapper.appendChild(title);
     wrapper.appendChild(category);
@@ -55,9 +111,9 @@ export function LeafletGatheringAreasMap({
     zoom = 14,
 }: LeafletGatheringAreasMapProps) {
     const mapRef = React.useRef<L.Map | null>(null);
-    const centerMarkerRef = React.useRef<L.CircleMarker | null>(null);
+    const centerMarkerRef = React.useRef<L.Marker | null>(null);
     const markerLayerRef = React.useRef<L.LayerGroup | null>(null);
-    const markerRefs = React.useRef<Map<string, L.CircleMarker>>(new Map());
+    const markerRefs = React.useRef<Map<string, L.Marker>>(new Map());
     const onSelectRef = React.useRef(onSelectFeature);
     const [mapReadyVersion, setMapReadyVersion] = React.useState(0);
 
@@ -96,12 +152,10 @@ export function LeafletGatheringAreasMap({
         });
 
         if (!centerMarkerRef.current) {
-            centerMarkerRef.current = L.circleMarker([center.latitude, center.longitude], {
-                radius: 8,
-                color: "#b23b3b",
-                weight: 2,
-                fillColor: "#d84a4a",
-                fillOpacity: 0.35,
+            centerMarkerRef.current = L.marker([center.latitude, center.longitude], {
+                icon: createLiveLocationIcon(),
+                interactive: false,
+                keyboard: false,
             }).addTo(map);
         } else {
             centerMarkerRef.current.setLatLng([center.latitude, center.longitude]);
@@ -118,12 +172,9 @@ export function LeafletGatheringAreasMap({
         markerRefs.current.clear();
 
         for (const feature of features) {
-            const marker = L.circleMarker([feature.latitude, feature.longitude], {
-                radius: feature.featureKey === selectedFeatureId ? 9 : 7,
-                color: feature.featureKey === selectedFeatureId ? "#a93232" : "#d84a4a",
-                weight: 2,
-                fillColor: feature.featureKey === selectedFeatureId ? "#c53e3e" : "#f4b740",
-                fillOpacity: 0.85,
+            const marker = L.marker([feature.latitude, feature.longitude], {
+                icon: gatheringAreaMarkerIcon,
+                riseOnHover: true,
             });
 
             marker.bindPopup(createPopupContent(feature));
@@ -136,17 +187,13 @@ export function LeafletGatheringAreasMap({
     React.useEffect(() => {
         for (const [featureId, marker] of markerRefs.current.entries()) {
             const isActive = featureId === selectedFeatureId;
-            marker.setStyle({
-                radius: isActive ? 9 : 7,
-                color: isActive ? "#a93232" : "#d84a4a",
-                fillColor: isActive ? "#c53e3e" : "#f4b740",
-            });
+            marker.setZIndexOffset(isActive ? 600 : 0);
 
             if (isActive) {
                 marker.openPopup();
             }
         }
-    }, [selectedFeatureId]);
+    }, [selectedFeatureId, features]);
 
     return (
         <LeafletMapCanvas

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -794,14 +794,30 @@ textarea::placeholder {
     isolation: isolate;
 }
 
+.gathering-areas-context-note {
+    margin-top: 12px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-soft);
+    padding: 10px 12px;
+    display: grid;
+    gap: 4px;
+}
+
+.gathering-areas-context-line {
+    margin: 0;
+    font-size: 0.84rem;
+    color: var(--text-secondary);
+}
+
 .gathering-areas-map-note {
     position: absolute;
     top: 12px;
-    left: 12px;
+    right: 120px;
     z-index: 25;
     pointer-events: none;
     margin: 0;
-    max-width: min(440px, calc(100% - 280px));
+    max-width: min(520px, calc(100% - 260px));
     border: 1px solid var(--border-subtle);
     border-radius: var(--radius-md);
     background: color-mix(in srgb, var(--surface-card) 94%, transparent);
@@ -809,6 +825,7 @@ textarea::placeholder {
     padding: 8px 10px;
     font-size: 0.8rem;
     color: var(--text-secondary);
+    text-align: right;
 }
 
 .gathering-areas-map-retry {
@@ -864,6 +881,108 @@ textarea::placeholder {
 
 .gathering-areas-map-wrap .leaflet-container {
     z-index: 1;
+}
+
+.gathering-areas-map-wrap .gathering-areas-pin {
+    background: transparent;
+    border: none;
+}
+
+.gathering-areas-map-wrap .gathering-areas-pin-core {
+    display: block;
+    width: 18px;
+    height: 18px;
+    border-radius: 999px;
+    border: 2px solid #ffffff;
+    position: relative;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.22);
+    transform-origin: center bottom;
+    transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.gathering-areas-map-wrap .gathering-areas-pin-core::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    bottom: -10px;
+    transform: translateX(-50%);
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 10px solid currentColor;
+    filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.18));
+}
+
+.gathering-areas-map-wrap .gathering-areas-pin.is-assembly {
+    color: #c73d2a;
+}
+
+.gathering-areas-map-wrap .gathering-areas-pin.is-assembly .gathering-areas-pin-core {
+    background: #e35f4f;
+}
+
+.gathering-areas-map-wrap .gathering-areas-pin.is-shelter {
+    color: #d08a1f;
+}
+
+.gathering-areas-map-wrap .gathering-areas-pin.is-shelter .gathering-areas-pin-core {
+    background: #f3b545;
+}
+
+.gathering-areas-map-wrap .gathering-areas-pin.is-other {
+    color: #2b7fc8;
+}
+
+.gathering-areas-map-wrap .gathering-areas-pin.is-other .gathering-areas-pin-core {
+    background: #4da2ea;
+}
+
+.gathering-areas-map-wrap .gathering-areas-pin.is-active .gathering-areas-pin-core {
+    transform: scale(1.16);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.26);
+}
+
+.gathering-areas-map-wrap .gathering-areas-live-dot {
+    background: transparent;
+    border: none;
+}
+
+.gathering-areas-map-wrap .gathering-areas-live-dot-core {
+    width: 14px;
+    height: 14px;
+    border-radius: 999px;
+    background: #1ea35c;
+    border: 2px solid #ffffff;
+    display: block;
+    position: relative;
+    box-shadow: 0 0 0 1px rgba(21, 109, 62, 0.35);
+}
+
+.gathering-areas-map-wrap .gathering-areas-live-dot-core::after {
+    content: "";
+    position: absolute;
+    inset: -7px;
+    border-radius: 999px;
+    border: 2px solid rgba(30, 163, 92, 0.4);
+    animation: gathering-areas-live-pulse 1800ms ease-out infinite;
+}
+
+@keyframes gathering-areas-live-pulse {
+    0% {
+        transform: scale(0.75);
+        opacity: 0.85;
+    }
+
+    70% {
+        transform: scale(1.15);
+        opacity: 0.2;
+    }
+
+    100% {
+        transform: scale(1.2);
+        opacity: 0;
+    }
 }
 
 .gathering-areas-map-wrap .leaflet-top,
@@ -924,7 +1043,8 @@ textarea::placeholder {
     }
 
     .gathering-areas-map-note {
-        max-width: calc(100% - 24px);
+        right: 10px;
+        max-width: calc(100% - 20px);
     }
 }
 


### PR DESCRIPTION
This PR improves the Gathering Areas flow across backend and web by addressing provider instability, explicit 406 handling, and usability issues in the map/details experience.

## Problem
Users were intermittently seeing provider unavailable states on the Gathering Areas page. Investigation showed Overpass responses could fail with status 406 under certain request conditions, causing degraded results and poor UX.

## What Changed

### Backend
- Added explicit User-Agent support for Overpass requests (configurable via environment variable with a safe default).
- Improved request resilience:
  - Primary query attempt
  - Automatic retry with a lightweight fallback query on provider unavailable/timeout style failures
- Kept clear error mapping for API consumers:
  - timeout -> 504
  - provider unavailable/invalid payload -> 503
- Preserved cache behavior for nearby queries.

### Web
- Improved Gathering Areas map experience and detail clarity.
- Replaced coordinate-focused detail display with address-first display where possible.
- Added reverse-geocoding fallback when raw map tags do not contain a usable address.
- Kept user-friendly error messaging for temporary provider failures.
- Included map UX refinements (marker/location feedback and readability improvements).

### Tests
- Expanded integration coverage for Gathering Areas reliability.
- Added explicit 406 regression scenarios:
  - 406 on first attempt then fallback success -> returns 200
  - repeated 406 on both attempts -> returns 503 OVERPASS_UNAVAILABLE

## Impact
- No API contract breaking changes.
- Improves stability and user experience for Gathering Areas under real-world provider behavior.

Closes: #366 