### PR TITLE
feat: Add Android Help Request Map for waiting crisis requests

### DIFF
--- a/android/app/src/androidTest/java/com/neph/e2e/AndroidE2ETest.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/AndroidE2ETest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -34,6 +35,30 @@ class AndroidE2ETest {
 
         waitForText("Request Help")
         composeRule.onNodeWithText("Request Help").assertIsDisplayed()
+    }
+
+    @Test
+    fun guest_can_openHelpRequestMap_andSeeWaitingRequests() {
+        waitForClickable("Continue as Guest")
+        clickableNode("Continue as Guest").performClick()
+
+        waitForText("Request Help")
+        composeRule.onAllNodesWithContentDescription("Open menu")[0].performClick()
+        waitForClickable("Help Request Map")
+        clickableNode("Help Request Map").performClick()
+
+        waitForText("Showing waiting help requests by type and priority.")
+        composeRule.onAllNodesWithText("Help Request Map")[0].assertIsDisplayed()
+        composeRule.onAllNodesWithText("First Aid")[0].assertIsDisplayed()
+        composeRule.onAllNodesWithText("Shelter")[0].assertIsDisplayed()
+        composeRule.onAllNodesWithText("Priority: High")[0].assertIsDisplayed()
+        composeRule.onAllNodesWithText("Waiting Requests")[0].assertIsDisplayed()
+
+        composeRule.waitUntil(5_000) {
+            contentDescriptionNodeCount("Crisis marker") == 2 &&
+                textNodeCount("Search and Rescue") == 0 &&
+                textNodeCount("sariyer") == 0
+        }
     }
 
     @Test
@@ -119,5 +144,17 @@ class AndroidE2ETest {
         return runCatching {
             composeRule.onAllNodesWithText(text).fetchSemanticsNodes().isNotEmpty()
         }.getOrDefault(false)
+    }
+
+    private fun textNodeCount(text: String): Int {
+        return runCatching {
+            composeRule.onAllNodesWithText(text).fetchSemanticsNodes().size
+        }.getOrDefault(0)
+    }
+
+    private fun contentDescriptionNodeCount(text: String): Int {
+        return runCatching {
+            composeRule.onAllNodesWithContentDescription(text, substring = true).fetchSemanticsNodes().size
+        }.getOrDefault(0)
     }
 }

--- a/android/app/src/androidTest/java/com/neph/e2e/FakeNephBackend.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/FakeNephBackend.kt
@@ -185,6 +185,7 @@ class FakeNephBackend {
             route == "/availability/status" && method == "GET" -> handleAvailabilityStatus(token)
             route == "/availability/my-assignment" && method == "GET" -> handleCurrentAssignment(token)
             route == "/help-requests" && method == "GET" -> handleHelpRequestList(token)
+            route == "/help-requests/active" && method == "GET" -> handleActiveHelpRequests(uri)
             route == "/location/tree" && method == "GET" -> handleLocationTree(uri)
             route == "/gathering-areas/nearby" && method == "GET" -> handleNearbyGatheringAreas(uri)
             else -> throw ApiException(
@@ -286,6 +287,79 @@ class FakeNephBackend {
                         }
                     })
             )
