### PR TITLE
fix: shown priority and urgency info to user

### DIFF
--- a/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/myhelprequests/presentation/MyHelpRequestsScreen.kt
@@ -141,16 +141,16 @@ fun MyHelpRequestsScreen(
                         }
                     }
 
-                        item {
-                            SectionHeader(
-                                title = "Current Request",
-                                subtitle = if (isAuthenticated) {
-                                    "Your latest active help request is shown first."
-                                } else {
-                                    "Your latest guest help request is shown first."
-                                }
-                            )
-                        }
+                    item {
+                        SectionHeader(
+                            title = "Current Request",
+                            subtitle = if (isAuthenticated) {
+                                "Your latest active help request is shown first."
+                            } else {
+                                "Your latest guest help request is shown first."
+                            }
+                        )
+                    }
 
                     if (currentActiveRequest == null) {
                         item {
@@ -454,22 +454,6 @@ private fun MyHelpRequestCard(
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.primary
             )
-
-            request.urgencyLabel?.let {
-                Text(
-                    text = "Urgency: $it",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-            }
-
-            request.priorityLabel?.let {
-                Text(
-                    text = "Priority: $it",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-            }
 
             request.openDurationLabel?.let {
                 Text(


### PR DESCRIPTION
## Summary

This PR hides the backend-computed urgency and priority values from the requester-facing **My Help Requests** screen on Android.

## Reason

The urgency and priority levels are calculated by the backend as operational/triage values. Since these values are meant to support internal response prioritization, assignment, volunteer, or admin workflows, the user who created the help request does not need to see them on their own request details screen.

The related requirement was a bit ambiguous because it mentions showing help request details including urgency level. This seems to have been interpreted as requester-facing visibility, but in this case the displayed urgency/priority values are backend-computed operational fields rather than user-entered request details.

## Changes

- Removed `Urgency: ...` from the requester-facing help request card.
- Removed `Priority: ...` from the requester-facing help request card.
- Kept the underlying data/model mapping unchanged so these values can still be used in backend, volunteer, admin, or assignment-related flows.

## Scope

- Android only.
- UI-only change.
- No backend, database, API, or sync behavior changes.

## Related Issue

Closes #409