### PR TITLE
feat: Add web Help Request Map for waiting crisis requests

### DIFF
--- a/web/e2e/global-setup.js
+++ b/web/e2e/global-setup.js
@@ -14,7 +14,13 @@ const {
   applyDefaultTestEnv,
 } = require('./helpers/config');
 
-const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const npmCommand = process.platform === 'win32' ? process.execPath : 'npm';
+const npmArgsPrefix = process.platform === 'win32'
+  ? [
+      process.env.npm_execpath
+      || path.join(path.dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    ]
+  : [];
 
 function createLogFile(name) {
   fs.mkdirSync(TEST_RESULTS_DIR, { recursive: true });
@@ -25,7 +31,7 @@ function createLogFile(name) {
 
 function startProcess({ name, cwd, args, env }) {
   const { logFd, logPath } = createLogFile(name);
-  const child = spawn(npmCommand, args, {
+  const child = spawn(npmCommand, [...npmArgsPrefix, ...args], {
     cwd,
     env,
     detached: true,

--- a/web/e2e/help-request-map.spec.js
+++ b/web/e2e/help-request-map.spec.js
@@ -1,0 +1,128 @@
+const { test, expect } = require('@playwright/test');
+const { resetDatabase } = require('./helpers/db');
+
+test.beforeEach(async () => {
+  await resetDatabase();
+});
+
+test('guest can view waiting help requests on the map without operational status details', async ({ page }) => {
+  let requestedUrl = '';
+
+  await page.route('**/api/help-requests/active**', async (route) => {
+    requestedUrl = route.request().url();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        requests: [
+          {
+            requestId: 'map_req_first_aid',
+            type: 'first_aid',
+            status: 'PENDING',
+            urgencyLevel: 'HIGH',
+            createdAt: '2026-05-01T10:15:00.000Z',
+            assignmentState: 'UNASSIGNED',
+            location: {
+              latitude: 41.043,
+              longitude: 29.009,
+              city: 'istanbul',
+              district: 'besiktas',
+            },
+          },
+          {
+            requestId: 'map_req_shelter',
+            type: 'shelter',
+            status: 'PENDING',
+            urgencyLevel: 'MEDIUM',
+            createdAt: '2026-05-01T10:05:00.000Z',
+            assignmentState: 'UNASSIGNED',
+            location: {
+              latitude: 41.066,
+              longitude: 28.993,
+              city: 'istanbul',
+              district: 'sisli',
+            },
+          },
+          {
+            requestId: 'map_req_assigned',
+            type: 'search_and_rescue',
+            status: 'PENDING',
+            urgencyLevel: 'HIGH',
+            createdAt: '2026-05-01T09:55:00.000Z',
+            assignmentState: 'ASSIGNED',
+            location: {
+              latitude: 41.079,
+              longitude: 29.022,
+              city: 'istanbul',
+              district: 'sariyer',
+            },
+          },
+        ],
+        total: 3,
+        pagination: { limit: 300, offset: 0 },
+      }),
+    });
+  });
+
+  await page.goto('/crisis-map');
+
+  await expect(page.getByRole('heading', { name: 'Help Request Map' })).toBeVisible();
+  await expect(page.getByText('Showing waiting help requests by type and priority.')).toBeVisible();
+  await expect(page.getByRole('button', { name: /First Aid/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Shelter/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Search and Rescue/i })).toHaveCount(0);
+  await expect(page.locator('.crisis-pin')).toHaveCount(2);
+  await expect(page.locator('.gathering-areas-selected-card')).toContainText('Priority: High');
+  await expect(page.getByText('PENDING')).toHaveCount(0);
+  await expect(page.getByText('ASSIGNED')).toHaveCount(0);
+
+  await page.locator('.crisis-pin').nth(1).click();
+  await expect(page.locator('.gathering-areas-selected-card')).toContainText('Shelter');
+  await expect(page.locator('.gathering-areas-selected-card')).toContainText('Priority: Medium');
+
+  const url = new URL(requestedUrl);
+  expect(url.searchParams.get('status')).toBe('PENDING');
+  expect(url.searchParams.get('limit')).toBe('300');
+
+  await page.locator('.crisis-pin').first().hover();
+  await expect(page.locator('.crisis-tooltip-card').filter({ hasText: 'Priority: High' })).toBeVisible();
+});
+
+test('shows empty state and supports refresh after active request lookup fails', async ({ page }) => {
+  let requestCount = 0;
+
+  await page.route('**/api/help-requests/active**', async (route) => {
+    requestCount += 1;
+
+    if (requestCount === 1) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          requests: [],
+          total: 0,
+          pagination: { limit: 300, offset: 0 },
+        }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 503,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Help request visibility is temporarily unavailable',
+      }),
+    });
+  });
+
+  await page.goto('/crisis-map');
+
+  await expect(page.getByText('No waiting requests in view.')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Refresh Help Request Map' }).click();
+
+  await expect(page.getByText('Help request visibility is temporarily unavailable')).toBeVisible();
+  await expect.poll(() => requestCount).toBe(2);
+});

