### PR TITLE
fix: reset gathering areas initial state and provider error messaging

### DIFF
--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,8 +44,10 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import java.util.Locale
 
-private const val DefaultCenterLatitude = 39.9334
-private const val DefaultCenterLongitude = 32.8597
+private enum class GatheringAreasSearchOrigin {
+    CURRENT_LOCATION,
+    OTHER
+}
 
 @Composable
 fun GatheringAreasScreen(
@@ -60,15 +61,28 @@ fun GatheringAreasScreen(
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
 
-    var loading by remember { mutableStateOf(true) }
+    var loading by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf("") }
     var infoMessage by remember { mutableStateOf("") }
-    var sourceLabel by remember { mutableStateOf("Ankara city center") }
-    var lastCenterLatitude by remember { mutableStateOf(DefaultCenterLatitude) }
-    var lastCenterLongitude by remember { mutableStateOf(DefaultCenterLongitude) }
+    var sourceLabel by remember { mutableStateOf("") }
+    var lastCenterLatitude by remember { mutableStateOf<Double?>(null) }
+    var lastCenterLongitude by remember { mutableStateOf<Double?>(null) }
+    var lastSearchOrigin by remember { mutableStateOf<GatheringAreasSearchOrigin?>(null) }
     var nearbyResult by remember { mutableStateOf<NearbyGatheringAreasResult?>(null) }
+    val hasSearchCenter = lastCenterLatitude != null && lastCenterLongitude != null
 
-    fun fetchGatheringAreas(lat: Double, lon: Double, label: String) {
+    fun fetchGatheringAreas(
+        lat: Double,
+        lon: Double,
+        label: String,
+        origin: GatheringAreasSearchOrigin
+    ) {
+        val normalizedLabel = label.ifBlank { "selected location" }
+        sourceLabel = normalizedLabel
+        lastCenterLatitude = lat
+        lastCenterLongitude = lon
+        lastSearchOrigin = origin
+
         scope.launch {
             loading = true
             errorMessage = ""
@@ -80,7 +94,7 @@ fun GatheringAreasScreen(
                     longitude = lon
                 )
                 nearbyResult = result
-                sourceLabel = label
+                sourceLabel = normalizedLabel
                 lastCenterLatitude = result.centerLatitude
                 lastCenterLongitude = result.centerLongitude
 
@@ -92,12 +106,9 @@ fun GatheringAreasScreen(
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (error: ApiException) {
-                errorMessage = when (error.code) {
-                    "OVERPASS_TIMEOUT" -> "Gathering area lookup timed out. Please retry."
-                    "OVERPASS_UNAVAILABLE" -> "Gathering area provider is temporarily unavailable."
-                    else -> error.message.ifBlank {
-                        "Could not load gathering areas right now."
-                    }
+                errorMessage = mapGatheringAreasErrorMessage(error)
+                if (lastSearchOrigin == GatheringAreasSearchOrigin.CURRENT_LOCATION && isProviderError(error)) {
+                    infoMessage = "Current location detected. Nearby gathering areas could not be loaded right now."
                 }
             } catch (_: Exception) {
                 errorMessage = "Could not load gathering areas right now."
@@ -124,7 +135,8 @@ fun GatheringAreasScreen(
                     fetchGatheringAreas(
                         lat = location.latitude,
                         lon = location.longitude,
-                        label = "your current location"
+                        label = "your current location",
+                        origin = GatheringAreasSearchOrigin.CURRENT_LOCATION
                     )
                     return@launch
                 }
@@ -132,7 +144,7 @@ fun GatheringAreasScreen(
                 loading = false
                 infoMessage = when (attempt.warning) {
                     CurrentLocationShareWarning.PERMISSION_DENIED ->
-                        "Location permission is denied. Nearby results were not updated."
+                        "Location permission was denied. Nearby results were not updated."
 
                     CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
                     null -> "Current location is unavailable. Nearby results were not updated."
@@ -152,7 +164,7 @@ fun GatheringAreasScreen(
         if (grants.values.any { it }) {
             requestCurrentLocationAndRefresh()
         } else {
-            infoMessage = "Location permission denied. Nearby results were not updated."
+            infoMessage = "Location permission was denied. Nearby results were not updated."
         }
     }
 
@@ -166,14 +178,6 @@ fun GatheringAreasScreen(
         if (!opened) {
             infoMessage = "Could not open map application."
         }
-    }
-
-    LaunchedEffect(Unit) {
-        fetchGatheringAreas(
-            lat = DefaultCenterLatitude,
-            lon = DefaultCenterLongitude,
-            label = "Ankara city center"
-        )
     }
 
     AppDrawerScaffold(
@@ -201,9 +205,13 @@ fun GatheringAreasScreen(
                         subtitle = "Location-based assembly points and shelters are retrieved from the gathering areas service."
                     )
 
-                    HelperText(
-                        text = "Showing results around $sourceLabel (${formatMapCoordinate(lastCenterLatitude)}, ${formatMapCoordinate(lastCenterLongitude)})."
-                    )
+                    if (hasSearchCenter && lastCenterLatitude != null && lastCenterLongitude != null) {
+                        HelperText(
+                            text = "Showing results around $sourceLabel (${formatMapCoordinate(lastCenterLatitude!!)}, ${formatMapCoordinate(lastCenterLongitude!!)})."
+                        )
+                    } else {
+                        HelperText(text = "Use your current location to find nearby gathering areas.")
+                    }
 
                     SecondaryButton(
                         text = "Use Current Location",
@@ -220,13 +228,16 @@ fun GatheringAreasScreen(
                     SecondaryButton(
                         text = "Refresh Nearby Areas",
                         onClick = {
+                            val lat = lastCenterLatitude ?: return@SecondaryButton
+                            val lon = lastCenterLongitude ?: return@SecondaryButton
                             fetchGatheringAreas(
-                                lat = lastCenterLatitude,
-                                lon = lastCenterLongitude,
-                                label = sourceLabel
+                                lat = lat,
+                                lon = lon,
+                                label = sourceLabel,
+                                origin = lastSearchOrigin ?: GatheringAreasSearchOrigin.OTHER
                             )
                         },
-                        enabled = !loading
+                        enabled = !loading && hasSearchCenter
                     )
                 }
             }
@@ -242,37 +253,49 @@ fun GatheringAreasScreen(
                     SectionCard {
                         Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
                             HelperText(text = errorMessage)
-                            SecondaryButton(
-                                text = "Retry",
-                                onClick = {
-                                    fetchGatheringAreas(
-                                        lat = lastCenterLatitude,
-                                        lon = lastCenterLongitude,
-                                        label = sourceLabel
-                                    )
-                                }
-                            )
+                            if (hasSearchCenter && lastCenterLatitude != null && lastCenterLongitude != null) {
+                                SecondaryButton(
+                                    text = "Retry",
+                                    onClick = {
+                                        fetchGatheringAreas(
+                                            lat = lastCenterLatitude!!,
+                                            lon = lastCenterLongitude!!,
+                                            label = sourceLabel,
+                                            origin = lastSearchOrigin ?: GatheringAreasSearchOrigin.OTHER
+                                        )
+                                    }
+                                )
+                            }
                         }
                     }
                 }
 
-                nearbyResult?.areas.isNullOrEmpty() -> {
+                !hasSearchCenter -> {
+                    SectionCard {
+                        HelperText(text = "Use your current location to find nearby gathering areas.")
+                    }
+                }
+
+                nearbyResult?.areas?.isEmpty() == true -> {
                     SectionCard {
                         Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
                             SectionHeader(
                                 title = "No Gathering Areas Found",
                                 subtitle = "Try refreshing or using your current location for a different area."
                             )
-                            SecondaryButton(
-                                text = "Retry",
-                                onClick = {
-                                    fetchGatheringAreas(
-                                        lat = lastCenterLatitude,
-                                        lon = lastCenterLongitude,
-                                        label = sourceLabel
-                                    )
-                                }
-                            )
+                            if (hasSearchCenter && lastCenterLatitude != null && lastCenterLongitude != null) {
+                                SecondaryButton(
+                                    text = "Retry",
+                                    onClick = {
+                                        fetchGatheringAreas(
+                                            lat = lastCenterLatitude!!,
+                                            lon = lastCenterLongitude!!,
+                                            label = sourceLabel,
+                                            origin = lastSearchOrigin ?: GatheringAreasSearchOrigin.OTHER
+                                        )
+                                    }
+                                )
+                            }
                         }
                     }
                 }
@@ -378,6 +401,26 @@ private fun formatCategory(category: String): String {
         "assembly_point" -> "Assembly Point"
         "shelter" -> "Shelter"
         else -> category.replace('_', ' ').replaceFirstChar { it.uppercase() }
+    }
+}
+
+private fun isProviderError(error: ApiException): Boolean {
+    return isProviderTimeout(error) || isProviderUnavailable(error)
+}
+
+private fun isProviderTimeout(error: ApiException): Boolean {
+    return error.code == "OVERPASS_TIMEOUT" || error.status == 504
+}
+
+private fun isProviderUnavailable(error: ApiException): Boolean {
+    return error.code == "OVERPASS_UNAVAILABLE" || error.status == 503
+}
+
+internal fun mapGatheringAreasErrorMessage(error: ApiException): String {
+    return when {
+        isProviderTimeout(error) -> "Gathering area lookup timed out. Please try again."
+        isProviderUnavailable(error) -> "Nearby gathering areas could not be loaded right now. Please try again later."
+        else -> error.message.ifBlank { "Could not load gathering areas right now." }
     }
 }
 

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -107,7 +107,7 @@ fun GatheringAreasScreen(
                 throw cancellationException
             } catch (error: ApiException) {
                 errorMessage = mapGatheringAreasErrorMessage(error)
-                if (lastSearchOrigin == GatheringAreasSearchOrigin.CURRENT_LOCATION && isProviderError(error)) {
+                if (origin == GatheringAreasSearchOrigin.CURRENT_LOCATION && isProviderError(error)) {
                     infoMessage = "Current location detected. Nearby gathering areas could not be loaded right now."
                 }
             } catch (_: Exception) {
@@ -164,6 +164,8 @@ fun GatheringAreasScreen(
         if (grants.values.any { it }) {
             requestCurrentLocationAndRefresh()
         } else {
+            errorMessage = ""
+            loading = false
             infoMessage = "Location permission was denied. Nearby results were not updated."
         }
     }
@@ -272,7 +274,10 @@ fun GatheringAreasScreen(
 
                 !hasSearchCenter -> {
                     SectionCard {
-                        HelperText(text = "Use your current location to find nearby gathering areas.")
+                        SectionHeader(
+                            title = "No Search Location Selected",
+                            subtitle = "No search location selected yet. Tap \"Use Current Location\" to search nearby gathering areas."
+                        )
                     }
                 }
 

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -385,6 +386,7 @@ private fun CrisisRequestMapPanel(
     val latSpan = (maxLatitude - minLatitude).takeIf { it > 0.000001 } ?: 0.01
     val lonSpan = (maxLongitude - minLongitude).takeIf { it > 0.000001 } ?: 0.01
     val selectedRequest = requests.firstOrNull { it.requestId == selectedRequestId }
+    val density = LocalDensity.current
 
     Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
         SectionHeader(
@@ -416,10 +418,12 @@ private fun CrisisRequestMapPanel(
                     }
                 }
         ) {
+            val availableHeight = maxHeight
+            val availableWidth = maxWidth
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(maxHeight)
+                    .height(availableHeight)
                     .graphicsLayer {
                         scaleX = zoom
                         scaleY = zoom
@@ -429,42 +433,56 @@ private fun CrisisRequestMapPanel(
             ) {
                 MapRoad(
                     modifier = Modifier
-                        .offset { IntOffset(0, (maxHeight * 0.22f).roundToPx()) }
+                        .offset { IntOffset(0, (availableHeight * 0.22f).roundToPx()) }
                         .fillMaxWidth()
                         .height(12.dp)
                 )
                 MapRoad(
                     modifier = Modifier
-                        .offset { IntOffset(0, (maxHeight * 0.58f).roundToPx()) }
+                        .offset { IntOffset(0, (availableHeight * 0.58f).roundToPx()) }
                         .fillMaxWidth()
                         .height(9.dp)
                 )
                 MapRoad(
                     modifier = Modifier
-                        .offset { IntOffset((maxWidth * 0.30f).roundToPx(), 0) }
-                        .size(11.dp, maxHeight)
+                        .offset { IntOffset((availableWidth * 0.30f).roundToPx(), 0) }
+                        .size(11.dp, availableHeight)
                 )
                 MapRoad(
                     modifier = Modifier
-                        .offset { IntOffset((maxWidth * 0.70f).roundToPx(), 0) }
-                        .size(8.dp, maxHeight)
+                        .offset { IntOffset((availableWidth * 0.70f).roundToPx(), 0) }
+                        .size(8.dp, availableHeight)
                 )
                 MapNeighborhoodPatch(
                     modifier = Modifier
-                        .offset { IntOffset((maxWidth * 0.08f).roundToPx(), (maxHeight * 0.10f).roundToPx()) }
-                        .size(width = maxWidth * 0.24f, height = maxHeight * 0.18f)
+                        .offset {
+                            IntOffset(
+                                (availableWidth * 0.08f).roundToPx(),
+                                (availableHeight * 0.10f).roundToPx()
+                            )
+                        }
+                        .size(width = availableWidth * 0.24f, height = availableHeight * 0.18f)
                 )
                 MapNeighborhoodPatch(
                     modifier = Modifier
-                        .offset { IntOffset((maxWidth * 0.58f).roundToPx(), (maxHeight * 0.68f).roundToPx()) }
-                        .size(width = maxWidth * 0.28f, height = maxHeight * 0.16f)
+                        .offset {
+                            IntOffset(
+                                (availableWidth * 0.58f).roundToPx(),
+                                (availableHeight * 0.68f).roundToPx()
+                            )
+                        }
+                        .size(width = availableWidth * 0.28f, height = availableHeight * 0.16f)
                 )
 
                 requests.forEach { item ->
                     val xFraction = ((item.longitude - minLongitude) / lonSpan).coerceIn(0.08, 0.92)
                     val yFraction = (1.0 - ((item.latitude - minLatitude) / latSpan)).coerceIn(0.10, 0.88)
-                    val x = (maxWidth * xFraction.toFloat()).roundToPx() - 21
-                    val y = (maxHeight * yFraction.toFloat()).roundToPx() - 42
+                    val x = with(density) {
+                        (availableWidth * xFraction.toFloat()).roundToPx()
+                    } - 21
+                    val y = with(density) {
+                        (availableHeight * yFraction.toFloat()).roundToPx()
+                    } - 42
 
                     MapMarker(
                         item = item,

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -433,32 +433,52 @@ private fun CrisisRequestMapPanel(
             ) {
                 MapRoad(
                     modifier = Modifier
-                        .offset { IntOffset(0, (availableHeight * 0.22f).roundToPx()) }
+                        .offset {
+                            IntOffset(
+                                0,
+                                with(density) { (availableHeight * 0.22f).roundToPx() }
+                            )
+                        }
                         .fillMaxWidth()
                         .height(12.dp)
                 )
                 MapRoad(
                     modifier = Modifier
-                        .offset { IntOffset(0, (availableHeight * 0.58f).roundToPx()) }
+                        .offset {
+                            IntOffset(
+                                0,
+                                with(density) { (availableHeight * 0.58f).roundToPx() }
+                            )
+                        }
                         .fillMaxWidth()
                         .height(9.dp)
                 )
                 MapRoad(
                     modifier = Modifier
-                        .offset { IntOffset((availableWidth * 0.30f).roundToPx(), 0) }
+                        .offset {
+                            IntOffset(
+                                with(density) { (availableWidth * 0.30f).roundToPx() },
+                                0
+                            )
+                        }
                         .size(11.dp, availableHeight)
                 )
                 MapRoad(
                     modifier = Modifier
-                        .offset { IntOffset((availableWidth * 0.70f).roundToPx(), 0) }
+                        .offset {
+                            IntOffset(
+                                with(density) { (availableWidth * 0.70f).roundToPx() },
+                                0
+                            )
+                        }
                         .size(8.dp, availableHeight)
                 )
                 MapNeighborhoodPatch(
                     modifier = Modifier
                         .offset {
                             IntOffset(
-                                (availableWidth * 0.08f).roundToPx(),
-                                (availableHeight * 0.10f).roundToPx()
+                                with(density) { (availableWidth * 0.08f).roundToPx() },
+                                with(density) { (availableHeight * 0.10f).roundToPx() }
                             )
                         }
                         .size(width = availableWidth * 0.24f, height = availableHeight * 0.18f)
@@ -467,8 +487,8 @@ private fun CrisisRequestMapPanel(
                     modifier = Modifier
                         .offset {
                             IntOffset(
-                                (availableWidth * 0.58f).roundToPx(),
-                                (availableHeight * 0.68f).roundToPx()
+                                with(density) { (availableWidth * 0.58f).roundToPx() },
+                                with(density) { (availableHeight * 0.68f).roundToPx() }
                             )
                         }
                         .size(width = availableWidth * 0.28f, height = availableHeight * 0.16f)

--- a/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.RowScope.weight
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items

--- a/android/app/src/test/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreenTest.kt
+++ b/android/app/src/test/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreenTest.kt
@@ -1,0 +1,58 @@
+package com.neph.features.gatheringareas.presentation
+
+import com.neph.core.network.ApiException
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GatheringAreasScreenTest {
+    @Test
+    fun mapGatheringAreasErrorMessage_mapsTimeoutCode() {
+        val error = ApiException("Provider timeout", 504, "OVERPASS_TIMEOUT")
+
+        val message = mapGatheringAreasErrorMessage(error)
+
+        assertEquals("Gathering area lookup timed out. Please try again.", message)
+    }
+
+    @Test
+    fun mapGatheringAreasErrorMessage_mapsTimeoutStatus() {
+        val error = ApiException("Gateway timeout", 504, null)
+
+        val message = mapGatheringAreasErrorMessage(error)
+
+        assertEquals("Gathering area lookup timed out. Please try again.", message)
+    }
+
+    @Test
+    fun mapGatheringAreasErrorMessage_mapsUnavailableCode() {
+        val error = ApiException("Service unavailable", 503, "OVERPASS_UNAVAILABLE")
+
+        val message = mapGatheringAreasErrorMessage(error)
+
+        assertEquals(
+            "Nearby gathering areas could not be loaded right now. Please try again later.",
+            message
+        )
+    }
+
+    @Test
+    fun mapGatheringAreasErrorMessage_mapsUnavailableStatus() {
+        val error = ApiException("Service unavailable", 503, null)
+
+        val message = mapGatheringAreasErrorMessage(error)
+
+        assertEquals(
+            "Nearby gathering areas could not be loaded right now. Please try again later.",
+            message
+        )
+    }
+
+    @Test
+    fun mapGatheringAreasErrorMessage_fallsBackToApiMessage() {
+        val error = ApiException("Something went wrong", 500, "SERVER_ERROR")
+
+        val message = mapGatheringAreasErrorMessage(error)
+
+        assertEquals("Something went wrong", message)
+    }
+}


### PR DESCRIPTION
## Summary

This PR improves the Android Gathering Areas screen behavior and error handling.

Previously, the screen could appear broken when the external gathering-areas provider was unavailable, and the default UI showed an unrelated “Ankara city center” state before the user selected or shared a location.

## What changed

- Removed the misleading default “Showing results around Ankara city center” user-facing state.
- Improved the initial Gathering Areas screen state to guide users toward using their current location.
- Made `Use Current Location` behavior clearer and more resilient.
- Improved permission-denied, location-unavailable, provider-timeout, and provider-unavailable messages.
- Made retry/refresh behavior depend on a meaningful last search location instead of blindly refreshing the default fallback area.
- Preserved existing gathering area list rendering and `Open in Map` actions.
- Kept guest access behavior unchanged.

## Important behavior notes

- The feature still uses the existing backend gathering-areas endpoint.
- Provider failures are now presented as gathering-area loading/provider issues, not as current-location failures.
- If location capture succeeds but the provider fails, the UI now communicates that nearby areas could not be loaded.
- No new map picker behavior is introduced in this PR.
- No Google Maps SDK/API key behavior is introduced.

## Scope notes

- Android/mobile-focused bugfix.
- No web changes.
- No backend schema changes.
- No help-request matching changes.
- No profile location picker changes.
- No notification/auth changes.
- No broad UI redesign.

## Validation

- `./gradlew :app:testE2eUnitTest`
- `./gradlew :app:assembleE2eAndroidTest`

## Limitations / follow-up

- Gathering area results still depend on the backend provider/Overpass availability.
- If the provider is unavailable, the app can now fail gracefully, but it cannot guarantee live nearby results until the backend/provider succeeds.

Closes #404 