+    }
+
+    private fun handleActiveHelpRequests(uri: Uri): JSONObject {
+        val status = uri.getQueryParameter("status").orEmpty().uppercase(Locale.ROOT).ifBlank { "PENDING" }
+        if (status != "PENDING") {
+            throw ApiException("`status` contains invalid values: $status.", 400, "VALIDATION_FAILED")
+        }
+
+        val limit = (uri.getQueryParameter("limit")?.toIntOrNull() ?: 300).coerceIn(1, 300)
+        val offset = (uri.getQueryParameter("offset")?.toIntOrNull() ?: 0).coerceAtLeast(0)
+
+        val allRequests = JSONArray().apply {
+            put(
+                JSONObject()
+                    .put("requestId", "fake-map-first-aid")
+                    .put("type", "first_aid")
+                    .put("status", "PENDING")
+                    .put("urgencyLevel", "HIGH")
+                    .put("createdAt", "2026-05-01T10:15:00.000Z")
+                    .put("assignmentState", "UNASSIGNED")
+                    .put(
+                        "location",
+                        JSONObject()
+                            .put("latitude", 41.043)
+                            .put("longitude", 29.009)
+                            .put("city", "istanbul")
+                            .put("district", "besiktas")
+                    )
+            )
+            put(
+                JSONObject()
+                    .put("requestId", "fake-map-shelter")
+                    .put("type", "shelter")
+                    .put("status", "PENDING")
+                    .put("urgencyLevel", "MEDIUM")
+                    .put("createdAt", "2026-05-01T10:05:00.000Z")
+                    .put("assignmentState", "UNASSIGNED")
+                    .put(
+                        "location",
+                        JSONObject()
+                            .put("latitude", 41.066)
+                            .put("longitude", 28.993)
+                            .put("city", "istanbul")
+                            .put("district", "sisli")
+                    )
+            )
+            put(
+                JSONObject()
+                    .put("requestId", "fake-map-assigned")
+                    .put("type", "search_and_rescue")
+                    .put("status", "PENDING")
+                    .put("urgencyLevel", "HIGH")
+                    .put("createdAt", "2026-05-01T09:55:00.000Z")
+                    .put("assignmentState", "ASSIGNED")
+                    .put(
+                        "location",
+                        JSONObject()
+                            .put("latitude", 41.079)
+                            .put("longitude", 29.022)
+                            .put("city", "istanbul")
+                            .put("district", "sariyer")
+                    )
+            )
+        }
+
+        return JSONObject()
+            .put("requests", JSONArray().apply {
+                for (index in offset until minOf(offset + limit, allRequests.length())) {
+                    put(allRequests.getJSONObject(index))
+                }
+            })
+            .put("total", allRequests.length())
+            .put("pagination", JSONObject().put("limit", limit).put("offset", offset))
     }
 
     private fun handleLocationTree(uri: Uri): JSONObject {

--- a/android/app/src/main/java/com/neph/features/helprequestmap/data/ActiveHelpRequestsRepository.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/data/ActiveHelpRequestsRepository.kt
@@ -6,10 +6,9 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
+import java.text.SimpleDateFormat
 import java.util.Locale
+import java.util.TimeZone
 
 enum class CrisisRequestType {
     SHELTER,
@@ -163,15 +162,31 @@ object ActiveHelpRequestsRepository {
     }
 
     fun formatOpenedAt(createdAt: String): String {
-        val parsed = runCatching { Instant.parse(createdAt) }.getOrNull() ?: return createdAt
-        return DateTimeFormatter
-            .ofPattern("MMM d, yyyy, HH:mm", Locale.US)
-            .withZone(ZoneId.systemDefault())
-            .format(parsed)
+        val parsed = runCatching {
+            IsoDateFormat.get().parse(createdAt)
+        }.getOrNull() ?: return createdAt
+
+        return DisplayDateFormat.get().format(parsed)
     }
 
     private fun urlEncode(value: String): String {
         return URLEncoder.encode(value, StandardCharsets.UTF_8.toString())
+    }
+
+    private val IsoDateFormat = object : ThreadLocal<SimpleDateFormat>() {
+        override fun initialValue(): SimpleDateFormat {
+            return SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }
+        }
+    }
+
+    private val DisplayDateFormat = object : ThreadLocal<SimpleDateFormat>() {
+        override fun initialValue(): SimpleDateFormat {
+            return SimpleDateFormat("MMM d, yyyy, HH:mm", Locale.US).apply {
+                timeZone = TimeZone.getDefault()
+            }
+        }
     }
 }
 