--- a/web/src/app/crisis-map/page.tsx
+++ b/web/src/app/crisis-map/page.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import * as React from "react";
+import { AppShell } from "@/components/layout/AppShell";
+import { SectionCard } from "@/components/ui/display/SectionCard";
+import { CrisisMap } from "@/components/feature/location/CrisisMap";
+import type { CrisisMapFeature, CrisisRequestType } from "@/components/feature/location/LeafletCrisisMap";
+import { fetchActiveHelpRequests } from "@/lib/crisisMap";
+import { getAccessToken } from "@/lib/auth";
+
+const DEFAULT_CENTER = {
+    latitude: 41.0082,
+    longitude: 28.9784,
+};
+
+const FETCH_LIMIT = 300;
+type FetchState = "idle" | "loading" | "success" | "empty" | "error";
+
+function normalizeType(type: string): CrisisRequestType {
+    const value = type.trim().toLowerCase();
+    if (value === "shelter") {
+        return "SHELTER";
+    }
+    if (value === "first_aid") {
+        return "FIRST_AID";
+    }
+    if (value === "fire_brigade" || value === "search_and_rescue") {
+        return "SEARCH_AND_RESCUE";
+    }
+    if (value === "food" || value === "water" || value === "food_water") {
+        return "FOOD_WATER";
+    }
+    return "OTHER";
+}
+
+function typeLabel(type: CrisisRequestType) {
+    switch (type) {
+        case "SHELTER":
+            return "Shelter";
+        case "FIRST_AID":
+            return "First Aid";
+        case "SEARCH_AND_RESCUE":
+            return "Search and Rescue";
+        case "FOOD_WATER":
+            return "Food / Water Supplies";
+        default:
+            return "Other / Unknown";
+    }
+}
+
+function formatRelative(createdAt: string) {
+    const date = new Date(createdAt);
+    if (Number.isNaN(date.getTime())) {
+        return createdAt;
+    }
+    return new Intl.DateTimeFormat("en-US", {
+        dateStyle: "medium",
+        timeStyle: "short",
+    }).format(date);
+}
+
+function formatPriority(priority: CrisisMapFeature["priorityLevel"]) {
+    return priority.charAt(0) + priority.slice(1).toLowerCase();
+}
+
+function toFeature(item: Awaited<ReturnType<typeof fetchActiveHelpRequests>>["requests"][number]): CrisisMapFeature | null {
+    if (item.status !== "PENDING" || item.assignmentState === "ASSIGNED") {
+        return null;
+    }
+
+    const latitude = item.location.latitude;
+    const longitude = item.location.longitude;
+    if (latitude == null || longitude == null) {
+        return null;
+    }
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+        return null;
+    }
+    const type = normalizeType(item.type);
+
+    return {
+        featureKey: item.requestId,
+        requestId: item.requestId,
+        type,
+        typeLabel: typeLabel(type),
+        priorityLevel: item.urgencyLevel,
+        createdAt: item.createdAt,
+        latitude,
+        longitude,
+        city: item.location.city || "unknown",
+        district: item.location.district || "unknown",
+    };
+}
+
+export default function CrisisMapPage() {
+    const [center] = React.useState(DEFAULT_CENTER);
+    const [requests, setRequests] = React.useState<CrisisMapFeature[]>([]);
+    const [selectedRequestId, setSelectedRequestId] = React.useState<string | null>(null);
+    const [isDetailsOpen, setIsDetailsOpen] = React.useState(true);
+    const [fetchState, setFetchState] = React.useState<FetchState>("idle");
+    const [error, setError] = React.useState("");
+    const requestIdRef = React.useRef(0);
+
+    const loadActiveRequests = React.useCallback(async () => {
+        const currentRequestId = ++requestIdRef.current;
+        try {
+            setFetchState("loading");
+            setError("");
+
+            const token = getAccessToken();
+            const response = await fetchActiveHelpRequests({
+                token,
+                status: "PENDING",
+                limit: FETCH_LIMIT,
+                offset: 0,
+            });
+
+            if (currentRequestId !== requestIdRef.current) {
+                return;
+            }
+
+            const mapped = response.requests
+                .map(toFeature)
+                .filter((item): item is CrisisMapFeature => item !== null);
+
+            setRequests(mapped);
+            setFetchState(mapped.length > 0 ? "success" : "empty");
+            setSelectedRequestId((current) => {
+                if (!mapped.length) {
+                    return null;
+                }
+                if (current && mapped.some((item) => item.featureKey === current)) {
+                    return current;
+                }
+                return mapped[0].featureKey;
+            });
+        } catch (err) {
+            if (currentRequestId !== requestIdRef.current) {
+                return;
+            }
+            const rawMessage =
+                err instanceof Error ? err.message : "Could not load active help requests.";
+            setError(rawMessage);
+            setRequests([]);
+            setSelectedRequestId(null);
+            setFetchState("error");
+        }
+    }, []);
+
+    React.useEffect(() => {
+        void loadActiveRequests();
+    }, [loadActiveRequests]);
+
+    const isLoading = fetchState === "loading";
+    const isEmpty = fetchState === "empty";
+    const selectedRequest =
+        requests.find((item) => item.featureKey === selectedRequestId) ||
+        (requests.length ? requests[0] : null);
+
+    return (
+        <AppShell title="Help Request Map" containerClassName="gathering-areas-page-container">
+            <div className="gathering-areas-page-grid">
+                <SectionCard className="gathering-areas-main-card">
+                    <div className="gathering-areas-map-wrap">
+                        <CrisisMap
+                            center={center}
+                            features={requests}
+                            selectedFeatureId={selectedRequestId}
+                            onSelectFeature={(featureId) => {
+                                setSelectedRequestId(featureId);
+                                setIsDetailsOpen(true);
+                            }}
+                            heightClassName="h-[380px] md:h-[500px]"
+                        />
+
+                        <p className="gathering-areas-map-note">
+                            Showing waiting help requests by type and priority.
+                        </p>
+
+                        <button
+                            type="button"
+                            aria-label="Refresh Help Request Map"
+                            title="Refresh Help Request Map"
+                            className="gathering-areas-map-retry"
+                            onClick={() => {
+                                void loadActiveRequests();
+                            }}
+                            disabled={isLoading}
+                        >
+                            <svg
+                                width="16"
+                                height="16"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                xmlns="http://www.w3.org/2000/svg"
+                                aria-hidden="true"
+                            >
+                                <path
+                                    d="M20 11.5A8 8 0 1 0 17.66 17M20 11.5V6M20 11.5H14.5"
+                                    stroke="currentColor"
+                                    strokeWidth="1.8"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                />
+                            </svg>
+                        </button>
+
+                        <button
+                            type="button"
+                            className="gathering-areas-overlay-toggle"
+                            onClick={() => setIsDetailsOpen((current) => !current)}
+                        >
+                            {isDetailsOpen ? "Hide Request Details" : "Show Request Details"}
+                        </button>
+
+                        {isDetailsOpen ? (
+                            <aside className="gathering-areas-map-overlay">
+                                <p className="gathering-areas-overlay-title">Selected Request</p>
+                                {selectedRequest ? (
+                                    <article className="gathering-areas-selected-card">
+                                        <p className="gathering-areas-selected-name">{selectedRequest.typeLabel}</p>
+                                        <p className="gathering-areas-selected-meta">
+                                            Priority: {formatPriority(selectedRequest.priorityLevel)}
+                                        </p>
+                                        <p className="gathering-areas-selected-meta">
+                                            Location: {selectedRequest.district}, {selectedRequest.city}
+                                        </p>
+                                        <p className="gathering-areas-selected-meta">
+                                            Opened: {formatRelative(selectedRequest.createdAt)}
+                                        </p>
+                                    </article>
+                                ) : (
+                                    <p className="gathering-areas-empty-detail">
+                                        Select a request marker to view details.
+                                    </p>
+                                )}
+
+                                <p className="gathering-areas-overlay-title">Waiting Requests</p>
+                                <div className="gathering-areas-list">
+                                    {requests.length ? (
+                                        requests.map((item) => (
+                                            <button
+                                                key={item.featureKey}
+                                                type="button"
+                                                className={`gathering-areas-item${selectedRequest?.featureKey === item.featureKey ? " is-active" : ""}`}
+                                                onClick={() => setSelectedRequestId(item.featureKey)}
+                                            >
+                                                <p className="gathering-areas-item-name">{item.typeLabel}</p>
+                                                <p className="gathering-areas-item-meta">
+                                                    Priority: {formatPriority(item.priorityLevel)} | {item.district}
+                                                </p>
+                                            </button>
+                                        ))
+                                    ) : (
+                                        <p className="gathering-areas-empty-detail">
+                                            No waiting requests in view.
+                                        </p>
+                                    )}
+                                </div>
+                            </aside>
+                        ) : null}
+                    </div>
+
+                    {isLoading ? (
+                        <div className="gathering-areas-status-box">
+                            <p>Loading waiting help requests...</p>
+                        </div>
+                    ) : null}
+
+                    {error ? (
+                        <div className="gathering-areas-status-box is-error">
+                            <p>{error}</p>
+                        </div>
+                    ) : null}
+
+                    {isEmpty ? (
+                        <div className="gathering-areas-status-box">
+                            <p>No waiting help requests are available right now.</p>
+                        </div>
+                    ) : null}
+                </SectionCard>
+            </div>
+        </AppShell>
+    );
+}

