### PR TITLE
fix: add in-app OSM map picker for location selection for mobile

### DIFF
--- a/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
@@ -42,8 +42,10 @@ import com.neph.features.profile.data.professionOptionsFor
 import com.neph.features.profile.data.sanitizeDecimalInput
 import com.neph.features.profile.data.splitFullName
 import com.neph.features.profile.data.toEditableString
+import com.neph.features.requesthelp.data.RequestHelpRepository
 import com.neph.features.profile.presentation.components.GenderSelector
 import com.neph.features.profile.presentation.components.LocationSelector
+import com.neph.ui.components.buttons.SecondaryButton
 import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.display.SaveActionBar
 import com.neph.ui.components.inputs.AppDropdown
@@ -52,8 +54,12 @@ import com.neph.ui.components.inputs.AppTextField
 import com.neph.ui.components.selection.AppCheckbox
 import com.neph.ui.components.selection.AppToggleSwitch
 import com.neph.ui.layout.AuthScaffold
+import com.neph.ui.map.MapPickerDialog
+import com.neph.ui.map.MapPickerSelection
 import com.neph.ui.map.LocationSelectionMapAction
 import com.neph.ui.map.SharedCoordinatesMapAction
+import com.neph.ui.map.formatMapCoordinate
+import com.neph.ui.map.resolveMapPickerLocationUpdate
 import com.neph.ui.theme.LocalNephSpacing
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
@@ -105,6 +111,9 @@ fun CompleteProfileScreen(
     var error by rememberSaveable { mutableStateOf("") }
     var info by rememberSaveable { mutableStateOf("") }
     var mapActionInfo by rememberSaveable { mutableStateOf("") }
+    var mapPickerOpen by rememberSaveable { mutableStateOf(false) }
+    var mapPickerLoading by rememberSaveable { mutableStateOf(false) }
+    var mapPickerSelection by remember { mutableStateOf<MapPickerSelection?>(null) }
     var availableLocationData by remember { mutableStateOf<LocationData>(locationData) }
     var locationLoading by remember { mutableStateOf(true) }
     var locationInfo by rememberSaveable { mutableStateOf("") }
@@ -132,6 +141,50 @@ fun CompleteProfileScreen(
             locationInfo = "Could not refresh location options. Showing saved location list."
         } finally {
             locationLoading = false
+        }
+    }
+
+    fun handleMapSelection(selection: MapPickerSelection) {
+        if (mapPickerLoading) return
+
+        mapPickerLoading = true
+        mapActionInfo = ""
+
+        scope.launch {
+            try {
+                val reverseLocation = RequestHelpRepository.reverseGeocodeCurrentLocation(
+                    latitude = selection.latitude,
+                    longitude = selection.longitude
+                )
+                val update = resolveMapPickerLocationUpdate(
+                    currentCountry = country,
+                    currentCity = city,
+                    currentDistrict = district,
+                    currentNeighborhood = neighborhood,
+                    currentExtraAddress = extraAddress,
+                    reverseLocation = reverseLocation,
+                    locations = availableLocationData
+                )
+
+                country = update.country
+                city = update.city
+                district = update.district
+                neighborhood = update.neighborhood
+                extraAddress = update.extraAddress
+                mapActionInfo = if (reverseLocation == null) {
+                    "Could not resolve selected coordinates. You can continue with manual location entry."
+                } else {
+                    "Selected location applied."
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                mapActionInfo = "Could not resolve selected coordinates. You can continue with manual location entry."
+            } finally {
+                mapPickerSelection = selection
+                mapPickerLoading = false
+                mapPickerOpen = false
+            }
         }
     }
 
@@ -441,6 +494,18 @@ fun CompleteProfileScreen(
                 enabled = !locationLoading
             )
 
+            SecondaryButton(
+                text = "Select Location on Map",
+                onClick = { mapPickerOpen = true },
+                enabled = !locationLoading && !loading
+            )
+
+            mapPickerSelection?.let { selection ->
+                HelperText(
+                    text = "Selected coordinates: ${formatMapCoordinate(selection.latitude)}, ${formatMapCoordinate(selection.longitude)}"
+                )
+            }
+
             AppTextField(
                 value = extraAddress,
                 onValueChange = { extraAddress = it },
@@ -484,6 +549,16 @@ fun CompleteProfileScreen(
                 },
                 label = "Share Current Location"
             )
+
+            if (mapPickerOpen) {
+                MapPickerDialog(
+                    initialLatitude = mapPickerSelection?.latitude ?: syncedSharedLatitude,
+                    initialLongitude = mapPickerSelection?.longitude ?: syncedSharedLongitude,
+                    loading = mapPickerLoading,
+                    onDismiss = { if (!mapPickerLoading) mapPickerOpen = false },
+                    onConfirm = ::handleMapSelection
+                )
+            }
 
             if (error.isNotBlank()) {
                 Text(error, color = MaterialTheme.colorScheme.error)

--- a/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
@@ -171,10 +171,13 @@ fun CompleteProfileScreen(
                 district = update.district
                 neighborhood = update.neighborhood
                 extraAddress = update.extraAddress
-                mapActionInfo = if (reverseLocation == null) {
-                    "Could not resolve selected coordinates. You can continue with manual location entry."
-                } else {
-                    "Selected location applied."
+                mapActionInfo = when {
+                    reverseLocation == null ->
+                        "Could not resolve selected coordinates. You can continue with manual location entry."
+                    update.isMeaningfulMapping ->
+                        "Selected location applied."
+                    else ->
+                        "Selected coordinates were detected. Please verify the location fields manually."
                 }
             } catch (cancellationException: CancellationException) {
                 throw cancellationException

--- a/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
@@ -207,10 +207,13 @@ fun EditProfileScreen(
                     neighborhood = update.neighborhood,
                     extraAddress = update.extraAddress
                 )
-                mapActionInfo = if (reverseLocation == null) {
-                    "Could not resolve selected coordinates. You can continue with manual location entry."
-                } else {
-                    "Selected location applied."
+                mapActionInfo = when {
+                    reverseLocation == null ->
+                        "Could not resolve selected coordinates. You can continue with manual location entry."
+                    update.isMeaningfulMapping ->
+                        "Selected location applied."
+                    else ->
+                        "Selected coordinates were detected. Please verify the location fields manually."
                 }
             } catch (cancellationException: CancellationException) {
                 throw cancellationException

--- a/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
@@ -40,9 +40,11 @@ import com.neph.features.profile.data.parseListField
 import com.neph.features.profile.data.professionOptionsFor
 import com.neph.features.profile.data.sanitizeDecimalInput
 import com.neph.features.profile.data.toEditableString
+import com.neph.features.requesthelp.data.RequestHelpRepository
 import com.neph.features.profile.presentation.components.GenderSelector
 import com.neph.features.profile.presentation.components.LocationSelector
 import com.neph.ui.components.buttons.PrimaryButton
+import com.neph.ui.components.buttons.SecondaryButton
 import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
@@ -52,8 +54,12 @@ import com.neph.ui.components.inputs.AppTextField
 import com.neph.ui.components.selection.AppCheckbox
 import com.neph.ui.components.selection.AppToggleSwitch
 import com.neph.ui.layout.AppScaffold
+import com.neph.ui.map.MapPickerDialog
+import com.neph.ui.map.MapPickerSelection
 import com.neph.ui.map.LocationSelectionMapAction
 import com.neph.ui.map.SharedCoordinatesMapAction
+import com.neph.ui.map.formatMapCoordinate
+import com.neph.ui.map.resolveMapPickerLocationUpdate
 import com.neph.ui.theme.LocalNephSpacing
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
@@ -84,6 +90,9 @@ fun EditProfileScreen(
     var error by rememberSaveable { mutableStateOf("") }
     var info by rememberSaveable { mutableStateOf("") }
     var mapActionInfo by rememberSaveable { mutableStateOf("") }
+    var mapPickerOpen by rememberSaveable { mutableStateOf(false) }
+    var mapPickerLoading by rememberSaveable { mutableStateOf(false) }
+    var mapPickerSelection by remember { mutableStateOf<MapPickerSelection?>(null) }
 
     var countryCode by rememberSaveable { mutableStateOf(initialPhoneParts.countryCode) }
     var phone by rememberSaveable { mutableStateOf(initialPhoneParts.phone) }
@@ -166,6 +175,52 @@ fun EditProfileScreen(
             locationInfo = "Could not refresh location options. Showing saved location list."
         } finally {
             locationLoading = false
+        }
+    }
+
+    fun handleMapSelection(selection: MapPickerSelection) {
+        if (mapPickerLoading) return
+
+        mapPickerLoading = true
+        mapActionInfo = ""
+
+        scope.launch {
+            try {
+                val reverseLocation = RequestHelpRepository.reverseGeocodeCurrentLocation(
+                    latitude = selection.latitude,
+                    longitude = selection.longitude
+                )
+                val update = resolveMapPickerLocationUpdate(
+                    currentCountry = profile.country.orEmpty(),
+                    currentCity = profile.city.orEmpty(),
+                    currentDistrict = profile.district.orEmpty(),
+                    currentNeighborhood = profile.neighborhood.orEmpty(),
+                    currentExtraAddress = profile.extraAddress.orEmpty(),
+                    reverseLocation = reverseLocation,
+                    locations = availableLocationData
+                )
+
+                profile = profile.copy(
+                    country = update.country,
+                    city = update.city,
+                    district = update.district,
+                    neighborhood = update.neighborhood,
+                    extraAddress = update.extraAddress
+                )
+                mapActionInfo = if (reverseLocation == null) {
+                    "Could not resolve selected coordinates. You can continue with manual location entry."
+                } else {
+                    "Selected location applied."
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                mapActionInfo = "Could not resolve selected coordinates. You can continue with manual location entry."
+            } finally {
+                mapPickerSelection = selection
+                mapPickerLoading = false
+                mapPickerOpen = false
+            }
         }
     }
 
@@ -477,6 +532,18 @@ fun EditProfileScreen(
                         enabled = !locationLoading
                     )
 
+                    SecondaryButton(
+                        text = "Select Location on Map",
+                        onClick = { mapPickerOpen = true },
+                        enabled = !locationLoading && !loading
+                    )
+
+                    mapPickerSelection?.let { selection ->
+                        HelperText(
+                            text = "Selected coordinates: ${formatMapCoordinate(selection.latitude)}, ${formatMapCoordinate(selection.longitude)}"
+                        )
+                    }
+
                     AppTextField(
                         value = profile.extraAddress.orEmpty(),
                         onValueChange = { profile = profile.copy(extraAddress = it) },
@@ -519,6 +586,16 @@ fun EditProfileScreen(
                         },
                         label = "Share Current Location"
                     )
+
+                    if (mapPickerOpen) {
+                        MapPickerDialog(
+                            initialLatitude = mapPickerSelection?.latitude ?: syncedSharedLatitude,
+                            initialLongitude = mapPickerSelection?.longitude ?: syncedSharedLongitude,
+                            loading = mapPickerLoading,
+                            onDismiss = { if (!mapPickerLoading) mapPickerOpen = false },
+                            onConfirm = ::handleMapSelection
+                        )
+                    }
                 }
             }
 

--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -496,10 +496,13 @@ fun RequestHelpScreen(
                     neighborhood = update.neighborhood,
                     shortAddress = update.extraAddress
                 )
-                mapActionMessage = if (reverseLocation == null) {
-                    "Could not resolve selected coordinates. You can continue with manual location entry."
-                } else {
-                    "Selected location applied."
+                mapActionMessage = when {
+                    reverseLocation == null ->
+                        "Could not resolve selected coordinates. You can continue with manual location entry."
+                    update.isMeaningfulMapping ->
+                        "Selected location applied."
+                    else ->
+                        "Selected coordinates were detected. Please verify the location fields manually."
                 }
             } catch (cancellationException: CancellationException) {
                 throw cancellationException

--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -55,7 +55,11 @@ import com.neph.ui.components.inputs.AppTextField
 import com.neph.ui.components.selection.AppCheckbox
 import com.neph.ui.components.selection.AppMultiSelectChipGroup
 import com.neph.ui.layout.AppScaffold
+import com.neph.ui.map.MapPickerDialog
+import com.neph.ui.map.MapPickerSelection
 import com.neph.ui.map.LocationSelectionMapAction
+import com.neph.ui.map.formatMapCoordinate
+import com.neph.ui.map.resolveMapPickerLocationUpdate
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
 import kotlinx.coroutines.CancellationException
@@ -393,6 +397,9 @@ fun RequestHelpScreen(
     var errorMessage by remember { mutableStateOf("") }
     var infoMessage by remember { mutableStateOf("") }
     var mapActionMessage by rememberSaveable { mutableStateOf("") }
+    var mapPickerOpen by rememberSaveable { mutableStateOf(false) }
+    var mapPickerLoading by rememberSaveable { mutableStateOf(false) }
+    var mapPickerSelection by remember { mutableStateOf<MapPickerSelection?>(null) }
     var checkingActiveRequest by remember { mutableStateOf(isLoggedIn) }
     var guestLocationAutoFillLoading by remember { mutableStateOf(false) }
     var guestLocationPermissionHandled by rememberSaveable { mutableStateOf(false) }
@@ -457,6 +464,51 @@ fun RequestHelpScreen(
                 infoMessage = "Could not retrieve your current location. You can continue with manual location entry."
             } finally {
                 guestLocationAutoFillLoading = false
+            }
+        }
+    }
+
+    fun handleMapSelection(selection: MapPickerSelection) {
+        if (mapPickerLoading) return
+
+        mapPickerLoading = true
+        mapActionMessage = ""
+
+        scope.launch {
+            try {
+                val reverseLocation = RequestHelpRepository.reverseGeocodeCurrentLocation(
+                    latitude = selection.latitude,
+                    longitude = selection.longitude
+                )
+                val update = resolveMapPickerLocationUpdate(
+                    currentCountry = formState.country,
+                    currentCity = formState.city,
+                    currentDistrict = formState.district,
+                    currentNeighborhood = formState.neighborhood,
+                    currentExtraAddress = formState.shortAddress,
+                    reverseLocation = reverseLocation,
+                    locations = availableLocationData
+                )
+                formState = formState.copy(
+                    country = update.country,
+                    city = update.city,
+                    district = update.district,
+                    neighborhood = update.neighborhood,
+                    shortAddress = update.extraAddress
+                )
+                mapActionMessage = if (reverseLocation == null) {
+                    "Could not resolve selected coordinates. You can continue with manual location entry."
+                } else {
+                    "Selected location applied."
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                mapActionMessage = "Could not resolve selected coordinates. You can continue with manual location entry."
+            } finally {
+                mapPickerSelection = selection
+                mapPickerLoading = false
+                mapPickerOpen = false
             }
         }
     }
@@ -740,6 +792,18 @@ fun RequestHelpScreen(
                         neighborhoodError = fieldErrors.neighborhood
                     )
 
+                    SecondaryButton(
+                        text = "Select Location on Map",
+                        onClick = { mapPickerOpen = true },
+                        enabled = !locationLoading && !loading
+                    )
+
+                    mapPickerSelection?.let { selection ->
+                        HelperText(
+                            text = "Selected coordinates: ${formatMapCoordinate(selection.latitude)}, ${formatMapCoordinate(selection.longitude)}"
+                        )
+                    }
+
                     AppTextField(
                         value = formState.shortAddress,
                         onValueChange = { formState = formState.copy(shortAddress = it) },
@@ -758,6 +822,16 @@ fun RequestHelpScreen(
                         onOpenFailure = { mapActionMessage = it },
                         onOpenSuccess = { mapActionMessage = "" }
                     )
+
+                    if (mapPickerOpen) {
+                        MapPickerDialog(
+                            initialLatitude = mapPickerSelection?.latitude,
+                            initialLongitude = mapPickerSelection?.longitude,
+                            loading = mapPickerLoading,
+                            onDismiss = { if (!mapPickerLoading) mapPickerOpen = false },
+                            onConfirm = ::handleMapSelection
+                        )
+                    }
                 }
             }
 

--- a/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
+++ b/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
@@ -1,6 +1,8 @@
 package com.neph.ui.map
 
 import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -170,19 +172,26 @@ private class MapPickerBridge(
     private val onMapReady: () -> Unit,
     private val onMapError: (String) -> Unit
 ) {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
     @JavascriptInterface
     fun onLocationSelected(latitude: Double, longitude: Double) {
-        onLocationSelected(latitude, longitude)
+        mainHandler.post {
+            onLocationSelected(latitude, longitude)
+        }
     }
 
     @JavascriptInterface
     fun onMapReady() {
-        onMapReady()
+        mainHandler.post(onMapReady)
     }
 
     @JavascriptInterface
     fun onMapError(message: String?) {
-        onMapError(message?.trim().orEmpty())
+        val trimmed = message?.trim().orEmpty()
+        mainHandler.post {
+            onMapError(trimmed)
+        }
     }
 }
 

--- a/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
+++ b/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
@@ -1,0 +1,258 @@
+package com.neph.ui.map
+
+import android.annotation.SuppressLint
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.viewinterop.AndroidView
+import com.neph.ui.components.buttons.PrimaryButton
+import com.neph.ui.components.buttons.SecondaryButton
+import com.neph.ui.components.display.HelperText
+import com.neph.ui.theme.LocalNephSpacing
+import java.util.Locale
+
+data class MapPickerSelection(
+    val latitude: Double,
+    val longitude: Double
+)
+
+@Composable
+fun MapPickerDialog(
+    title: String = "Select Location on Map",
+    initialLatitude: Double? = null,
+    initialLongitude: Double? = null,
+    loading: Boolean = false,
+    onDismiss: () -> Unit,
+    onConfirm: (MapPickerSelection) -> Unit
+) {
+    val spacing = LocalNephSpacing.current
+    val initialSelection = remember(initialLatitude, initialLongitude) {
+        if (initialLatitude != null && initialLongitude != null) {
+            MapPickerSelection(initialLatitude, initialLongitude)
+        } else {
+            null
+        }
+    }
+    var selection by remember(initialLatitude, initialLongitude) {
+        mutableStateOf(initialSelection)
+    }
+    var mapReady by remember { mutableStateOf(false) }
+    var mapError by remember { mutableStateOf("") }
+
+    Dialog(onDismissRequest = { if (!loading) onDismiss() }) {
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            tonalElevation = 6.dp,
+            modifier = Modifier
+                .fillMaxWidth()
+                .widthIn(max = 640.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(spacing.lg),
+                verticalArrangement = Arrangement.spacedBy(spacing.md)
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                HelperText(text = "Tap on the map to place a pin.")
+
+                MapPickerMap(
+                    initialLatitude = initialLatitude,
+                    initialLongitude = initialLongitude,
+                    onLocationSelected = { lat, lon ->
+                        selection = MapPickerSelection(lat, lon)
+                    },
+                    onMapReady = { mapReady = true },
+                    onMapError = { message ->
+                        mapError = message.ifBlank { "Map failed to load. Check your connection and try again." }
+                    }
+                )
+
+                if (!mapReady && mapError.isBlank()) {
+                    HelperText(text = "Loading map...")
+                }
+
+                if (mapError.isNotBlank()) {
+                    HelperText(text = mapError)
+                }
+
+                selection?.let {
+                    HelperText(
+                        text = "Selected coordinates: ${formatMapCoordinate(it.latitude)}, ${formatMapCoordinate(it.longitude)}"
+                    )
+                }
+
+                if (loading) {
+                    HelperText(text = "Resolving selected coordinates...")
+                }
+
+                PrimaryButton(
+                    text = "Use Selected Location",
+                    onClick = { selection?.let(onConfirm) },
+                    enabled = selection != null && !loading
+                )
+
+                SecondaryButton(
+                    text = "Cancel",
+                    onClick = onDismiss,
+                    enabled = !loading
+                )
+            }
+        }
+    }
+}
+
+private const val MapPickerBridgeName = "AndroidMapPicker"
+private const val DefaultCenterLatitude = 39.9334
+private const val DefaultCenterLongitude = 32.8597
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+private fun MapPickerMap(
+    initialLatitude: Double?,
+    initialLongitude: Double?,
+    onLocationSelected: (Double, Double) -> Unit,
+    onMapReady: () -> Unit,
+    onMapError: (String) -> Unit
+) {
+    val context = LocalContext.current
+    val html = remember(initialLatitude, initialLongitude) {
+        buildMapHtml(initialLatitude, initialLongitude)
+    }
+    val bridge = remember {
+        MapPickerBridge(onLocationSelected, onMapReady, onMapError)
+    }
+
+    key(html) {
+        AndroidView(
+            factory = {
+                WebView(context).apply {
+                    settings.javaScriptEnabled = true
+                    settings.domStorageEnabled = true
+                    settings.useWideViewPort = true
+                    settings.loadWithOverviewMode = true
+                    webViewClient = WebViewClient()
+                    addJavascriptInterface(bridge, MapPickerBridgeName)
+                    loadDataWithBaseURL("https://neph.app", html, "text/html", "utf-8", null)
+                }
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(260.dp)
+        )
+    }
+}
+
+private class MapPickerBridge(
+    private val onLocationSelected: (Double, Double) -> Unit,
+    private val onMapReady: () -> Unit,
+    private val onMapError: (String) -> Unit
+) {
+    @JavascriptInterface
+    fun onLocationSelected(latitude: Double, longitude: Double) {
+        onLocationSelected(latitude, longitude)
+    }
+
+    @JavascriptInterface
+    fun onMapReady() {
+        onMapReady()
+    }
+
+    @JavascriptInterface
+    fun onMapError(message: String?) {
+        onMapError(message?.trim().orEmpty())
+    }
+}
+
+private fun buildMapHtml(initialLatitude: Double?, initialLongitude: Double?): String {
+    val hasInitial = initialLatitude != null && initialLongitude != null
+    val centerLat = initialLatitude ?: DefaultCenterLatitude
+    val centerLon = initialLongitude ?: DefaultCenterLongitude
+    val zoom = if (hasInitial) 15 else 6
+    val formattedLat = String.format(Locale.US, "%.6f", centerLat)
+    val formattedLon = String.format(Locale.US, "%.6f", centerLon)
+
+    return """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+            <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+            <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+            <style>
+                html, body, #map { height: 100%; margin: 0; padding: 0; }
+            </style>
+        </head>
+        <body>
+            <div id="map"></div>
+            <script>
+                var map = L.map('map').setView([$formattedLat, $formattedLon], $zoom);
+                var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                    maxZoom: 19,
+                    attribution: '(c) OpenStreetMap'
+                }).addTo(map);
+
+                var marker = null;
+
+                if (window.$MapPickerBridgeName && window.$MapPickerBridgeName.onMapReady) {
+                    map.whenReady(function() {
+                        window.$MapPickerBridgeName.onMapReady();
+                    });
+                }
+
+                if (window.$MapPickerBridgeName && window.$MapPickerBridgeName.onMapError) {
+                    tiles.on('tileerror', function() {
+                        window.$MapPickerBridgeName.onMapError('Map tiles could not be loaded.');
+                    });
+                    window.onerror = function(message) {
+                        window.$MapPickerBridgeName.onMapError(String(message || 'Map failed to load.'));
+                    };
+                }
+
+                function setMarker(lat, lon) {
+                    if (marker) {
+                        marker.setLatLng([lat, lon]);
+                    } else {
+                        marker = L.marker([lat, lon]).addTo(map);
+                    }
+                }
+
+                if (${hasInitial.toString()}) {
+                    setMarker($formattedLat, $formattedLon);
+                }
+
+                map.on('click', function(e) {
+                    var lat = e.latlng.lat;
+                    var lon = e.latlng.lng;
+                    setMarker(lat, lon);
+                    if (window.$MapPickerBridgeName && window.$MapPickerBridgeName.onLocationSelected) {
+                        window.$MapPickerBridgeName.onLocationSelected(lat, lon);
+                    }
+                });
+            </script>
+        </body>
+        </html>
+    """.trimIndent()
+}

--- a/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
+++ b/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
@@ -183,7 +183,7 @@ private class MapPickerBridge(
 
     @JavascriptInterface
     fun onMapReady() {
-        mainHandler.post(onMapReady)
+        mainHandler.post { onMapReady() }
     }
 
     @JavascriptInterface

--- a/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
+++ b/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
@@ -1,9 +1,13 @@
 package com.neph.ui.map
 
 import android.annotation.SuppressLint
+import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.webkit.JavascriptInterface
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.Arrangement
@@ -30,6 +34,7 @@ import com.neph.ui.components.buttons.PrimaryButton
 import com.neph.ui.components.buttons.SecondaryButton
 import com.neph.ui.components.display.HelperText
 import com.neph.ui.theme.LocalNephSpacing
+import java.io.ByteArrayInputStream
 import java.util.Locale
 
 data class MapPickerSelection(
@@ -127,8 +132,18 @@ fun MapPickerDialog(
 }
 
 private const val MapPickerBridgeName = "AndroidMapPicker"
+private const val MapPickerBaseUrl = "https://neph.app/map-picker/"
+private const val LeafletCssUrl = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+private const val LeafletJsUrl = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
 private const val DefaultCenterLatitude = 39.9334
 private const val DefaultCenterLongitude = 32.8597
+private val AllowedOpenStreetMapTileHosts = setOf(
+    "tile.openstreetmap.org",
+    "a.tile.openstreetmap.org",
+    "b.tile.openstreetmap.org",
+    "c.tile.openstreetmap.org"
+)
+private val OpenStreetMapTilePathPattern = Regex("""^/\d+/\d+/\d+\.png$""")
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -152,12 +167,16 @@ private fun MapPickerMap(
             factory = {
                 WebView(context).apply {
                     settings.javaScriptEnabled = true
-                    settings.domStorageEnabled = true
+                    settings.domStorageEnabled = false
                     settings.useWideViewPort = true
                     settings.loadWithOverviewMode = true
-                    webViewClient = WebViewClient()
+                    settings.allowFileAccess = false
+                    settings.allowContentAccess = false
+                    settings.javaScriptCanOpenWindowsAutomatically = false
+                    settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+                    webViewClient = MapPickerWebViewClient()
                     addJavascriptInterface(bridge, MapPickerBridgeName)
-                    loadDataWithBaseURL("https://neph.app", html, "text/html", "utf-8", null)
+                    loadDataWithBaseURL(MapPickerBaseUrl, html, "text/html", "utf-8", null)
                 }
             },
             modifier = Modifier
@@ -195,6 +214,57 @@ private class MapPickerBridge(
     }
 }
 
+private class MapPickerWebViewClient : WebViewClient() {
+    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        val uri = request?.url ?: return true
+        return !request.isForMainFrame || !isAllowedMapPickerNavigation(uri)
+    }
+
+    @Suppress("DEPRECATION")
+    override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+        val uri = url?.let(Uri::parse) ?: return true
+        return !isAllowedMapPickerNavigation(uri)
+    }
+
+    override fun shouldInterceptRequest(view: WebView?, request: WebResourceRequest?): WebResourceResponse? {
+        val uri = request?.url ?: return emptyBlockedResponse()
+        return if (isAllowedMapPickerResource(uri)) {
+            null
+        } else {
+            emptyBlockedResponse()
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    override fun shouldInterceptRequest(view: WebView?, url: String?): WebResourceResponse? {
+        val uri = url?.let(Uri::parse) ?: return emptyBlockedResponse()
+        return if (isAllowedMapPickerResource(uri)) {
+            null
+        } else {
+            emptyBlockedResponse()
+        }
+    }
+
+    private fun emptyBlockedResponse(): WebResourceResponse {
+        return WebResourceResponse("text/plain", "utf-8", ByteArrayInputStream(ByteArray(0)))
+    }
+}
+
+private fun isAllowedMapPickerNavigation(uri: Uri): Boolean {
+    return uri.toString() == MapPickerBaseUrl
+}
+
+private fun isAllowedMapPickerResource(uri: Uri): Boolean {
+    val url = uri.toString()
+    if (url == MapPickerBaseUrl || url == LeafletCssUrl || url == LeafletJsUrl) {
+        return true
+    }
+
+    return uri.scheme == "https" &&
+        uri.host in AllowedOpenStreetMapTileHosts &&
+        OpenStreetMapTilePathPattern.matches(uri.path.orEmpty())
+}
+
 private fun buildMapHtml(initialLatitude: Double?, initialLongitude: Double?): String {
     val hasInitial = initialLatitude != null && initialLongitude != null
     val centerLat = initialLatitude ?: DefaultCenterLatitude
@@ -208,8 +278,10 @@ private fun buildMapHtml(initialLatitude: Double?, initialLongitude: Double?): S
         <html>
         <head>
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
-            <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+            <!-- Keep the embedded picker limited to Leaflet assets, OSM tiles, and its inline script. -->
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; form-action 'none'; frame-src 'none'; object-src 'none'; style-src 'self' '$LeafletCssUrl' 'unsafe-inline'; script-src '$LeafletJsUrl' 'unsafe-inline'; img-src https://tile.openstreetmap.org https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'none'; font-src 'none'; media-src 'none'; navigate-to 'none'" />
+            <link rel="stylesheet" href="$LeafletCssUrl" />
+            <script src="$LeafletJsUrl"></script>
             <style>
                 html, body, #map { height: 100%; margin: 0; padding: 0; }
             </style>
@@ -244,7 +316,13 @@ private fun buildMapHtml(initialLatitude: Double?, initialLongitude: Double?): S
                     if (marker) {
                         marker.setLatLng([lat, lon]);
                     } else {
-                        marker = L.marker([lat, lon]).addTo(map);
+                        marker = L.circleMarker([lat, lon], {
+                            radius: 8,
+                            color: '#B91C1C',
+                            weight: 2,
+                            fillColor: '#DC2626',
+                            fillOpacity: 0.85
+                        }).addTo(map);
                     }
                 }
 

--- a/android/app/src/main/java/com/neph/ui/map/MapPickerMapping.kt
+++ b/android/app/src/main/java/com/neph/ui/map/MapPickerMapping.kt
@@ -12,7 +12,9 @@ data class MapPickerLocationUpdate(
     val city: String,
     val district: String,
     val neighborhood: String,
-    val extraAddress: String
+    val extraAddress: String,
+    val hasStructuredMatch: Boolean,
+    val isMeaningfulMapping: Boolean
 )
 
 fun resolveMapPickerLocationUpdate(
@@ -24,18 +26,15 @@ fun resolveMapPickerLocationUpdate(
     reverseLocation: RequestHelpReverseLocation?,
     locations: LocationData
 ): MapPickerLocationUpdate {
-    val normalizedExtraAddress = reverseLocation?.extraAddress
-        ?.trim()
-        ?.takeIf { it.isNotBlank() }
-        ?: currentExtraAddress
-
     if (reverseLocation == null) {
         return MapPickerLocationUpdate(
             country = currentCountry,
             city = currentCity,
             district = currentDistrict,
             neighborhood = currentNeighborhood,
-            extraAddress = normalizedExtraAddress
+            extraAddress = currentExtraAddress,
+            hasStructuredMatch = false,
+            isMeaningfulMapping = false
         )
     }
 
@@ -61,6 +60,24 @@ fun resolveMapPickerLocationUpdate(
         findNeighborhoodValueByLabel(mappedCountry, mappedCity, mappedDistrict, reverseLocation.neighborhood, locations)
     } else {
         ""
+    }
+
+    val hasStructuredMatch = mappedCountry.isNotBlank() ||
+        mappedCity.isNotBlank() ||
+        mappedDistrict.isNotBlank() ||
+        mappedNeighborhood.isNotBlank()
+    val isMeaningfulMapping = mappedCountry.isNotBlank() &&
+        mappedCity.isNotBlank() &&
+        mappedDistrict.isNotBlank() &&
+        mappedNeighborhood.isNotBlank()
+
+    val normalizedExtraAddress = if (hasStructuredMatch) {
+        reverseLocation.extraAddress
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?: currentExtraAddress
+    } else {
+        currentExtraAddress
     }
 
     var nextCountry = currentCountry
@@ -104,6 +121,8 @@ fun resolveMapPickerLocationUpdate(
         city = nextCity,
         district = nextDistrict,
         neighborhood = nextNeighborhood,
-        extraAddress = normalizedExtraAddress
+        extraAddress = normalizedExtraAddress,
+        hasStructuredMatch = hasStructuredMatch,
+        isMeaningfulMapping = isMeaningfulMapping
     )
 }

--- a/android/app/src/main/java/com/neph/ui/map/MapPickerMapping.kt
+++ b/android/app/src/main/java/com/neph/ui/map/MapPickerMapping.kt
@@ -1,0 +1,109 @@
+package com.neph.ui.map
+
+import com.neph.features.profile.data.LocationData
+import com.neph.features.profile.data.findCityKeyByLabel
+import com.neph.features.profile.data.findCountryKeyByLabel
+import com.neph.features.profile.data.findDistrictKeyByLabel
+import com.neph.features.profile.data.findNeighborhoodValueByLabel
+import com.neph.features.requesthelp.data.RequestHelpReverseLocation
+
+data class MapPickerLocationUpdate(
+    val country: String,
+    val city: String,
+    val district: String,
+    val neighborhood: String,
+    val extraAddress: String
+)
+
+fun resolveMapPickerLocationUpdate(
+    currentCountry: String,
+    currentCity: String,
+    currentDistrict: String,
+    currentNeighborhood: String,
+    currentExtraAddress: String,
+    reverseLocation: RequestHelpReverseLocation?,
+    locations: LocationData
+): MapPickerLocationUpdate {
+    val normalizedExtraAddress = reverseLocation?.extraAddress
+        ?.trim()
+        ?.takeIf { it.isNotBlank() }
+        ?: currentExtraAddress
+
+    if (reverseLocation == null) {
+        return MapPickerLocationUpdate(
+            country = currentCountry,
+            city = currentCity,
+            district = currentDistrict,
+            neighborhood = currentNeighborhood,
+            extraAddress = normalizedExtraAddress
+        )
+    }
+
+    val countryFromCode = reverseLocation.countryCode
+        ?.trim()
+        ?.lowercase()
+        ?.takeIf { it.isNotBlank() && locations.containsKey(it) }
+        .orEmpty()
+    val countryFromLabel = findCountryKeyByLabel(reverseLocation.country, locations)
+    val mappedCountry = countryFromCode.ifBlank { countryFromLabel }
+
+    val mappedCity = if (mappedCountry.isNotBlank()) {
+        findCityKeyByLabel(mappedCountry, reverseLocation.city, locations)
+    } else {
+        ""
+    }
+    val mappedDistrict = if (mappedCountry.isNotBlank() && mappedCity.isNotBlank()) {
+        findDistrictKeyByLabel(mappedCountry, mappedCity, reverseLocation.district, locations)
+    } else {
+        ""
+    }
+    val mappedNeighborhood = if (mappedCountry.isNotBlank() && mappedCity.isNotBlank() && mappedDistrict.isNotBlank()) {
+        findNeighborhoodValueByLabel(mappedCountry, mappedCity, mappedDistrict, reverseLocation.neighborhood, locations)
+    } else {
+        ""
+    }
+
+    var nextCountry = currentCountry
+    var nextCity = currentCity
+    var nextDistrict = currentDistrict
+    var nextNeighborhood = currentNeighborhood
+
+    if (mappedCountry.isNotBlank()) {
+        val countryChanged = mappedCountry != currentCountry
+        nextCountry = mappedCountry
+        if (countryChanged && mappedCity.isBlank()) {
+            nextCity = ""
+            nextDistrict = ""
+            nextNeighborhood = ""
+        }
+    }
+
+    if (mappedCity.isNotBlank()) {
+        val cityChanged = mappedCity != nextCity
+        nextCity = mappedCity
+        if (cityChanged && mappedDistrict.isBlank()) {
+            nextDistrict = ""
+            nextNeighborhood = ""
+        }
+    }
+
+    if (mappedDistrict.isNotBlank()) {
+        val districtChanged = mappedDistrict != nextDistrict
+        nextDistrict = mappedDistrict
+        if (districtChanged && mappedNeighborhood.isBlank()) {
+            nextNeighborhood = ""
+        }
+    }
+
+    if (mappedNeighborhood.isNotBlank()) {
+        nextNeighborhood = mappedNeighborhood
+    }
+
+    return MapPickerLocationUpdate(
+        country = nextCountry,
+        city = nextCity,
+        district = nextDistrict,
+        neighborhood = nextNeighborhood,
+        extraAddress = normalizedExtraAddress
+    )
+}

--- a/android/app/src/test/java/com/neph/ui/map/MapPickerMappingTest.kt
+++ b/android/app/src/test/java/com/neph/ui/map/MapPickerMappingTest.kt
@@ -30,6 +30,8 @@ class MapPickerMappingTest {
         assertEquals("besiktas", result.district)
         assertEquals("balmumcu", result.neighborhood)
         assertEquals("Buyukdere Cd.", result.extraAddress)
+        assertEquals(true, result.hasStructuredMatch)
+        assertEquals(true, result.isMeaningfulMapping)
     }
 
     @Test
@@ -56,6 +58,8 @@ class MapPickerMappingTest {
         assertEquals("", result.district)
         assertEquals("", result.neighborhood)
         assertEquals("New Address", result.extraAddress)
+        assertEquals(true, result.hasStructuredMatch)
+        assertEquals(false, result.isMeaningfulMapping)
     }
 
     @Test
@@ -82,6 +86,8 @@ class MapPickerMappingTest {
         assertEquals("cankaya", result.district)
         assertEquals("anittepe", result.neighborhood)
         assertEquals("Existing Address", result.extraAddress)
+        assertEquals(true, result.hasStructuredMatch)
+        assertEquals(false, result.isMeaningfulMapping)
     }
 
     @Test
@@ -108,6 +114,8 @@ class MapPickerMappingTest {
         assertEquals("besiktas", result.district)
         assertEquals("", result.neighborhood)
         assertEquals("Existing Address", result.extraAddress)
+        assertEquals(true, result.hasStructuredMatch)
+        assertEquals(false, result.isMeaningfulMapping)
     }
 
     @Test
@@ -127,6 +135,8 @@ class MapPickerMappingTest {
         assertEquals("cankaya", result.district)
         assertEquals("anittepe", result.neighborhood)
         assertEquals("Existing Address", result.extraAddress)
+        assertEquals(false, result.hasStructuredMatch)
+        assertEquals(false, result.isMeaningfulMapping)
     }
 
     @Test
@@ -152,6 +162,8 @@ class MapPickerMappingTest {
         assertEquals("ankara", result.city)
         assertEquals("cankaya", result.district)
         assertEquals("anittepe", result.neighborhood)
-        assertEquals("Pinned Address", result.extraAddress)
+        assertEquals("Existing Address", result.extraAddress)
+        assertEquals(false, result.hasStructuredMatch)
+        assertEquals(false, result.isMeaningfulMapping)
     }
 }

--- a/android/app/src/test/java/com/neph/ui/map/MapPickerMappingTest.kt
+++ b/android/app/src/test/java/com/neph/ui/map/MapPickerMappingTest.kt
@@ -1,0 +1,157 @@
+package com.neph.ui.map
+
+import com.neph.features.profile.data.locationData
+import com.neph.features.requesthelp.data.RequestHelpReverseLocation
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MapPickerMappingTest {
+    @Test
+    fun resolveMapPickerLocationUpdate_mapsFullReverseLocationLabels() {
+        val result = resolveMapPickerLocationUpdate(
+            currentCountry = "",
+            currentCity = "",
+            currentDistrict = "",
+            currentNeighborhood = "",
+            currentExtraAddress = "",
+            reverseLocation = RequestHelpReverseLocation(
+                countryCode = "TR",
+                country = "Turkey",
+                city = "Istanbul",
+                district = "Beşiktaş",
+                neighborhood = "Balmumcu",
+                extraAddress = "Buyukdere Cd."
+            ),
+            locations = locationData
+        )
+
+        assertEquals("tr", result.country)
+        assertEquals("istanbul", result.city)
+        assertEquals("besiktas", result.district)
+        assertEquals("balmumcu", result.neighborhood)
+        assertEquals("Buyukdere Cd.", result.extraAddress)
+    }
+
+    @Test
+    fun resolveMapPickerLocationUpdate_mapsCountryAndCityAndClearsDependentOnCityChange() {
+        val result = resolveMapPickerLocationUpdate(
+            currentCountry = "tr",
+            currentCity = "ankara",
+            currentDistrict = "cankaya",
+            currentNeighborhood = "anittepe",
+            currentExtraAddress = "Old Address",
+            reverseLocation = RequestHelpReverseLocation(
+                countryCode = "TR",
+                country = "Turkey",
+                city = "Istanbul",
+                district = "Unknown District",
+                neighborhood = "Unknown Neighborhood",
+                extraAddress = "New Address"
+            ),
+            locations = locationData
+        )
+
+        assertEquals("tr", result.country)
+        assertEquals("istanbul", result.city)
+        assertEquals("", result.district)
+        assertEquals("", result.neighborhood)
+        assertEquals("New Address", result.extraAddress)
+    }
+
+    @Test
+    fun resolveMapPickerLocationUpdate_keepsExistingCityWhenReverseHasOnlyCountry() {
+        val result = resolveMapPickerLocationUpdate(
+            currentCountry = "tr",
+            currentCity = "ankara",
+            currentDistrict = "cankaya",
+            currentNeighborhood = "anittepe",
+            currentExtraAddress = "Existing Address",
+            reverseLocation = RequestHelpReverseLocation(
+                countryCode = "TR",
+                country = "Turkey",
+                city = null,
+                district = null,
+                neighborhood = null,
+                extraAddress = null
+            ),
+            locations = locationData
+        )
+
+        assertEquals("tr", result.country)
+        assertEquals("ankara", result.city)
+        assertEquals("cankaya", result.district)
+        assertEquals("anittepe", result.neighborhood)
+        assertEquals("Existing Address", result.extraAddress)
+    }
+
+    @Test
+    fun resolveMapPickerLocationUpdate_updatesDistrictAndClearsNeighborhoodWhenMissing() {
+        val result = resolveMapPickerLocationUpdate(
+            currentCountry = "tr",
+            currentCity = "istanbul",
+            currentDistrict = "kadikoy",
+            currentNeighborhood = "bostanci",
+            currentExtraAddress = "Existing Address",
+            reverseLocation = RequestHelpReverseLocation(
+                countryCode = "TR",
+                country = "Turkey",
+                city = "Istanbul",
+                district = "Beşiktaş",
+                neighborhood = null,
+                extraAddress = null
+            ),
+            locations = locationData
+        )
+
+        assertEquals("tr", result.country)
+        assertEquals("istanbul", result.city)
+        assertEquals("besiktas", result.district)
+        assertEquals("", result.neighborhood)
+        assertEquals("Existing Address", result.extraAddress)
+    }
+
+    @Test
+    fun resolveMapPickerLocationUpdate_keepsValuesWhenReverseLocationIsNull() {
+        val result = resolveMapPickerLocationUpdate(
+            currentCountry = "tr",
+            currentCity = "ankara",
+            currentDistrict = "cankaya",
+            currentNeighborhood = "anittepe",
+            currentExtraAddress = "Existing Address",
+            reverseLocation = null,
+            locations = locationData
+        )
+
+        assertEquals("tr", result.country)
+        assertEquals("ankara", result.city)
+        assertEquals("cankaya", result.district)
+        assertEquals("anittepe", result.neighborhood)
+        assertEquals("Existing Address", result.extraAddress)
+    }
+
+    @Test
+    fun resolveMapPickerLocationUpdate_keepsLocationWhenReverseLocationCannotMap() {
+        val result = resolveMapPickerLocationUpdate(
+            currentCountry = "tr",
+            currentCity = "ankara",
+            currentDistrict = "cankaya",
+            currentNeighborhood = "anittepe",
+            currentExtraAddress = "Existing Address",
+            reverseLocation = RequestHelpReverseLocation(
+                countryCode = null,
+                country = "Unknown Country",
+                city = "Unknown City",
+                district = null,
+                neighborhood = null,
+                extraAddress = "Pinned Address"
+            ),
+            locations = locationData
+        )
+
+        assertEquals("tr", result.country)
+        assertEquals("ankara", result.city)
+        assertEquals("cankaya", result.district)
+        assertEquals("anittepe", result.neighborhood)
+        assertEquals("Pinned Address", result.extraAddress)
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a reusable Android in-app map picker for mobile location selection.

Previously, mobile location flows supported dropdown-based location selection, current-location sharing, guest current-location autofill, and external “Open in Map” actions, but users could not select a point directly inside the app and apply it back to the form.

## What changed

- Added a reusable in-app OpenStreetMap/Leaflet-based map picker dialog.
- Added tap-to-pin location selection with confirm/cancel behavior.
- Added reverse-geocode mapping from selected coordinates into existing location fields where possible:
  - country
  - city
  - district
  - neighborhood
  - extra address / address description
- Added `Select Location on Map` action to:
  - Complete Profile
  - Edit Profile
  - Request Help
- Kept the existing manual dropdown location flow available after map selection.
- Added focused mapping tests for map picker result handling.

## Important behavior notes

- This PR does **not** use Google Maps SDK.
- This PR does **not** add Google Maps API keys.
- This PR does **not** add Play Services Maps for the picker.
- The picker is in-app and OpenStreetMap-based.
- Existing external `Open in Map` actions are preserved.
- Existing current-location sharing behavior is preserved.
- Existing guest Request Help current-location autofill behavior is preserved.
- If reverse geocoding returns partial data, only safe/resolved fields are applied and the user can still edit location manually.

## Scope notes

- Android/mobile only.
- No web changes.
- No backend schema changes.
- No help-request matching changes.
- No gathering-areas changes.
- No broad UI redesign.

## Validation

- `./gradlew :app:testE2eUnitTest`
- `./gradlew :app:assembleE2eAndroidTest`

## Limitations / follow-up

- The map picker uses network-loaded OpenStreetMap tiles through WebView, so map tile rendering requires network access.
- Selected coordinates are currently used for reverse geocoding and form-field population. Precise coordinate persistence depends on the existing backend contract for each flow.

Closes #417 