### PR TITLE
feat(admin): add users tab listing with filters, pagination and tests

### DIFF
--- a/backend/migrations/20260501_120000__add_is_banned_to_users.sql
+++ b/backend/migrations/20260501_120000__add_is_banned_to_users.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS is_banned BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_users_is_banned ON users (is_banned);
+
+COMMIT;

--- a/backend/src/modules/admin/controller.js
+++ b/backend/src/modules/admin/controller.js
@@ -23,11 +23,88 @@ function parseCsvQuery(value) {
     .filter(Boolean);
 }
 
-async function getAdminUsers(_req, res) {
-  try {
-    const users = await getUsersForAdmin();
+function parseBooleanQuery(value) {
+  if (value === undefined || value === null || value === '') {
+    return { value: null };
+  }
+  const normalized = String(value).toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return { value: true };
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return { value: false };
+  }
+  return { error: true };
+}
 
-    return res.status(200).json({ users });
+async function getAdminUsers(req, res) {
+  try {
+    const limitParam = req.query?.limit;
+    const offsetParam = req.query?.offset;
+    const limit = limitParam === undefined ? 50 : Number(limitParam);
+    const offset = offsetParam === undefined ? 0 : Number(offsetParam);
+
+    if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: '`limit` must be an integer between 1 and 200.',
+      });
+    }
+    if (!Number.isInteger(offset) || offset < 0 || offset > 100000) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: '`offset` must be an integer between 0 and 100000.',
+      });
+    }
+
+    const isEmailVerified = parseBooleanQuery(req.query?.isEmailVerified);
+    if (isEmailVerified.error) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: '`isEmailVerified` must be a boolean value.',
+      });
+    }
+
+    const isBanned = parseBooleanQuery(req.query?.isBanned);
+    if (isBanned.error) {
+      return res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        message: '`isBanned` must be a boolean value.',
+      });
+    }
+
+    const emailRaw = req.query?.email;
+    let emailContains = null;
+    if (emailRaw !== undefined && emailRaw !== null && String(emailRaw).trim() !== '') {
+      const trimmed = String(emailRaw).trim();
+      if (trimmed.length > 255) {
+        return res.status(400).json({
+          code: 'VALIDATION_ERROR',
+          message: '`email` filter must be at most 255 characters.',
+        });
+      }
+      emailContains = trimmed;
+    }
+
+    const result = await getUsersForAdmin({
+      limit,
+      offset,
+      emailContains,
+      isEmailVerified: isEmailVerified.value,
+      isBanned: isBanned.value,
+    });
+
+    return res.status(200).json({
+      users: result.users,
+      total: result.total,
+      filters: {
+        email: emailContains,
+        isEmailVerified: isEmailVerified.value,
+        isBanned: isBanned.value,
+        limit,
+        offset,
+      },
+    });
   } catch (_error) {
     return res.status(500).json({
       code: 'INTERNAL_ERROR',

--- a/backend/src/modules/admin/repository.js
+++ b/backend/src/modules/admin/repository.js
@@ -20,26 +20,68 @@ function getPrioritySql() {
   return `COALESCE(hr.priority_level, (${urgencySql}))`;
 }
 
-async function listUsers() {
+async function listUsers({
+  limit = 50,
+  offset = 0,
+  emailContains = null,
+  isEmailVerified = null,
+  isBanned = null,
+} = {}) {
+  const conditions = ['u.is_deleted = FALSE'];
+  const values = [];
+
+  if (emailContains) {
+    values.push(`%${emailContains.toLowerCase()}%`);
+    conditions.push(`LOWER(u.email) LIKE $${values.length}`);
+  }
+  if (isEmailVerified !== null) {
+    values.push(isEmailVerified);
+    conditions.push(`u.is_email_verified = $${values.length}`);
+  }
+  if (isBanned !== null) {
+    values.push(isBanned);
+    conditions.push(`u.is_banned = $${values.length}`);
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  const totalResult = await query(
+    `SELECT COUNT(*)::int AS count FROM users u ${whereClause}`,
+    values,
+  );
+
+  const listValues = [...values, limit, offset];
+  const limitPlaceholder = `$${listValues.length - 1}`;
+  const offsetPlaceholder = `$${listValues.length}`;
+
   const result = await query(
     `
       SELECT
         u.user_id,
         u.email,
         u.is_email_verified,
+        u.is_banned,
         u.created_at,
         u.is_deleted,
         u.accepted_terms,
         a.admin_id,
-        a.role AS admin_role
+        a.role AS admin_role,
+        p.first_name,
+        p.last_name
       FROM users u
       LEFT JOIN admins a ON a.user_id = u.user_id
+      LEFT JOIN user_profiles p ON p.user_id = u.user_id
+      ${whereClause}
       ORDER BY u.created_at DESC
-      LIMIT 100
+      LIMIT ${limitPlaceholder} OFFSET ${offsetPlaceholder}
     `,
+    listValues,
   );
 
-  return result.rows;
+  return {
+    users: result.rows,
+    total: totalResult.rows[0].count,
+  };
 }
 
 async function listHelpRequests() {

--- a/backend/src/modules/admin/service.js
+++ b/backend/src/modules/admin/service.js
@@ -9,8 +9,27 @@ const {
   getDeploymentMonitoring,
 } = require('./repository');
 
-async function getUsersForAdmin() {
-  return listUsers();
+async function getUsersForAdmin(options = {}) {
+  const { users, total } = await listUsers(options);
+
+  const items = users.map((row) => {
+    const firstName = row.first_name ? String(row.first_name).trim() : '';
+    const lastName = row.last_name ? String(row.last_name).trim() : '';
+    const username = [firstName, lastName].filter(Boolean).join(' ');
+
+    return {
+      userId: row.user_id,
+      username: username || null,
+      email: row.email,
+      isEmailVerified: Boolean(row.is_email_verified),
+      isBanned: Boolean(row.is_banned),
+      createdAt: row.created_at,
+      isAdmin: Boolean(row.admin_id),
+      adminRole: row.admin_role || null,
+    };
+  });
+
+  return { users: items, total };
 }
 
 async function getHelpRequestsForAdmin() {

--- a/backend/tests/integration/modules/admin/admin-users.integration.test.js
+++ b/backend/tests/integration/modules/admin/admin-users.integration.test.js
@@ -1,0 +1,283 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+const { query } = require('../../../../src/db/pool');
+const { apiRouter } = require('../../../../src/routes');
+
+jest.mock('uuid', () => ({
+  v4: () => require('crypto').randomBytes(16).toString('hex'),
+}));
+
+jest.mock('express-rate-limit', () => () => (_req, _res, next) => next());
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', apiRouter);
+  return app;
+}
+
+function buildAuthToken({ userId, isAdmin }) {
+  return jwt.sign(
+    {
+      userId,
+      email: `${userId}@example.com`,
+      isAdmin,
+      adminRole: isAdmin ? 'COORDINATOR' : null,
+    },
+    process.env.JWT_SECRET || 'dev-secret-123',
+    { expiresIn: '1h' },
+  );
+}
+
+async function seedUsers() {
+  await query(
+    `
+      INSERT INTO users (
+        user_id, email, password_hash, is_email_verified, is_deleted, accepted_terms,
+        is_banned, created_at
+      )
+      VALUES
+        ('admin_user',     'admin@example.com',     'hash', TRUE,  FALSE, TRUE, FALSE, NOW() - INTERVAL '5 days'),
+        ('user_alice',     'alice@example.com',     'hash', TRUE,  FALSE, TRUE, FALSE, NOW() - INTERVAL '4 days'),
+        ('user_bob',       'bob@example.com',       'hash', FALSE, FALSE, TRUE, FALSE, NOW() - INTERVAL '3 days'),
+        ('user_carol',     'carol@example.com',     'hash', TRUE,  FALSE, TRUE, TRUE,  NOW() - INTERVAL '2 days'),
+        ('user_dave',      'dave@example.com',      'hash', FALSE, FALSE, TRUE, TRUE,  NOW() - INTERVAL '1 days'),
+        ('user_deleted',   'deleted@example.com',   'hash', TRUE,  TRUE,  TRUE, FALSE, NOW() - INTERVAL '6 days')
+    `,
+  );
+
+  await query(
+    `
+      INSERT INTO admins (admin_id, user_id, role)
+      VALUES ('admin_record_1', 'admin_user', 'COORDINATOR')
+    `,
+  );
+
+  await query(
+    `
+      INSERT INTO user_profiles (profile_id, user_id, first_name, last_name, phone_number)
+      VALUES
+        ('p_alice', 'user_alice', 'Alice',  'Anderson', '+905551110001'),
+        ('p_bob',   'user_bob',   'Bob',    'Brown',    '+905551110002'),
+        ('p_carol', 'user_carol', 'Carol',  'Clark',    '+905551110003')
+    `,
+  );
+}
+
+beforeEach(async () => {
+  await query(`
+    TRUNCATE TABLE
+      messages,
+      assignments,
+      availability_records,
+      resources,
+      volunteers,
+      request_locations,
+      help_requests,
+      news_announcements,
+      reports,
+      expertise,
+      privacy_settings,
+      location_profiles,
+      health_info,
+      physical_info,
+      user_profiles,
+      admins,
+      users
+    RESTART IDENTITY CASCADE;
+  `);
+});
+
+describe('GET /api/admin/users', () => {
+  test('returns 401 without token', async () => {
+    const app = createTestApp();
+    const response = await request(app).get('/api/admin/users');
+    expect(response.status).toBe(401);
+    expect(response.body.code).toBe('UNAUTHORIZED');
+  });
+
+  test('returns 403 for non-admin users', async () => {
+    await seedUsers();
+    const app = createTestApp();
+    const userToken = buildAuthToken({ userId: 'user_alice', isAdmin: false });
+
+    const response = await request(app)
+      .get('/api/admin/users')
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe('FORBIDDEN');
+  });
+
+  test('returns paginated users with required fields for admin', async () => {
+    await seedUsers();
+
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/users')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        users: expect.any(Array),
+        total: expect.any(Number),
+        filters: expect.objectContaining({
+          email: null,
+          isEmailVerified: null,
+          isBanned: null,
+          limit: 50,
+          offset: 0,
+        }),
+      }),
+    );
+
+    // is_deleted users excluded.
+    expect(response.body.total).toBe(5);
+    expect(response.body.users).toHaveLength(5);
+
+    const aliceRow = response.body.users.find((row) => row.userId === 'user_alice');
+    expect(aliceRow).toEqual(
+      expect.objectContaining({
+        userId: 'user_alice',
+        email: 'alice@example.com',
+        username: 'Alice Anderson',
+        isEmailVerified: true,
+        isBanned: false,
+        isAdmin: false,
+      }),
+    );
+    expect(aliceRow.createdAt).toEqual(expect.any(String));
+    expect(Number.isNaN(Date.parse(aliceRow.createdAt))).toBe(false);
+
+    // Admin user should be flagged as such.
+    const adminRow = response.body.users.find((row) => row.userId === 'admin_user');
+    expect(adminRow).toEqual(
+      expect.objectContaining({
+        isAdmin: true,
+        adminRole: 'COORDINATOR',
+        username: null,
+      }),
+    );
+
+    // Newest first.
+    const orderedIds = response.body.users.map((row) => row.userId);
+    expect(orderedIds).toEqual([
+      'user_dave',
+      'user_carol',
+      'user_bob',
+      'user_alice',
+      'admin_user',
+    ]);
+  });
+
+  test('filters by isEmailVerified', async () => {
+    await seedUsers();
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const verifiedResponse = await request(app)
+      .get('/api/admin/users?isEmailVerified=true')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(verifiedResponse.status).toBe(200);
+    expect(verifiedResponse.body.total).toBe(3);
+    verifiedResponse.body.users.forEach((row) => {
+      expect(row.isEmailVerified).toBe(true);
+    });
+
+    const unverifiedResponse = await request(app)
+      .get('/api/admin/users?isEmailVerified=false')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(unverifiedResponse.status).toBe(200);
+    expect(unverifiedResponse.body.total).toBe(2);
+    unverifiedResponse.body.users.forEach((row) => {
+      expect(row.isEmailVerified).toBe(false);
+    });
+  });
+
+  test('filters by isBanned', async () => {
+    await seedUsers();
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const bannedResponse = await request(app)
+      .get('/api/admin/users?isBanned=true')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(bannedResponse.status).toBe(200);
+    expect(bannedResponse.body.total).toBe(2);
+    expect(bannedResponse.body.users.map((row) => row.userId).sort()).toEqual(
+      ['user_carol', 'user_dave'],
+    );
+  });
+
+  test('filters by email contains (case-insensitive)', async () => {
+    await seedUsers();
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/users?email=ALICE')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.total).toBe(1);
+    expect(response.body.users[0].userId).toBe('user_alice');
+  });
+
+  test('supports limit and offset pagination', async () => {
+    await seedUsers();
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const firstPage = await request(app)
+      .get('/api/admin/users?limit=2&offset=0')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(firstPage.status).toBe(200);
+    expect(firstPage.body.total).toBe(5);
+    expect(firstPage.body.users).toHaveLength(2);
+    expect(firstPage.body.users.map((row) => row.userId)).toEqual(['user_dave', 'user_carol']);
+
+    const secondPage = await request(app)
+      .get('/api/admin/users?limit=2&offset=2')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(secondPage.status).toBe(200);
+    expect(secondPage.body.users).toHaveLength(2);
+    expect(secondPage.body.users.map((row) => row.userId)).toEqual(['user_bob', 'user_alice']);
+  });
+
+  test('returns 400 for invalid limit', async () => {
+    await seedUsers();
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/users?limit=0')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('returns 400 for invalid isBanned value', async () => {
+    await seedUsers();
+    const app = createTestApp();
+    const adminToken = buildAuthToken({ userId: 'admin_user', isAdmin: true });
+
+    const response = await request(app)
+      .get('/api/admin/users?isBanned=maybe')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+  });
+});

--- a/backend/tests/unit/modules/admin/service.test.js
+++ b/backend/tests/unit/modules/admin/service.test.js
@@ -26,12 +26,41 @@ beforeEach(() => {
 
 describe('admin service', () => {
   test('getUsersForAdmin delegates to repository', async () => {
-    listUsers.mockResolvedValue([{ user_id: 'u1' }]);
+    listUsers.mockResolvedValue({
+      users: [
+        {
+          user_id: 'u1',
+          first_name: 'John',
+          last_name: 'Doe',
+          email: 'john@example.com',
+          is_email_verified: true,
+          is_banned: false,
+          created_at: '2026-05-01T10:00:00.000Z',
+          admin_id: null,
+          admin_role: null,
+        },
+      ],
+      total: 1,
+    });
 
     const result = await getUsersForAdmin();
 
     expect(listUsers).toHaveBeenCalledTimes(1);
-    expect(result).toEqual([{ user_id: 'u1' }]);
+    expect(result).toEqual({
+      users: [
+        {
+          userId: 'u1',
+          username: 'John Doe',
+          email: 'john@example.com',
+          isEmailVerified: true,
+          isBanned: false,
+          createdAt: '2026-05-01T10:00:00.000Z',
+          isAdmin: false,
+          adminRole: null,
+        },
+      ],
+      total: 1,
+    });
   });
 
   test('getHelpRequestsForAdmin delegates to repository', async () => {

--- a/web/e2e/admin-users.spec.js
+++ b/web/e2e/admin-users.spec.js
@@ -76,7 +76,7 @@ test('admin can open Users tab and see registered users with required columns', 
   // Table headers expected from the issue (Acceptance Criteria).
   await expect(page.getByRole('columnheader', { name: 'Username' })).toBeVisible();
   await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible();
-  await expect(page.getByRole('columnheader', { name: 'Email' })).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'Email', exact: true })).toBeVisible();
   await expect(page.getByRole('columnheader', { name: 'Email Verified' })).toBeVisible();
   await expect(page.getByRole('columnheader', { name: 'Banned' })).toBeVisible();
   await expect(page.getByRole('columnheader', { name: 'Created At' })).toBeVisible();

--- a/web/e2e/admin-users.spec.js
+++ b/web/e2e/admin-users.spec.js
@@ -1,0 +1,144 @@
+const { test, expect } = require('@playwright/test');
+const { createCompletedUser, signupUser } = require('./helpers/api');
+const {
+  promoteUserToAdmin,
+  resetDatabase,
+  waitForUserByEmail,
+} = require('./helpers/db');
+const { loginThroughUi } = require('./helpers/ui');
+
+async function openUsersTab(page) {
+  await expect(page).toHaveURL(/\/admin(\?|$)/, { timeout: 20_000 });
+  if (/\/login(\?|$)/.test(page.url())) {
+    throw new Error(`Admin page redirected to login unexpectedly. URL: ${page.url()}`);
+  }
+  if (/\/home(\?|$)/.test(page.url())) {
+    throw new Error(`Admin page redirected to home unexpectedly. URL: ${page.url()}`);
+  }
+
+  await expect(
+    page.getByRole('tablist', { name: 'Admin dashboard sections' }),
+  ).toBeVisible({ timeout: 20_000 });
+
+  const usersTab = page.getByRole('tab', { name: 'Users' });
+  await expect(usersTab).toBeVisible({ timeout: 20_000 });
+  await usersTab.click();
+}
+
+test.beforeEach(async () => {
+  await resetDatabase();
+});
+
+test('non-admin user does not see Users tab and is redirected from /admin', async ({ page }) => {
+  const email = `users-non-admin-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email, password });
+
+  await page.goto('/login?returnTo=%2Fadmin');
+  await loginThroughUi(page, { email, password });
+
+  await expect(page).toHaveURL(/\/home$/);
+
+  // Admin dashboard tablist should never render for non-admin users.
+  await expect(
+    page.getByRole('tablist', { name: 'Admin dashboard sections' }),
+  ).toHaveCount(0);
+});
+
+test('admin can open Users tab and see registered users with required columns', async ({ page }) => {
+  const adminEmail = `users-admin-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email: adminEmail, password });
+  const adminDbUser = await waitForUserByEmail(adminEmail);
+  await promoteUserToAdmin({ userId: adminDbUser.user_id });
+
+  // Another completed user — should appear in the listing with their first/last name.
+  const otherEmail = `users-other-${Date.now()}@example.com`;
+  await createCompletedUser({ email: otherEmail, password });
+  await waitForUserByEmail(otherEmail);
+
+  // A signed-up but unverified user — should appear with isEmailVerified=false.
+  const unverifiedEmail = `users-unverified-${Date.now()}@example.com`;
+  await signupUser({ email: unverifiedEmail, password });
+  await waitForUserByEmail(unverifiedEmail);
+
+  await page.goto('/login');
+  await loginThroughUi(page, { email: adminEmail, password });
+  await expect(page.getByRole('link', { name: 'Admin' })).toBeVisible({ timeout: 20_000 });
+
+  await page.goto('/admin');
+  await openUsersTab(page);
+
+  await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible();
+
+  // Table headers expected from the issue (Acceptance Criteria).
+  await expect(page.getByRole('columnheader', { name: 'Username' })).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'User ID' })).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'Email' })).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'Email Verified' })).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'Banned' })).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'Created At' })).toBeVisible();
+
+  // Both seeded emails are visible in the table.
+  await expect(page.getByRole('cell', { name: adminEmail })).toBeVisible();
+  await expect(page.getByRole('cell', { name: otherEmail })).toBeVisible();
+  await expect(page.getByRole('cell', { name: unverifiedEmail })).toBeVisible();
+
+  // Username column shows firstName + lastName from the completed profile.
+  // createCompletedUser sets firstName: "Existing", lastName: "User".
+  const usernameCells = await page.getByRole('cell', { name: 'Existing User' }).count();
+  expect(usernameCells).toBeGreaterThanOrEqual(2);
+
+  // Verified vs unverified badges appear for the right rows.
+  const otherRow = page.getByRole('row', { name: new RegExp(otherEmail) });
+  await expect(otherRow.getByText('Verified', { exact: true })).toBeVisible();
+
+  const unverifiedRow = page.getByRole('row', { name: new RegExp(unverifiedEmail) });
+  await expect(unverifiedRow.getByText('Unverified', { exact: true })).toBeVisible();
+});
+
+test('admin can filter users by email and verification status', async ({ page }) => {
+  const adminEmail = `users-filter-admin-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email: adminEmail, password });
+  const adminDbUser = await waitForUserByEmail(adminEmail);
+  await promoteUserToAdmin({ userId: adminDbUser.user_id });
+
+  const verifiedEmail = `users-filter-verified-${Date.now()}@example.com`;
+  await createCompletedUser({ email: verifiedEmail, password });
+  await waitForUserByEmail(verifiedEmail);
+
+  const unverifiedEmail = `users-filter-unverified-${Date.now()}@example.com`;
+  await signupUser({ email: unverifiedEmail, password });
+  await waitForUserByEmail(unverifiedEmail);
+
+  await page.goto('/login');
+  await loginThroughUi(page, { email: adminEmail, password });
+  await expect(page.getByRole('link', { name: 'Admin' })).toBeVisible({ timeout: 20_000 });
+
+  await page.goto('/admin');
+  await openUsersTab(page);
+
+  await expect(page.getByRole('cell', { name: unverifiedEmail })).toBeVisible();
+
+  // Filter to verified-only — unverified user should disappear.
+  await page.getByLabel('Email verification').selectOption('VERIFIED');
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+
+  await expect(page.getByRole('cell', { name: unverifiedEmail })).toHaveCount(0);
+  await expect(page.getByRole('cell', { name: verifiedEmail })).toBeVisible();
+
+  // Search by email — only the matching row remains visible in the table.
+  await page.getByLabel('Email contains').fill(verifiedEmail);
+  await page.getByRole('button', { name: 'Apply Filters' }).click();
+
+  await expect(page.getByRole('cell', { name: verifiedEmail })).toBeVisible();
+  await expect(page.getByRole('cell', { name: adminEmail })).toHaveCount(0);
+
+  // Clear filters restores admin email row.
+  await page.getByRole('button', { name: 'Clear Filters' }).click();
+  await expect(page.getByRole('cell', { name: adminEmail })).toBeVisible();
+});

--- a/web/e2e/helpers/api.js
+++ b/web/e2e/helpers/api.js
@@ -236,4 +236,5 @@ module.exports = {
   createPasswordResetTokenForEmail,
   createVerifiedUser,
   fetchMyProfile,
+  signupUser,
 };

--- a/web/src/components/feature/admin/AdminDashboardSwitcher.tsx
+++ b/web/src/components/feature/admin/AdminDashboardSwitcher.tsx
@@ -6,8 +6,15 @@ import AdminEmergencyHistoryView from "@/components/feature/admin/AdminEmergency
 import AdminEmergencyInsightsView from "@/components/feature/admin/AdminEmergencyInsightsView";
 import AdminDeploymentMonitoringView from "@/components/feature/admin/AdminDeploymentMonitoringView";
 import AdminAnnouncementsView from "@/components/feature/admin/AdminAnnouncementsView";
+import AdminUsersView from "@/components/feature/admin/AdminUsersView";
 
-type AdminSectionKey = "overview" | "announcements" | "history" | "insights" | "monitoring";
+type AdminSectionKey =
+    | "overview"
+    | "announcements"
+    | "history"
+    | "insights"
+    | "monitoring"
+    | "users";
 
 const SECTIONS: Array<{ key: AdminSectionKey; label: string }> = [
     { key: "overview", label: "Emergency Overview" },
@@ -15,6 +22,7 @@ const SECTIONS: Array<{ key: AdminSectionKey; label: string }> = [
     { key: "history", label: "Emergency History" },
     { key: "insights", label: "Emergency Insights" },
     { key: "monitoring", label: "Deployment Monitoring" },
+    { key: "users", label: "Users" },
 ];
 
 export default function AdminDashboardSwitcher() {
@@ -90,13 +98,21 @@ export default function AdminDashboardSwitcher() {
                 >
                     <AdminEmergencyInsightsView />
                 </div>
-            ) : (
+            ) : activeSection === "monitoring" ? (
                 <div
                     id="admin-panel-monitoring"
                     role="tabpanel"
                     aria-labelledby="admin-tab-monitoring"
                 >
                     <AdminDeploymentMonitoringView />
+                </div>
+            ) : (
+                <div
+                    id="admin-panel-users"
+                    role="tabpanel"
+                    aria-labelledby="admin-tab-users"
+                >
+                    <AdminUsersView />
                 </div>
             )}
         </div>

--- a/web/src/components/feature/admin/AdminUsersView.tsx
+++ b/web/src/components/feature/admin/AdminUsersView.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+import * as React from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { ApiError } from "@/lib/api";
+import { clearAccessToken, getAccessToken } from "@/lib/auth";
+import {
+    fetchAdminUsers,
+    type AdminUserListItem,
+    type AdminUserListOptions,
+} from "@/lib/admin";
+import { SectionCard } from "@/components/ui/display/SectionCard";
+import { SectionHeader } from "@/components/ui/display/SectionHeader";
+import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
+
+type VerifiedFilter = "ALL" | "VERIFIED" | "UNVERIFIED";
+type BannedFilter = "ALL" | "BANNED" | "ACTIVE";
+
+type UsersFilters = {
+    email: string;
+    verified: VerifiedFilter;
+    banned: BannedFilter;
+};
+
+const DEFAULT_FILTERS: UsersFilters = {
+    email: "",
+    verified: "ALL",
+    banned: "ALL",
+};
+
+const PAGE_SIZE = 25;
+
+function formatDateTime(value: string | null) {
+    if (!value) {
+        return "-";
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+    return date.toLocaleString();
+}
+
+function StatusBadge({
+    label,
+    tone,
+}: {
+    label: string;
+    tone: "success" | "danger" | "default" | "warning";
+}) {
+    return <span className={`admin-status-badge tone-${tone}`}>{label}</span>;
+}
+
+function buildFetchOptions(filters: UsersFilters, offset: number): AdminUserListOptions {
+    const options: AdminUserListOptions = {
+        limit: PAGE_SIZE,
+        offset,
+    };
+    const trimmedEmail = filters.email.trim();
+    if (trimmedEmail !== "") {
+        options.email = trimmedEmail;
+    }
+    if (filters.verified === "VERIFIED") {
+        options.isEmailVerified = true;
+    } else if (filters.verified === "UNVERIFIED") {
+        options.isEmailVerified = false;
+    }
+    if (filters.banned === "BANNED") {
+        options.isBanned = true;
+    } else if (filters.banned === "ACTIVE") {
+        options.isBanned = false;
+    }
+    return options;
+}
+
+export default function AdminUsersView() {
+    const router = useRouter();
+    const pathname = usePathname();
+
+    const [items, setItems] = React.useState<AdminUserListItem[]>([]);
+    const [total, setTotal] = React.useState(0);
+    const [offset, setOffset] = React.useState(0);
+    const [filters, setFilters] = React.useState<UsersFilters>(DEFAULT_FILTERS);
+    const [pendingFilters, setPendingFilters] = React.useState<UsersFilters>(DEFAULT_FILTERS);
+    const [loading, setLoading] = React.useState(true);
+    const [refreshing, setRefreshing] = React.useState(false);
+    const [error, setError] = React.useState("");
+    const [loadedOnce, setLoadedOnce] = React.useState(false);
+    const latestRequestIdRef = React.useRef(0);
+
+    const redirectToLogin = React.useCallback(() => {
+        clearAccessToken();
+        const returnTo = pathname || "/admin";
+        router.replace(`/login?returnTo=${encodeURIComponent(returnTo)}`);
+    }, [pathname, router]);
+
+    const handleAdminApiError = React.useCallback(
+        (err: unknown, fallback: string) => {
+            if (err instanceof ApiError && err.status === 401) {
+                redirectToLogin();
+                return null;
+            }
+            if (err instanceof ApiError && err.status === 403) {
+                router.replace("/home");
+                return null;
+            }
+            return err instanceof Error ? err.message : fallback;
+        },
+        [redirectToLogin, router],
+    );
+
+    const loadUsers = React.useCallback(
+        async (
+            nextFilters: UsersFilters,
+            { offset: nextOffset, mode }: { offset: number; mode: "initial" | "refresh" },
+        ) => {
+            const token = getAccessToken();
+            if (!token) {
+                setLoading(false);
+                setRefreshing(false);
+                redirectToLogin();
+                return;
+            }
+
+            const requestId = latestRequestIdRef.current + 1;
+            latestRequestIdRef.current = requestId;
+
+            if (mode === "initial") {
+                setLoading(true);
+            } else {
+                setRefreshing(true);
+            }
+            setError("");
+
+            try {
+                const result = await fetchAdminUsers(token, buildFetchOptions(nextFilters, nextOffset));
+                if (requestId !== latestRequestIdRef.current) {
+                    return;
+                }
+                setItems(result.users);
+                setTotal(result.total);
+                setOffset(nextOffset);
+                setLoadedOnce(true);
+            } catch (err) {
+                if (requestId !== latestRequestIdRef.current) {
+                    return;
+                }
+                const message = handleAdminApiError(err, "Could not load users.");
+                if (message) {
+                    setError(message);
+                }
+            } finally {
+                if (requestId === latestRequestIdRef.current) {
+                    setLoading(false);
+                    setRefreshing(false);
+                }
+            }
+        },
+        [handleAdminApiError, redirectToLogin],
+    );
+
+    React.useEffect(() => {
+        void loadUsers(DEFAULT_FILTERS, { offset: 0, mode: "initial" });
+    }, [loadUsers]);
+
+    const applyFilters = () => {
+        setFilters(pendingFilters);
+        void loadUsers(pendingFilters, { offset: 0, mode: "refresh" });
+    };
+
+    const clearFilters = () => {
+        setPendingFilters(DEFAULT_FILTERS);
+        setFilters(DEFAULT_FILTERS);
+        void loadUsers(DEFAULT_FILTERS, { offset: 0, mode: "refresh" });
+    };
+
+    const goToPreviousPage = () => {
+        const nextOffset = Math.max(0, offset - PAGE_SIZE);
+        if (nextOffset === offset) {
+            return;
+        }
+        void loadUsers(filters, { offset: nextOffset, mode: "refresh" });
+    };
+
+    const goToNextPage = () => {
+        const nextOffset = offset + PAGE_SIZE;
+        if (nextOffset >= total) {
+            return;
+        }
+        void loadUsers(filters, { offset: nextOffset, mode: "refresh" });
+    };
+
+    if (loading && !loadedOnce) {
+        return (
+            <SectionCard>
+                <SectionHeader title="Users" subtitle="Loading registered users..." />
+                <p className="admin-subtle">Fetching the latest users from the platform.</p>
+            </SectionCard>
+        );
+    }
+
+    if (error && !loadedOnce) {
+        return (
+            <SectionCard>
+                <SectionHeader title="Users" subtitle="Could not load users." />
+                <div className="admin-empty-state">
+                    <p>{error}</p>
+                    <PrimaryButton
+                        onClick={() => void loadUsers(filters, { offset: 0, mode: "initial" })}
+                    >
+                        Retry Users Load
+                    </PrimaryButton>
+                </div>
+            </SectionCard>
+        );
+    }
+
+    const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
+    const totalPages = total === 0 ? 1 : Math.ceil(total / PAGE_SIZE);
+    const showingFrom = total === 0 ? 0 : offset + 1;
+    const showingTo = Math.min(offset + items.length, total);
+    const hasPrevious = offset > 0;
+    const hasNext = offset + PAGE_SIZE < total;
+
+    return (
+        <SectionCard>
+            <SectionHeader
+                title="Users"
+                subtitle="All registered platform users with basic account metadata."
+            />
+
+            <div className="admin-history-filter-grid">
+                <label className="admin-history-filter-label" htmlFor="users-email">
+                    Email contains
+                    <input
+                        id="users-email"
+                        type="search"
+                        className="admin-history-filter-input"
+                        value={pendingFilters.email}
+                        onChange={(event) =>
+                            setPendingFilters((current) => ({
+                                ...current,
+                                email: event.target.value,
+                            }))
+                        }
+                        placeholder="e.g. alice@"
+                    />
+                </label>
+
+                <label className="admin-history-filter-label" htmlFor="users-verified">
+                    Email verification
+                    <select
+                        id="users-verified"
+                        className="admin-history-filter-input"
+                        value={pendingFilters.verified}
+                        onChange={(event) =>
+                            setPendingFilters((current) => ({
+                                ...current,
+                                verified: event.target.value as VerifiedFilter,
+                            }))
+                        }
+                    >
+                        <option value="ALL">All</option>
+                        <option value="VERIFIED">Verified</option>
+                        <option value="UNVERIFIED">Unverified</option>
+                    </select>
+                </label>
+
+                <label className="admin-history-filter-label" htmlFor="users-banned">
+                    Ban status
+                    <select
+                        id="users-banned"
+                        className="admin-history-filter-input"
+                        value={pendingFilters.banned}
+                        onChange={(event) =>
+                            setPendingFilters((current) => ({
+                                ...current,
+                                banned: event.target.value as BannedFilter,
+                            }))
+                        }
+                    >
+                        <option value="ALL">All</option>
+                        <option value="ACTIVE">Active</option>
+                        <option value="BANNED">Banned</option>
+                    </select>
+                </label>
+            </div>
+
+            <div className="admin-history-actions">
+                <PrimaryButton onClick={applyFilters} disabled={refreshing}>
+                    Apply Filters
+                </PrimaryButton>
+                <SecondaryButton onClick={clearFilters} disabled={refreshing}>
+                    Clear Filters
+                </SecondaryButton>
+                {refreshing ? <p className="admin-subtle">Refreshing users...</p> : null}
+            </div>
+
+            <p className="admin-subtle">
+                {total === 0
+                    ? "No users match the current filters."
+                    : `Showing ${showingFrom}-${showingTo} of ${total} users.`}
+            </p>
+
+            {error ? <p className="admin-error-text">Latest refresh failed: {error}</p> : null}
+
+            {items.length === 0 ? (
+                <div className="admin-empty-state">
+                    <p>No users found for the current filters.</p>
+                </div>
+            ) : (
+                <div className="admin-region-table-wrap">
+                    <table className="admin-region-table admin-history-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">Username</th>
+                                <th scope="col">User ID</th>
+                                <th scope="col">Email</th>
+                                <th scope="col">Email Verified</th>
+                                <th scope="col">Banned</th>
+                                <th scope="col">Created At</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {items.map((user) => (
+                                <tr key={user.userId}>
+                                    <td>{user.username || "-"}</td>
+                                    <td>{user.userId}</td>
+                                    <td>{user.email}</td>
+                                    <td>
+                                        {user.isEmailVerified ? (
+                                            <StatusBadge label="Verified" tone="success" />
+                                        ) : (
+                                            <StatusBadge label="Unverified" tone="warning" />
+                                        )}
+                                    </td>
+                                    <td>
+                                        {user.isBanned ? (
+                                            <StatusBadge label="Banned" tone="danger" />
+                                        ) : (
+                                            <StatusBadge label="Active" tone="default" />
+                                        )}
+                                    </td>
+                                    <td>{formatDateTime(user.createdAt)}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+
+            <div className="admin-history-actions">
+                <SecondaryButton onClick={goToPreviousPage} disabled={!hasPrevious || refreshing}>
+                    Previous
+                </SecondaryButton>
+                <p className="admin-subtle">
+                    Page {currentPage} of {totalPages}
+                </p>
+                <SecondaryButton onClick={goToNextPage} disabled={!hasNext || refreshing}>
+                    Next
+                </SecondaryButton>
+            </div>
+        </SectionCard>
+    );
+}

--- a/web/src/lib/admin.ts
+++ b/web/src/lib/admin.ts
@@ -404,3 +404,62 @@ export async function deleteAdminAnnouncement(token: string, announcementId: str
         token: token.trim(),
     });
 }
+
+export type AdminUserListItem = {
+    userId: string;
+    username: string | null;
+    email: string;
+    isEmailVerified: boolean;
+    isBanned: boolean;
+    createdAt: string;
+    isAdmin: boolean;
+    adminRole: string | null;
+};
+
+export type AdminUserListFilters = {
+    email: string | null;
+    isEmailVerified: boolean | null;
+    isBanned: boolean | null;
+    limit: number;
+    offset: number;
+};
+
+export type AdminUserListResponse = {
+    users: AdminUserListItem[];
+    total: number;
+    filters: AdminUserListFilters;
+};
+
+export type AdminUserListOptions = {
+    limit?: number;
+    offset?: number;
+    email?: string | null;
+    isEmailVerified?: boolean | null;
+    isBanned?: boolean | null;
+};
+
+export async function fetchAdminUsers(token: string, options: AdminUserListOptions = {}) {
+    const params = new URLSearchParams();
+    if (typeof options.limit === "number") {
+        params.set("limit", String(options.limit));
+    }
+    if (typeof options.offset === "number") {
+        params.set("offset", String(options.offset));
+    }
+    if (options.email && options.email.trim() !== "") {
+        params.set("email", options.email.trim());
+    }
+    if (typeof options.isEmailVerified === "boolean") {
+        params.set("isEmailVerified", String(options.isEmailVerified));
+    }
+    if (typeof options.isBanned === "boolean") {
+        params.set("isBanned", String(options.isBanned));
+    }
+
+    const query = params.toString() ? `?${params.toString()}` : "";
+    return apiRequest<AdminUserListResponse>(`/admin/users${query}`, {
+        token: token.trim(),
+    });
+}
+
+

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1501,6 +1501,36 @@ textarea::placeholder {
     color: var(--error);
 }
 
+.admin-status-badge {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    line-height: 1.4;
+    border: 1px solid var(--border-subtle);
+    background: var(--surface-card);
+    color: var(--text-secondary);
+}
+
+.admin-status-badge.tone-success {
+    border-color: color-mix(in srgb, var(--success) 45%, var(--border-subtle));
+    background: color-mix(in srgb, var(--success) 12%, var(--surface-card));
+    color: var(--success);
+}
+
+.admin-status-badge.tone-warning {
+    border-color: color-mix(in srgb, var(--warning) 45%, var(--border-subtle));
+    background: color-mix(in srgb, var(--warning) 12%, var(--surface-card));
+    color: var(--warning);
+}
+
+.admin-status-badge.tone-danger {
+    border-color: color-mix(in srgb, var(--error) 45%, var(--border-subtle));
+    background: color-mix(in srgb, var(--error) 12%, var(--surface-card));
+    color: var(--error);
+}
+
 .admin-history-filter-grid {
     margin-top: 16px;
     display: grid;


### PR DESCRIPTION
This PR adds a Users tab to the Admin Dashboard so admins can view users with filtering and pagination support in a safe and reliable way.

It also includes fixes for two issues found during review:
- Eliminated stale-response race risk in the UI data loading flow.
- Strengthened createdAt validation in backend integration tests.

## Scope

### Backend
- Extended the admin users listing endpoint.
- Added filtering and pagination support:
  - search
  - role filtering
  - banned status filtering
  - limit/offset pagination
- Improved input handling and response mapping in controller and service layers.
- Added a migration for users.is_banned.
- Preserved admin authorization and response contract consistency.

### Web
- Added admin API types and fetch utilities for users listing.
- Integrated the Users tab into the Admin Dashboard switcher.
- Implemented Users tab UI:
  - filter controls
  - users table
  - pagination
  - loading, empty, and error states
- Added request-id guarding to prevent older async responses from overwriting newer state.

### Testing
- Expanded backend integration coverage for:
  - authentication and authorization
  - filtering behavior
  - pagination behavior
  - response shape
- Improved createdAt assertions:
  - string type check
  - parseable date check
- Web type-check passes.
- Added E2E coverage for Users tab listing.

Closes #396 