### PR TITLE
Implement trusted safety circles

### DIFF
--- a/android/app/src/main/java/com/neph/features/safetycircles/data/SafetyCirclesRepository.kt
+++ b/android/app/src/main/java/com/neph/features/safetycircles/data/SafetyCirclesRepository.kt
@@ -32,6 +32,7 @@ data class SafetyCircleInvite(
 
 data class SafetyCircleDetail(
     val circle: SafetyCircleSummary,
+    val currentUserRole: String,
     val members: List<SafetyCircleMember>
 )
 
@@ -67,6 +68,7 @@ object SafetyCirclesRepository {
         val membersJson = response.optJSONArray("members")
         return SafetyCircleDetail(
             circle = response.getJSONObject("circle").toCircleSummary(),
+            currentUserRole = response.optString("currentUserRole").ifBlank { "member" },
             members = buildList {
                 if (membersJson != null) {
                     for (index in 0 until membersJson.length()) {
@@ -149,6 +151,23 @@ object SafetyCirclesRepository {
             path = "/safety-circles/$circleId/members/me",
             method = "DELETE",
             token = token
+        )
+    }
+
+    suspend fun deleteCircle(token: String, circleId: String) {
+        JsonHttpClient.request(
+            path = "/safety-circles/$circleId",
+            method = "DELETE",
+            token = token
+        )
+    }
+
+    suspend fun transferOwnership(token: String, circleId: String, nextOwnerUserId: String) {
+        JsonHttpClient.request(
+            path = "/safety-circles/$circleId/owner",
+            method = "PATCH",
+            token = token,
+            body = JSONObject().put("nextOwnerUserId", nextOwnerUserId)
         )
     }
 }

--- a/android/app/src/main/java/com/neph/features/safetycircles/data/SafetyCirclesRepository.kt
+++ b/android/app/src/main/java/com/neph/features/safetycircles/data/SafetyCirclesRepository.kt
@@ -1,0 +1,188 @@
+package com.neph.features.safetycircles.data
+
+import com.neph.core.network.JsonHttpClient
+import com.neph.features.profile.data.CurrentDeviceLocation
+import org.json.JSONObject
+
+data class SafetyCircleSummary(
+    val circleId: String,
+    val name: String,
+    val ownerUserId: String,
+    val memberCount: Int
+)
+
+data class SafetyCircleMember(
+    val userId: String,
+    val displayName: String?,
+    val emergencyContactPhone: String?,
+    val role: String,
+    val status: String,
+    val note: String?,
+    val lastCheckedInAt: String?,
+    val hasSharedLocation: Boolean
+)
+
+data class SafetyCircleInvite(
+    val inviteId: String,
+    val circleId: String,
+    val circleName: String?,
+    val inviterDisplayName: String?,
+    val status: String
+)
+
+data class SafetyCircleDetail(
+    val circle: SafetyCircleSummary,
+    val members: List<SafetyCircleMember>
+)
+
+object SafetyCirclesRepository {
+    suspend fun listCircles(token: String): List<SafetyCircleSummary> {
+        val response = JsonHttpClient.request(
+            path = "/safety-circles",
+            token = token
+        )
+        val circles = response.optJSONArray("circles") ?: return emptyList()
+        return buildList {
+            for (index in 0 until circles.length()) {
+                circles.optJSONObject(index)?.toCircleSummary()?.let(::add)
+            }
+        }
+    }
+
+    suspend fun createCircle(token: String, name: String): SafetyCircleSummary {
+        val response = JsonHttpClient.request(
+            path = "/safety-circles",
+            method = "POST",
+            token = token,
+            body = JSONObject().put("name", name.trim())
+        )
+        return response.getJSONObject("circle").toCircleSummary()
+    }
+
+    suspend fun getCircle(token: String, circleId: String): SafetyCircleDetail {
+        val response = JsonHttpClient.request(
+            path = "/safety-circles/$circleId",
+            token = token
+        )
+        val membersJson = response.optJSONArray("members")
+        return SafetyCircleDetail(
+            circle = response.getJSONObject("circle").toCircleSummary(),
+            members = buildList {
+                if (membersJson != null) {
+                    for (index in 0 until membersJson.length()) {
+                        membersJson.optJSONObject(index)?.toCircleMember()?.let(::add)
+                    }
+                }
+            }
+        )
+    }
+
+    suspend fun invite(token: String, circleId: String, invitee: String) {
+        val trimmed = invitee.trim()
+        val key = if (trimmed.contains("@")) "inviteeEmail" else "inviteeUserId"
+        JsonHttpClient.request(
+            path = "/safety-circles/$circleId/invites",
+            method = "POST",
+            token = token,
+            body = JSONObject().put(key, trimmed)
+        )
+    }
+
+    suspend fun listInvites(token: String): List<SafetyCircleInvite> {
+        val response = JsonHttpClient.request(
+            path = "/safety-circles/invites",
+            token = token
+        )
+        val invites = response.optJSONArray("invites") ?: return emptyList()
+        return buildList {
+            for (index in 0 until invites.length()) {
+                invites.optJSONObject(index)?.toInvite()?.let(::add)
+            }
+        }
+    }
+
+    suspend fun respondToInvite(token: String, inviteId: String, accept: Boolean) {
+        JsonHttpClient.request(
+            path = "/safety-circles/invites/$inviteId/respond",
+            method = "POST",
+            token = token,
+            body = JSONObject().put("decision", if (accept) "accept" else "reject")
+        )
+    }
+
+    suspend fun checkIn(
+        token: String,
+        circleId: String,
+        status: String,
+        location: CurrentDeviceLocation? = null,
+        shareLocationConsent: Boolean = false
+    ) {
+        val sharedLocation = location.takeIf { shareLocationConsent }
+        val body = JSONObject()
+            .put("status", status)
+            .put("shareLocationConsent", sharedLocation != null)
+
+        if (sharedLocation != null) {
+            body.put(
+                "location",
+                JSONObject()
+                    .put("latitude", sharedLocation.latitude)
+                    .put("longitude", sharedLocation.longitude)
+                    .put("accuracyMeters", sharedLocation.accuracyMeters)
+                    .put("source", sharedLocation.source)
+                    .put("capturedAt", sharedLocation.capturedAt)
+            )
+        } else {
+            body.put("location", JSONObject.NULL)
+        }
+
+        JsonHttpClient.request(
+            path = "/safety-circles/$circleId/check-in",
+            method = "PATCH",
+            token = token,
+            body = body
+        )
+    }
+
+    suspend fun leave(token: String, circleId: String) {
+        JsonHttpClient.request(
+            path = "/safety-circles/$circleId/members/me",
+            method = "DELETE",
+            token = token
+        )
+    }
+}
+
+private fun JSONObject.toCircleSummary(): SafetyCircleSummary {
+    return SafetyCircleSummary(
+        circleId = getString("circleId"),
+        name = optString("name").ifBlank { "Safety Circle" },
+        ownerUserId = optString("ownerUserId"),
+        memberCount = optInt("memberCount", 0)
+    )
+}
+
+private fun JSONObject.toCircleMember(): SafetyCircleMember {
+    return SafetyCircleMember(
+        userId = optString("userId"),
+        displayName = optString("displayName").takeIf { it.isNotBlank() && it != "null" },
+        emergencyContactPhone = optJSONObject("emergencyContact")
+            ?.optString("phoneNumber")
+            ?.takeIf { it.isNotBlank() && it != "null" },
+        role = optString("role").ifBlank { "member" },
+        status = optString("status").ifBlank { "unknown" },
+        note = optString("note").takeIf { it.isNotBlank() && it != "null" },
+        lastCheckedInAt = optString("lastCheckedInAt").takeIf { it.isNotBlank() && it != "null" },
+        hasSharedLocation = !isNull("location")
+    )
+}
+
+private fun JSONObject.toInvite(): SafetyCircleInvite {
+    return SafetyCircleInvite(
+        inviteId = getString("inviteId"),
+        circleId = optString("circleId"),
+        circleName = optString("circleName").takeIf { it.isNotBlank() && it != "null" },
+        inviterDisplayName = optString("inviterDisplayName").takeIf { it.isNotBlank() && it != "null" },
+        status = optString("status")
+    )
+}

--- a/android/app/src/main/java/com/neph/features/safetycircles/presentation/SafetyCirclesScreen.kt
+++ b/android/app/src/main/java/com/neph/features/safetycircles/presentation/SafetyCirclesScreen.kt
@@ -1,0 +1,486 @@
+package com.neph.features.safetycircles.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.neph.core.network.ApiException
+import com.neph.features.auth.data.AuthRepository
+import com.neph.features.auth.data.AuthSessionStore
+import com.neph.features.profile.data.DeviceLocationProvider
+import com.neph.features.safetycircles.data.SafetyCircleDetail
+import com.neph.features.safetycircles.data.SafetyCircleInvite
+import com.neph.features.safetycircles.data.SafetyCircleMember
+import com.neph.features.safetycircles.data.SafetyCircleSummary
+import com.neph.features.safetycircles.data.SafetyCirclesRepository
+import com.neph.navigation.Routes
+import com.neph.ui.components.buttons.PrimaryButton
+import com.neph.ui.components.buttons.SecondaryButton
+import com.neph.ui.components.display.SectionCard
+import com.neph.ui.components.display.SectionHeader
+import com.neph.ui.layout.AppDrawerScaffold
+import com.neph.ui.theme.LocalNephSpacing
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+
+@Composable
+fun SafetyCirclesScreen(
+    onNavigateToRoute: (String) -> Unit,
+    onOpenSettings: () -> Unit,
+    onProfileClick: () -> Unit,
+    onNavigateToLogin: () -> Unit,
+    profileBadgeText: String,
+    modifier: Modifier = Modifier
+) {
+    val spacing = LocalNephSpacing.current
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val token = AuthSessionStore.getAccessToken()
+    var circles by remember { mutableStateOf<List<SafetyCircleSummary>>(emptyList()) }
+    var invites by remember { mutableStateOf<List<SafetyCircleInvite>>(emptyList()) }
+    var selectedCircleId by remember { mutableStateOf<String?>(null) }
+    var detail by remember { mutableStateOf<SafetyCircleDetail?>(null) }
+    var newCircleName by remember { mutableStateOf("") }
+    var invitee by remember { mutableStateOf("") }
+    var loading by remember { mutableStateOf(false) }
+    var actionLoading by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf("") }
+    var infoMessage by remember { mutableStateOf("") }
+    var pendingCheckIn by remember { mutableStateOf<Pair<String, String>?>(null) }
+
+    fun handleAuthError(error: ApiException): Boolean {
+        if (error.status != 401) return false
+        AuthRepository.logout()
+        errorMessage = "Session expired. Please log in again."
+        onNavigateToLogin()
+        return true
+    }
+
+    fun refresh() {
+        val safeToken = token
+        if (safeToken.isNullOrBlank()) {
+            onNavigateToLogin()
+            return
+        }
+
+        loading = true
+        errorMessage = ""
+        scope.launch {
+            try {
+                val nextCircles = SafetyCirclesRepository.listCircles(safeToken)
+                val nextInvites = SafetyCirclesRepository.listInvites(safeToken)
+                circles = nextCircles
+                invites = nextInvites.filter { it.status == "pending" }
+                val nextSelectedId = selectedCircleId ?: nextCircles.firstOrNull()?.circleId
+                selectedCircleId = nextSelectedId
+                detail = nextSelectedId?.let { SafetyCirclesRepository.getCircle(safeToken, it) }
+            } catch (error: ApiException) {
+                if (!handleAuthError(error)) {
+                    errorMessage = error.message.ifBlank { "Could not load safety circles. Please retry." }
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                errorMessage = "Could not load safety circles. Please retry."
+            } finally {
+                loading = false
+            }
+        }
+    }
+
+    fun runAction(successMessage: String, action: suspend (String) -> Unit) {
+        val safeToken = token
+        if (safeToken.isNullOrBlank()) {
+            onNavigateToLogin()
+            return
+        }
+
+        actionLoading = true
+        errorMessage = ""
+        infoMessage = ""
+        scope.launch {
+            try {
+                action(safeToken)
+                infoMessage = successMessage
+                refresh()
+            } catch (error: ApiException) {
+                if (!handleAuthError(error)) {
+                    errorMessage = error.message.ifBlank { "Action failed. Please retry." }
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                errorMessage = "Action failed. Please retry."
+            } finally {
+                actionLoading = false
+            }
+        }
+    }
+
+    fun submitCheckIn(circleId: String, status: String, shareLocation: Boolean) {
+        runAction(
+            successMessage = if (status == "safe") "You are marked safe." else "You are marked as needing help."
+        ) { safeToken ->
+            val locationAttempt = if (shareLocation) {
+                DeviceLocationProvider.captureCurrentLocationForSharing(
+                    context = context,
+                    sharingEnabled = true
+                )
+            } else {
+                null
+            }
+            val sharedLocation = locationAttempt?.location
+            SafetyCirclesRepository.checkIn(
+                token = safeToken,
+                circleId = circleId,
+                status = status,
+                location = sharedLocation,
+                shareLocationConsent = shareLocation && sharedLocation != null
+            )
+            if (shareLocation && sharedLocation == null) {
+                infoMessage = "Check-in saved. Location was not shared because permission or location was unavailable."
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        refresh()
+    }
+
+    pendingCheckIn?.let { (circleId, status) ->
+        AlertDialog(
+            onDismissRequest = { pendingCheckIn = null },
+            title = {
+                Text(text = "Share location with this check-in?")
+            },
+            text = {
+                Text(
+                    text = "Your circle can see your status without location. Share location only if you want trusted members allowed by privacy settings to see where this check-in came from."
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        pendingCheckIn = null
+                        submitCheckIn(circleId, status, shareLocation = true)
+                    }
+                ) {
+                    Text("Share location")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        pendingCheckIn = null
+                        submitCheckIn(circleId, status, shareLocation = false)
+                    }
+                ) {
+                    Text("Without location")
+                }
+            }
+        )
+    }
+
+    AppDrawerScaffold(
+        title = "Safety Circles",
+        currentRoute = Routes.SafetyCircles.route,
+        onNavigateToRoute = onNavigateToRoute,
+        drawerItems = Routes.authenticatedDrawerItems,
+        modifier = modifier,
+        onOpenSettings = onOpenSettings,
+        onProfileClick = onProfileClick,
+        profileBadgeText = profileBadgeText,
+        profileLabel = "Profile",
+        contentMaxWidth = 560.dp,
+        contentAlignment = Alignment.TopCenter
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(spacing.md)
+        ) {
+            if (loading) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
+            }
+
+            SectionCard {
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                    SectionHeader(
+                        title = "Create Circle",
+                        subtitle = "Start with family, neighbors, or a trusted group."
+                    )
+                    OutlinedTextField(
+                        value = newCircleName,
+                        onValueChange = { newCircleName = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text("Circle name") },
+                        singleLine = true
+                    )
+                    PrimaryButton(
+                        text = "Create circle",
+                        onClick = {
+                            val name = newCircleName.trim()
+                            if (name.isBlank()) {
+                                errorMessage = "Circle name is required."
+                            } else {
+                                runAction("Circle created.") { safeToken ->
+                                    val circle = SafetyCirclesRepository.createCircle(safeToken, name)
+                                    selectedCircleId = circle.circleId
+                                    newCircleName = ""
+                                }
+                            }
+                        },
+                        loading = actionLoading,
+                        enabled = !actionLoading
+                    )
+                }
+            }
+
+            if (invites.isNotEmpty()) {
+                SectionCard {
+                    Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                        SectionHeader(
+                            title = "Invites",
+                            subtitle = "Accept only circles you recognize."
+                        )
+                        invites.forEach { invite ->
+                            InviteRow(
+                                invite = invite,
+                                actionLoading = actionLoading,
+                                onAccept = {
+                                    runAction("Invite accepted.") { safeToken ->
+                                        SafetyCirclesRepository.respondToInvite(safeToken, invite.inviteId, accept = true)
+                                    }
+                                },
+                                onReject = {
+                                    runAction("Invite rejected.") { safeToken ->
+                                        SafetyCirclesRepository.respondToInvite(safeToken, invite.inviteId, accept = false)
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+
+            SectionCard {
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                    SectionHeader(
+                        title = "My Circles",
+                        subtitle = if (circles.isEmpty()) "No circles yet." else "Choose a circle to view members."
+                    )
+                    circles.forEach { circle ->
+                        AssistChip(
+                            onClick = {
+                                selectedCircleId = circle.circleId
+                                runAction("") { safeToken ->
+                                    detail = SafetyCirclesRepository.getCircle(safeToken, circle.circleId)
+                                }
+                            },
+                            label = {
+                                Text(
+                                    text = "${circle.name} (${circle.memberCount})",
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+
+            detail?.let { circleDetail ->
+                SectionCard {
+                    Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                        SectionHeader(
+                            title = circleDetail.circle.name,
+                            subtitle = "Members can see each other's latest check-in."
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(spacing.sm)
+                        ) {
+                            PrimaryButton(
+                                text = "I am safe",
+                                onClick = {
+                                    pendingCheckIn = circleDetail.circle.circleId to "safe"
+                                },
+                                modifier = Modifier.weight(1f),
+                                enabled = !actionLoading
+                            )
+                            SecondaryButton(
+                                text = "Needs help",
+                                onClick = {
+                                    pendingCheckIn = circleDetail.circle.circleId to "not_safe"
+                                },
+                                modifier = Modifier.weight(1f),
+                                enabled = !actionLoading
+                            )
+                        }
+                        OutlinedTextField(
+                            value = invitee,
+                            onValueChange = { invitee = it },
+                            modifier = Modifier.fillMaxWidth(),
+                            label = { Text("Invite by email or user ID") },
+                            singleLine = true
+                        )
+                        SecondaryButton(
+                            text = "Send invite",
+                            onClick = {
+                                val target = invitee.trim()
+                                if (target.isBlank()) {
+                                    errorMessage = "Invitee email or user ID is required."
+                                } else {
+                                    runAction("Invite sent.") { safeToken ->
+                                        SafetyCirclesRepository.invite(safeToken, circleDetail.circle.circleId, target)
+                                        invitee = ""
+                                    }
+                                }
+                            },
+                            enabled = !actionLoading
+                        )
+                        if (circleDetail.members.size <= 1) {
+                            Text(
+                                text = "No accepted members yet.",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        circleDetail.members.forEach { member ->
+                            MemberRow(member = member)
+                        }
+                        SecondaryButton(
+                            text = "Leave circle",
+                            onClick = {
+                                runAction("You left the circle.") { safeToken ->
+                                    SafetyCirclesRepository.leave(safeToken, circleDetail.circle.circleId)
+                                    selectedCircleId = null
+                                    detail = null
+                                }
+                            },
+                            enabled = !actionLoading
+                        )
+                    }
+                }
+            }
+
+            if (errorMessage.isNotBlank()) {
+                Text(
+                    text = "$errorMessage Please retry.",
+                    modifier = Modifier.fillMaxWidth(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+
+            if (infoMessage.isNotBlank()) {
+                Text(
+                    text = infoMessage,
+                    modifier = Modifier.fillMaxWidth(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InviteRow(
+    invite: SafetyCircleInvite,
+    actionLoading: Boolean,
+    onAccept: () -> Unit,
+    onReject: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 56.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = invite.circleName ?: "Safety Circle",
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = invite.inviterDisplayName ?: "Trusted circle invite",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        TextButton(onClick = onReject, enabled = !actionLoading) {
+            Text("Reject")
+        }
+        TextButton(onClick = onAccept, enabled = !actionLoading) {
+            Text("Accept")
+        }
+    }
+}
+
+@Composable
+private fun MemberRow(member: SafetyCircleMember) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+    ) {
+        Text(
+            text = member.displayName ?: member.userId,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.SemiBold
+        )
+        Text(
+            text = listOf(
+                formatSafetyStatus(member.status),
+                member.emergencyContactPhone?.let { "Contact: $it" },
+                member.lastCheckedInAt?.let { "Last checked in: $it" },
+                if (member.hasSharedLocation) "Location shared" else null
+            ).filterNotNull().joinToString(" · "),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        if (!member.note.isNullOrBlank()) {
+            Text(
+                text = member.note,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private fun formatSafetyStatus(status: String): String {
+    return when (status.trim().lowercase()) {
+        "safe" -> "Safe"
+        "not_safe" -> "Needs help"
+        else -> "No response"
+    }
+}

--- a/android/app/src/main/java/com/neph/features/safetycircles/presentation/SafetyCirclesScreen.kt
+++ b/android/app/src/main/java/com/neph/features/safetycircles/presentation/SafetyCirclesScreen.kt
@@ -72,6 +72,7 @@ fun SafetyCirclesScreen(
     var infoMessage by remember { mutableStateOf("") }
     var pendingCheckIn by remember { mutableStateOf<Pair<String, String>?>(null) }
     var pendingDeleteCircleId by remember { mutableStateOf<String?>(null) }
+    var pendingTransferOwnership by remember { mutableStateOf<Pair<String, SafetyCircleMember>?>(null) }
 
     fun handleAuthError(error: ApiException): Boolean {
         if (error.status != 401) return false
@@ -126,7 +127,9 @@ fun SafetyCirclesScreen(
         scope.launch {
             try {
                 action(safeToken)
-                infoMessage = successMessage
+                if (infoMessage.isBlank()) {
+                    infoMessage = successMessage
+                }
                 refresh()
             } catch (error: ApiException) {
                 if (!handleAuthError(error)) {
@@ -231,6 +234,39 @@ fun SafetyCirclesScreen(
             },
             dismissButton = {
                 TextButton(onClick = { pendingDeleteCircleId = null }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
+    pendingTransferOwnership?.let { (circleId, member) ->
+        AlertDialog(
+            onDismissRequest = { pendingTransferOwnership = null },
+            title = {
+                Text(text = "Transfer ownership?")
+            },
+            text = {
+                Text(text = "This will make ${member.displayName ?: member.userId} the owner of this safety circle.")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        pendingTransferOwnership = null
+                        runAction("Ownership transferred.") { safeToken ->
+                            SafetyCirclesRepository.transferOwnership(
+                                token = safeToken,
+                                circleId = circleId,
+                                nextOwnerUserId = member.userId
+                            )
+                        }
+                    }
+                ) {
+                    Text("Transfer")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingTransferOwnership = null }) {
                     Text("Cancel")
                 }
             }
@@ -410,13 +446,7 @@ fun SafetyCirclesScreen(
                                 actionLoading = actionLoading,
                                 showTransferAction = isOwner && member.role != "owner",
                                 onTransferOwnership = {
-                                    runAction("Ownership transferred.") { safeToken ->
-                                        SafetyCirclesRepository.transferOwnership(
-                                            token = safeToken,
-                                            circleId = circleDetail.circle.circleId,
-                                            nextOwnerUserId = member.userId
-                                        )
-                                    }
+                                    pendingTransferOwnership = circleDetail.circle.circleId to member
                                 }
                             )
                         }

--- a/android/app/src/main/java/com/neph/features/safetycircles/presentation/SafetyCirclesScreen.kt
+++ b/android/app/src/main/java/com/neph/features/safetycircles/presentation/SafetyCirclesScreen.kt
@@ -71,6 +71,7 @@ fun SafetyCirclesScreen(
     var errorMessage by remember { mutableStateOf("") }
     var infoMessage by remember { mutableStateOf("") }
     var pendingCheckIn by remember { mutableStateOf<Pair<String, String>?>(null) }
+    var pendingDeleteCircleId by remember { mutableStateOf<String?>(null) }
 
     fun handleAuthError(error: ApiException): Boolean {
         if (error.status != 401) return false
@@ -205,6 +206,37 @@ fun SafetyCirclesScreen(
         )
     }
 
+    pendingDeleteCircleId?.let { circleId ->
+        AlertDialog(
+            onDismissRequest = { pendingDeleteCircleId = null },
+            title = {
+                Text(text = "Delete safety circle?")
+            },
+            text = {
+                Text(text = "This removes the circle, invites, and memberships for everyone.")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        pendingDeleteCircleId = null
+                        runAction("Circle deleted.") { safeToken ->
+                            SafetyCirclesRepository.deleteCircle(safeToken, circleId)
+                            selectedCircleId = null
+                            detail = null
+                        }
+                    }
+                ) {
+                    Text("Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDeleteCircleId = null }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+
     AppDrawerScaffold(
         title = "Safety Circles",
         currentRoute = Routes.SafetyCircles.route,
@@ -315,6 +347,7 @@ fun SafetyCirclesScreen(
             }
 
             detail?.let { circleDetail ->
+                val isOwner = circleDetail.currentUserRole == "owner"
                 SectionCard {
                     Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
                         SectionHeader(
@@ -372,19 +405,47 @@ fun SafetyCirclesScreen(
                             )
                         }
                         circleDetail.members.forEach { member ->
-                            MemberRow(member = member)
-                        }
-                        SecondaryButton(
-                            text = "Leave circle",
-                            onClick = {
-                                runAction("You left the circle.") { safeToken ->
-                                    SafetyCirclesRepository.leave(safeToken, circleDetail.circle.circleId)
-                                    selectedCircleId = null
-                                    detail = null
+                            MemberRow(
+                                member = member,
+                                actionLoading = actionLoading,
+                                showTransferAction = isOwner && member.role != "owner",
+                                onTransferOwnership = {
+                                    runAction("Ownership transferred.") { safeToken ->
+                                        SafetyCirclesRepository.transferOwnership(
+                                            token = safeToken,
+                                            circleId = circleDetail.circle.circleId,
+                                            nextOwnerUserId = member.userId
+                                        )
+                                    }
                                 }
-                            },
-                            enabled = !actionLoading
-                        )
+                            )
+                        }
+                        if (isOwner) {
+                            Text(
+                                text = "Owners can delete the circle or transfer ownership to a member.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            SecondaryButton(
+                                text = "Delete circle",
+                                onClick = {
+                                    pendingDeleteCircleId = circleDetail.circle.circleId
+                                },
+                                enabled = !actionLoading
+                            )
+                        } else {
+                            SecondaryButton(
+                                text = "Leave circle",
+                                onClick = {
+                                    runAction("You left the circle.") { safeToken ->
+                                        SafetyCirclesRepository.leave(safeToken, circleDetail.circle.circleId)
+                                        selectedCircleId = null
+                                        detail = null
+                                    }
+                                },
+                                enabled = !actionLoading
+                            )
+                        }
                     }
                 }
             }
@@ -446,7 +507,12 @@ private fun InviteRow(
 }
 
 @Composable
-private fun MemberRow(member: SafetyCircleMember) {
+private fun MemberRow(
+    member: SafetyCircleMember,
+    actionLoading: Boolean,
+    showTransferAction: Boolean,
+    onTransferOwnership: () -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -473,6 +539,14 @@ private fun MemberRow(member: SafetyCircleMember) {
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+        }
+        if (showTransferAction) {
+            TextButton(
+                onClick = onTransferOwnership,
+                enabled = !actionLoading
+            ) {
+                Text("Make owner")
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
@@ -35,6 +35,7 @@ import com.neph.features.profile.data.composeFullName
 import com.neph.features.profile.presentation.EditProfileScreen
 import com.neph.features.profile.presentation.ProfileScreen
 import com.neph.features.requesthelp.presentation.RequestHelpScreen
+import com.neph.features.safetycircles.presentation.SafetyCirclesScreen
 import com.neph.features.settings.presentation.SettingsScreen
 
 @Composable
@@ -61,6 +62,7 @@ fun AppNavGraph(
             Routes.Profile.route,
             Routes.EditProfile.route,
             Routes.Settings.route,
+            Routes.SafetyCircles.route,
             Routes.PrivacySecurity.route
         )
 
@@ -342,6 +344,31 @@ fun AppNavGraph(
                 },
                 profileBadgeText = profileBadgeText,
                 isAuthenticated = authenticated
+            )
+        }
+
+        composable(Routes.SafetyCircles.route) {
+            if (!isAuthenticated()) {
+                LaunchedEffect(Unit) {
+                    navigateToLogin()
+                }
+                return@composable
+            }
+
+            val profileBadgeText = resolveProfileBadgeText(authenticated = true)
+
+            SafetyCirclesScreen(
+                onNavigateToRoute = ::navigateToDrawerRoute,
+                onOpenSettings = {
+                    navigateToDrawerRoute(Routes.Settings.route)
+                },
+                onProfileClick = {
+                    navigateToDrawerRoute(Routes.Profile.route)
+                },
+                onNavigateToLogin = {
+                    navigateToLogin()
+                },
+                profileBadgeText = profileBadgeText
             )
         }
 

--- a/android/app/src/main/java/com/neph/navigation/Routes.kt
+++ b/android/app/src/main/java/com/neph/navigation/Routes.kt
@@ -12,6 +12,7 @@ sealed class Routes(
     data object EmergencyInfo : Routes("emergency_info", "Emergency Numbers")
     data object HelpRequestMap : Routes("help_request_map", "Help Request Map")
     data object GatheringAreas : Routes("gathering_areas", "Gathering Areas")
+    data object SafetyCircles : Routes("safety_circles", "Safety Circles")
     data object Notifications : Routes("notifications", "Notifications")
     data object Settings : Routes("settings", "Settings")
     data object PrivacySecurity : Routes("privacy_security")
@@ -40,6 +41,7 @@ sealed class Routes(
             EmergencyInfo,
             HelpRequestMap,
             GatheringAreas,
+            SafetyCircles,
             Notifications
         )
 

--- a/backend/migrations/20260502_170000__create_safety_circles.sql
+++ b/backend/migrations/20260502_170000__create_safety_circles.sql
@@ -1,0 +1,85 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS safety_circles (
+  circle_id VARCHAR(64) PRIMARY KEY,
+  owner_user_id VARCHAR(64) NOT NULL,
+  name VARCHAR(120) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_safety_circles_owner
+    FOREIGN KEY (owner_user_id)
+    REFERENCES users(user_id)
+    ON DELETE CASCADE,
+
+  CONSTRAINT chk_safety_circles_name_not_blank
+    CHECK (LENGTH(TRIM(name)) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS safety_circle_members (
+  circle_id VARCHAR(64) NOT NULL,
+  user_id VARCHAR(64) NOT NULL,
+  role VARCHAR(20) NOT NULL DEFAULT 'member',
+  joined_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  PRIMARY KEY (circle_id, user_id),
+
+  CONSTRAINT fk_safety_circle_members_circle
+    FOREIGN KEY (circle_id)
+    REFERENCES safety_circles(circle_id)
+    ON DELETE CASCADE,
+
+  CONSTRAINT fk_safety_circle_members_user
+    FOREIGN KEY (user_id)
+    REFERENCES users(user_id)
+    ON DELETE CASCADE,
+
+  CONSTRAINT chk_safety_circle_members_role
+    CHECK (role IN ('owner', 'member'))
+);
+
+CREATE TABLE IF NOT EXISTS safety_circle_invites (
+  invite_id VARCHAR(64) PRIMARY KEY,
+  circle_id VARCHAR(64) NOT NULL,
+  inviter_user_id VARCHAR(64) NOT NULL,
+  invitee_user_id VARCHAR(64) NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  responded_at TIMESTAMP,
+
+  CONSTRAINT fk_safety_circle_invites_circle
+    FOREIGN KEY (circle_id)
+    REFERENCES safety_circles(circle_id)
+    ON DELETE CASCADE,
+
+  CONSTRAINT fk_safety_circle_invites_inviter
+    FOREIGN KEY (inviter_user_id)
+    REFERENCES users(user_id)
+    ON DELETE CASCADE,
+
+  CONSTRAINT fk_safety_circle_invites_invitee
+    FOREIGN KEY (invitee_user_id)
+    REFERENCES users(user_id)
+    ON DELETE CASCADE,
+
+  CONSTRAINT chk_safety_circle_invites_status
+    CHECK (status IN ('pending', 'accepted', 'rejected')),
+
+  CONSTRAINT chk_safety_circle_invites_not_self
+    CHECK (inviter_user_id <> invitee_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_safety_circles_owner
+  ON safety_circles (owner_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_safety_circle_members_user
+  ON safety_circle_members (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_safety_circle_invites_invitee_status
+  ON safety_circle_invites (invitee_user_id, status);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_safety_circle_invites_one_open
+  ON safety_circle_invites (circle_id, invitee_user_id)
+  WHERE status = 'pending';
+
+COMMIT;

--- a/backend/src/modules/profiles/service.js
+++ b/backend/src/modules/profiles/service.js
@@ -18,9 +18,21 @@ function toIsoDateString(value) {
     return null;
   }
 
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    const year = value.getFullYear();
+    const month = String(value.getMonth() + 1).padStart(2, '0');
+    const day = String(value.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
   const raw = String(value).trim();
   if (!raw) {
     return null;
+  }
+
+  const dateOnlyMatch = raw.match(/^(\d{4}-\d{2}-\d{2})/);
+  if (dateOnlyMatch) {
+    return dateOnlyMatch[1];
   }
 
   const parsedMs = Date.parse(raw);

--- a/backend/src/modules/safety-circles/controller.js
+++ b/backend/src/modules/safety-circles/controller.js
@@ -1,0 +1,138 @@
+const {
+  createSafetyCircle,
+  listMySafetyCircles,
+  getSafetyCircle,
+  inviteToSafetyCircle,
+  listMySafetyCircleInvites,
+  respondToSafetyCircleInvite,
+  checkInToSafetyCircle,
+  leaveSafetyCircle,
+} = require('./service');
+const {
+  validateCreateCircle,
+  validateCreateInvite,
+  validateInviteResponse,
+} = require('./validators');
+const { validateSafetyStatusPatch } = require('../safety-status/validators');
+
+function sendError(response, status, code, message, details) {
+  const payload = { code, message };
+  if (details) {
+    payload.details = details;
+  }
+  return response.status(status).json(payload);
+}
+
+function handleServiceError(response, error) {
+  if (error.code === 'NOT_FOUND') {
+    return sendError(response, 404, 'NOT_FOUND', error.message);
+  }
+  if (error.code === 'CONFLICT') {
+    return sendError(response, 409, 'CONFLICT', error.message);
+  }
+  console.error('safetyCircles request failed', error);
+  return sendError(response, 500, 'INTERNAL_ERROR', 'Unexpected server error');
+}
+
+async function handleCreateCircle(request, response) {
+  const { errors, value } = validateCreateCircle(request.body || {});
+  if (errors.length > 0) {
+    return sendError(response, 400, 'VALIDATION_FAILED', 'Validation failed', errors);
+  }
+
+  try {
+    const circle = await createSafetyCircle(request.user.userId, value);
+    return response.status(201).json({ circle });
+  } catch (error) {
+    return handleServiceError(response, error);
+  }
+}
+
+async function handleListCircles(request, response) {
+  try {
+    const circles = await listMySafetyCircles(request.user.userId);
+    return response.status(200).json({ circles });
+  } catch (error) {
+    return handleServiceError(response, error);
+  }
+}
+
+async function handleGetCircle(request, response) {
+  try {
+    const circle = await getSafetyCircle(request.user.userId, request.params.circleId);
+    return response.status(200).json(circle);
+  } catch (error) {
+    return handleServiceError(response, error);
+  }
+}
+
+async function handleCreateInvite(request, response) {
+  const { errors, value } = validateCreateInvite(request.body || {});
+  if (errors.length > 0) {
+    return sendError(response, 400, 'VALIDATION_FAILED', 'Validation failed', errors);
+  }
+
+  try {
+    const invite = await inviteToSafetyCircle(request.user.userId, request.params.circleId, value);
+    return response.status(201).json({ invite });
+  } catch (error) {
+    return handleServiceError(response, error);
+  }
+}
+
+async function handleListInvites(request, response) {
+  try {
+    const invites = await listMySafetyCircleInvites(request.user.userId);
+    return response.status(200).json({ invites });
+  } catch (error) {
+    return handleServiceError(response, error);
+  }
+}
+
+async function handleRespondToInvite(request, response) {
+  const { errors, value } = validateInviteResponse(request.body || {});
+  if (errors.length > 0) {
+    return sendError(response, 400, 'VALIDATION_FAILED', 'Validation failed', errors);
+  }
+
+  try {
+    const invite = await respondToSafetyCircleInvite(request.user.userId, request.params.inviteId, value.decision);
+    return response.status(200).json({ invite });
+  } catch (error) {
+    return handleServiceError(response, error);
+  }
+}
+
+async function handleCircleCheckIn(request, response) {
+  const { errors, value } = validateSafetyStatusPatch(request.body || {});
+  if (errors.length > 0) {
+    return sendError(response, 400, 'VALIDATION_FAILED', 'Validation failed', errors);
+  }
+
+  try {
+    const result = await checkInToSafetyCircle(request.user.userId, request.params.circleId, value);
+    return response.status(200).json(result);
+  } catch (error) {
+    return handleServiceError(response, error);
+  }
+}
+
+async function handleLeaveCircle(request, response) {
+  try {
+    const result = await leaveSafetyCircle(request.user.userId, request.params.circleId);
+    return response.status(200).json(result);
+  } catch (error) {
+    return handleServiceError(response, error);
+  }
+}
+
+module.exports = {
+  handleCreateCircle,
+  handleListCircles,
+  handleGetCircle,
+  handleCreateInvite,
+  handleListInvites,
+  handleRespondToInvite,
+  handleCircleCheckIn,
+  handleLeaveCircle,
+};

--- a/backend/src/modules/safety-circles/controller.js
+++ b/backend/src/modules/safety-circles/controller.js
@@ -7,11 +7,14 @@ const {
   respondToSafetyCircleInvite,
   checkInToSafetyCircle,
   leaveSafetyCircle,
+  deleteSafetyCircle,
+  transferSafetyCircleOwnership,
 } = require('./service');
 const {
   validateCreateCircle,
   validateCreateInvite,
   validateInviteResponse,
+  validateTransferOwnership,
 } = require('./validators');
 const { validateSafetyStatusPatch } = require('../safety-status/validators');
 
@@ -29,6 +32,9 @@ function handleServiceError(response, error) {
   }
   if (error.code === 'CONFLICT') {
     return sendError(response, 409, 'CONFLICT', error.message);
+  }
+  if (error.code === 'FORBIDDEN') {
+    return sendError(response, 403, 'FORBIDDEN', error.message);
   }
   console.error('safetyCircles request failed', error);
   return sendError(response, 500, 'INTERNAL_ERROR', 'Unexpected server error');
@@ -126,6 +132,33 @@ async function handleLeaveCircle(request, response) {
   }
 }
 
+async function handleDeleteCircle(request, response) {
+  try {
+    const result = await deleteSafetyCircle(request.user.userId, request.params.circleId);
+    return response.status(200).json(result);
+  } catch (error) {
+    return handleServiceError(response, error);
+  }
+}
+
+async function handleTransferOwnership(request, response) {
+  const { errors, value } = validateTransferOwnership(request.body || {});
+  if (errors.length > 0) {
+    return sendError(response, 400, 'VALIDATION_FAILED', 'Validation failed', errors);
+  }
+
+  try {
+    const result = await transferSafetyCircleOwnership(
+      request.user.userId,
+      request.params.circleId,
+      value.nextOwnerUserId,
+    );
+    return response.status(200).json(result);
+  } catch (error) {
+    return handleServiceError(response, error);
+  }
+}
+
 module.exports = {
   handleCreateCircle,
   handleListCircles,
@@ -135,4 +168,6 @@ module.exports = {
   handleRespondToInvite,
   handleCircleCheckIn,
   handleLeaveCircle,
+  handleDeleteCircle,
+  handleTransferOwnership,
 };

--- a/backend/src/modules/safety-circles/repository.js
+++ b/backend/src/modules/safety-circles/repository.js
@@ -1,0 +1,371 @@
+const { randomUUID } = require('crypto');
+const { query } = require('../../db/pool');
+
+function buildId(prefix) {
+  return `${prefix}_${randomUUID().replace(/-/g, '')}`.slice(0, 64);
+}
+
+function displayName(row) {
+  return [row.first_name, row.last_name].filter(Boolean).join(' ').trim() || null;
+}
+
+function mapCircle(row) {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    circleId: row.circle_id,
+    name: row.name,
+    ownerUserId: row.owner_user_id,
+    memberCount: Number(row.member_count || 0),
+    createdAt: row.created_at || null,
+    updatedAt: row.updated_at || null,
+  };
+}
+
+function mapMember(row) {
+  return {
+    userId: row.user_id,
+    displayName: displayName(row),
+    emergencyContact: row.phone_number
+      ? {
+        phoneNumber: row.phone_number,
+      }
+      : null,
+    role: row.role,
+    status: row.status || 'unknown',
+    note: row.status_note || null,
+    shareLocationConsent: Boolean(row.share_location_consent),
+    lastCheckedInAt: row.status_updated_at || null,
+    location: row.can_see_location && row.latitude != null && row.longitude != null
+      ? {
+        latitude: Number(row.latitude),
+        longitude: Number(row.longitude),
+        accuracyMeters: row.location_accuracy_meters == null ? null : Number(row.location_accuracy_meters),
+        source: row.location_source || null,
+        capturedAt: row.location_captured_at || null,
+      }
+      : null,
+    joinedAt: row.joined_at || null,
+  };
+}
+
+function mapInvite(row) {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    inviteId: row.invite_id,
+    circleId: row.circle_id,
+    circleName: row.circle_name || row.name || null,
+    inviterUserId: row.inviter_user_id,
+    inviterDisplayName: row.inviter_first_name || row.inviter_last_name
+      ? [row.inviter_first_name, row.inviter_last_name].filter(Boolean).join(' ').trim()
+      : null,
+    inviteeUserId: row.invitee_user_id,
+    inviteeDisplayName: row.invitee_first_name || row.invitee_last_name
+      ? [row.invitee_first_name, row.invitee_last_name].filter(Boolean).join(' ').trim()
+      : null,
+    status: row.status,
+    createdAt: row.created_at || null,
+    respondedAt: row.responded_at || null,
+  };
+}
+
+async function createCircle(ownerUserId, { name }) {
+  const circleId = buildId('circle');
+  const result = await query(
+    `
+      WITH created_circle AS (
+        INSERT INTO safety_circles (circle_id, owner_user_id, name)
+        VALUES ($1, $2, $3)
+        RETURNING circle_id, owner_user_id, name, created_at, updated_at
+      ),
+      owner_member AS (
+        INSERT INTO safety_circle_members (circle_id, user_id, role)
+        SELECT circle_id, owner_user_id, 'owner'
+        FROM created_circle
+      )
+      SELECT cc.*, 1 AS member_count
+      FROM created_circle cc;
+    `,
+    [circleId, ownerUserId, name],
+  );
+
+  return mapCircle(result.rows[0]);
+}
+
+async function listCirclesForUser(userId) {
+  const result = await query(
+    `
+      SELECT
+        sc.circle_id,
+        sc.owner_user_id,
+        sc.name,
+        sc.created_at,
+        sc.updated_at,
+        COUNT(scm_all.user_id) AS member_count
+      FROM safety_circles sc
+      JOIN safety_circle_members scm_self
+        ON scm_self.circle_id = sc.circle_id
+       AND scm_self.user_id = $1
+      LEFT JOIN safety_circle_members scm_all
+        ON scm_all.circle_id = sc.circle_id
+      GROUP BY sc.circle_id
+      ORDER BY sc.updated_at DESC, sc.name ASC;
+    `,
+    [userId],
+  );
+
+  return result.rows.map(mapCircle);
+}
+
+async function findCircleForMember(circleId, userId) {
+  const result = await query(
+    `
+      SELECT
+        sc.circle_id,
+        sc.owner_user_id,
+        sc.name,
+        sc.created_at,
+        sc.updated_at,
+        COUNT(scm_all.user_id) AS member_count
+      FROM safety_circles sc
+      JOIN safety_circle_members scm_self
+        ON scm_self.circle_id = sc.circle_id
+       AND scm_self.user_id = $2
+      LEFT JOIN safety_circle_members scm_all
+        ON scm_all.circle_id = sc.circle_id
+      WHERE sc.circle_id = $1
+      GROUP BY sc.circle_id
+      LIMIT 1;
+    `,
+    [circleId, userId],
+  );
+
+  return mapCircle(result.rows[0]);
+}
+
+async function listCircleMembers(circleId, viewerUserId) {
+  const result = await query(
+    `
+      SELECT
+        scm.user_id,
+        scm.role,
+        scm.joined_at,
+        up.first_name,
+        up.last_name,
+        up.phone_number,
+        uss.status,
+        uss.status_note,
+        uss.share_location_consent,
+        uss.latitude,
+        uss.longitude,
+        uss.location_accuracy_meters,
+        uss.location_source,
+        uss.location_captured_at,
+        uss.updated_at AS status_updated_at,
+        (
+          uss.share_location_consent = TRUE
+          AND COALESCE(ps.location_sharing_enabled, FALSE) = TRUE
+          AND COALESCE(ps.location_visibility::text, 'PRIVATE') <> 'PRIVATE'
+        ) AS can_see_location
+      FROM safety_circle_members viewer
+      JOIN safety_circle_members scm
+        ON scm.circle_id = viewer.circle_id
+      LEFT JOIN user_profiles up
+        ON up.user_id = scm.user_id
+      LEFT JOIN privacy_settings ps
+        ON ps.profile_id = up.profile_id
+      LEFT JOIN user_safety_statuses uss
+        ON uss.user_id = scm.user_id
+      WHERE viewer.circle_id = $1
+        AND viewer.user_id = $2
+      ORDER BY
+        CASE scm.role WHEN 'owner' THEN 0 ELSE 1 END,
+        up.first_name ASC NULLS LAST,
+        scm.user_id ASC;
+    `,
+    [circleId, viewerUserId],
+  );
+
+  return result.rows.map(mapMember);
+}
+
+async function findUserByIdOrEmail({ inviteeUserId, inviteeEmail }) {
+  const result = await query(
+    `
+      SELECT user_id
+      FROM users
+      WHERE ($1::varchar IS NOT NULL AND user_id = $1)
+         OR ($2::varchar IS NOT NULL AND LOWER(email) = $2)
+      LIMIT 1;
+    `,
+    [inviteeUserId, inviteeEmail],
+  );
+
+  return result.rows[0] || null;
+}
+
+async function isCircleMember(circleId, userId) {
+  const result = await query(
+    `
+      SELECT 1
+      FROM safety_circle_members
+      WHERE circle_id = $1
+        AND user_id = $2
+      LIMIT 1;
+    `,
+    [circleId, userId],
+  );
+
+  return result.rows.length > 0;
+}
+
+async function createInvite(circleId, inviterUserId, inviteeUserId) {
+  const inviteId = buildId('invite');
+  const result = await query(
+    `
+      INSERT INTO safety_circle_invites (
+        invite_id,
+        circle_id,
+        inviter_user_id,
+        invitee_user_id
+      )
+      VALUES ($1, $2, $3, $4)
+      RETURNING invite_id, circle_id, inviter_user_id, invitee_user_id, status, created_at, responded_at;
+    `,
+    [inviteId, circleId, inviterUserId, inviteeUserId],
+  );
+
+  return mapInvite(result.rows[0]);
+}
+
+async function listInvitesForUser(userId) {
+  const result = await query(
+    `
+      SELECT
+        sci.invite_id,
+        sci.circle_id,
+        sc.name AS circle_name,
+        sci.inviter_user_id,
+        inviter_profile.first_name AS inviter_first_name,
+        inviter_profile.last_name AS inviter_last_name,
+        sci.invitee_user_id,
+        invitee_profile.first_name AS invitee_first_name,
+        invitee_profile.last_name AS invitee_last_name,
+        sci.status,
+        sci.created_at,
+        sci.responded_at
+      FROM safety_circle_invites sci
+      JOIN safety_circles sc ON sc.circle_id = sci.circle_id
+      LEFT JOIN user_profiles inviter_profile ON inviter_profile.user_id = sci.inviter_user_id
+      LEFT JOIN user_profiles invitee_profile ON invitee_profile.user_id = sci.invitee_user_id
+      WHERE sci.invitee_user_id = $1
+      ORDER BY sci.created_at DESC;
+    `,
+    [userId],
+  );
+
+  return result.rows.map(mapInvite);
+}
+
+async function findInviteForUser(inviteId, userId) {
+  const result = await query(
+    `
+      SELECT
+        sci.invite_id,
+        sci.circle_id,
+        sc.name AS circle_name,
+        sci.inviter_user_id,
+        sci.invitee_user_id,
+        sci.status,
+        sci.created_at,
+        sci.responded_at
+      FROM safety_circle_invites sci
+      JOIN safety_circles sc ON sc.circle_id = sci.circle_id
+      WHERE sci.invite_id = $1
+        AND sci.invitee_user_id = $2
+      LIMIT 1;
+    `,
+    [inviteId, userId],
+  );
+
+  return result.rows[0] || null;
+}
+
+async function respondToInvite(inviteId, userId, decision) {
+  const invite = await findInviteForUser(inviteId, userId);
+  if (!invite) {
+    return null;
+  }
+  if (invite.status !== 'pending') {
+    return mapInvite(invite);
+  }
+
+  const nextStatus = decision === 'accept' ? 'accepted' : 'rejected';
+  const result = await query(
+    `
+      WITH updated_invite AS (
+        UPDATE safety_circle_invites
+        SET status = $3,
+            responded_at = CURRENT_TIMESTAMP
+        WHERE invite_id = $1
+          AND invitee_user_id = $2
+          AND status = 'pending'
+        RETURNING invite_id, circle_id, inviter_user_id, invitee_user_id, status, created_at, responded_at
+      ),
+      inserted_member AS (
+        INSERT INTO safety_circle_members (circle_id, user_id, role)
+        SELECT circle_id, invitee_user_id, 'member'
+        FROM updated_invite
+        WHERE $3 = 'accepted'
+        ON CONFLICT (circle_id, user_id) DO NOTHING
+      )
+      SELECT
+        ui.invite_id,
+        ui.circle_id,
+        sc.name AS circle_name,
+        ui.inviter_user_id,
+        ui.invitee_user_id,
+        ui.status,
+        ui.created_at,
+        ui.responded_at
+      FROM updated_invite ui
+      JOIN safety_circles sc ON sc.circle_id = ui.circle_id;
+    `,
+    [inviteId, userId, nextStatus],
+  );
+
+  return mapInvite(result.rows[0]);
+}
+
+async function removeMember(circleId, userId) {
+  const result = await query(
+    `
+      DELETE FROM safety_circle_members
+      WHERE circle_id = $1
+        AND user_id = $2
+        AND role <> 'owner'
+      RETURNING circle_id, user_id;
+    `,
+    [circleId, userId],
+  );
+
+  return result.rows.length > 0;
+}
+
+module.exports = {
+  createCircle,
+  listCirclesForUser,
+  findCircleForMember,
+  listCircleMembers,
+  findUserByIdOrEmail,
+  isCircleMember,
+  createInvite,
+  listInvitesForUser,
+  respondToInvite,
+  removeMember,
+};

--- a/backend/src/modules/safety-circles/repository.js
+++ b/backend/src/modules/safety-circles/repository.js
@@ -1,5 +1,5 @@
 const { randomUUID } = require('crypto');
-const { query } = require('../../db/pool');
+const { pool, query } = require('../../db/pool');
 
 function buildId(prefix) {
   return `${prefix}_${randomUUID().replace(/-/g, '')}`.slice(0, 64);
@@ -357,6 +357,66 @@ async function removeMember(circleId, userId) {
   return result.rows.length > 0;
 }
 
+async function deleteCircle(circleId, ownerUserId) {
+  const result = await query(
+    `
+      DELETE FROM safety_circles
+      WHERE circle_id = $1
+        AND owner_user_id = $2
+      RETURNING circle_id;
+    `,
+    [circleId, ownerUserId],
+  );
+
+  return result.rows.length > 0;
+}
+
+async function transferCircleOwnership(circleId, ownerUserId, nextOwnerUserId) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const circleResult = await client.query(
+      `
+        UPDATE safety_circles
+        SET owner_user_id = $3,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE circle_id = $1
+          AND owner_user_id = $2
+        RETURNING circle_id;
+      `,
+      [circleId, ownerUserId, nextOwnerUserId],
+    );
+
+    if (circleResult.rows.length === 0) {
+      await client.query('ROLLBACK');
+      return false;
+    }
+
+    await client.query(
+      `
+        UPDATE safety_circle_members
+        SET role = CASE
+          WHEN user_id = $3 THEN 'owner'
+          WHEN user_id = $2 THEN 'member'
+          ELSE role
+        END
+        WHERE circle_id = $1
+          AND user_id IN ($2, $3);
+      `,
+      [circleId, ownerUserId, nextOwnerUserId],
+    );
+
+    await client.query('COMMIT');
+    return true;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
 module.exports = {
   createCircle,
   listCirclesForUser,
@@ -368,4 +428,6 @@ module.exports = {
   listInvitesForUser,
   respondToInvite,
   removeMember,
+  deleteCircle,
+  transferCircleOwnership,
 };

--- a/backend/src/modules/safety-circles/routes.js
+++ b/backend/src/modules/safety-circles/routes.js
@@ -9,6 +9,8 @@ const {
   handleRespondToInvite,
   handleCircleCheckIn,
   handleLeaveCircle,
+  handleDeleteCircle,
+  handleTransferOwnership,
 } = require('./controller');
 
 const safetyCirclesRouter = express.Router();
@@ -21,7 +23,9 @@ safetyCirclesRouter.get('/invites', handleListInvites);
 safetyCirclesRouter.post('/invites/:inviteId/respond', handleRespondToInvite);
 safetyCirclesRouter.get('/:circleId', handleGetCircle);
 safetyCirclesRouter.post('/:circleId/invites', handleCreateInvite);
+safetyCirclesRouter.patch('/:circleId/owner', handleTransferOwnership);
 safetyCirclesRouter.patch('/:circleId/check-in', handleCircleCheckIn);
+safetyCirclesRouter.delete('/:circleId', handleDeleteCircle);
 safetyCirclesRouter.delete('/:circleId/members/me', handleLeaveCircle);
 
 module.exports = {

--- a/backend/src/modules/safety-circles/routes.js
+++ b/backend/src/modules/safety-circles/routes.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const { requireAuth } = require('../auth/middleware');
+const {
+  handleCreateCircle,
+  handleListCircles,
+  handleGetCircle,
+  handleCreateInvite,
+  handleListInvites,
+  handleRespondToInvite,
+  handleCircleCheckIn,
+  handleLeaveCircle,
+} = require('./controller');
+
+const safetyCirclesRouter = express.Router();
+
+safetyCirclesRouter.use(requireAuth);
+
+safetyCirclesRouter.get('/', handleListCircles);
+safetyCirclesRouter.post('/', handleCreateCircle);
+safetyCirclesRouter.get('/invites', handleListInvites);
+safetyCirclesRouter.post('/invites/:inviteId/respond', handleRespondToInvite);
+safetyCirclesRouter.get('/:circleId', handleGetCircle);
+safetyCirclesRouter.post('/:circleId/invites', handleCreateInvite);
+safetyCirclesRouter.patch('/:circleId/check-in', handleCircleCheckIn);
+safetyCirclesRouter.delete('/:circleId/members/me', handleLeaveCircle);
+
+module.exports = {
+  safetyCirclesRouter,
+};

--- a/backend/src/modules/safety-circles/service.js
+++ b/backend/src/modules/safety-circles/service.js
@@ -9,6 +9,8 @@ const {
   listInvitesForUser,
   respondToInvite,
   removeMember,
+  deleteCircle,
+  transferCircleOwnership,
 } = require('./repository');
 const { patchMySafetyStatus } = require('../safety-status/service');
 
@@ -21,6 +23,12 @@ function notFound(message = 'Safety circle not found') {
 function conflict(message) {
   const error = new Error(message);
   error.code = 'CONFLICT';
+  return error;
+}
+
+function forbidden(message) {
+  const error = new Error(message);
+  error.code = 'FORBIDDEN';
   return error;
 }
 
@@ -39,7 +47,8 @@ async function getSafetyCircle(userId, circleId) {
   }
 
   const members = await listCircleMembers(circleId, userId);
-  return { circle, members };
+  const currentUser = members.find((member) => member.userId === userId);
+  return { circle, currentUserRole: currentUser?.role || 'member', members };
 }
 
 async function inviteToSafetyCircle(userId, circleId, input) {
@@ -113,6 +122,46 @@ async function leaveSafetyCircle(userId, circleId) {
   return { message: 'You left the safety circle.' };
 }
 
+async function deleteSafetyCircle(userId, circleId) {
+  const circle = await findCircleForMember(circleId, userId);
+  if (!circle) {
+    throw notFound();
+  }
+  if (circle.ownerUserId !== userId) {
+    throw forbidden('Only the circle owner can delete this safety circle.');
+  }
+
+  const deleted = await deleteCircle(circleId, userId);
+  if (!deleted) {
+    throw notFound();
+  }
+
+  return { message: 'Safety circle deleted.' };
+}
+
+async function transferSafetyCircleOwnership(userId, circleId, nextOwnerUserId) {
+  const circle = await findCircleForMember(circleId, userId);
+  if (!circle) {
+    throw notFound();
+  }
+  if (circle.ownerUserId !== userId) {
+    throw forbidden('Only the circle owner can transfer ownership.');
+  }
+  if (nextOwnerUserId === userId) {
+    throw conflict('You are already the owner of this safety circle.');
+  }
+  if (!(await isCircleMember(circleId, nextOwnerUserId))) {
+    throw conflict('New owner must be an accepted circle member.');
+  }
+
+  const transferred = await transferCircleOwnership(circleId, userId, nextOwnerUserId);
+  if (!transferred) {
+    throw notFound();
+  }
+
+  return getSafetyCircle(userId, circleId);
+}
+
 module.exports = {
   createSafetyCircle,
   listMySafetyCircles,
@@ -122,4 +171,6 @@ module.exports = {
   respondToSafetyCircleInvite,
   checkInToSafetyCircle,
   leaveSafetyCircle,
+  deleteSafetyCircle,
+  transferSafetyCircleOwnership,
 };

--- a/backend/src/modules/safety-circles/service.js
+++ b/backend/src/modules/safety-circles/service.js
@@ -1,0 +1,125 @@
+const {
+  createCircle,
+  listCirclesForUser,
+  findCircleForMember,
+  listCircleMembers,
+  findUserByIdOrEmail,
+  isCircleMember,
+  createInvite,
+  listInvitesForUser,
+  respondToInvite,
+  removeMember,
+} = require('./repository');
+const { patchMySafetyStatus } = require('../safety-status/service');
+
+function notFound(message = 'Safety circle not found') {
+  const error = new Error(message);
+  error.code = 'NOT_FOUND';
+  return error;
+}
+
+function conflict(message) {
+  const error = new Error(message);
+  error.code = 'CONFLICT';
+  return error;
+}
+
+async function createSafetyCircle(userId, input) {
+  return createCircle(userId, input);
+}
+
+async function listMySafetyCircles(userId) {
+  return listCirclesForUser(userId);
+}
+
+async function getSafetyCircle(userId, circleId) {
+  const circle = await findCircleForMember(circleId, userId);
+  if (!circle) {
+    throw notFound();
+  }
+
+  const members = await listCircleMembers(circleId, userId);
+  return { circle, members };
+}
+
+async function inviteToSafetyCircle(userId, circleId, input) {
+  const circle = await findCircleForMember(circleId, userId);
+  if (!circle) {
+    throw notFound();
+  }
+
+  const invitee = await findUserByIdOrEmail(input);
+  if (!invitee) {
+    throw notFound('Invitee user not found');
+  }
+  if (invitee.user_id === userId) {
+    throw conflict('You cannot invite yourself to a safety circle.');
+  }
+  if (await isCircleMember(circleId, invitee.user_id)) {
+    throw conflict('User is already a member of this safety circle.');
+  }
+
+  try {
+    return await createInvite(circleId, userId, invitee.user_id);
+  } catch (error) {
+    if (error && error.code === '23505') {
+      throw conflict('A pending invite already exists for this user.');
+    }
+    throw error;
+  }
+}
+
+async function listMySafetyCircleInvites(userId) {
+  return listInvitesForUser(userId);
+}
+
+async function respondToSafetyCircleInvite(userId, inviteId, decision) {
+  const invite = await respondToInvite(inviteId, userId, decision);
+  if (!invite) {
+    throw notFound('Safety circle invite not found');
+  }
+  return invite;
+}
+
+async function checkInToSafetyCircle(userId, circleId, input) {
+  const circle = await findCircleForMember(circleId, userId);
+  if (!circle) {
+    throw notFound();
+  }
+
+  const safetyStatus = await patchMySafetyStatus(userId, input);
+  const circleDetail = await getSafetyCircle(userId, circleId);
+  return {
+    safetyStatus,
+    circle: circleDetail.circle,
+    members: circleDetail.members,
+  };
+}
+
+async function leaveSafetyCircle(userId, circleId) {
+  const circle = await findCircleForMember(circleId, userId);
+  if (!circle) {
+    throw notFound();
+  }
+  if (circle.ownerUserId === userId) {
+    throw conflict('Circle owner cannot leave the circle.');
+  }
+
+  const removed = await removeMember(circleId, userId);
+  if (!removed) {
+    throw notFound();
+  }
+
+  return { message: 'You left the safety circle.' };
+}
+
+module.exports = {
+  createSafetyCircle,
+  listMySafetyCircles,
+  getSafetyCircle,
+  inviteToSafetyCircle,
+  listMySafetyCircleInvites,
+  respondToSafetyCircleInvite,
+  checkInToSafetyCircle,
+  leaveSafetyCircle,
+};

--- a/backend/src/modules/safety-circles/validators.js
+++ b/backend/src/modules/safety-circles/validators.js
@@ -1,0 +1,54 @@
+function hasText(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function validateCreateCircle(payload) {
+  const errors = [];
+  const name = typeof payload.name === 'string' ? payload.name.trim() : '';
+
+  if (!name) {
+    errors.push('`name` is required.');
+  } else if (name.length > 120) {
+    errors.push('`name` must be at most 120 characters.');
+  }
+
+  return {
+    errors,
+    value: { name },
+  };
+}
+
+function validateCreateInvite(payload) {
+  const errors = [];
+  const inviteeUserId = hasText(payload.inviteeUserId) ? payload.inviteeUserId.trim() : null;
+  const inviteeEmail = hasText(payload.inviteeEmail) ? payload.inviteeEmail.trim().toLowerCase() : null;
+
+  if (!inviteeUserId && !inviteeEmail) {
+    errors.push('`inviteeUserId` or `inviteeEmail` is required.');
+  }
+
+  return {
+    errors,
+    value: { inviteeUserId, inviteeEmail },
+  };
+}
+
+function validateInviteResponse(payload) {
+  const errors = [];
+  const decision = hasText(payload.decision) ? payload.decision.trim().toLowerCase() : '';
+
+  if (!['accept', 'reject'].includes(decision)) {
+    errors.push('`decision` must be one of: accept, reject.');
+  }
+
+  return {
+    errors,
+    value: { decision },
+  };
+}
+
+module.exports = {
+  validateCreateCircle,
+  validateCreateInvite,
+  validateInviteResponse,
+};

--- a/backend/src/modules/safety-circles/validators.js
+++ b/backend/src/modules/safety-circles/validators.js
@@ -47,8 +47,23 @@ function validateInviteResponse(payload) {
   };
 }
 
+function validateTransferOwnership(payload) {
+  const errors = [];
+  const nextOwnerUserId = hasText(payload.nextOwnerUserId) ? payload.nextOwnerUserId.trim() : '';
+
+  if (!nextOwnerUserId) {
+    errors.push('`nextOwnerUserId` is required.');
+  }
+
+  return {
+    errors,
+    value: { nextOwnerUserId },
+  };
+}
+
 module.exports = {
   validateCreateCircle,
   validateCreateInvite,
   validateInviteResponse,
+  validateTransferOwnership,
 };

--- a/backend/src/modules/safety-status/repository.js
+++ b/backend/src/modules/safety-status/repository.js
@@ -183,6 +183,14 @@ async function listVisibleSafetyStatuses(viewerUserId, { isAdmin = false } = {})
       WHERE uss.user_id = $1
         OR $2 = TRUE
         OR COALESCE(ps.profile_visibility::text, 'PRIVATE') = 'PUBLIC'
+        OR EXISTS (
+          SELECT 1
+          FROM safety_circle_members viewer_member
+          JOIN safety_circle_members visible_member
+            ON visible_member.circle_id = viewer_member.circle_id
+          WHERE viewer_member.user_id = $1
+            AND visible_member.user_id = uss.user_id
+        )
       ORDER BY uss.updated_at DESC, uss.user_id ASC;
     `,
     [viewerUserId, isAdmin],

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -12,6 +12,7 @@ const { notificationsRouter } = require('../modules/notifications/routes');
 const { announcementsRouter } = require('../modules/announcements/routes');
 const { safetyStatusRouter } = require('../modules/safety-status/routes');
 const { operationalLocationRouter } = require('../modules/operational-location/routes');
+const { safetyCirclesRouter } = require('../modules/safety-circles/routes');
 
 const apiRouter = express.Router();
 
@@ -20,7 +21,7 @@ apiRouter.get('/', (_request, response) => {
     service: 'api',
     status: 'ok',
     name: 'Neighborhood Emergency Preparedness Hub API',
-    modules: ['auth', 'admin', 'profiles', 'help-requests', 'availability', 'assignments', 'location', 'gathering-areas', 'notifications', 'announcements', 'safety-status', 'operational-location'],
+    modules: ['auth', 'admin', 'profiles', 'help-requests', 'availability', 'assignments', 'location', 'gathering-areas', 'notifications', 'announcements', 'safety-status', 'operational-location', 'safety-circles'],
   });
 });
 
@@ -36,6 +37,7 @@ apiRouter.use('/notifications', notificationsRouter);
 apiRouter.use('/announcements', announcementsRouter);
 apiRouter.use('/safety-status', safetyStatusRouter);
 apiRouter.use('/operational-location', operationalLocationRouter);
+apiRouter.use('/safety-circles', safetyCirclesRouter);
 
 module.exports = {
   apiRouter,

--- a/backend/tests/integration/modules/safety-circles/safety-circles.integration.test.js
+++ b/backend/tests/integration/modules/safety-circles/safety-circles.integration.test.js
@@ -141,6 +141,7 @@ describe('safety-circles integration', () => {
         lastCheckedInAt: null,
       }),
     ]);
+    expect(detailResponse.body.currentUserRole).toBe('owner');
   });
 
   test('invitee can accept an invite and both members see latest safety statuses', async () => {
@@ -376,5 +377,91 @@ describe('safety-circles integration', () => {
       .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`);
 
     expect(ownerLeaveResponse.status).toBe(409);
+  });
+
+  test('owner can transfer ownership to an accepted member', async () => {
+    const app = createTestApp();
+    const ownerId = 'circle_owner_transfer';
+    const memberId = 'circle_member_transfer';
+    await seedActiveUser(ownerId);
+    await seedActiveUser(memberId);
+
+    const circleResponse = await request(app)
+      .post('/api/safety-circles')
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ name: 'Transfer Test' })
+      .expect(201);
+    const circleId = circleResponse.body.circle.circleId;
+
+    const inviteResponse = await request(app)
+      .post(`/api/safety-circles/${circleId}/invites`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ inviteeUserId: memberId })
+      .expect(201);
+
+    await request(app)
+      .post(`/api/safety-circles/invites/${inviteResponse.body.invite.inviteId}/respond`)
+      .set('Authorization', `Bearer ${buildAuthToken(memberId)}`)
+      .send({ decision: 'accept' })
+      .expect(200);
+
+    const transferResponse = await request(app)
+      .patch(`/api/safety-circles/${circleId}/owner`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ nextOwnerUserId: memberId })
+      .expect(200);
+
+    expect(transferResponse.body.circle.ownerUserId).toBe(memberId);
+    expect(transferResponse.body.currentUserRole).toBe('member');
+    const roles = Object.fromEntries(transferResponse.body.members.map((member) => [member.userId, member.role]));
+    expect(roles[ownerId]).toBe('member');
+    expect(roles[memberId]).toBe('owner');
+
+    await request(app)
+      .delete(`/api/safety-circles/${circleId}/members/me`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .expect(200);
+  });
+
+  test('only the owner can delete a circle', async () => {
+    const app = createTestApp();
+    const ownerId = 'circle_owner_delete';
+    const memberId = 'circle_member_delete';
+    await seedActiveUser(ownerId);
+    await seedActiveUser(memberId);
+
+    const circleResponse = await request(app)
+      .post('/api/safety-circles')
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ name: 'Delete Test' })
+      .expect(201);
+    const circleId = circleResponse.body.circle.circleId;
+
+    const inviteResponse = await request(app)
+      .post(`/api/safety-circles/${circleId}/invites`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ inviteeUserId: memberId })
+      .expect(201);
+
+    await request(app)
+      .post(`/api/safety-circles/invites/${inviteResponse.body.invite.inviteId}/respond`)
+      .set('Authorization', `Bearer ${buildAuthToken(memberId)}`)
+      .send({ decision: 'accept' })
+      .expect(200);
+
+    await request(app)
+      .delete(`/api/safety-circles/${circleId}`)
+      .set('Authorization', `Bearer ${buildAuthToken(memberId)}`)
+      .expect(403);
+
+    await request(app)
+      .delete(`/api/safety-circles/${circleId}`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .expect(200);
+
+    await request(app)
+      .get(`/api/safety-circles/${circleId}`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .expect(404);
   });
 });

--- a/backend/tests/integration/modules/safety-circles/safety-circles.integration.test.js
+++ b/backend/tests/integration/modules/safety-circles/safety-circles.integration.test.js
@@ -423,6 +423,53 @@ describe('safety-circles integration', () => {
       .expect(200);
   });
 
+  test('ownership transfer rejects non-owners, self-transfer, and non-members', async () => {
+    const app = createTestApp();
+    const ownerId = 'circle_owner_transfer_reject';
+    const memberId = 'circle_member_transfer_reject';
+    const strangerId = 'circle_stranger_transfer_reject';
+    await seedActiveUser(ownerId);
+    await seedActiveUser(memberId);
+    await seedActiveUser(strangerId);
+
+    const circleResponse = await request(app)
+      .post('/api/safety-circles')
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ name: 'Rejected Transfer Test' })
+      .expect(201);
+    const circleId = circleResponse.body.circle.circleId;
+
+    const inviteResponse = await request(app)
+      .post(`/api/safety-circles/${circleId}/invites`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ inviteeUserId: memberId })
+      .expect(201);
+
+    await request(app)
+      .post(`/api/safety-circles/invites/${inviteResponse.body.invite.inviteId}/respond`)
+      .set('Authorization', `Bearer ${buildAuthToken(memberId)}`)
+      .send({ decision: 'accept' })
+      .expect(200);
+
+    await request(app)
+      .patch(`/api/safety-circles/${circleId}/owner`)
+      .set('Authorization', `Bearer ${buildAuthToken(memberId)}`)
+      .send({ nextOwnerUserId: ownerId })
+      .expect(403);
+
+    await request(app)
+      .patch(`/api/safety-circles/${circleId}/owner`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ nextOwnerUserId: ownerId })
+      .expect(409);
+
+    await request(app)
+      .patch(`/api/safety-circles/${circleId}/owner`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ nextOwnerUserId: strangerId })
+      .expect(409);
+  });
+
   test('only the owner can delete a circle', async () => {
     const app = createTestApp();
     const ownerId = 'circle_owner_delete';

--- a/backend/tests/integration/modules/safety-circles/safety-circles.integration.test.js
+++ b/backend/tests/integration/modules/safety-circles/safety-circles.integration.test.js
@@ -1,0 +1,380 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+const { safetyCirclesRouter } = require('../../../../src/modules/safety-circles/routes');
+const { safetyStatusRouter } = require('../../../../src/modules/safety-status/routes');
+const { query } = require('../../../../src/db/pool');
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/safety-circles', safetyCirclesRouter);
+  app.use('/api/safety-status', safetyStatusRouter);
+  return app;
+}
+
+function buildAuthToken(userId, overrides = {}) {
+  return jwt.sign(
+    {
+      userId,
+      email: `${userId}@example.com`,
+      isAdmin: false,
+      adminRole: null,
+      ...overrides,
+    },
+    process.env.JWT_SECRET || 'dev-secret-123',
+    { expiresIn: '1h' },
+  );
+}
+
+async function seedActiveUser(userId, email = `${userId}@example.com`) {
+  await query(
+    `
+      INSERT INTO users (
+        user_id,
+        email,
+        password_hash,
+        is_email_verified,
+        is_deleted,
+        accepted_terms
+      )
+      VALUES ($1, $2, 'hash', TRUE, FALSE, TRUE);
+    `,
+    [userId, email],
+  );
+}
+
+async function seedProfile(userId, options = {}) {
+  const profileId = `prf_${userId}`;
+  await query(
+    `
+      INSERT INTO user_profiles (profile_id, user_id, first_name, last_name, phone_number)
+      VALUES ($1, $2, $3, $4, '5301234567');
+    `,
+    [profileId, userId, options.firstName || 'Circle', options.lastName || 'User'],
+  );
+
+  await query(
+    `
+      INSERT INTO privacy_settings (
+        settings_id,
+        profile_id,
+        profile_visibility,
+        health_info_visibility,
+        location_visibility,
+        location_sharing_enabled
+      )
+      VALUES ($1, $2, $3, 'PRIVATE', $4, $5);
+    `,
+    [
+      `priv_${userId}`,
+      profileId,
+      options.profileVisibility || 'PRIVATE',
+      options.locationVisibility || 'PRIVATE',
+      Boolean(options.locationSharingEnabled),
+    ],
+  );
+}
+
+beforeEach(async () => {
+  await query(`
+    TRUNCATE TABLE
+      safety_circle_invites,
+      safety_circle_members,
+      safety_circles,
+      user_safety_statuses,
+      messages,
+      assignments,
+      availability_records,
+      resources,
+      volunteers,
+      request_locations,
+      help_requests,
+      news_announcements,
+      reports,
+      expertise,
+      privacy_settings,
+      location_profiles,
+      health_info,
+      physical_info,
+      user_profiles,
+      admins,
+      users
+    RESTART IDENTITY CASCADE;
+  `);
+});
+
+describe('safety-circles integration', () => {
+  test('user can create a circle and sees an empty accepted member list besides owner', async () => {
+    const app = createTestApp();
+    const ownerId = 'circle_owner';
+    await seedActiveUser(ownerId);
+    await seedProfile(ownerId, { firstName: 'Circle', lastName: 'Owner' });
+
+    const createResponse = await request(app)
+      .post('/api/safety-circles')
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ name: 'My Family' });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.circle).toMatchObject({
+      name: 'My Family',
+      ownerUserId: ownerId,
+      memberCount: 1,
+    });
+
+    const circleId = createResponse.body.circle.circleId;
+    const detailResponse = await request(app)
+      .get(`/api/safety-circles/${circleId}`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`);
+
+    expect(detailResponse.status).toBe(200);
+    expect(detailResponse.body.members).toEqual([
+      expect.objectContaining({
+        userId: ownerId,
+        displayName: 'Circle Owner',
+        role: 'owner',
+        status: 'unknown',
+        lastCheckedInAt: null,
+      }),
+    ]);
+  });
+
+  test('invitee can accept an invite and both members see latest safety statuses', async () => {
+    const app = createTestApp();
+    const ownerId = 'circle_owner_accept';
+    const inviteeId = 'circle_invitee_accept';
+    await seedActiveUser(ownerId);
+    await seedActiveUser(inviteeId, 'invitee@example.com');
+    await seedProfile(ownerId, { firstName: 'First', lastName: 'User' });
+    await seedProfile(inviteeId, {
+      firstName: 'Second',
+      lastName: 'User',
+      locationVisibility: 'EMERGENCY_ONLY',
+      locationSharingEnabled: true,
+    });
+
+    const circleResponse = await request(app)
+      .post('/api/safety-circles')
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ name: 'My Family' })
+      .expect(201);
+    const circleId = circleResponse.body.circle.circleId;
+
+    const inviteResponse = await request(app)
+      .post(`/api/safety-circles/${circleId}/invites`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ inviteeEmail: 'invitee@example.com' })
+      .expect(201);
+
+    await request(app)
+      .post(`/api/safety-circles/invites/${inviteResponse.body.invite.inviteId}/respond`)
+      .set('Authorization', `Bearer ${buildAuthToken(inviteeId)}`)
+      .send({ decision: 'accept' })
+      .expect(200);
+
+    await request(app)
+      .patch(`/api/safety-circles/${circleId}/check-in`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ status: 'safe', note: 'With family' })
+      .expect(200);
+
+    await request(app)
+      .patch(`/api/safety-circles/${circleId}/check-in`)
+      .set('Authorization', `Bearer ${buildAuthToken(inviteeId)}`)
+      .send({
+        status: 'not_safe',
+        shareLocationConsent: true,
+        location: {
+          latitude: 41.043,
+          longitude: 29.009,
+          accuracyMeters: 12,
+          source: 'GPS',
+          capturedAt: '2026-05-02T12:00:00.000Z',
+        },
+      })
+      .expect(200);
+
+    const detailResponse = await request(app)
+      .get(`/api/safety-circles/${circleId}`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .expect(200);
+
+    const byUserId = Object.fromEntries(detailResponse.body.members.map((member) => [member.userId, member]));
+    expect(byUserId[ownerId]).toMatchObject({
+      displayName: 'First User',
+      status: 'safe',
+      note: 'With family',
+    });
+    expect(byUserId[ownerId].lastCheckedInAt).toBeTruthy();
+    expect(byUserId[inviteeId]).toMatchObject({
+      displayName: 'Second User',
+      emergencyContact: {
+        phoneNumber: '5301234567',
+      },
+      status: 'not_safe',
+      location: {
+        latitude: 41.043,
+        longitude: 29.009,
+      },
+    });
+  });
+
+  test('invitee can reject and is not visible as an accepted member', async () => {
+    const app = createTestApp();
+    const ownerId = 'circle_owner_reject';
+    const inviteeId = 'circle_invitee_reject';
+    await seedActiveUser(ownerId);
+    await seedActiveUser(inviteeId);
+
+    const circleResponse = await request(app)
+      .post('/api/safety-circles')
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ name: 'Neighbors' })
+      .expect(201);
+
+    const inviteResponse = await request(app)
+      .post(`/api/safety-circles/${circleResponse.body.circle.circleId}/invites`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ inviteeUserId: inviteeId })
+      .expect(201);
+
+    await request(app)
+      .post(`/api/safety-circles/invites/${inviteResponse.body.invite.inviteId}/respond`)
+      .set('Authorization', `Bearer ${buildAuthToken(inviteeId)}`)
+      .send({ decision: 'reject' })
+      .expect(200);
+
+    const detailResponse = await request(app)
+      .get(`/api/safety-circles/${circleResponse.body.circle.circleId}`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .expect(200);
+
+    expect(detailResponse.body.members.map((member) => member.userId)).not.toContain(inviteeId);
+  });
+
+  test('unauthorized users cannot view private circle information', async () => {
+    const app = createTestApp();
+    const ownerId = 'circle_owner_private';
+    const strangerId = 'circle_stranger';
+    await seedActiveUser(ownerId);
+    await seedActiveUser(strangerId);
+
+    const circleResponse = await request(app)
+      .post('/api/safety-circles')
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ name: 'Private Circle' })
+      .expect(201);
+
+    const response = await request(app)
+      .get(`/api/safety-circles/${circleResponse.body.circle.circleId}`)
+      .set('Authorization', `Bearer ${buildAuthToken(strangerId)}`);
+
+    expect(response.status).toBe(404);
+  });
+
+  test('circle members make private safety statuses visible without exposing private locations', async () => {
+    const app = createTestApp();
+    const ownerId = 'circle_owner_visible';
+    const memberId = 'circle_member_visible';
+    const strangerId = 'circle_stranger_visible';
+    await seedActiveUser(ownerId);
+    await seedActiveUser(memberId);
+    await seedActiveUser(strangerId);
+    await seedProfile(memberId, {
+      firstName: 'Private',
+      lastName: 'Member',
+      profileVisibility: 'PRIVATE',
+      locationVisibility: 'PRIVATE',
+      locationSharingEnabled: true,
+    });
+
+    const circleResponse = await request(app)
+      .post('/api/safety-circles')
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ name: 'Trusted' })
+      .expect(201);
+    const circleId = circleResponse.body.circle.circleId;
+
+    const inviteResponse = await request(app)
+      .post(`/api/safety-circles/${circleId}/invites`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ inviteeUserId: memberId })
+      .expect(201);
+
+    await request(app)
+      .post(`/api/safety-circles/invites/${inviteResponse.body.invite.inviteId}/respond`)
+      .set('Authorization', `Bearer ${buildAuthToken(memberId)}`)
+      .send({ decision: 'accept' })
+      .expect(200);
+
+    await request(app)
+      .patch('/api/safety-status/me')
+      .set('Authorization', `Bearer ${buildAuthToken(memberId)}`)
+      .send({
+        status: 'not_safe',
+        shareLocationConsent: true,
+        location: { latitude: 41.04, longitude: 29.01 },
+      })
+      .expect(200);
+
+    const ownerVisible = await request(app)
+      .get('/api/safety-status/visible')
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .expect(200);
+    const ownerByUserId = Object.fromEntries(ownerVisible.body.safetyStatuses.map((item) => [item.userId, item]));
+    expect(ownerByUserId[memberId]).toMatchObject({
+      displayName: 'Private Member',
+      status: 'not_safe',
+      location: null,
+    });
+
+    const strangerVisible = await request(app)
+      .get('/api/safety-status/visible')
+      .set('Authorization', `Bearer ${buildAuthToken(strangerId)}`)
+      .expect(200);
+    const strangerUserIds = strangerVisible.body.safetyStatuses.map((item) => item.userId);
+    expect(strangerUserIds).not.toContain(memberId);
+  });
+
+  test('member can leave a circle but owner cannot leave as the last authority', async () => {
+    const app = createTestApp();
+    const ownerId = 'circle_owner_leave';
+    const memberId = 'circle_member_leave';
+    await seedActiveUser(ownerId);
+    await seedActiveUser(memberId);
+
+    const circleResponse = await request(app)
+      .post('/api/safety-circles')
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ name: 'Leave Test' })
+      .expect(201);
+    const circleId = circleResponse.body.circle.circleId;
+
+    const inviteResponse = await request(app)
+      .post(`/api/safety-circles/${circleId}/invites`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`)
+      .send({ inviteeUserId: memberId })
+      .expect(201);
+
+    await request(app)
+      .post(`/api/safety-circles/invites/${inviteResponse.body.invite.inviteId}/respond`)
+      .set('Authorization', `Bearer ${buildAuthToken(memberId)}`)
+      .send({ decision: 'accept' })
+      .expect(200);
+
+    await request(app)
+      .delete(`/api/safety-circles/${circleId}/members/me`)
+      .set('Authorization', `Bearer ${buildAuthToken(memberId)}`)
+      .expect(200);
+
+    const ownerLeaveResponse = await request(app)
+      .delete(`/api/safety-circles/${circleId}/members/me`)
+      .set('Authorization', `Bearer ${buildAuthToken(ownerId)}`);
+
+    expect(ownerLeaveResponse.status).toBe(409);
+  });
+});


### PR DESCRIPTION
## Summary
- Added trusted safety circles with circle creation, member invites, invite accept/reject, member listing, check-in, and leave-circle flows.
- Added Android Safety Circles screen to create circles, send invites, respond to invites, view member statuses, and mark Safe / Needs Help.
- Extended visible safety status rules so accepted circle members can see each other’s latest safety status.
- Added privacy-first location sharing: location is included only after explicit user consent.
- Exposed member emergency contact phone within private circle member details.
- Fixed date-only profile formatting to avoid timezone date shifts.

## Database Changes
- Added a new migration file:
  - `backend/migrations/20260502_170000__create_safety_circles.sql`
- Created new tables:
  - `safety_circles`
  - `safety_circle_members`
  - `safety_circle_invites`
- Added indexes for circle owner lookup, member lookup, invite lookup, and one pending invite per user/circle.
- Did not modify `infra/docker/postgres/init.sql`.


Closes #382