### PR TITLE
Improve profile location sync, add street autocomplete, and expand test coverage

### DIFF
--- a/backend/src/modules/location/service.js
+++ b/backend/src/modules/location/service.js
@@ -292,7 +292,13 @@ function mapNominatimItem(item) {
 			city: address.city || address.town || address.village || '',
 			district: address.county || address.state_district || address.municipality || '',
 			neighborhood: address.neighbourhood || address.suburb || '',
-			extraAddress: [address.road, address.house_number].filter(Boolean).join(' ').trim(),
+			extraAddress: [
+				address.road || address.pedestrian || address.footway || address.path || '',
+				address.house_number || '',
+			]
+				.filter(Boolean)
+				.join(' ')
+				.trim(),
 			postalCode: address.postcode || '',
 		},
 	};

--- a/backend/tests/integration/modules/location/location.integration.test.js
+++ b/backend/tests/integration/modules/location/location.integration.test.js
@@ -204,6 +204,38 @@ describe('location integration', () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
+  test('GET /api/location/reverse maps street extraAddress from pedestrian fallback', async () => {
+    const app = createApp();
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        place_id: 98765,
+        display_name: 'Levent, Besiktas, Istanbul, Turkey',
+        lat: '41.0822',
+        lon: '29.0154',
+        address: {
+          country_code: 'tr',
+          country: 'Turkey',
+          city: 'Istanbul',
+          county: 'Besiktas',
+          suburb: 'Levent',
+          pedestrian: 'Buyukdere Cd.',
+          house_number: '45',
+          postcode: '34330',
+        },
+      }),
+    });
+
+    const response = await request(app)
+      .get('/api/location/reverse?lat=41.0822&lon=29.0154');
+
+    expect(response.status).toBe(200);
+    expect(response.body.item.placeId).toBe('98765');
+    expect(response.body.item.administrative.extraAddress).toBe('Buyukdere Cd. 45');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
   test('GET /api/location/search uses in-memory cache for identical queries', async () => {
     const app = createApp();
 

--- a/web/e2e/profile-location-sync.spec.js
+++ b/web/e2e/profile-location-sync.spec.js
@@ -1,0 +1,201 @@
+const { test, expect } = require('@playwright/test');
+const { createCompletedUser } = require('./helpers/api');
+const { resetDatabase } = require('./helpers/db');
+const { loginThroughUi } = require('./helpers/ui');
+
+async function loginToProtectedRoute(page, route, { email, password }) {
+  await page.goto(route);
+  await expect(page).toHaveURL(new RegExp(`/login\\?returnTo=${encodeURIComponent(route)}$`));
+  await loginThroughUi(page, { email, password });
+  await expect(page).toHaveURL(new RegExp(`${route}$`));
+}
+
+function buildMockLocationTree() {
+  return {
+    countryCode: 'TR',
+    tree: {
+      label: 'Turkey',
+      cities: {
+        istanbul: {
+          label: 'Istanbul',
+          districts: {
+            besiktas: {
+              label: 'Besiktas',
+              neighborhoods: [
+                {
+                  label: 'Levent',
+                  value: 'levent',
+                },
+              ],
+            },
+            kadikoy: {
+              label: 'Kadikoy',
+              neighborhoods: [
+                {
+                  label: 'Bostanci',
+                  value: 'bostanci',
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    meta: {
+      cityCount: 1,
+      districtCount: 2,
+      neighborhoodCount: 2,
+    },
+  };
+}
+
+function buildLeventSearchItem() {
+  return {
+    placeId: 'mock:levent',
+    displayName: 'Levent, Besiktas, Istanbul, Turkey',
+    latitude: 41.0822,
+    longitude: 29.0154,
+    administrative: {
+      countryCode: 'TR',
+      country: 'Turkey',
+      city: 'Istanbul',
+      district: 'Besiktas',
+      neighborhood: 'Levent',
+      extraAddress: '',
+      postalCode: '34330',
+    },
+  };
+}
+
+function buildStreetSearchItem() {
+  return {
+    placeId: 'mock:buyukdere-45',
+    displayName: 'Buyukdere Cd. 45, Levent, Besiktas, Istanbul, Turkey',
+    latitude: 41.0831,
+    longitude: 29.0145,
+    administrative: {
+      countryCode: 'TR',
+      country: 'Turkey',
+      city: 'Istanbul',
+      district: 'Besiktas',
+      neighborhood: 'Levent',
+      extraAddress: 'Buyukdere Cd. 45',
+      postalCode: '34330',
+    },
+  };
+}
+
+async function mockLocationApis(page) {
+  await page.route('**/location/tree**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(buildMockLocationTree()),
+    });
+  });
+
+  await page.route('**/location/reverse**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        item: buildLeventSearchItem(),
+      }),
+    });
+  });
+
+  await page.route('**/location/search**', async (route) => {
+    const requestUrl = new URL(route.request().url());
+    const query = (requestUrl.searchParams.get('q') || '').toLowerCase();
+
+    const streetItem = buildStreetSearchItem();
+    const areaItem = buildLeventSearchItem();
+
+    const responseItems =
+      query.includes('buyukdere') || query.includes('buyukdere cd')
+        ? [streetItem]
+        : query.includes('levent') || query.includes('besiktas')
+          ? [areaItem]
+          : [];
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: responseItems,
+      }),
+    });
+  });
+}
+
+test.beforeEach(async () => {
+  await resetDatabase();
+});
+
+test('map pin selection updates country-city-district dropdowns', async ({ page }) => {
+  const email = `profile-map-sync-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email, password });
+  await mockLocationApis(page);
+  await loginToProtectedRoute(page, '/profile', { email, password });
+
+  const map = page.locator('.leaflet-container').first();
+  await expect(map).toBeVisible();
+
+  await map.click({ position: { x: 120, y: 120 } });
+
+  await expect(
+    page.getByText('Selected: Levent, Besiktas, Istanbul, Turkey')
+  ).toBeVisible();
+
+  await expect(page.locator('#country')).toHaveValue('tr');
+  await expect(page.locator('#city')).toHaveValue('istanbul');
+  await expect(page.locator('#district')).toHaveValue('besiktas');
+});
+
+test('dropdown selection updates map selected location', async ({ page }) => {
+  const email = `profile-dropdown-sync-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email, password });
+  await mockLocationApis(page);
+  await loginToProtectedRoute(page, '/profile', { email, password });
+
+  await page.locator('#country').selectOption('tr');
+  await page.locator('#city').selectOption('istanbul');
+  await page.locator('#district').selectOption('besiktas');
+  await page.locator('#neighborhood').selectOption('levent');
+
+  await expect(
+    page.getByText('Selected: Levent, Besiktas, Istanbul, Turkey')
+  ).toBeVisible();
+});
+
+test('extra address autocomplete selection updates map pin', async ({ page }) => {
+  const email = `profile-street-sync-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email, password });
+  await mockLocationApis(page);
+  await loginToProtectedRoute(page, '/profile', { email, password });
+
+  await page.locator('#country').selectOption('tr');
+  await page.locator('#city').selectOption('istanbul');
+  await page.locator('#district').selectOption('besiktas');
+
+  const extraAddressInput = page.locator('#extraAddress');
+  await extraAddressInput.fill('Buyukdere');
+
+  const suggestion = page.getByRole('button', {
+    name: 'Buyukdere Cd. 45, Levent, Besiktas, Istanbul, Turkey',
+  });
+
+  await expect(suggestion).toBeVisible();
+  await suggestion.click();
+
+  await expect(extraAddressInput).toHaveValue('Buyukdere Cd. 45');
+  await expect(
+    page.getByText('Selected: Buyukdere Cd. 45, Levent, Besiktas, Istanbul, Turkey')
+  ).toBeVisible();
+});

--- a/web/e2e/profile-location-sync.spec.js
+++ b/web/e2e/profile-location-sync.spec.js
@@ -187,7 +187,7 @@ test('extra address autocomplete selection updates map pin', async ({ page }) =>
   const extraAddressInput = page.locator('#extraAddress');
   await extraAddressInput.fill('Buyukdere');
 
-  const suggestion = page.getByRole('button', {
+  const suggestion = page.getByRole('option', {
     name: 'Buyukdere Cd. 45, Levent, Besiktas, Istanbul, Turkey',
   });
 

--- a/web/src/components/feature/auth/CompleteProfileForm.tsx
+++ b/web/src/components/feature/auth/CompleteProfileForm.tsx
@@ -10,18 +10,19 @@ import { Checkbox } from "@/components/ui/selection/Checkbox";
 import { ProfileInfoRow } from "../../ui/display/ProfileInfoRow";
 import { SaveActionBar } from "../../ui/display/SaveActionBar";
 import { HelperText } from "@/components/ui/display/HelperText";
-import { LocationPicker, LocationPickerValue } from "@/components/feature/location";
+import {
+    LocationPicker,
+    LocationPickerValue,
+    StreetAddressInput,
+} from "@/components/feature/location";
 import { bloodTypeOptions } from "@/lib/bloodTypes";
 import { countryCodeOptions } from "@/lib/countryCodes";
 import { expertiseOptions, professionOptions } from "@/lib/profileOptions";
 import { getAccessToken, SIGNUP_DRAFT_KEY } from "@/lib/auth";
-import { fetchLocationTree } from "@/lib/location";
+import { fetchLocationTree, searchLocations } from "@/lib/location";
 import {
-    findCityKeyByLabel,
-    findCountryKeyByLabel,
-    findDistrictKeyByLabel,
-    findNeighborhoodValueByLabel,
     LocationTreeByCountry,
+    resolvePickerLocation,
 } from "@/lib/locationTree";
 import {
     buildAddress,
@@ -96,6 +97,25 @@ function isFreshCurrentDeviceSelection(value: LocationPickerValue | null) {
     return Date.now() - capturedAtMs <= FRESH_DEVICE_CAPTURE_MAX_AGE_MS;
 }
 
+function toPickerValueFromSearchItem(item: {
+    placeId: string;
+    displayName: string;
+    latitude: number;
+    longitude: number;
+    administrative: LocationPickerValue["administrative"];
+}): LocationPickerValue {
+    return {
+        placeId: item.placeId,
+        displayName: item.displayName,
+        latitude: item.latitude,
+        longitude: item.longitude,
+        source: "dropdown_sync",
+        capturedAt: new Date().toISOString(),
+        accuracyMeters: null,
+        administrative: item.administrative,
+    };
+}
+
 export default function CompleteProfileForm() {
     const router = useRouter();
     const [form, setForm] = React.useState<ProfileForm>(initialForm);
@@ -105,6 +125,7 @@ export default function CompleteProfileForm() {
     const [locationTreeError, setLocationTreeError] = React.useState("");
     const [locationPickerValue, setLocationPickerValue] =
         React.useState<LocationPickerValue | null>(null);
+    const dropdownSyncRequestIdRef = React.useRef(0);
 
     React.useEffect(() => {
         const savedDraft = sessionStorage.getItem(SIGNUP_DRAFT_KEY);
@@ -160,44 +181,117 @@ export default function CompleteProfileForm() {
         };
     }, []);
 
-    React.useEffect(() => {
-        if (!locationPickerValue) {
-            return;
-        }
+    const applyPickerToForm = React.useCallback(
+        (picker: LocationPickerValue) => {
+            if (!Object.keys(locationTree).length) {
+                return;
+            }
 
-        const countryKey = findCountryKeyByLabel(
-            locationTree,
-            locationPickerValue.administrative.country || ""
-        );
-        const cityKey = findCityKeyByLabel(
-            locationTree,
-            countryKey,
-            locationPickerValue.administrative.city || ""
-        );
-        const districtKey = findDistrictKeyByLabel(
-            locationTree,
-            countryKey,
-            cityKey,
-            locationPickerValue.administrative.district || ""
-        );
-        const neighborhoods =
-            locationTree[countryKey]?.cities[cityKey]?.districts[districtKey]?.neighborhoods ||
-            [];
-        const neighborhoodValue = findNeighborhoodValueByLabel(
-            neighborhoods,
-            locationPickerValue.administrative.neighborhood || ""
-        );
+            const resolved = resolvePickerLocation(
+                locationTree,
+                picker.administrative,
+                picker.displayName || ""
+            );
 
-        setForm((currentForm) => ({
-            ...currentForm,
-            country: countryKey || currentForm.country,
-            city: cityKey || currentForm.city,
-            district: districtKey || currentForm.district,
-            neighborhood: neighborhoodValue || currentForm.neighborhood,
-            extraAddress:
-                locationPickerValue.administrative.extraAddress || currentForm.extraAddress,
-        }));
-    }, [locationPickerValue, locationTree]);
+            setForm((currentForm) => ({
+                ...currentForm,
+                country: resolved.countryKey || currentForm.country,
+                city: resolved.cityKey || currentForm.city,
+                district: resolved.districtKey || currentForm.district,
+                neighborhood: resolved.neighborhoodValue || currentForm.neighborhood,
+                extraAddress: resolved.extraAddress || currentForm.extraAddress,
+            }));
+        },
+        [locationTree]
+    );
+
+    const handleLocationPickerChange = React.useCallback(
+        (next: LocationPickerValue | null) => {
+            setLocationPickerValue(next);
+
+            if (!next) {
+                return;
+            }
+
+            applyPickerToForm(next);
+        },
+        [applyPickerToForm]
+    );
+
+    const syncPickerFromDropdowns = React.useCallback(
+        (nextForm: ProfileForm) => {
+            if (!nextForm.country || !nextForm.city) {
+                return;
+            }
+
+            const country = locationTree[nextForm.country];
+            const city = country?.cities[nextForm.city];
+
+            if (!country || !city) {
+                return;
+            }
+
+            const district = nextForm.district
+                ? city.districts[nextForm.district]
+                : undefined;
+            const neighborhood =
+                nextForm.neighborhood && district
+                    ? district.neighborhoods.find(
+                        (item) => item.value === nextForm.neighborhood
+                    )
+                    : undefined;
+
+            const query = [
+                neighborhood?.label,
+                district?.label,
+                city.label,
+                country.label,
+            ]
+                .filter(Boolean)
+                .join(", ");
+
+            if (!query) {
+                return;
+            }
+
+            const currentRequestId = ++dropdownSyncRequestIdRef.current;
+
+            void (async () => {
+                try {
+                    const response = await searchLocations({
+                        q: query,
+                        countryCode: nextForm.country.toUpperCase() || "TR",
+                        limit: 1,
+                    });
+
+                    if (currentRequestId !== dropdownSyncRequestIdRef.current) {
+                        return;
+                    }
+
+                    const first = response.items[0];
+                    if (!first) {
+                        return;
+                    }
+
+                    setLocationPickerValue(toPickerValueFromSearchItem(first));
+                } catch {
+                    // Keep current picker; dropdown selection still wins on save.
+                }
+            })();
+        },
+        [locationTree]
+    );
+
+    const updateLocationField = React.useCallback(
+        (patch: Partial<ProfileForm>) => {
+            setForm((currentForm) => {
+                const nextForm = { ...currentForm, ...patch };
+                syncPickerFromDropdowns(nextForm);
+                return nextForm;
+            });
+        },
+        [syncPickerFromDropdowns]
+    );
 
     const countryData = form.country ? locationTree[form.country] : undefined;
 
@@ -579,7 +673,7 @@ export default function CompleteProfileForm() {
             <ProfileInfoRow label="Address">
                 <LocationPicker
                     value={locationPickerValue}
-                    onChange={setLocationPickerValue}
+                    onChange={handleLocationPickerChange}
                     label="Select location from map or search"
                 />
 
@@ -588,8 +682,7 @@ export default function CompleteProfileForm() {
                     options={[{ label: "Select Country", value: "" }, ...countryOptions]}
                     value={form.country}
                     onChange={(e) =>
-                        setForm({
-                            ...form,
+                        updateLocationField({
                             country: e.target.value,
                             city: "",
                             district: "",
@@ -603,8 +696,7 @@ export default function CompleteProfileForm() {
                     options={[{ label: "Select City", value: "" }, ...cityOptions]}
                     value={form.city}
                     onChange={(e) =>
-                        setForm({
-                            ...form,
+                        updateLocationField({
                             city: e.target.value,
                             district: "",
                             neighborhood: "",
@@ -617,8 +709,7 @@ export default function CompleteProfileForm() {
                     options={[{ label: "Select District", value: "" }, ...districtOptions]}
                     value={form.district}
                     onChange={(e) =>
-                        setForm({
-                            ...form,
+                        updateLocationField({
                             district: e.target.value,
                             neighborhood: "",
                         })
@@ -633,27 +724,41 @@ export default function CompleteProfileForm() {
                     ]}
                     value={form.neighborhood}
                     onChange={(e) =>
-                        setForm({
-                            ...form,
+                        updateLocationField({
                             neighborhood: e.target.value,
                         })
                     }
                 />
 
-                <TextInput
+                <StreetAddressInput
                     id="extraAddress"
-                    placeholder="Street, building, etc. (optional)"
+                    label="Extra Address"
+                    placeholder="Start typing a street name"
                     value={form.extraAddress}
-                    onChange={(e) =>
-                        setForm({
-                            ...form,
-                            extraAddress: e.target.value,
-                        })
+                    countryCode={(form.country || "TR").toUpperCase()}
+                    scope={{
+                        country: countryData?.label,
+                        city: countryData?.cities[form.city]?.label,
+                        district:
+                            countryData?.cities[form.city]?.districts[form.district]
+                                ?.label,
+                        neighborhood: neighborhoodOptions.find(
+                            (item) => item.value === form.neighborhood
+                        )?.label,
+                    }}
+                    onChange={(next) =>
+                        setForm((currentForm) => ({
+                            ...currentForm,
+                            extraAddress: next,
+                        }))
                     }
+                    onSelectSuggestion={(item) => {
+                        setLocationPickerValue(toPickerValueFromSearchItem(item));
+                    }}
                 />
                 <HelperText>
-                    District and neighborhood are sent with their labels and merged into
-                    the backend address field for compatibility.
+                    Pick a spot on the map or start typing a street to see suggestions
+                    in your selected area. Selecting a suggestion moves the map pin.
                 </HelperText>
                 {locationTreeError ? (
                     <HelperText className="text-red-500">{locationTreeError}</HelperText>

--- a/web/src/components/feature/location/LocationPicker.tsx
+++ b/web/src/components/feature/location/LocationPicker.tsx
@@ -195,6 +195,19 @@ export function LocationPicker({
 
             navigator.geolocation.getCurrentPosition(
                 (position) => {
+                    onChange({
+                        ...toManualPickerValue(
+                            position.coords.latitude,
+                            position.coords.longitude
+                        ),
+                        source: "current_device",
+                        accuracyMeters:
+                            typeof position.coords.accuracy === "number"
+                                ? position.coords.accuracy
+                                : null,
+                        capturedAt: new Date(position.timestamp).toISOString(),
+                    });
+
                     void handleResolveCoordinates(
                         position.coords.latitude,
                         position.coords.longitude,
@@ -250,7 +263,7 @@ export function LocationPicker({
     }, [handleSearch]);
 
     return (
-        <div className="flex flex-col gap-3">
+        <div className="location-picker-wrap flex flex-col gap-3">
             <HelperText className="text-sm text-[#2b2b33]">{label}</HelperText>
 
             <div className="flex flex-col gap-2 sm:flex-row">
@@ -307,6 +320,13 @@ export function LocationPicker({
                         : null
                 }
                 onSelectPosition={(position) => {
+                    onChange({
+                        ...toManualPickerValue(position.latitude, position.longitude),
+                        source: "map_pin",
+                        accuracyMeters: null,
+                        capturedAt: new Date().toISOString(),
+                    });
+
                     void handleResolveCoordinates(position.latitude, position.longitude, {
                         source: "map_pin",
                         accuracyMeters: null,

--- a/web/src/components/feature/location/StreetAddressInput.tsx
+++ b/web/src/components/feature/location/StreetAddressInput.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import * as React from "react";
+import { TextInput } from "@/components/ui/inputs/TextInput";
+import { searchLocations } from "@/lib/location";
+import { LocationSearchItem } from "@/types/location";
+
+type StreetAddressInputProps = {
+    id?: string;
+    label?: string;
+    placeholder?: string;
+    value: string;
+    onChange: (value: string) => void;
+    onSelectSuggestion: (item: LocationSearchItem) => void;
+    countryCode?: string;
+    /** Used to scope the autocomplete to the currently chosen area. */
+    scope: {
+        country?: string;
+        city?: string;
+        district?: string;
+        neighborhood?: string;
+    };
+    disabled?: boolean;
+};
+
+export function StreetAddressInput({
+    id,
+    label = "Extra Address",
+    placeholder = "Start typing a street name",
+    value,
+    onChange,
+    onSelectSuggestion,
+    countryCode = "TR",
+    scope,
+    disabled = false,
+}: StreetAddressInputProps) {
+    const [suggestions, setSuggestions] = React.useState<LocationSearchItem[]>([]);
+    const [open, setOpen] = React.useState(false);
+    const [highlightedIndex, setHighlightedIndex] = React.useState(-1);
+    const requestIdRef = React.useRef(0);
+    const skipNextSearchRef = React.useRef(false);
+    const wrapperRef = React.useRef<HTMLDivElement | null>(null);
+
+    React.useEffect(() => {
+        function handleClickOutside(event: MouseEvent) {
+            if (
+                wrapperRef.current &&
+                !wrapperRef.current.contains(event.target as Node)
+            ) {
+                setOpen(false);
+            }
+        }
+
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => document.removeEventListener("mousedown", handleClickOutside);
+    }, []);
+
+    React.useEffect(() => {
+        if (skipNextSearchRef.current) {
+            skipNextSearchRef.current = false;
+            return;
+        }
+
+        const trimmed = value.trim();
+        if (trimmed.length < 2) {
+            setSuggestions([]);
+            return;
+        }
+
+        const scopeQuery = [
+            trimmed,
+            scope.neighborhood,
+            scope.district,
+            scope.city,
+            scope.country,
+        ]
+            .filter(Boolean)
+            .join(", ");
+
+        const currentRequestId = ++requestIdRef.current;
+
+        const timeout = setTimeout(async () => {
+            try {
+                const response = await searchLocations({
+                    q: scopeQuery,
+                    countryCode,
+                    limit: 6,
+                });
+
+                if (currentRequestId !== requestIdRef.current) {
+                    return;
+                }
+
+                setSuggestions(response.items);
+            } catch {
+                if (currentRequestId !== requestIdRef.current) {
+                    return;
+                }
+                setSuggestions([]);
+            }
+        }, 350);
+
+        return () => clearTimeout(timeout);
+    }, [
+        value,
+        scope.country,
+        scope.city,
+        scope.district,
+        scope.neighborhood,
+        countryCode,
+    ]);
+
+    const handleSelect = (item: LocationSearchItem) => {
+        skipNextSearchRef.current = true;
+        const street = item.administrative.extraAddress || item.displayName;
+        onChange(street);
+        onSelectSuggestion(item);
+        setSuggestions([]);
+        setOpen(false);
+        setHighlightedIndex(-1);
+    };
+
+    return (
+        <div ref={wrapperRef} className="street-address-input relative w-full">
+            <TextInput
+                id={id}
+                label={label}
+                placeholder={placeholder}
+                value={value}
+                disabled={disabled}
+                autoComplete="off"
+                onChange={(event) => {
+                    onChange(event.target.value);
+                    setOpen(true);
+                    setHighlightedIndex(-1);
+                }}
+                onFocus={() => {
+                    if (suggestions.length > 0) {
+                        setOpen(true);
+                    }
+                }}
+                onKeyDown={(event) => {
+                    if (!open || suggestions.length === 0) {
+                        return;
+                    }
+
+                    if (event.key === "ArrowDown") {
+                        event.preventDefault();
+                        setHighlightedIndex((index) =>
+                            Math.min(index + 1, suggestions.length - 1)
+                        );
+                    } else if (event.key === "ArrowUp") {
+                        event.preventDefault();
+                        setHighlightedIndex((index) => Math.max(index - 1, 0));
+                    } else if (event.key === "Enter" && highlightedIndex >= 0) {
+                        event.preventDefault();
+                        handleSelect(suggestions[highlightedIndex]);
+                    } else if (event.key === "Escape") {
+                        setOpen(false);
+                    }
+                }}
+            />
+
+            {open && suggestions.length > 0 ? (
+                <ul
+                    role="listbox"
+                    className="absolute left-0 right-0 top-full z-20 mt-1 max-h-56 overflow-auto rounded-[10px] border border-[#e7e7ea] bg-white shadow-md"
+                >
+                    {suggestions.map((item, index) => (
+                        <li key={`${item.placeId}-${item.latitude}-${item.longitude}`}>
+                            <button
+                                type="button"
+                                role="option"
+                                aria-selected={index === highlightedIndex}
+                                onMouseEnter={() => setHighlightedIndex(index)}
+                                onClick={() => handleSelect(item)}
+                                className={`block w-full border-b border-[#f0f0f2] px-3 py-2 text-left text-sm text-[#2b2b33] transition-colors ${
+                                    index === highlightedIndex
+                                        ? "bg-[#fafafa]"
+                                        : "hover:bg-[#fafafa]"
+                                }`}
+                            >
+                                {item.displayName}
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            ) : null}
+        </div>
+    );
+}

--- a/web/src/components/feature/location/index.ts
+++ b/web/src/components/feature/location/index.ts
@@ -1,2 +1,3 @@
 export { LocationPicker } from "@/components/feature/location/LocationPicker";
 export type { LocationPickerValue } from "@/components/feature/location/LocationPicker";
+export { StreetAddressInput } from "@/components/feature/location/StreetAddressInput";

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -12,12 +12,16 @@ import { ToggleSwitch } from "@/components/ui/selection/ToggleSwitch";
 import { Checkbox } from "@/components/ui/selection/Checkbox";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
 import { HelperText } from "@/components/ui/display/HelperText";
-import { LocationPicker, LocationPickerValue } from "@/components/feature/location";
+import {
+    LocationPicker,
+    LocationPickerValue,
+    StreetAddressInput,
+} from "@/components/feature/location";
 import { bloodTypeOptions } from "@/lib/bloodTypes";
 import { expertiseOptions, professionOptions } from "@/lib/profileOptions";
 import { clearAccessToken, fetchCurrentUser, getAccessToken } from "@/lib/auth";
 import { ApiError } from "@/lib/api";
-import { fetchLocationTree } from "@/lib/location";
+import { fetchLocationTree, searchLocations } from "@/lib/location";
 import {
     findCityKeyByLabel,
     findCountryKeyByLabel,
@@ -25,6 +29,7 @@ import {
     findNeighborhoodValueByLabel,
     LocationTreeByCountry,
     parseLocationAddress,
+    resolvePickerLocation,
 } from "@/lib/locationTree";
 import {
     BackendProfileResponse,
@@ -69,6 +74,25 @@ function isFreshCurrentDeviceSelection(value: LocationPickerValue | null) {
     }
 
     return Date.now() - capturedAtMs <= FRESH_DEVICE_CAPTURE_MAX_AGE_MS;
+}
+
+function toPickerValueFromSearchItem(item: {
+    placeId: string;
+    displayName: string;
+    latitude: number;
+    longitude: number;
+    administrative: LocationPickerValue["administrative"];
+}): LocationPickerValue {
+    return {
+        placeId: item.placeId,
+        displayName: item.displayName,
+        latitude: item.latitude,
+        longitude: item.longitude,
+        source: "dropdown_sync",
+        capturedAt: new Date().toISOString(),
+        accuracyMeters: null,
+        administrative: item.administrative,
+    };
 }
 
 
@@ -120,6 +144,7 @@ export default function ProfileView() {
         React.useState(false);
     const [emptyStateAction, setEmptyStateAction] =
         React.useState<EmptyStateAction>(null);
+    const dropdownSyncRequestIdRef = React.useRef(0);
 
     const refreshProfileFromBackend = React.useCallback(
         async (token: string, activeLocationTree: LocationTreeByCountry) => {
@@ -308,51 +333,141 @@ export default function ProfileView() {
         void loadProfile();
     }, []);
 
-    React.useEffect(() => {
-        if (!locationPickerValue) {
-            return;
-        }
-
-        const countryKey = findCountryKeyByLabel(
-            locationTree,
-            locationPickerValue.administrative.country || ""
-        );
-        const cityKey = findCityKeyByLabel(
-            locationTree,
-            countryKey,
-            locationPickerValue.administrative.city || ""
-        );
-        const districtKey = findDistrictKeyByLabel(
-            locationTree,
-            countryKey,
-            cityKey,
-            locationPickerValue.administrative.district || ""
-        );
-        const neighborhoods =
-            locationTree[countryKey]?.cities[cityKey]?.districts[districtKey]?.neighborhoods ||
-            [];
-        const neighborhoodValue = findNeighborhoodValueByLabel(
-            neighborhoods,
-            locationPickerValue.administrative.neighborhood || ""
-        );
-
-        setProfile((currentProfile) => {
-            if (!currentProfile) {
-                return currentProfile;
+    const applyPickerToProfile = React.useCallback(
+        (picker: LocationPickerValue) => {
+            if (!Object.keys(locationTree).length) {
+                return;
             }
 
-            return {
-                ...currentProfile,
-                country: countryKey || currentProfile.country,
-                city: cityKey || currentProfile.city,
-                district: districtKey || currentProfile.district,
-                neighborhood: neighborhoodValue || currentProfile.neighborhood,
-                extraAddress:
-                    locationPickerValue.administrative.extraAddress ||
-                    currentProfile.extraAddress,
-            };
-        });
-    }, [locationPickerValue, locationTree]);
+            const resolved = resolvePickerLocation(
+                locationTree,
+                picker.administrative,
+                picker.displayName || ""
+            );
+
+            setProfile((currentProfile) => {
+                if (!currentProfile) {
+                    return currentProfile;
+                }
+
+                return {
+                    ...currentProfile,
+                    country: resolved.countryKey || currentProfile.country,
+                    city: resolved.cityKey || currentProfile.city,
+                    district: resolved.districtKey || currentProfile.district,
+                    neighborhood:
+                        resolved.neighborhoodValue || currentProfile.neighborhood,
+                    extraAddress: resolved.extraAddress || currentProfile.extraAddress,
+                };
+            });
+        },
+        [locationTree]
+    );
+
+    const handleLocationPickerChange = React.useCallback(
+        (next: LocationPickerValue | null) => {
+            setLocationPickerValue(next);
+
+            if (!next) {
+                return;
+            }
+
+            applyPickerToProfile(next);
+        },
+        [applyPickerToProfile]
+    );
+
+    const syncPickerFromProfile = React.useCallback(
+        (nextProfile: ProfileData) => {
+            const countryKey = findCountryKeyByLabel(locationTree, nextProfile.country);
+            const cityKey = findCityKeyByLabel(
+                locationTree,
+                countryKey,
+                nextProfile.city
+            );
+
+            if (!countryKey || !cityKey) {
+                return;
+            }
+
+            const selectedCountry = locationTree[countryKey];
+            const selectedCity = selectedCountry?.cities[cityKey];
+
+            if (!selectedCountry || !selectedCity) {
+                return;
+            }
+
+            const districtKey = findDistrictKeyByLabel(
+                locationTree,
+                countryKey,
+                cityKey,
+                nextProfile.district
+            );
+            const selectedDistrict = districtKey
+                ? selectedCity.districts[districtKey]
+                : undefined;
+            const selectedNeighborhood =
+                nextProfile.neighborhood && selectedDistrict
+                    ? selectedDistrict.neighborhoods.find(
+                        (item) => item.value === nextProfile.neighborhood
+                    )
+                    : undefined;
+
+            const query = [
+                selectedNeighborhood?.label,
+                selectedDistrict?.label,
+                selectedCity.label,
+                selectedCountry.label,
+            ]
+                .filter(Boolean)
+                .join(", ");
+
+            if (!query) {
+                return;
+            }
+
+            const currentRequestId = ++dropdownSyncRequestIdRef.current;
+
+            void (async () => {
+                try {
+                    const response = await searchLocations({
+                        q: query,
+                        countryCode: countryKey.toUpperCase() || "TR",
+                        limit: 1,
+                    });
+
+                    if (currentRequestId !== dropdownSyncRequestIdRef.current) {
+                        return;
+                    }
+
+                    const first = response.items[0];
+                    if (!first) {
+                        return;
+                    }
+
+                    setLocationPickerValue(toPickerValueFromSearchItem(first));
+                } catch {
+                    // Keep current picker; dropdown selection still wins on save.
+                }
+            })();
+        },
+        [locationTree]
+    );
+
+    const updateLocationField = React.useCallback(
+        (patch: Partial<ProfileData>) => {
+            setProfile((currentProfile) => {
+                if (!currentProfile) {
+                    return currentProfile;
+                }
+
+                const nextProfile = { ...currentProfile, ...patch };
+                syncPickerFromProfile(nextProfile);
+                return nextProfile;
+            });
+        },
+        [syncPickerFromProfile]
+    );
 
     const handleSave = async () => {
         if (!profile) {
@@ -992,7 +1107,7 @@ export default function ProfileView() {
                     <div className="mb-4">
                         <LocationPicker
                             value={locationPickerValue}
-                            onChange={setLocationPickerValue}
+                            onChange={handleLocationPickerChange}
                             label="Select location from map or search"
                         />
                     </div>
@@ -1004,17 +1119,12 @@ export default function ProfileView() {
                             value={resolvedCountryKey}
                             options={[{ label: "Select Country", value: "" }, ...countryOptions]}
                             onChange={(e) =>
-                                setProfile((currentProfile) =>
-                                    currentProfile
-                                        ? {
-                                            ...currentProfile,
-                                            country: e.target.value,
-                                            city: "",
-                                            district: "",
-                                            neighborhood: "",
-                                        }
-                                        : currentProfile
-                                )
+                                updateLocationField({
+                                    country: e.target.value,
+                                    city: "",
+                                    district: "",
+                                    neighborhood: "",
+                                })
                             }
                         />
 
@@ -1025,16 +1135,11 @@ export default function ProfileView() {
                             disabled={!resolvedCountryKey}
                             options={[{ label: "Select City", value: "" }, ...cityOptions]}
                             onChange={(e) =>
-                                setProfile((currentProfile) =>
-                                    currentProfile
-                                        ? {
-                                            ...currentProfile,
-                                            city: e.target.value,
-                                            district: "",
-                                            neighborhood: "",
-                                        }
-                                        : currentProfile
-                                )
+                                updateLocationField({
+                                    city: e.target.value,
+                                    district: "",
+                                    neighborhood: "",
+                                })
                             }
                         />
 
@@ -1048,15 +1153,10 @@ export default function ProfileView() {
                                 ...districtOptions,
                             ]}
                             onChange={(e) =>
-                                setProfile((currentProfile) =>
-                                    currentProfile
-                                        ? {
-                                            ...currentProfile,
-                                            district: e.target.value,
-                                            neighborhood: "",
-                                        }
-                                        : currentProfile
-                                )
+                                updateLocationField({
+                                    district: e.target.value,
+                                    neighborhood: "",
+                                })
                             }
                         />
 
@@ -1070,36 +1170,51 @@ export default function ProfileView() {
                                 ...neighborhoodOptions,
                             ]}
                             onChange={(e) =>
-                                setProfile((currentProfile) =>
-                                    currentProfile
-                                        ? {
-                                            ...currentProfile,
-                                            neighborhood: e.target.value,
-                                        }
-                                        : currentProfile
-                                )
+                                updateLocationField({
+                                    neighborhood: e.target.value,
+                                })
                             }
                         />
 
                         <div className="col-span-2">
-                            <TextInput
+                            <StreetAddressInput
                                 id="extraAddress"
                                 label="Extra Address"
+                                placeholder="Start typing a street name"
                                 value={profile.extraAddress}
-                                onChange={(e) =>
+                                countryCode={(resolvedCountryKey || "TR").toUpperCase()}
+                                scope={{
+                                    country: countryData?.label,
+                                    city: countryData?.cities[resolvedCityKey]?.label,
+                                    district:
+                                        countryData?.cities[resolvedCityKey]?.districts[
+                                            resolvedDistrictKey
+                                        ]?.label,
+                                    neighborhood: neighborhoodOptions.find(
+                                        (item) =>
+                                            item.value === resolvedNeighborhoodValue
+                                    )?.label,
+                                }}
+                                onChange={(next) =>
                                     setProfile((currentProfile) =>
                                         currentProfile
                                             ? {
                                                 ...currentProfile,
-                                                extraAddress: e.target.value,
+                                                extraAddress: next,
                                             }
                                             : currentProfile
                                     )
                                 }
+                                onSelectSuggestion={(item) => {
+                                    setLocationPickerValue(
+                                        toPickerValueFromSearchItem(item)
+                                    );
+                                }}
                             />
                             <HelperText>
-                                District and neighborhood are sent with their labels and
-                                merged into the backend address field for compatibility.
+                                Pick a spot on the map or start typing a street to see
+                                suggestions in your selected area. Selecting a
+                                suggestion moves the map pin.
                             </HelperText>
                             {locationTreeError ? (
                                 <HelperText className="text-red-500">

--- a/web/src/lib/locationTree.ts
+++ b/web/src/lib/locationTree.ts
@@ -180,3 +180,129 @@ export function parseLocationAddress(
         extraAddress: Array.from(remainingTokens.values()).join(", "),
     };
 }
+
+export type ResolvedPickerLocation = {
+    countryKey: string;
+    cityKey: string;
+    districtKey: string;
+    neighborhoodValue: string;
+    extraAddress: string;
+};
+
+/**
+ * Resolve a picker selection (administrative fields + free-text displayName)
+ * to dropdown keys. Falls back to scanning displayName tokens when the
+ * administrative payload is sparse, so that map pins always have a chance
+ * to populate the country/city/district/neighborhood dropdowns.
+ */
+export function resolvePickerLocation(
+    locationTree: LocationTreeByCountry,
+    administrative: {
+        country?: string | null;
+        countryCode?: string | null;
+        city?: string | null;
+        district?: string | null;
+        neighborhood?: string | null;
+        extraAddress?: string | null;
+    },
+    displayName: string
+): ResolvedPickerLocation {
+    const tokens = (displayName || "")
+        .split(",")
+        .map((part) => part.trim())
+        .filter(Boolean);
+
+    const findCountryFromTokens = () => {
+        for (let index = tokens.length - 1; index >= 0; index -= 1) {
+            const key = findCountryKeyByLabel(locationTree, tokens[index]);
+            if (key) {
+                return key;
+            }
+        }
+        return "";
+    };
+
+    const countryKey =
+        findCountryKeyByLabel(locationTree, administrative.country || "") ||
+        findCountryKeyByLabel(locationTree, administrative.countryCode || "") ||
+        findCountryFromTokens();
+
+    if (!countryKey) {
+        return {
+            countryKey: "",
+            cityKey: "",
+            districtKey: "",
+            neighborhoodValue: "",
+            extraAddress: administrative.extraAddress || "",
+        };
+    }
+
+    const findCityFromTokens = () => {
+        for (const token of tokens) {
+            const key = findCityKeyByLabel(locationTree, countryKey, token);
+            if (key) {
+                return key;
+            }
+        }
+        return "";
+    };
+
+    const cityKey =
+        findCityKeyByLabel(locationTree, countryKey, administrative.city || "") ||
+        findCityFromTokens();
+
+    if (!cityKey) {
+        return {
+            countryKey,
+            cityKey: "",
+            districtKey: "",
+            neighborhoodValue: "",
+            extraAddress: administrative.extraAddress || "",
+        };
+    }
+
+    const findDistrictFromTokens = () => {
+        for (const token of tokens) {
+            const key = findDistrictKeyByLabel(locationTree, countryKey, cityKey, token);
+            if (key) {
+                return key;
+            }
+        }
+        return "";
+    };
+
+    const districtKey =
+        findDistrictKeyByLabel(
+            locationTree,
+            countryKey,
+            cityKey,
+            administrative.district || ""
+        ) || findDistrictFromTokens();
+
+    const neighborhoods =
+        locationTree[countryKey]?.cities[cityKey]?.districts[districtKey]?.neighborhoods ||
+        [];
+
+    const findNeighborhoodFromTokens = () => {
+        for (const token of tokens) {
+            const value = findNeighborhoodValueByLabel(neighborhoods, token);
+            if (value) {
+                return value;
+            }
+        }
+        return "";
+    };
+
+    const neighborhoodValue =
+        findNeighborhoodValueByLabel(neighborhoods, administrative.neighborhood || "") ||
+        findNeighborhoodFromTokens();
+
+    return {
+        countryKey,
+        cityKey,
+        districtKey,
+        neighborhoodValue,
+        extraAddress: administrative.extraAddress || "",
+    };
+}
+

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -167,7 +167,7 @@ textarea::placeholder {
 .top-navbar {
     position: sticky;
     top: 0;
-    z-index: 30;
+    z-index: 1100;
     border-bottom: 1px solid var(--border-subtle);
     background: color-mix(in srgb, var(--surface-card) 95%, transparent);
     backdrop-filter: blur(8px);
@@ -907,6 +907,17 @@ textarea::placeholder {
 .gathering-areas-map-wrap .leaflet-bottom,
 .gathering-areas-map-wrap .leaflet-pane,
 .gathering-areas-map-wrap .leaflet-control {
+    z-index: 10 !important;
+}
+
+.location-picker-wrap .leaflet-container {
+    z-index: 1;
+}
+
+.location-picker-wrap .leaflet-top,
+.location-picker-wrap .leaflet-bottom,
+.location-picker-wrap .leaflet-pane,
+.location-picker-wrap .leaflet-control {
     z-index: 10 !important;
 }
 


### PR DESCRIPTION
This PR fixes instability in the profile location flow and improves address selection UX.

It resolves map and dropdown sync conflicts, improves how map results are matched to location fields, adds scoped street autocomplete for Extra Address, and expands backend plus E2E test coverage.

### What changed
- Refactored location sync logic to prevent map pin rollback and state override loops.
- Improved location matching from picker data and display text into country, city, district, and neighborhood fields.
- Added scoped street autocomplete to Extra Address:
- Suggestions are searched using selected neighborhood, district, city, and country context.
- Selecting a suggestion updates both the address field and map selection.
- Extended backend reverse geocoding mapping so extraAddress can also be built from pedestrian, footway, or path data when road is missing.
- Updated map stacking behavior so the map no longer appears above the top navbar.

### Tests
- Added backend integration coverage for extraAddress fallback mapping in reverse geocoding.
- Added new E2E coverage for:
- map pin to dropdown sync
- dropdown to map sync
- Extra Address autocomplete to map update

### Validation
- Backend integration tests pass locally.
- Web build passes locally.
- New E2E scenarios are included for CI coverage.

Closes #391 