### PR TITLE
chore(web): remove switch account from top navbar menu

### DIFF
--- a/web/src/components/layout/TopNavbar.tsx
+++ b/web/src/components/layout/TopNavbar.tsx
@@ -303,19 +303,6 @@ export function TopNavbar() {
 
                                     <button
                                         type="button"
-                                        className="top-navbar-dropdown-item"
-                                        onClick={() => {
-                                            clearAccessToken();
-                                            void refresh({ force: true });
-                                            setIsMenuOpen(false);
-                                            router.push("/login");
-                                        }}
-                                    >
-                                        Switch Account
-                                    </button>
-
-                                    <button
-                                        type="button"
                                         className="top-navbar-dropdown-item is-danger"
                                         onClick={handleLogout}
                                     >


### PR DESCRIPTION
Removed the Switch Account option from the menu since it duplicated the logout flow.