### PR TITLE
feat: Add assignment route distance support

### DIFF
--- a/android/app/src/main/java/com/neph/features/assignedrequest/data/AssignedRequestRepository.kt
+++ b/android/app/src/main/java/com/neph/features/assignedrequest/data/AssignedRequestRepository.kt
@@ -55,6 +55,12 @@ data class AssignedRequestUiModel(
         get() = syncStatus == SyncStatus.FAILED || syncStatus == SyncStatus.CONFLICTED
 }
 
+data class AssignmentRouteUiModel(
+    val distanceKm: Double,
+    val estimatedTimeMin: Int?,
+    val source: String
+)
+
 object AssignedRequestRepository {
     private val database get() = NephDatabaseProvider.requireInstance()
 
@@ -113,6 +119,34 @@ object AssignedRequestRepository {
         )
         OfflineSyncScheduler.enqueueSync(NephAppContext.get(), reason = "assignment-cancelled")
         return pending.toUiModel()
+    }
+
+    suspend fun fetchAssignmentRoute(token: String, assignmentId: String): AssignmentRouteUiModel? {
+        val response = JsonHttpClient.request(
+            path = "/assignments/$assignmentId/route",
+            token = token
+        )
+
+        if (response.optString("error") == "location_unavailable") {
+            return null
+        }
+
+        val distanceKm = response.optDouble("distance_km", Double.NaN)
+        if (!distanceKm.isFinite() || distanceKm < 0.0) {
+            return null
+        }
+
+        val estimatedTimeMin = response.opt("estimated_time_min")
+            ?.toString()
+            ?.toDoubleOrNull()
+            ?.toInt()
+            ?.takeIf { it > 0 }
+
+        return AssignmentRouteUiModel(
+            distanceKm = distanceKm,
+            estimatedTimeMin = estimatedTimeMin,
+            source = response.optString("source").ifBlank { "fallback" }
+        )
     }
 
     internal suspend fun pushCancelOperation(operation: SyncOperationEntity, token: String?) {

--- a/android/app/src/main/java/com/neph/features/assignedrequest/presentation/AssignedRequestScreen.kt
+++ b/android/app/src/main/java/com/neph/features/assignedrequest/presentation/AssignedRequestScreen.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.neph.core.sync.OfflineSyncScheduler
 import com.neph.features.assignedrequest.data.AssignedRequestRepository
+import com.neph.features.assignedrequest.data.AssignmentRouteUiModel
 import com.neph.features.assignedrequest.data.AssignedRequestUiModel
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.navigation.Routes
@@ -57,6 +58,9 @@ fun AssignedRequestScreen(
     var infoMessage by remember { mutableStateOf("") }
     var refreshVersion by remember { mutableStateOf(0) }
     var cancelling by remember { mutableStateOf(false) }
+    var routeInfo by remember { mutableStateOf<AssignmentRouteUiModel?>(null) }
+    var routeLoading by remember { mutableStateOf(false) }
+    var routeMessage by remember { mutableStateOf("") }
 
     DisposableEffect(lifecycleOwner, token) {
         val observer = LifecycleEventObserver { _, event ->
@@ -97,6 +101,47 @@ fun AssignedRequestScreen(
         } catch (_: Exception) {
             error = "Could not save the assignment update locally."
         }
+    }
+
+    suspend fun loadRouteInfo(assignmentId: String) {
+        if (token.isBlank()) {
+            routeInfo = null
+            routeMessage = ""
+            return
+        }
+
+        routeLoading = true
+        routeMessage = ""
+
+        try {
+            val result = AssignedRequestRepository.fetchAssignmentRoute(
+                token = token,
+                assignmentId = assignmentId
+            )
+            routeInfo = result
+            routeMessage = if (result == null) {
+                "Route is unavailable until both locations are available."
+            } else {
+                ""
+            }
+        } catch (_: Exception) {
+            routeInfo = null
+            routeMessage = "Route information is unavailable right now."
+        } finally {
+            routeLoading = false
+        }
+    }
+
+    LaunchedEffect(currentRequest?.assignmentId, token, refreshVersion) {
+        val assignmentId = currentRequest?.assignmentId
+        if (assignmentId.isNullOrBlank()) {
+            routeInfo = null
+            routeMessage = ""
+            routeLoading = false
+            return@LaunchedEffect
+        }
+
+        loadRouteInfo(assignmentId)
     }
 
     AppDrawerScaffold(
@@ -287,6 +332,34 @@ fun AssignedRequestScreen(
                             )
 
                             DetailLine(label = "Location", value = request.locationLabel)
+
+                            when {
+                                routeLoading -> {
+                                    HelperText(text = "Loading route information...")
+                                }
+
+                                routeInfo != null -> {
+                                    val route = routeInfo!!
+                                    DetailLine(
+                                        label = "Distance",
+                                        value = formatRouteDistance(route.distanceKm)
+                                    )
+                                    route.estimatedTimeMin?.let {
+                                        DetailLine(
+                                            label = "Estimated travel time",
+                                            value = "$it min"
+                                        )
+                                    }
+                                    DetailLine(
+                                        label = "Route source",
+                                        value = formatRouteSource(route.source)
+                                    )
+                                }
+
+                                routeMessage.isNotBlank() -> {
+                                    HelperText(text = routeMessage)
+                                }
+                            }
                         }
                     }
 
@@ -399,6 +472,22 @@ private fun DetailLine(label: String, value: String, onClick: (() -> Unit)? = nu
                     }
                 )
         )
