### PR TITLE
uı: Move Notifications from Navbar Tab to Right-Side Bell Icon

### DIFF
--- a/web/src/components/layout/TopNavbar.tsx
+++ b/web/src/components/layout/TopNavbar.tsx
@@ -12,7 +12,6 @@ import { fetchMyProfile } from "@/lib/profile";
 const navItemsOrdered = [
     { label: "Home", href: "/home" },
     { label: "News", href: "/news" },
-    { label: "Notifications", href: "/notifications" },
     { label: "Emergency Numbers", href: "/emergency-numbers" },
     { label: "Help Request Map", href: "/crisis-map" },
     { label: "Gathering Areas", href: "/gathering-areas" },
@@ -222,26 +221,47 @@ export function TopNavbar() {
                             className={`top-navbar-nav-item${pathname === item.href || pathname.startsWith(`${item.href}/`) ? " is-active" : ""}`}
                         >
                             {item.label}
-                            {item.href === "/notifications" && isAuthenticated && unreadCount > 0 ? (
-                                <span
-                                    style={{
-                                        marginLeft: 8,
-                                        background: "#b42318",
-                                        color: "white",
-                                        borderRadius: 999,
-                                        padding: "2px 8px",
-                                        fontSize: 12,
-                                        fontWeight: 700,
-                                    }}
-                                >
-                                    {unreadCount > 99 ? "99+" : unreadCount}
-                                </span>
-                            ) : null}
                         </Link>
                     ))}
                 </nav>
 
-                <div className="top-navbar-user-menu" ref={menuRef}>
+                <div className="top-navbar-right">
+                    <Link
+                        href="/notifications"
+                        className={`top-navbar-notification-button${pathname === "/notifications" || pathname.startsWith("/notifications/") ? " is-active" : ""}`}
+                        aria-label="Notifications"
+                    >
+                        <svg
+                            width="18"
+                            height="18"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                            aria-hidden="true"
+                        >
+                            <path
+                                d="M6.5 9.5C6.5 6.46243 8.96243 4 12 4C15.0376 4 17.5 6.46243 17.5 9.5V12.4C17.5 13.1675 17.7436 13.9152 18.196 14.5351L19.2 15.9105C19.7298 16.6362 19.2117 17.6667 18.3128 17.6667H5.6872C4.78835 17.6667 4.27019 16.6362 4.79998 15.9105L5.80404 14.5351C6.25637 13.9152 6.5 13.1675 6.5 12.4V9.5Z"
+                                stroke="currentColor"
+                                strokeWidth="1.8"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                            <path
+                                d="M10 19.1667C10.3522 20.0112 11.1147 20.5833 12 20.5833C12.8853 20.5833 13.6478 20.0112 14 19.1667"
+                                stroke="currentColor"
+                                strokeWidth="1.8"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                        </svg>
+                        {isAuthenticated && unreadCount > 0 ? (
+                            <span className="top-navbar-notification-badge">
+                                {unreadCount > 99 ? "99+" : unreadCount}
+                            </span>
+                        ) : null}
+                    </Link>
+
+                    <div className="top-navbar-user-menu" ref={menuRef}>
                     <button
                         type="button"
                         className="top-navbar-avatar-button"
@@ -329,6 +349,7 @@ export function TopNavbar() {
                             )}
                         </div>
                     ) : null}
+                    </div>
                 </div>
             </PageContainer>
         </header>

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -265,6 +265,56 @@ textarea::placeholder {
     position: relative;
 }
 
+.top-navbar-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.top-navbar-notification-button {
+    position: relative;
+    display: inline-flex;
+    height: 40px;
+    width: 40px;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-pill);
+    border: 1px solid var(--border-subtle);
+    background: var(--surface-card);
+    color: var(--text-secondary);
+    transition: color 180ms ease, background-color 180ms ease, border-color 180ms ease;
+}
+
+.top-navbar-notification-button:hover {
+    color: var(--primary-500);
+    background: var(--surface-soft);
+}
+
+.top-navbar-notification-button.is-active {
+    color: var(--text-on-primary);
+    border-color: transparent;
+    background: linear-gradient(135deg, var(--hero-from), var(--hero-via), var(--hero-to));
+}
+
+.top-navbar-notification-badge {
+    position: absolute;
+    top: -5px;
+    right: -6px;
+    min-width: 18px;
+    height: 18px;
+    border-radius: var(--radius-pill);
+    border: 2px solid var(--surface-card);
+    background: #b42318;
+    color: var(--text-on-primary);
+    padding: 0 4px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.65rem;
+    font-weight: 700;
+    line-height: 1;
+}
+
 .top-navbar-avatar-button {
     display: flex;
     height: 40px;


### PR DESCRIPTION
### Summary
This PR updates the top navigation by removing the `Notifications` text tab from the main navbar and introducing a bell icon on the right side, next to the user avatar/menu.

### Changes Made
1. Removed `Notifications` from the main nav item list.
2. Added a right-side notification bell icon linking to `/notifications`.
3. Added unread badge support on the bell icon:
   - Shows unread count when `unreadCount > 0`
   - Caps display at `99+`
4. Added active state styling for notification icon when user is on `/notifications`.
5. Added dedicated navbar-right layout and notification icon styles in global CSS.

### Files Updated
1. `web/src/components/layout/TopNavbar.tsx`
2. `web/src/styles/globals.css`

### Acceptance Criteria Coverage
1. Notifications text item removed from main navbar tabs.
2. Notification icon added on the right side.
3. Icon placed near user avatar/profile button.
4. Clicking icon navigates to Notifications page.
5. Icon styling matches current navbar visual language.
6. Unread indicator badge appears when there are unread notifications.
7. Icon remains visible without badge when no unread notifications.
8. Active/selected state handled for Notifications page.
9. Layout remains responsive by grouping notification + avatar in right-side flex container.

Closes #395 