--- a/android/app/src/main/java/com/neph/features/helprequestmap/data/ActiveHelpRequestsRepository.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/data/ActiveHelpRequestsRepository.kt
@@ -1,0 +1,182 @@
+package com.neph.features.helprequestmap.data
+
+import com.neph.core.network.JsonHttpClient
+import com.neph.features.auth.data.AuthSessionStore
+import org.json.JSONArray
+import org.json.JSONObject
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+enum class CrisisRequestType {
+    SHELTER,
+    FIRST_AID,
+    SEARCH_AND_RESCUE,
+    FOOD_WATER,
+    OTHER
+}
+
+data class ActiveHelpRequestMapItem(
+    val requestId: String,
+    val rawType: String,
+    val type: CrisisRequestType,
+    val typeLabel: String,
+    val priorityLevel: String,
+    val createdAt: String,
+    val latitude: Double,
+    val longitude: Double,
+    val city: String,
+    val district: String
+)
+
+data class ActiveHelpRequestsResult(
+    val requests: List<ActiveHelpRequestMapItem>,
+    val total: Int,
+    val limit: Int,
+    val offset: Int,
+    val skippedCount: Int
+)
+
+object ActiveHelpRequestsRepository {
+    private const val DefaultLimit = 300
+
+    suspend fun fetchWaitingHelpRequests(
+        limit: Int = DefaultLimit,
+        offset: Int = 0,
+        type: String? = null,
+        bbox: String? = null
+    ): ActiveHelpRequestsResult {
+        val query = buildList {
+            add("status=PENDING")
+            add("limit=${limit.coerceIn(1, DefaultLimit)}")
+            add("offset=${offset.coerceAtLeast(0)}")
+            type?.trim()?.takeIf { it.isNotBlank() }?.let {
+                add("type=${urlEncode(it)}")
+            }
+            bbox?.trim()?.takeIf { it.isNotBlank() }?.let {
+                add("bbox=${urlEncode(it)}")
+            }
+        }.joinToString("&")
+
+        val response = JsonHttpClient.request(
+            path = "/help-requests/active?$query",
+            token = AuthSessionStore.getAccessToken()
+        )
+
+        return parseActiveHelpRequestsResponse(response)
+    }
+
+    internal fun parseActiveHelpRequestsResponse(response: JSONObject): ActiveHelpRequestsResult {
+        val rawRequests = response.optJSONArray("requests") ?: JSONArray()
+        var skippedCount = 0
+        val parsed = buildList {
+            for (index in 0 until rawRequests.length()) {
+                val item = rawRequests.optJSONObject(index)
+                if (item == null) {
+                    skippedCount += 1
+                    continue
+                }
+
+                val mapped = parseActiveHelpRequest(item)
+                if (mapped == null) {
+                    skippedCount += 1
+                    continue
+                }
+
+                add(mapped)
+            }
+        }
+
+        val pagination = response.optJSONObject("pagination") ?: JSONObject()
+        return ActiveHelpRequestsResult(
+            requests = parsed,
+            total = response.optInt("total", parsed.size),
+            limit = pagination.optInt("limit", DefaultLimit),
+            offset = pagination.optInt("offset", 0),
+            skippedCount = skippedCount
+        )
+    }
+
+    private fun parseActiveHelpRequest(item: JSONObject): ActiveHelpRequestMapItem? {
+        val status = item.optString("status").trim().uppercase(Locale.ROOT)
+        val assignmentState = item.optString("assignmentState").trim().uppercase(Locale.ROOT)
+        if (status != "PENDING" || assignmentState == "ASSIGNED") {
+            return null
+        }
+
+        val location = item.optJSONObject("location") ?: return null
+        val latitude = location.optFiniteDouble("latitude") ?: return null
+        val longitude = location.optFiniteDouble("longitude") ?: return null
+        if (latitude !in -90.0..90.0 || longitude !in -180.0..180.0) {
+            return null
+        }
+
+        val rawType = item.optString("type").trim().ifBlank { "unknown" }
+        val type = normalizeRequestType(rawType)
+        val priority = item.optString("urgencyLevel").trim().uppercase(Locale.ROOT).ifBlank { "MEDIUM" }
+
+        return ActiveHelpRequestMapItem(
+            requestId = item.optString("requestId").trim().ifBlank { return null },
+            rawType = rawType,
+            type = type,
+            typeLabel = labelForType(type),
+            priorityLevel = when (priority) {
+                "LOW", "MEDIUM", "HIGH" -> priority
+                else -> "MEDIUM"
+            },
+            createdAt = item.optString("createdAt").trim(),
+            latitude = latitude,
+            longitude = longitude,
+            city = location.optString("city").trim().ifBlank { "unknown" },
+            district = location.optString("district").trim().ifBlank { "unknown" }
+        )
+    }
+
+    fun normalizeRequestType(rawType: String): CrisisRequestType {
+        return when (rawType.trim().lowercase(Locale.ROOT)) {
+            "shelter" -> CrisisRequestType.SHELTER
+            "first_aid" -> CrisisRequestType.FIRST_AID
+            "fire_brigade",
+            "search_and_rescue" -> CrisisRequestType.SEARCH_AND_RESCUE
+            "food",
+            "water",
+            "food_water" -> CrisisRequestType.FOOD_WATER
+            else -> CrisisRequestType.OTHER
+        }
+    }
+
+    fun labelForType(type: CrisisRequestType): String {
+        return when (type) {
+            CrisisRequestType.SHELTER -> "Shelter"
+            CrisisRequestType.FIRST_AID -> "First Aid"
+            CrisisRequestType.SEARCH_AND_RESCUE -> "Search and Rescue"
+            CrisisRequestType.FOOD_WATER -> "Food / Water Supplies"
+            CrisisRequestType.OTHER -> "Other / Unknown"
+        }
+    }
+
+    fun formatPriority(priority: String): String {
+        return priority.trim().lowercase(Locale.ROOT).replaceFirstChar { it.uppercase() }
+    }
+
+    fun formatOpenedAt(createdAt: String): String {
+        val parsed = runCatching { Instant.parse(createdAt) }.getOrNull() ?: return createdAt
+        return DateTimeFormatter
+            .ofPattern("MMM d, yyyy, HH:mm", Locale.US)
+            .withZone(ZoneId.systemDefault())
+            .format(parsed)
+    }
+
+    private fun urlEncode(value: String): String {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8.toString())
+    }
+}
+
+private fun JSONObject.optFiniteDouble(key: String): Double? {
+    if (!has(key) || isNull(key)) return null
+    val value = optDouble(key)
+    return value.takeIf { it.isFinite() }
+}

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -1,0 +1,627 @@
+package com.neph.features.helprequestmap.presentation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import com.neph.core.network.ApiException
+import com.neph.features.helprequestmap.data.ActiveHelpRequestMapItem
+import com.neph.features.helprequestmap.data.ActiveHelpRequestsRepository
+import com.neph.features.helprequestmap.data.CrisisRequestType
+import com.neph.navigation.Routes
+import com.neph.ui.components.buttons.SecondaryButton
+import com.neph.ui.components.buttons.TextActionButton
+import com.neph.ui.components.display.HelperText
+import com.neph.ui.components.display.SectionCard
+import com.neph.ui.components.display.SectionHeader
+import com.neph.ui.layout.AppDrawerScaffold
+import com.neph.ui.map.NephMapIntegration
+import com.neph.ui.theme.LocalNephSpacing
+import com.neph.ui.theme.NephTheme
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+
+@Composable
+fun HelpRequestMapScreen(
+    onNavigateToRoute: (String) -> Unit,
+    onOpenSettings: (() -> Unit)?,
+    onProfileClick: () -> Unit,
+    profileBadgeText: String,
+    isAuthenticated: Boolean
+) {
+    val spacing = LocalNephSpacing.current
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
+    var loading by remember { mutableStateOf(true) }
+    var errorMessage by remember { mutableStateOf("") }
+    var infoMessage by remember { mutableStateOf("") }
+    var requests by remember { mutableStateOf(emptyList<ActiveHelpRequestMapItem>()) }
+    var selectedRequestId by remember { mutableStateOf<String?>(null) }
+
+    fun loadWaitingRequests() {
+        scope.launch {
+            loading = true
+            errorMessage = ""
+            infoMessage = ""
+
+            try {
+                val result = ActiveHelpRequestsRepository.fetchWaitingHelpRequests()
+                requests = result.requests
+                selectedRequestId = when {
+                    result.requests.isEmpty() -> null
+                    selectedRequestId != null && result.requests.any { it.requestId == selectedRequestId } -> selectedRequestId
+                    else -> result.requests.first().requestId
+                }
+
+                if (result.requests.isEmpty()) {
+                    infoMessage = "No waiting help requests are available right now."
+                } else if (result.skippedCount > 0) {
+                    infoMessage = "${result.skippedCount} inactive or malformed request entries were hidden."
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (error: ApiException) {
+                errorMessage = error.message.ifBlank {
+                    "Could not load waiting help requests."
+                }
+                requests = emptyList()
+                selectedRequestId = null
+            } catch (_: Exception) {
+                errorMessage = "Could not load waiting help requests."
+                requests = emptyList()
+                selectedRequestId = null
+            } finally {
+                loading = false
+            }
+        }
+    }
+
+    fun openRequestInMap(item: ActiveHelpRequestMapItem) {
+        val opened = NephMapIntegration.openCoordinates(
+            context = context,
+            latitude = item.latitude,
+            longitude = item.longitude,
+            label = item.typeLabel
+        )
+        if (!opened) {
+            infoMessage = "Could not open map application."
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        loadWaitingRequests()
+    }
+
+    val selectedRequest = requests.firstOrNull { it.requestId == selectedRequestId } ?: requests.firstOrNull()
+
+    AppDrawerScaffold(
+        title = "Help Request Map",
+        currentRoute = Routes.HelpRequestMap.route,
+        onNavigateToRoute = onNavigateToRoute,
+        drawerItems = if (isAuthenticated) {
+            Routes.authenticatedDrawerItems
+        } else {
+            Routes.guestDrawerItems
+        },
+        onOpenSettings = onOpenSettings,
+        onProfileClick = onProfileClick,
+        profileBadgeText = profileBadgeText,
+        profileLabel = if (isAuthenticated) "Profile" else "Login / Create Account"
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(spacing.lg),
+            modifier = Modifier.verticalScroll(rememberScrollState())
+        ) {
+            SectionCard {
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                    SectionHeader(
+                        title = "Help Request Map",
+                        subtitle = "Showing waiting help requests by type and priority."
+                    )
+
+                    SecondaryButton(
+                        text = "Refresh Help Request Map",
+                        onClick = { loadWaitingRequests() },
+                        enabled = !loading
+                    )
+                }
+            }
+
+            when {
+                loading -> {
+                    SectionCard {
+                        HelperText(text = "Loading waiting help requests...")
+                    }
+                }
+
+                errorMessage.isNotBlank() -> {
+                    SectionCard {
+                        Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                            HelperText(text = errorMessage)
+                            SecondaryButton(
+                                text = "Retry",
+                                onClick = { loadWaitingRequests() }
+                            )
+                        }
+                    }
+                }
+
+                requests.isEmpty() -> {
+                    SectionCard {
+                        Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                            SectionHeader(
+                                title = "No Waiting Requests",
+                                subtitle = "There are no waiting help requests to show on the map right now."
+                            )
+                            SecondaryButton(
+                                text = "Retry",
+                                onClick = { loadWaitingRequests() }
+                            )
+                        }
+                    }
+                }
+
+                else -> {
+                    SectionCard {
+                        CrisisRequestMapPanel(
+                            requests = requests,
+                            selectedRequestId = selectedRequest?.requestId,
+                            onSelectRequest = { selectedRequestId = it }
+                        )
+                    }
+
+                    SectionCard {
+                        Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                            Text(
+                                text = "Selected Request",
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontWeight = FontWeight.SemiBold
+                            )
+
+                            if (selectedRequest != null) {
+                                RequestDetails(
+                                    item = selectedRequest,
+                                    onOpenMap = { openRequestInMap(selectedRequest) }
+                                )
+                            }
+                        }
+                    }
+
+                    SectionCard {
+                        Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                            Text(
+                                text = "Waiting Requests",
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                fontWeight = FontWeight.SemiBold
+                            )
+
+                            requests.forEachIndexed { index, item ->
+                                RequestListItem(
+                                    item = item,
+                                    selected = item.requestId == selectedRequest?.requestId,
+                                    onSelect = { selectedRequestId = item.requestId },
+                                    onOpenMap = { openRequestInMap(item) }
+                                )
+
+                                if (index < requests.lastIndex) {
+                                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (infoMessage.isNotBlank()) {
+                SectionCard {
+                    HelperText(text = infoMessage)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RequestDetails(
+    item: ActiveHelpRequestMapItem,
+    onOpenMap: () -> Unit
+) {
+    val spacing = LocalNephSpacing.current
+
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(spacing.md),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            PinGlyph(type = item.type)
+            Text(
+                text = item.typeLabel,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+
+        Text(
+            text = "Priority: ${ActiveHelpRequestsRepository.formatPriority(item.priorityLevel)}",
+            style = MaterialTheme.typography.bodyMedium,
+            color = priorityColor(item.priorityLevel)
+        )
+        Text(
+            text = "Location: ${item.district}, ${item.city}",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Text(
+            text = "Opened: ${ActiveHelpRequestsRepository.formatOpenedAt(item.createdAt)}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+        ) {
+            TextActionButton(
+                text = "Open in Map",
+                onClick = onOpenMap
+            )
+        }
+    }
+}
+
+@Composable
+private fun RequestListItem(
+    item: ActiveHelpRequestMapItem,
+    selected: Boolean,
+    onSelect: () -> Unit,
+    onOpenMap: () -> Unit
+) {
+    val spacing = LocalNephSpacing.current
+    val backgroundColor = if (selected) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.surface
+    }
+    val textColor = if (selected) {
+        MaterialTheme.colorScheme.onPrimaryContainer
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(backgroundColor, RoundedCornerShape(16.dp))
+            .clickable(onClick = onSelect),
+        verticalArrangement = Arrangement.spacedBy(spacing.xs)
+    ) {
+        Spacer(modifier = Modifier.height(spacing.sm))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(spacing.md),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            PinGlyph(type = item.type)
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.typeLabel,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = textColor,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Text(
+                    text = "Priority: ${ActiveHelpRequestsRepository.formatPriority(item.priorityLevel)} | ${item.district}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (selected) {
+                        MaterialTheme.colorScheme.onPrimaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    }
+                )
+            }
+            TextActionButton(text = "Open", onClick = onOpenMap)
+        }
+        Spacer(modifier = Modifier.height(spacing.sm))
+    }
+}
+
+@Composable
+private fun CrisisRequestMapPanel(
+    requests: List<ActiveHelpRequestMapItem>,
+    selectedRequestId: String?,
+    onSelectRequest: (String) -> Unit
+) {
+    val spacing = LocalNephSpacing.current
+    var zoom by remember { mutableStateOf(1f) }
+    var panX by remember { mutableStateOf(0f) }
+    var panY by remember { mutableStateOf(0f) }
+    val minLatitude = requests.minOfOrNull { it.latitude } ?: 0.0
+    val maxLatitude = requests.maxOfOrNull { it.latitude } ?: minLatitude
+    val minLongitude = requests.minOfOrNull { it.longitude } ?: 0.0
+    val maxLongitude = requests.maxOfOrNull { it.longitude } ?: minLongitude
+    val latSpan = (maxLatitude - minLatitude).takeIf { it > 0.000001 } ?: 0.01
+    val lonSpan = (maxLongitude - minLongitude).takeIf { it > 0.000001 } ?: 0.01
+    val selectedRequest = requests.firstOrNull { it.requestId == selectedRequestId }
+
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+        SectionHeader(
+            title = "Live Crisis Map",
+            subtitle = "Pinch or drag the map, then tap a marker to see request details."
+        )
+
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1.18f)
+                .clip(RoundedCornerShape(20.dp))
+                .background(
+                    Brush.linearGradient(
+                        listOf(
+                            Color(0xFFE2ECE8),
+                            Color(0xFFDDE7EF),
+                            Color(0xFFECE6D8)
+                        )
+                    )
+                )
+                .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(20.dp))
+                .pointerInput(Unit) {
+                    detectTransformGestures { _, pan, gestureZoom, _ ->
+                        val nextZoom = (zoom * gestureZoom).coerceIn(1f, 2.6f)
+                        zoom = nextZoom
+                        panX = (panX + pan.x).coerceIn(-220f * nextZoom, 220f * nextZoom)
+                        panY = (panY + pan.y).coerceIn(-220f * nextZoom, 220f * nextZoom)
+                    }
+                }
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(maxHeight)
+                    .graphicsLayer {
+                        scaleX = zoom
+                        scaleY = zoom
+                        translationX = panX
+                        translationY = panY
+                    }
+            ) {
+                MapRoad(
+                    modifier = Modifier
+                        .offset { IntOffset(0, (maxHeight * 0.22f).roundToPx()) }
+                        .fillMaxWidth()
+                        .height(12.dp)
+                )
+                MapRoad(
+                    modifier = Modifier
+                        .offset { IntOffset(0, (maxHeight * 0.58f).roundToPx()) }
+                        .fillMaxWidth()
+                        .height(9.dp)
+                )
+                MapRoad(
+                    modifier = Modifier
+                        .offset { IntOffset((maxWidth * 0.30f).roundToPx(), 0) }
+                        .size(11.dp, maxHeight)
+                )
+                MapRoad(
+                    modifier = Modifier
+                        .offset { IntOffset((maxWidth * 0.70f).roundToPx(), 0) }
+                        .size(8.dp, maxHeight)
+                )
+                MapNeighborhoodPatch(
+                    modifier = Modifier
+                        .offset { IntOffset((maxWidth * 0.08f).roundToPx(), (maxHeight * 0.10f).roundToPx()) }
+                        .size(width = maxWidth * 0.24f, height = maxHeight * 0.18f)
+                )
+                MapNeighborhoodPatch(
+                    modifier = Modifier
+                        .offset { IntOffset((maxWidth * 0.58f).roundToPx(), (maxHeight * 0.68f).roundToPx()) }
+                        .size(width = maxWidth * 0.28f, height = maxHeight * 0.16f)
+                )
+
+                requests.forEach { item ->
+                    val xFraction = ((item.longitude - minLongitude) / lonSpan).coerceIn(0.08, 0.92)
+                    val yFraction = (1.0 - ((item.latitude - minLatitude) / latSpan)).coerceIn(0.10, 0.88)
+                    val x = (maxWidth * xFraction.toFloat()).roundToPx() - 21
+                    val y = (maxHeight * yFraction.toFloat()).roundToPx() - 42
+
+                    MapMarker(
+                        item = item,
+                        selected = item.requestId == selectedRequestId,
+                        modifier = Modifier.offset { IntOffset(x, y) },
+                        onClick = { onSelectRequest(item.requestId) }
+                    )
+                }
+            }
+
+            if (selectedRequest != null) {
+                MapTooltip(
+                    item = selectedRequest,
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(spacing.md)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MapRoad(modifier: Modifier) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(999.dp))
+            .background(Color.White.copy(alpha = 0.72f))
+            .border(1.dp, Color(0xFFC8D4D8).copy(alpha = 0.70f), RoundedCornerShape(999.dp))
+    )
+}
+
+@Composable
+private fun MapNeighborhoodPatch(modifier: Modifier) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(18.dp))
+            .background(Color.White.copy(alpha = 0.32f))
+            .border(1.dp, Color.White.copy(alpha = 0.45f), RoundedCornerShape(18.dp))
+    )
+}
+
+@Composable
+private fun MapTooltip(
+    item: ActiveHelpRequestMapItem,
+    modifier: Modifier
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(14.dp))
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.94f))
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(14.dp))
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(3.dp)
+    ) {
+        Text(
+            text = item.typeLabel,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.SemiBold
+        )
+        Text(
+            text = "Priority: ${ActiveHelpRequestsRepository.formatPriority(item.priorityLevel)}",
+            style = MaterialTheme.typography.labelMedium,
+            color = priorityColor(item.priorityLevel)
+        )
+        Text(
+            text = "${item.district}, ${item.city}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun MapMarker(
+    item: ActiveHelpRequestMapItem,
+    selected: Boolean,
+    modifier: Modifier,
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .semantics {
+                contentDescription = "Crisis marker ${item.typeLabel}"
+            }
+            .clickable(onClick = onClick),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        PinGlyph(type = item.type, selected = selected)
+        Box(
+            modifier = Modifier
+                .padding(top = 3.dp)
+                .size(width = 16.dp, height = 5.dp)
+                .clip(RoundedCornerShape(999.dp))
+                .background(Color.Black.copy(alpha = if (selected) 0.30f else 0.18f))
+        )
+    }
+}
+
+@Composable
+private fun PinGlyph(type: CrisisRequestType, selected: Boolean = false) {
+    val style = markerStyle(type)
+
+    Box(
+        modifier = Modifier
+            .size(if (selected) 40.dp else 34.dp)
+            .background(style.color, RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp, bottomEnd = 14.dp, bottomStart = 5.dp))
+            .border(
+                width = if (selected) 3.dp else 2.dp,
+                color = if (selected) MaterialTheme.colorScheme.onSurface else Color.White,
+                shape = RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp, bottomEnd = 14.dp, bottomStart = 5.dp)
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = style.glyph,
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+private data class MarkerStyle(
+    val color: Color,
+    val glyph: String
+)
+
+private fun markerStyle(type: CrisisRequestType): MarkerStyle {
+    return when (type) {
+        CrisisRequestType.SHELTER -> MarkerStyle(Color(0xFF3B66D8), "SH")
+        CrisisRequestType.FIRST_AID -> MarkerStyle(Color(0xFFD94141), "+")
+        CrisisRequestType.SEARCH_AND_RESCUE -> MarkerStyle(Color(0xFFF08C00), "SR")
+        CrisisRequestType.FOOD_WATER -> MarkerStyle(Color(0xFF2F9E67), "FW")
+        CrisisRequestType.OTHER -> MarkerStyle(Color(0xFF687280), "?")
+    }
+}
+
+private fun priorityColor(priority: String): Color {
+    return when (priority.trim().uppercase()) {
+        "HIGH" -> Color(0xFFA62626)
+        "LOW" -> Color(0xFF166534)
+        else -> Color(0xFF8A5A00)
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+private fun HelpRequestMapScreenPreview() {
+    NephTheme {
+        HelpRequestMapScreen(
+            onNavigateToRoute = {},
+            onOpenSettings = {},
+            onProfileClick = {},
+            profileBadgeText = "PP",
+            isAuthenticated = true
+        )
+    }
+}

--- a/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
@@ -24,6 +24,7 @@ import com.neph.features.auth.presentation.VerifyEmailScreen
 import com.neph.features.auth.presentation.WelcomeScreen
 import com.neph.features.emergencyinfo.presentation.EmergencyInfoScreen
 import com.neph.features.gatheringareas.presentation.GatheringAreasScreen
+import com.neph.features.helprequestmap.presentation.HelpRequestMapScreen
 import com.neph.features.home.presentation.HomeScreen
 import com.neph.features.myhelprequests.presentation.MyHelpRequestsScreen
 import com.neph.features.news.presentation.NewsScreen
@@ -270,6 +271,29 @@ fun AppNavGraph(
             val profileBadgeText = resolveProfileBadgeText(authenticated)
 
             GatheringAreasScreen(
+                onNavigateToRoute = ::navigateToDrawerRoute,
+                onOpenSettings = if (authenticated) {
+                    { navigateToDrawerRoute(Routes.Settings.route) }
+                } else {
+                    null
+                },
+                onProfileClick = {
+                    if (authenticated) {
+                        navigateToDrawerRoute(Routes.Profile.route)
+                    } else {
+                        navigateToLogin()
+                    }
+                },
+                profileBadgeText = profileBadgeText,
+                isAuthenticated = authenticated
+            )
+        }
+
+        composable(Routes.HelpRequestMap.route) {
+            val authenticated = isAuthenticated()
+            val profileBadgeText = resolveProfileBadgeText(authenticated)
+
+            HelpRequestMapScreen(
                 onNavigateToRoute = ::navigateToDrawerRoute,
                 onOpenSettings = if (authenticated) {
                     { navigateToDrawerRoute(Routes.Settings.route) }

--- a/android/app/src/main/java/com/neph/navigation/Routes.kt
+++ b/android/app/src/main/java/com/neph/navigation/Routes.kt
@@ -10,6 +10,7 @@ sealed class Routes(
     data object MyHelpRequests : Routes("my_help_requests", "My Help Requests")
     data object AssignedRequest : Routes("assigned_request", "Assigned Request")
     data object EmergencyInfo : Routes("emergency_info", "Emergency Numbers")
+    data object HelpRequestMap : Routes("help_request_map", "Help Request Map")
     data object GatheringAreas : Routes("gathering_areas", "Gathering Areas")
     data object Notifications : Routes("notifications", "Notifications")
     data object Settings : Routes("settings", "Settings")
@@ -33,6 +34,7 @@ sealed class Routes(
             MyHelpRequests,
             AssignedRequest,
             EmergencyInfo,
+            HelpRequestMap,
             GatheringAreas,
             Notifications
         )
@@ -42,6 +44,7 @@ sealed class Routes(
             News,
             MyHelpRequests,
             EmergencyInfo,
+            HelpRequestMap,
             GatheringAreas
         )
 

--- a/android/app/src/test/java/com/neph/features/helprequestmap/data/ActiveHelpRequestsRepositoryTest.kt
+++ b/android/app/src/test/java/com/neph/features/helprequestmap/data/ActiveHelpRequestsRepositoryTest.kt
@@ -1,0 +1,91 @@
+package com.neph.features.helprequestmap.data
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ActiveHelpRequestsRepositoryTest {
+    @Test
+    fun parseActiveHelpRequestsResponse_mapsWaitingUnassignedRequestsAndHidesAssignedOnes() {
+        val response = JSONObject()
+            .put(
+                "requests",
+                JSONArray()
+                    .put(
+                        JSONObject()
+                            .put("requestId", "req-first-aid")
+                            .put("type", "first_aid")
+                            .put("status", "PENDING")
+                            .put("urgencyLevel", "HIGH")
+                            .put("createdAt", "2026-05-01T10:15:00.000Z")
+                            .put("assignmentState", "UNASSIGNED")
+                            .put(
+                                "location",
+                                JSONObject()
+                                    .put("latitude", 41.043)
+                                    .put("longitude", 29.009)
+                                    .put("city", "istanbul")
+                                    .put("district", "besiktas")
+                            )
+                    )
+                    .put(
+                        JSONObject()
+                            .put("requestId", "req-assigned")
+                            .put("type", "search_and_rescue")
+                            .put("status", "PENDING")
+                            .put("urgencyLevel", "HIGH")
+                            .put("createdAt", "2026-05-01T10:05:00.000Z")
+                            .put("assignmentState", "ASSIGNED")
+                            .put(
+                                "location",
+                                JSONObject()
+                                    .put("latitude", 41.079)
+                                    .put("longitude", 29.022)
+                                    .put("city", "istanbul")
+                                    .put("district", "sariyer")
+                            )
+                    )
+                    .put(
+                        JSONObject()
+                            .put("requestId", "req-resolved")
+                            .put("type", "shelter")
+                            .put("status", "RESOLVED")
+                            .put("urgencyLevel", "MEDIUM")
+                            .put("createdAt", "2026-05-01T09:55:00.000Z")
+                            .put("assignmentState", "UNASSIGNED")
+                            .put(
+                                "location",
+                                JSONObject()
+                                    .put("latitude", 41.0)
+                                    .put("longitude", 29.0)
+                                    .put("city", "istanbul")
+                                    .put("district", "sisli")
+                            )
+                    )
+            )
+            .put("total", 3)
+            .put("pagination", JSONObject().put("limit", 300).put("offset", 0))
+
+        val parsed = ActiveHelpRequestsRepository.parseActiveHelpRequestsResponse(response)
+
+        assertEquals(1, parsed.requests.size)
+        assertEquals(2, parsed.skippedCount)
+        assertEquals(3, parsed.total)
+        assertEquals(300, parsed.limit)
+        assertEquals("req-first-aid", parsed.requests.first().requestId)
+        assertEquals(CrisisRequestType.FIRST_AID, parsed.requests.first().type)
+        assertEquals("First Aid", parsed.requests.first().typeLabel)
+        assertEquals("HIGH", parsed.requests.first().priorityLevel)
+    }
+
+    @Test
+    fun normalizeRequestType_groupsFoodWaterAndSearchRescueTypes() {
+        assertEquals(CrisisRequestType.FOOD_WATER, ActiveHelpRequestsRepository.normalizeRequestType("food"))
+        assertEquals(CrisisRequestType.FOOD_WATER, ActiveHelpRequestsRepository.normalizeRequestType("water"))
+        assertEquals(CrisisRequestType.FOOD_WATER, ActiveHelpRequestsRepository.normalizeRequestType("food_water"))
+        assertEquals(CrisisRequestType.SEARCH_AND_RESCUE, ActiveHelpRequestsRepository.normalizeRequestType("fire_brigade"))
+        assertEquals(CrisisRequestType.SEARCH_AND_RESCUE, ActiveHelpRequestsRepository.normalizeRequestType("search_and_rescue"))
+        assertEquals(CrisisRequestType.OTHER, ActiveHelpRequestsRepository.normalizeRequestType("unknown"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add Android Help Request Map screen for guest and authenticated users
- Fetch active help requests with `status=PENDING`
- Show only waiting/unassigned requests as crisis markers
- Display selected request details with type, priority, location, and opened time
- Hide assigned/resolved/inactive requests from the mobile map UI
- Add refresh, loading, empty, and error states
- Add Android unit and E2E coverage for active request parsing and guest map visibility

## Notes
- Mobile uses the existing shared map-opening integration for external map actions.
- The in-app crisis map is implemented with Compose marker UI to match the web behavior without adding a new Android map dependency.

## Tests
- Added repository parsing tests for filtering and type normalization
- Added Android E2E coverage for guest Help Request Map access and assigned request visibility filtering

Closes #381 