+    }
+}
+
+private fun formatRouteDistance(distanceKm: Double): String {
+    return if (distanceKm < 1.0) {
+        "${(distanceKm * 1000).toInt()} m"
+    } else {
+        String.format(java.util.Locale.US, "%.1f km", distanceKm)
+    }
+}
+
+private fun formatRouteSource(source: String): String {
+    return when (source.trim().lowercase()) {
+        "routing" -> "Routing provider"
+        "fallback" -> "Straight-line estimate"
+        else -> "Estimate"
     }
 }
 

--- a/backend/src/modules/assignments/controller.js
+++ b/backend/src/modules/assignments/controller.js
@@ -1,0 +1,40 @@
+const { getAssignmentRoute } = require('./service');
+
+function sendError(response, status, code, message) {
+  return response.status(status).json({ code, message });
+}
+
+async function handleGetAssignmentRoute(request, response) {
+  const { assignmentId } = request.params;
+  if (!assignmentId) {
+    return sendError(response, 400, 'VALIDATION_ERROR', 'assignmentId is required');
+  }
+
+  try {
+    const route = await getAssignmentRoute({
+      assignmentId,
+      userId: request.user.userId,
+    });
+
+    return response.status(200).json(route);
+  } catch (error) {
+    if (error.code === 'ASSIGNMENT_NOT_FOUND') {
+      return sendError(response, 404, 'ASSIGNMENT_NOT_FOUND', 'Assignment not found');
+    }
+
+    if (error.code === 'FORBIDDEN') {
+      return sendError(response, 403, 'FORBIDDEN', 'You cannot access this assignment route');
+    }
+
+    if (error.code === 'LOCATION_UNAVAILABLE') {
+      return response.status(200).json({ error: 'location_unavailable' });
+    }
+
+    console.error('assignments.route failed', error);
+    return sendError(response, 500, 'INTERNAL_ERROR', 'Something went wrong');
+  }
+}
+
+module.exports = {
+  handleGetAssignmentRoute,
+};

--- a/backend/src/modules/assignments/repository.js
+++ b/backend/src/modules/assignments/repository.js
@@ -1,0 +1,53 @@
+const { query } = require('../../db/pool');
+
+async function findRouteContextByAssignmentId(assignmentId) {
+  const result = await query(
+    `
+      SELECT
+        a.assignment_id,
+        a.volunteer_id,
+        a.request_id,
+        v.user_id AS volunteer_user_id,
+        v.last_known_latitude AS responder_latitude,
+        v.last_known_longitude AS responder_longitude,
+        rl.latitude AS request_latitude,
+        rl.longitude AS request_longitude
+      FROM assignments a
+      JOIN volunteers v ON v.volunteer_id = a.volunteer_id
+      JOIN help_requests hr ON hr.request_id = a.request_id
+      LEFT JOIN LATERAL (
+        SELECT loc.latitude, loc.longitude
+        FROM request_locations loc
+        WHERE loc.request_id = a.request_id
+        ORDER BY loc.captured_at DESC, loc.location_id DESC
+        LIMIT 1
+      ) rl ON TRUE
+      WHERE a.assignment_id = $1
+        AND a.is_cancelled = FALSE
+        AND hr.status NOT IN ('RESOLVED', 'CANCELLED')
+      LIMIT 1;
+    `,
+    [assignmentId],
+  );
+
+  return result.rows[0] || null;
+}
+
+async function findAdminByUserId(userId) {
+  const result = await query(
+    `
+      SELECT admin_id, user_id, role
+      FROM admins
+      WHERE user_id = $1
+      LIMIT 1;
+    `,
+    [userId],
+  );
+
+  return result.rows[0] || null;
+}
+
+module.exports = {
+  findRouteContextByAssignmentId,
+  findAdminByUserId,
+};