--- a/web/src/components/feature/location/CrisisMap.tsx
+++ b/web/src/components/feature/location/CrisisMap.tsx
@@ -1,0 +1,15 @@
+import dynamic from "next/dynamic";
+
+const LeafletCrisisMap = dynamic(
+    () =>
+        import("@/components/feature/location/LeafletCrisisMap").then(
+            (mod) => mod.LeafletCrisisMap
+        ),
+    {
+        ssr: false,
+        loading: () => <div className="h-[380px] w-full animate-pulse rounded-[10px] bg-[#eef0f3] md:h-[500px]" />,
+    }
+);
+
+export { LeafletCrisisMap as CrisisMap };
+

--- a/web/src/components/feature/location/LeafletCrisisMap.tsx
+++ b/web/src/components/feature/location/LeafletCrisisMap.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import * as React from "react";
+import L from "leaflet";
+import { LeafletMapCanvas } from "@/components/feature/location/LeafletMapCanvas";
+import type { LatLng } from "@/components/feature/location/LeafletMapCanvas";
+
+type CrisisRequestType =
+    | "SHELTER"
+    | "FIRST_AID"
+    | "SEARCH_AND_RESCUE"
+    | "FOOD_WATER"
+    | "OTHER";
+
+type CrisisMapFeature = {
+    featureKey: string;
+    requestId: string;
+    type: CrisisRequestType;
+    typeLabel: string;
+    priorityLevel: "LOW" | "MEDIUM" | "HIGH";
+    createdAt: string;
+    latitude: number;
+    longitude: number;
+    city: string;
+    district: string;
+};
+
+type LeafletCrisisMapProps = {
+    center: LatLng;
+    features: CrisisMapFeature[];
+    selectedFeatureId: string | null;
+    onSelectFeature: (featureId: string) => void;
+    heightClassName?: string;
+    zoom?: number;
+};
+
+const TYPE_STYLES: Record<CrisisRequestType, { fill: string; stroke: string; glyph: string }> = {
+    SHELTER: { fill: "#3b66d8", stroke: "#244ba7", glyph: "SH" },
+    FIRST_AID: { fill: "#d94141", stroke: "#a92c2c", glyph: "+" },
+    SEARCH_AND_RESCUE: { fill: "#f08c00", stroke: "#b96b00", glyph: "SR" },
+    FOOD_WATER: { fill: "#2f9e67", stroke: "#22754c", glyph: "FW" },
+    OTHER: { fill: "#687280", stroke: "#48515d", glyph: "?" },
+};
+
+function createMarkerIcon(feature: CrisisMapFeature, isSelected: boolean) {
+    const style = TYPE_STYLES[feature.type];
+    const selectedClass = isSelected ? " is-selected" : "";
+
+    return L.divIcon({
+        className: "",
+        iconSize: [42, 52],
+        iconAnchor: [21, 48],
+        html: `
+            <div class="crisis-pin${selectedClass}" style="--pin-fill:${style.fill};--pin-stroke:${style.stroke};">
+                <span class="crisis-pin-head">
+                    <span class="crisis-pin-glyph">${style.glyph}</span>
+                </span>
+                <span class="crisis-pin-point"></span>
+            </div>
+        `,
+    });
+}
+
+function formatPriority(priority: CrisisMapFeature["priorityLevel"]) {
+    return priority.charAt(0) + priority.slice(1).toLowerCase();
+}
+
+function createTooltipContent(feature: CrisisMapFeature) {
+    const wrapper = document.createElement("div");
+    wrapper.className = "crisis-tooltip-card";
+
+    const title = document.createElement("strong");
+    title.className = "crisis-tooltip-title";
+    title.textContent = feature.typeLabel;
+
+    const priority = document.createElement("span");
+    priority.className = `crisis-tooltip-priority is-${feature.priorityLevel.toLowerCase()}`;
+    priority.textContent = `Priority: ${formatPriority(feature.priorityLevel)}`;
+
+    const location = document.createElement("span");
+    location.className = "crisis-tooltip-location";
+    location.textContent = `${feature.district}, ${feature.city}`;
+
+    wrapper.appendChild(title);
+    wrapper.appendChild(priority);
+    wrapper.appendChild(location);
+
+    return wrapper;
+}
+
+export function LeafletCrisisMap({
+    center,
+    features,
+    selectedFeatureId,
+    onSelectFeature,
+    heightClassName = "h-[380px] md:h-[500px]",
+    zoom = 11,
+}: LeafletCrisisMapProps) {
+    const mapRef = React.useRef<L.Map | null>(null);
+    const markerLayerRef = React.useRef<L.LayerGroup | null>(null);
+    const markerRefs = React.useRef<Map<string, L.Marker>>(new Map());
+    const onSelectRef = React.useRef(onSelectFeature);
+    const [mapReadyVersion, setMapReadyVersion] = React.useState(0);
+
+    React.useEffect(() => {
+        onSelectRef.current = onSelectFeature;
+    }, [onSelectFeature]);
+
+    React.useEffect(() => {
+        const map = mapRef.current;
+        if (!map || markerLayerRef.current) {
+            return;
+        }
+
+        markerLayerRef.current = L.layerGroup().addTo(map);
+    }, [mapReadyVersion]);
+
+    React.useEffect(() => {
+        return () => {
+            markerRefs.current.clear();
+            markerLayerRef.current?.clearLayers();
+            markerLayerRef.current = null;
+            mapRef.current = null;
+        };
+    }, []);
+
+    React.useEffect(() => {
+        const markerLayer = markerLayerRef.current;
+        if (!markerLayer) {
+            return;
+        }
+
+        for (const marker of markerRefs.current.values()) {
+            marker.closeTooltip();
+            marker.off();
+        }
+        markerLayer.clearLayers();
+        markerRefs.current.clear();
+
+        for (const feature of features) {
+            const marker = L.marker([feature.latitude, feature.longitude], {
+                icon: createMarkerIcon(feature, false),
+            });
+
+            marker.bindTooltip(createTooltipContent(feature), {
+                direction: "top",
+                offset: [0, -42],
+                opacity: 1,
+                sticky: true,
+                className: "crisis-leaflet-tooltip",
+            });
+            marker.on("mouseover", () => {
+                for (const [featureId, activeMarker] of markerRefs.current.entries()) {
+                    if (featureId !== feature.featureKey) {
+                        activeMarker.closeTooltip();
+                    }
+                }
+            });
+            marker.on("click", () => {
+                for (const activeMarker of markerRefs.current.values()) {
+                    activeMarker.closeTooltip();
+                }
+                onSelectRef.current(feature.featureKey);
+            });
+            marker.addTo(markerLayer);
+            markerRefs.current.set(feature.featureKey, marker);
+        }
+    }, [features, mapReadyVersion]);
+
+    React.useEffect(() => {
+        const map = mapRef.current;
+        if (!map) {
+            return;
+        }
+
+        if (!features.length) {
+            map.setView([center.latitude, center.longitude], zoom, { animate: true });
+            return;
+        }
+
+        const bounds = L.latLngBounds(features.map((item) => [item.latitude, item.longitude] as [number, number]));
+        map.fitBounds(bounds, { padding: [28, 28], maxZoom: 14 });
+    }, [features, center.latitude, center.longitude, zoom, mapReadyVersion]);
+
+    React.useEffect(() => {
+        for (const [featureId, marker] of markerRefs.current.entries()) {
+            const feature = features.find((item) => item.featureKey === featureId);
+            if (!feature) {
+                continue;
+            }
+            const isSelected = featureId === selectedFeatureId;
+            marker.setIcon(createMarkerIcon(feature, isSelected));
+            marker.setTooltipContent(createTooltipContent(feature));
+        }
+    }, [selectedFeatureId, features]);
+
+    return (
+        <LeafletMapCanvas
+            center={center}
+            zoom={zoom}
+            heightClassName={heightClassName}
+            ariaLabel="Live crisis help requests map"
+            onMapReady={(map) => {
+                mapRef.current = map;
+                setMapReadyVersion((version) => version + 1);
+            }}
+        />
+    );
+}
+
+export type { CrisisMapFeature, CrisisRequestType };

