### PR TITLE
feat: add android ci workflow

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -39,6 +39,40 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
+      - name: Create CI google-services.json
+        run: |
+          cat > app/google-services.json <<'JSON'
+          {
+            "project_info": {
+              "project_number": "000000000000",
+              "project_id": "neph-ci",
+              "storage_bucket": "neph-ci.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+                  "android_client_info": {
+                    "package_name": "com.neph"
+                  }
+                },
+                "oauth_client": [],
+                "api_key": [
+                  {
+                    "current_key": "ci-placeholder-api-key"
+                  }
+                ],
+                "services": {
+                  "appinvite_service": {
+                    "other_platform_oauth_client": []
+                  }
+                }
+              }
+            ],
+            "configuration_version": "1"
+          }
+          JSON
+
       - name: Run E2E unit tests
         run: ./gradlew :app:testE2eUnitTest
 
@@ -65,6 +99,40 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x gradlew
+
+      - name: Create CI google-services.json
+        run: |
+          cat > app/google-services.json <<'JSON'
+          {
+            "project_info": {
+              "project_number": "000000000000",
+              "project_id": "neph-ci",
+              "storage_bucket": "neph-ci.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+                  "android_client_info": {
+                    "package_name": "com.neph"
+                  }
+                },
+                "oauth_client": [],
+                "api_key": [
+                  {
+                    "current_key": "ci-placeholder-api-key"
+                  }
+                ],
+                "services": {
+                  "appinvite_service": {
+                    "other_platform_oauth_client": []
+                  }
+                }
+              }
+            ],
+            "configuration_version": "1"
+          }
+          JSON
 
       - name: Build E2E app APK
         run: ./gradlew :app:assembleE2e

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,73 @@
+name: Android CI
+
+on:
+  pull_request:
+    paths:
+      - 'android/**'
+      - '.github/workflows/android-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: android
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Run E2E unit tests
+        run: ./gradlew :app:testE2eUnitTest
+
+  build-test-apk:
+    name: Build E2E APKs
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: android
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Build E2E app APK
+        run: ./gradlew :app:assembleE2e
+
+      - name: Build E2E androidTest APK
+        run: ./gradlew :app:assembleE2eAndroidTest


### PR DESCRIPTION
## Summary

This PR adds a dedicated Android PR CI workflow.

Previously, Android-only pull requests did not automatically run Android unit/build checks before merge. Existing workflows covered web, backend, deployment, database sync, and Android release APK generation, but the Android release workflow is not a substitute for PR CI because it runs after merges to `main` or through manual dispatch and depends on release signing configuration.

## What changed

- Added `.github/workflows/android-ci.yml`.
- Added automatic CI trigger for pull requests that modify:
  - `android/**`
  - `.github/workflows/android-ci.yml`
- Added manual `workflow_dispatch` support.
- Added Android unit test validation.
- Added E2E app and androidTest APK build validation.
- Added concurrency so stale runs for the same PR/ref are cancelled.

## Checks added

The workflow runs:

- `./gradlew :app:testE2eUnitTest`
- `./gradlew :app:assembleE2e`
- `./gradlew :app:assembleE2eAndroidTest`

## Validation

- Verified the workflow uses Java 17.
- Verified Gradle commands run from the `android` working directory.
- Verified no release build task is used.
- Verified no release signing secrets are referenced.

## Limitations / follow-up

- This workflow validates unit tests and APK compilation only.
- It does not run emulator-based `connectedAndroidTest` to avoid slower and potentially flaky PR checks.

Closes #420 