--- a/backend/src/modules/assignments/routes.js
+++ b/backend/src/modules/assignments/routes.js
@@ -1,0 +1,14 @@
+const express = require('express');
+
+const { requireAuth } = require('../auth/middleware');
+const { handleGetAssignmentRoute } = require('./controller');
+
+const assignmentsRouter = express.Router();
+
+assignmentsRouter.use(requireAuth);
+
+assignmentsRouter.get('/:assignmentId/route', handleGetAssignmentRoute);
+
+module.exports = {
+  assignmentsRouter,
+};

--- a/backend/src/modules/assignments/service.js
+++ b/backend/src/modules/assignments/service.js
@@ -1,0 +1,176 @@
+const {
+  findRouteContextByAssignmentId,
+  findAdminByUserId,
+} = require('./repository');
+
+const EARTH_RADIUS_KM = 6371;
+const DEFAULT_SPEED_KMH = 35;
+
+function toFiniteNumber(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toRadians(value) {
+  return (value * Math.PI) / 180;
+}
+
+function calculateHaversineDistanceKm(from, to) {
+  const dLat = toRadians(to.latitude - from.latitude);
+  const dLon = toRadians(to.longitude - from.longitude);
+
+  const a =
+    Math.sin(dLat / 2) ** 2
+    + Math.cos(toRadians(from.latitude))
+      * Math.cos(toRadians(to.latitude))
+      * Math.sin(dLon / 2) ** 2;
+
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_KM * c;
+}
+
+function roundDistanceKm(distanceKm) {
+  return Math.round(distanceKm * 100) / 100;
+}
+
+function estimateFallbackMinutes(distanceKm) {
+  if (!Number.isFinite(distanceKm)) {
+    return null;
+  }
+
+  return Math.max(1, Math.round((distanceKm / DEFAULT_SPEED_KMH) * 60));
+}
+
+function buildFallbackRoute(from, to) {
+  const distanceKm = calculateHaversineDistanceKm(from, to);
+  return {
+    distance_km: roundDistanceKm(distanceKm),
+    estimated_time_min: estimateFallbackMinutes(distanceKm),
+    route: null,
+    source: 'fallback',
+  };
+}
+
+function getRoutingProviderUrl() {
+  return (process.env.ASSIGNMENT_ROUTING_URL || '').trim();
+}
+
+function buildRoutingProviderUrl(baseUrl, from, to) {
+  const url = new URL(baseUrl);
+  url.searchParams.set('fromLat', String(from.latitude));
+  url.searchParams.set('fromLon', String(from.longitude));
+  url.searchParams.set('toLat', String(to.latitude));
+  url.searchParams.set('toLon', String(to.longitude));
+  return url;
+}
+
+function parseRoutingProviderPayload(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const distanceKm = toFiniteNumber(payload.distance_km ?? payload.distanceKm);
+  if (distanceKm === null || distanceKm < 0) {
+    return null;
+  }
+
+  const estimatedTimeMin = toFiniteNumber(payload.estimated_time_min ?? payload.estimatedTimeMin);
+  const route = Array.isArray(payload.route) ? payload.route : null;
+
+  return {
+    distance_km: roundDistanceKm(distanceKm),
+    estimated_time_min: estimatedTimeMin === null ? null : Math.max(1, Math.round(estimatedTimeMin)),
+    route,
+    source: 'routing',
+  };
+}
+
+async function tryRoutingProvider(from, to) {
+  const providerUrl = getRoutingProviderUrl();
+  if (!providerUrl) {
+    return null;
+  }
+
+  const response = await fetch(buildRoutingProviderUrl(providerUrl, from, to), {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return parseRoutingProviderPayload(await response.json());
+}
+
+function readCoordinates(context) {
+  const responderLatitude = toFiniteNumber(context.responder_latitude);
+  const responderLongitude = toFiniteNumber(context.responder_longitude);
+  const requestLatitude = toFiniteNumber(context.request_latitude);
+  const requestLongitude = toFiniteNumber(context.request_longitude);
+
+  if (
+    responderLatitude === null
+    || responderLongitude === null
+    || requestLatitude === null
+    || requestLongitude === null
+  ) {
+    return null;
+  }
+
+  return {
+    responder: {
+      latitude: responderLatitude,
+      longitude: responderLongitude,
+    },
+    request: {
+      latitude: requestLatitude,
+      longitude: requestLongitude,
+    },
+  };
+}
+
+async function getAssignmentRoute({ assignmentId, userId }) {
+  const context = await findRouteContextByAssignmentId(assignmentId);
+  if (!context) {
+    const error = new Error('Assignment not found');
+    error.code = 'ASSIGNMENT_NOT_FOUND';
+    throw error;
+  }
+
+  const isAssignedResponder = context.volunteer_user_id === userId;
+  const isAdmin = Boolean(await findAdminByUserId(userId));
+  if (!isAssignedResponder && !isAdmin) {
+    const error = new Error('Forbidden');
+    error.code = 'FORBIDDEN';
+    throw error;
+  }
+
+  const coordinates = readCoordinates(context);
+  if (!coordinates) {
+    const error = new Error('Location unavailable');
+    error.code = 'LOCATION_UNAVAILABLE';
+    throw error;
+  }
+
+  try {
+    const routed = await tryRoutingProvider(coordinates.responder, coordinates.request);
+    if (routed) {
+      return routed;
+    }
+  } catch (_error) {
+    // Provider failures must not block responders from seeing approximate distance.
+  }
+
+  return buildFallbackRoute(coordinates.responder, coordinates.request);
+}
+
+module.exports = {
+  calculateHaversineDistanceKm,
+  getAssignmentRoute,
+};

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -5,6 +5,7 @@ const { adminRouter } = require('../modules/admin/routes');
 const { profilesRouter } = require('../modules/profiles/routes');
 const { helpRequestsRouter } = require('../modules/help-requests/routes');
 const { availabilityRouter } = require('../modules/availability/routes');
+const { assignmentsRouter } = require('../modules/assignments/routes');
 const { locationRouter } = require('../modules/location/routes');
 const { gatheringAreasRouter } = require('../modules/gathering-areas/routes');
 const { notificationsRouter } = require('../modules/notifications/routes');
@@ -17,7 +18,7 @@ apiRouter.get('/', (_request, response) => {
     service: 'api',
     status: 'ok',
     name: 'Neighborhood Emergency Preparedness Hub API',
-    modules: ['auth', 'admin', 'profiles', 'help-requests', 'availability', 'location', 'gathering-areas', 'notifications', 'announcements'],
+    modules: ['auth', 'admin', 'profiles', 'help-requests', 'availability', 'assignments', 'location', 'gathering-areas', 'notifications', 'announcements'],
   });
 });
 
@@ -26,6 +27,7 @@ apiRouter.use('/admin', adminRouter);
 apiRouter.use('/profiles', profilesRouter);
 apiRouter.use('/help-requests', helpRequestsRouter);
 apiRouter.use('/availability', availabilityRouter);
+apiRouter.use('/assignments', assignmentsRouter);
 apiRouter.use('/location', locationRouter);
 apiRouter.use('/gathering-areas', gatheringAreasRouter);
 apiRouter.use('/notifications', notificationsRouter);

--- a/backend/tests/integration/modules/assignments/assignment-route.integration.test.js
+++ b/backend/tests/integration/modules/assignments/assignment-route.integration.test.js
@@ -1,0 +1,283 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+const { assignmentsRouter } = require('../../../../src/modules/assignments/routes');
+const { query } = require('../../../../src/db/pool');
+
+const originalFetch = global.fetch;
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/assignments', assignmentsRouter);
+  return app;
+}
+
+function buildAuthToken({ userId, isAdmin = false }) {
+  return jwt.sign(
+    {
+      userId,
+      email: `${userId}@example.com`,
+      isAdmin,
+      adminRole: isAdmin ? 'COORDINATOR' : null,
+    },
+    process.env.JWT_SECRET || 'dev-secret-123',
+    { expiresIn: '1h' },
+  );
+}
+
+async function seedUser(userId, email = `${userId}@example.com`) {
+  await query(
+    `
+      INSERT INTO users (
+        user_id,
+        email,
+        password_hash,
+        is_email_verified,
+        is_deleted,
+        accepted_terms,
+        is_banned
+      )
+      VALUES ($1, $2, 'hash', TRUE, FALSE, TRUE, FALSE);
+    `,
+    [userId, email],
+  );
+}
+
+async function seedAdmin(userId = 'admin_user') {
+  await seedUser(userId, `${userId}@example.com`);
+  await query(
+    `
+      INSERT INTO admins (admin_id, user_id, role)
+      VALUES ($1, $2, 'COORDINATOR');
+    `,
+    [`adm_${userId}`, userId],
+  );
+}
+
+async function seedVolunteer({
+  volunteerId = 'vol_responder',
+  userId = 'responder_user',
+  latitude = 41,
+  longitude = 29,
+} = {}) {
+  await seedUser(userId, `${userId}@example.com`);
+  await query(
+    `
+      INSERT INTO volunteers (
+        volunteer_id,
+        user_id,
+        is_available,
+        last_known_latitude,
+        last_known_longitude,
+        location_updated_at
+      )
+      VALUES ($1, $2, TRUE, $3, $4, CURRENT_TIMESTAMP);
+    `,
+    [volunteerId, userId, latitude, longitude],
+  );
+}
+
+async function seedHelpRequest({
+  requestId = 'req_route',
+  requesterId = 'requester_user',
+  latitude = 41.1,
+  longitude = 29.1,
+} = {}) {
+  await seedUser(requesterId, `${requesterId}@example.com`);
+  await query(
+    `
+      INSERT INTO help_requests (
+        request_id,
+        user_id,
+        help_types,
+        affected_people_count,
+        need_type,
+        description,
+        status,
+        contact_full_name,
+        contact_phone
+      )
+      VALUES ($1, $2, ARRAY['general'], 1, 'general', 'Need help', 'ASSIGNED', 'Requester', 5550000000);
+    `,
+    [requestId, requesterId],
+  );
+
+  if (latitude !== null && longitude !== null) {
+    await query(
+      `
+        INSERT INTO request_locations (
+          location_id,
+          request_id,
+          country,
+          city,
+          district,
+          neighborhood,
+          extra_address,
+          latitude,
+          longitude
+        )
+        VALUES ($1, $2, 'turkiye', 'istanbul', 'besiktas', 'levazim', '', $3, $4);
+      `,
+      [`loc_${requestId}`, requestId, latitude, longitude],
+    );
+  }
+}
+
+async function seedAssignment({
+  assignmentId = 'asg_route',
+  volunteerId = 'vol_responder',
+  requestId = 'req_route',
+} = {}) {
+  await query(
+    `
+      INSERT INTO assignments (assignment_id, volunteer_id, request_id, assigned_at, is_cancelled)
+      VALUES ($1, $2, $3, CURRENT_TIMESTAMP, FALSE);
+    `,
+    [assignmentId, volunteerId, requestId],
+  );
+}
+
+async function seedRouteScenario(options = {}) {
+  await seedVolunteer(options.volunteer || {});
+  await seedHelpRequest(options.request || {});
+  await seedAssignment(options.assignment || {});
+}
+
+beforeEach(async () => {
+  await query(`
+    TRUNCATE TABLE
+      assignments,
+      availability_records,
+      volunteers,
+      request_locations,
+      help_requests,
+      admins,
+      user_profiles,
+      users
+    RESTART IDENTITY CASCADE;
+  `);
+  delete process.env.ASSIGNMENT_ROUTING_URL;
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  delete process.env.ASSIGNMENT_ROUTING_URL;
+  jest.restoreAllMocks();
+  global.fetch = originalFetch;
+});
+
+describe('assignment route integration', () => {
+  test('GET /api/assignments/:assignmentId/route returns fallback distance for assigned responder', async () => {
+    const app = createTestApp();
+    await seedRouteScenario();
+
+    const response = await request(app)
+      .get('/api/assignments/asg_route/route')
+      .set('Authorization', `Bearer ${buildAuthToken({ userId: 'responder_user' })}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.source).toBe('fallback');
+    expect(response.body.distance_km).toBeGreaterThan(0);
+    expect(response.body.estimated_time_min).toEqual(expect.any(Number));
+    expect(response.body.route).toBeNull();
+  });
+
+  test('GET /api/assignments/:assignmentId/route allows admin users', async () => {
+    const app = createTestApp();
+    await seedRouteScenario();
+    await seedAdmin('admin_user');
+
+    const response = await request(app)
+      .get('/api/assignments/asg_route/route')
+      .set('Authorization', `Bearer ${buildAuthToken({ userId: 'admin_user', isAdmin: true })}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.source).toBe('fallback');
+    expect(response.body.distance_km).toBeGreaterThan(0);
+  });
+
+  test('GET /api/assignments/:assignmentId/route rejects other users', async () => {
+    const app = createTestApp();
+    await seedRouteScenario();
+    await seedUser('other_user');
+
+    const response = await request(app)
+      .get('/api/assignments/asg_route/route')
+      .set('Authorization', `Bearer ${buildAuthToken({ userId: 'other_user' })}`);
+
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe('FORBIDDEN');
+  });
+
+  test('GET /api/assignments/:assignmentId/route returns 404 when assignment is missing', async () => {
+    const app = createTestApp();
+    await seedUser('responder_user');
+
+    const response = await request(app)
+      .get('/api/assignments/missing_assignment/route')
+      .set('Authorization', `Bearer ${buildAuthToken({ userId: 'responder_user' })}`);
+
+    expect(response.status).toBe(404);
+    expect(response.body.code).toBe('ASSIGNMENT_NOT_FOUND');
+  });
+
+  test('GET /api/assignments/:assignmentId/route returns location_unavailable when coordinates are missing', async () => {
+    const app = createTestApp();
+    await seedRouteScenario({
+      volunteer: { latitude: null, longitude: null },
+    });
+
+    const response = await request(app)
+      .get('/api/assignments/asg_route/route')
+      .set('Authorization', `Bearer ${buildAuthToken({ userId: 'responder_user' })}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ error: 'location_unavailable' });
+  });
+
+  test('GET /api/assignments/:assignmentId/route uses routing provider when configured', async () => {
+    const app = createTestApp();
+    await seedRouteScenario();
+    process.env.ASSIGNMENT_ROUTING_URL = 'https://router.example.test/route';
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        distance_km: 12.345,
+        estimated_time_min: 18,
+        route: [{ latitude: 41, longitude: 29 }],
+      }),
+    });
+
+    const response = await request(app)
+      .get('/api/assignments/asg_route/route')
+      .set('Authorization', `Bearer ${buildAuthToken({ userId: 'responder_user' })}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      distance_km: 12.35,
+      estimated_time_min: 18,
+      route: [{ latitude: 41, longitude: 29 }],
+      source: 'routing',
+    });
+  });
+
+  test('GET /api/assignments/:assignmentId/route falls back when routing provider fails', async () => {
+    const app = createTestApp();
+    await seedRouteScenario();
+    process.env.ASSIGNMENT_ROUTING_URL = 'https://router.example.test/route';
+    global.fetch.mockRejectedValueOnce(new Error('provider failed'));
+
+    const response = await request(app)
+      .get('/api/assignments/asg_route/route')
+      .set('Authorization', `Bearer ${buildAuthToken({ userId: 'responder_user' })}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.source).toBe('fallback');
+    expect(response.body.distance_km).toBeGreaterThan(0);
+    expect(response.body.route).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Added `GET /api/assignments/:assignmentId/route` for assigned responders and admins.
- Implemented route distance calculation with Haversine fallback.
- Added Android Assigned Request UI support for distance and estimated time.
- Added backend integration tests for authorization, missing location, success, and fallback cases.

## Testing
- Backend assignment route integration tests added.
- Android debug build checked locally.

closes [#386](https://github.com/bounswe/bounswe2026group6/issues/386)