--- a/web/src/components/layout/TopNavbar.tsx
+++ b/web/src/components/layout/TopNavbar.tsx
@@ -13,13 +13,14 @@ const navItemsOrdered = [
     { label: "News", href: "/news" },
     { label: "Notifications", href: "/notifications" },
     { label: "Emergency Numbers", href: "/emergency-numbers" },
+    { label: "Help Request Map", href: "/crisis-map" },
     { label: "Gathering Areas", href: "/gathering-areas" },
     { label: "Admin", href: "/admin", requiresAdmin: true },
     { label: "Profile", href: "/profile" },
     { label: "Privacy & Security", href: "/privacy-security" },
 ];
 
-const guestAllowedPaths = new Set(["/home", "/news", "/emergency-numbers", "/gathering-areas"]);
+const guestAllowedPaths = new Set(["/home", "/news", "/emergency-numbers", "/crisis-map", "/gathering-areas"]);
 
 export function TopNavbar() {
     const router = useRouter();

--- a/web/src/lib/crisisMap.ts
+++ b/web/src/lib/crisisMap.ts
@@ -1,0 +1,62 @@
+import { apiRequest } from "@/lib/api";
+
+export type ActiveHelpRequestStatus = "PENDING" | "ASSIGNED" | "IN_PROGRESS";
+export type AssignmentState = "ASSIGNED" | "UNASSIGNED";
+
+export type ActiveHelpRequestItem = {
+    requestId: string;
+    type: string;
+    status: ActiveHelpRequestStatus;
+    urgencyLevel: "LOW" | "MEDIUM" | "HIGH";
+    createdAt: string;
+    assignmentState: AssignmentState;
+    location: {
+        latitude: number | null;
+        longitude: number | null;
+        city: string;
+        district: string;
+        neighborhood?: string;
+    };
+};
+
+type ActiveHelpRequestsResponse = {
+    requests: ActiveHelpRequestItem[];
+    total: number;
+    pagination: {
+        limit: number;
+        offset: number;
+    };
+};
+
+export async function fetchActiveHelpRequests(options: {
+    token?: string | null;
+    type?: string;
+    status?: string;
+    bbox?: string;
+    limit?: number;
+    offset?: number;
+} = {}) {
+    const params = new URLSearchParams();
+
+    if (options.type?.trim()) {
+        params.set("type", options.type.trim());
+    }
+    if (options.status?.trim()) {
+        params.set("status", options.status.trim());
+    }
+    if (options.bbox?.trim()) {
+        params.set("bbox", options.bbox.trim());
+    }
+    if (typeof options.limit === "number") {
+        params.set("limit", String(options.limit));
+    }
+    if (typeof options.offset === "number") {
+        params.set("offset", String(options.offset));
+    }
+
+    const query = params.toString() ? `?${params.toString()}` : "";
+    return apiRequest<ActiveHelpRequestsResponse>(`/help-requests/active${query}`, {
+        token: options.token || undefined,
+    });
+}
+

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -175,10 +175,14 @@ textarea::placeholder {
 
 .top-navbar-inner {
     display: flex;
+    width: 100%;
+    max-width: 96rem;
     height: 64px;
     align-items: center;
     justify-content: space-between;
-    gap: 16px;
+    gap: 12px;
+    padding-left: 16px;
+    padding-right: 16px;
 }
 
 .top-navbar-brand {
@@ -195,22 +199,47 @@ textarea::placeholder {
 @media (min-width: 768px) {
     .top-navbar-nav {
         display: flex;
+        flex: 0 1 auto;
         align-items: center;
-        gap: 8px;
+        justify-content: flex-start;
+        gap: 6px;
+        min-width: 0;
+        max-width: calc(100% - 112px);
+        overflow-x: auto;
         border: 1px solid var(--border-subtle);
         border-radius: var(--radius-pill);
         background: var(--surface-soft);
         padding: 4px;
+        scrollbar-width: none;
+    }
+
+    .top-navbar-nav::-webkit-scrollbar {
+        display: none;
     }
 }
 
 .top-navbar-nav-item {
+    flex: 0 0 auto;
     border-radius: var(--radius-pill);
-    padding: 8px 14px;
-    font-size: 0.875rem;
+    padding: 8px 10px;
+    font-size: 0.82rem;
     font-weight: 600;
+    white-space: nowrap;
     color: var(--text-secondary);
     transition: color 180ms ease, background-color 180ms ease, box-shadow 180ms ease;
+}
+
+@media (min-width: 1280px) {
+    .top-navbar-nav {
+        justify-content: center;
+        gap: 8px;
+        max-width: calc(100% - 128px);
+    }
+
+    .top-navbar-nav-item {
+        padding: 8px 14px;
+        font-size: 0.875rem;
+    }
 }
 
 .top-navbar-nav-item:hover {
@@ -901,6 +930,125 @@ textarea::placeholder {
 
 .gathering-areas-map-wrap .leaflet-container {
     z-index: 1;
+}
+
+.crisis-pin {
+    position: relative;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    filter: drop-shadow(0 8px 14px rgba(17, 24, 39, 0.22));
+    transform: translateY(-4px);
+    transition: transform 160ms ease, filter 160ms ease;
+}
+
+.crisis-pin-head {
+    position: relative;
+    display: grid;
+    width: 34px;
+    height: 34px;
+    place-items: center;
+    border: 2px solid #ffffff;
+    border-radius: 13px 13px 13px 4px;
+    background:
+        radial-gradient(circle at 32% 28%, rgba(255, 255, 255, 0.32), transparent 34%),
+        linear-gradient(135deg, color-mix(in srgb, var(--pin-fill) 90%, #ffffff), var(--pin-fill));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--pin-stroke) 70%, transparent);
+    transform: rotate(-45deg);
+}
+
+.crisis-pin-glyph {
+    display: inline-flex;
+    min-width: 18px;
+    align-items: center;
+    justify-content: center;
+    color: #ffffff;
+    font-size: 0.72rem;
+    font-weight: 800;
+    line-height: 1;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.24);
+    transform: rotate(45deg);
+}
+
+.crisis-pin-point {
+    width: 10px;
+    height: 4px;
+    margin-top: 5px;
+    border-radius: 999px;
+    background: rgba(17, 24, 39, 0.22);
+    transform: scaleX(0.8);
+}
+
+.crisis-pin.is-selected {
+    filter: drop-shadow(0 10px 18px rgba(17, 24, 39, 0.34));
+    transform: translateY(-8px) scale(1.06);
+}
+
+.crisis-pin.is-selected .crisis-pin-head {
+    border-color: #111827;
+    box-shadow:
+        0 0 0 3px rgba(255, 255, 255, 0.92),
+        inset 0 0 0 1px color-mix(in srgb, var(--pin-stroke) 70%, transparent);
+}
+
+.crisis-leaflet-tooltip {
+    border: 0 !important;
+    border-radius: 12px !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+}
+
+.crisis-leaflet-tooltip::before {
+    display: none;
+}
+
+.crisis-tooltip-card {
+    display: grid;
+    min-width: 170px;
+    gap: 6px;
+    border: 1px solid rgba(17, 24, 39, 0.08);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 14px 28px rgba(17, 24, 39, 0.18);
+    padding: 10px 12px;
+    backdrop-filter: blur(8px);
+}
+
+.crisis-tooltip-title {
+    color: var(--text-primary);
+    font-size: 0.84rem;
+    line-height: 1.2;
+}
+
+.crisis-tooltip-priority {
+    width: fit-content;
+    border-radius: 999px;
+    padding: 3px 8px;
+    font-size: 0.72rem;
+    font-weight: 800;
+    line-height: 1;
+}
+
+.crisis-tooltip-priority.is-high {
+    background: #ffe3e3;
+    color: #a62626;
+}
+
+.crisis-tooltip-priority.is-medium {
+    background: #fff3bf;
+    color: #8a5a00;
+}
+
+.crisis-tooltip-priority.is-low {
+    background: #dcfce7;
+    color: #166534;
+}
+
+.crisis-tooltip-location {
+    color: var(--text-secondary);
+    font-size: 0.76rem;
 }
 
 .gathering-areas-map-wrap .leaflet-top,


### PR DESCRIPTION
## Summary
- Add the web Help Request Map screen using the shared Leaflet map infrastructure.
- Fetch active help requests from the backend with `status=PENDING`.
- Display only waiting/unassigned help requests as typed map markers.
- Add distinct marker styles for shelter, first aid, search and rescue, food/water, and unknown request types.
- Show request type, priority, location, and opened time when a marker is selected.
- Add loading, empty, error, and refresh states.
- Allow guest users to access the Help Request Map.
- Update the top navbar to include Help Request Map.
- Add web e2e coverage for guest visibility, marker details, filtering assigned requests from the UI, empty state, error state, and refresh behavior.

Related to #381 web scope
