### PR TITLE
feat: add operational location model and api

### DIFF
--- a/backend/migrations/20260504_130000__create_user_operational_locations.sql
+++ b/backend/migrations/20260504_130000__create_user_operational_locations.sql
@@ -1,0 +1,33 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS user_operational_locations (
+  user_id VARCHAR(64) PRIMARY KEY,
+  latitude DOUBLE PRECISION NOT NULL,
+  longitude DOUBLE PRECISION NOT NULL,
+  accuracy_meters DOUBLE PRECISION,
+  source VARCHAR(100),
+  captured_at TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_user_operational_location_user
+    FOREIGN KEY (user_id)
+    REFERENCES users(user_id)
+    ON DELETE CASCADE,
+
+  CONSTRAINT chk_user_operational_location_coordinates
+    CHECK (
+      latitude BETWEEN -90 AND 90
+      AND longitude BETWEEN -180 AND 180
+    ),
+
+  CONSTRAINT chk_user_operational_location_accuracy
+    CHECK (
+      accuracy_meters IS NULL
+      OR accuracy_meters >= 0
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_operational_locations_updated_at
+  ON user_operational_locations (updated_at DESC);
+
+COMMIT;

--- a/backend/src/modules/operational-location/controller.js
+++ b/backend/src/modules/operational-location/controller.js
@@ -1,0 +1,45 @@
+const {
+  getMyOperationalLocation,
+  patchMyOperationalLocation,
+} = require('./service');
+const { validateOperationalLocationPatch } = require('./validators');
+
+function sendError(response, status, code, message) {
+  return response.status(status).json({ code, message });
+}
+
+async function handleGetMyOperationalLocation(request, response) {
+  try {
+    const operationalLocation = await getMyOperationalLocation(request.user.userId);
+
+    if (!operationalLocation) {
+      return sendError(response, 404, 'NOT_FOUND', 'Operational location not found');
+    }
+
+    return response.status(200).json(operationalLocation);
+  } catch (error) {
+    console.error('operationalLocation.handleGetMyOperationalLocation failed', error);
+    return sendError(response, 500, 'INTERNAL_ERROR', 'Unexpected server error');
+  }
+}
+
+async function handlePatchMyOperationalLocation(request, response) {
+  const validation = validateOperationalLocationPatch(request.body);
+
+  if (!validation.ok) {
+    return sendError(response, 400, validation.code, validation.message);
+  }
+
+  try {
+    const operationalLocation = await patchMyOperationalLocation(request.user.userId, validation.data);
+    return response.status(200).json(operationalLocation);
+  } catch (error) {
+    console.error('operationalLocation.handlePatchMyOperationalLocation failed', error);
+    return sendError(response, 500, 'INTERNAL_ERROR', 'Unexpected server error');
+  }
+}
+
+module.exports = {
+  handleGetMyOperationalLocation,
+  handlePatchMyOperationalLocation,
+};

--- a/backend/src/modules/operational-location/repository.js
+++ b/backend/src/modules/operational-location/repository.js
@@ -1,0 +1,84 @@
+const { query } = require('../../db/pool');
+
+function mapOperationalLocation(row) {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    userId: row.user_id,
+    latitude: Number(row.latitude),
+    longitude: Number(row.longitude),
+    accuracyMeters: row.accuracy_meters === null ? null : Number(row.accuracy_meters),
+    source: row.source || null,
+    capturedAt: row.captured_at || null,
+    updatedAt: row.updated_at || null,
+  };
+}
+
+async function findOperationalLocationByUserId(userId) {
+  const result = await query(
+    `
+      SELECT
+        user_id,
+        latitude,
+        longitude,
+        accuracy_meters,
+        source,
+        captured_at,
+        updated_at
+      FROM user_operational_locations
+      WHERE user_id = $1;
+    `,
+    [userId],
+  );
+
+  return mapOperationalLocation(result.rows[0]);
+}
+
+async function upsertOperationalLocation(userId, input) {
+  const result = await query(
+    `
+      INSERT INTO user_operational_locations (
+        user_id,
+        latitude,
+        longitude,
+        accuracy_meters,
+        source,
+        captured_at,
+        updated_at
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, CURRENT_TIMESTAMP)
+      ON CONFLICT (user_id) DO UPDATE
+      SET latitude = EXCLUDED.latitude,
+          longitude = EXCLUDED.longitude,
+          accuracy_meters = EXCLUDED.accuracy_meters,
+          source = EXCLUDED.source,
+          captured_at = EXCLUDED.captured_at,
+          updated_at = CURRENT_TIMESTAMP
+      RETURNING
+        user_id,
+        latitude,
+        longitude,
+        accuracy_meters,
+        source,
+        captured_at,
+        updated_at;
+    `,
+    [
+      userId,
+      input.latitude,
+      input.longitude,
+      input.accuracyMeters,
+      input.source,
+      input.capturedAt,
+    ],
+  );
+
+  return mapOperationalLocation(result.rows[0]);
+}
+
+module.exports = {
+  findOperationalLocationByUserId,
+  upsertOperationalLocation,
+};

--- a/backend/src/modules/operational-location/routes.js
+++ b/backend/src/modules/operational-location/routes.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const { requireAuth } = require('../auth/middleware');
+const {
+  handleGetMyOperationalLocation,
+  handlePatchMyOperationalLocation,
+} = require('./controller');
+
+const operationalLocationRouter = express.Router();
+
+operationalLocationRouter.use(requireAuth);
+
+operationalLocationRouter.get('/me', handleGetMyOperationalLocation);
+operationalLocationRouter.patch('/me', handlePatchMyOperationalLocation);
+
+module.exports = {
+  operationalLocationRouter,
+};

--- a/backend/src/modules/operational-location/service.js
+++ b/backend/src/modules/operational-location/service.js
@@ -1,0 +1,17 @@
+const {
+  findOperationalLocationByUserId,
+  upsertOperationalLocation,
+} = require('./repository');
+
+async function getMyOperationalLocation(userId) {
+  return findOperationalLocationByUserId(userId);
+}
+
+async function patchMyOperationalLocation(userId, input) {
+  return upsertOperationalLocation(userId, input);
+}
+
+module.exports = {
+  getMyOperationalLocation,
+  patchMyOperationalLocation,
+};

--- a/backend/src/modules/operational-location/validators.js
+++ b/backend/src/modules/operational-location/validators.js
@@ -1,0 +1,97 @@
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasOwn(object, key) {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function normalizeOptionalString(fieldName, value) {
+  if (value === undefined || value === null) {
+    return { ok: true, value: null };
+  }
+
+  if (typeof value !== 'string') {
+    return { ok: false, message: `${fieldName} must be a string or null` };
+  }
+
+  const normalized = value.trim();
+  return { ok: true, value: normalized || null };
+}
+
+function normalizeOptionalTimestamp(fieldName, value) {
+  const stringResult = normalizeOptionalString(fieldName, value);
+  if (!stringResult.ok || stringResult.value === null) {
+    return stringResult;
+  }
+
+  const parsedMs = Date.parse(stringResult.value);
+  if (Number.isNaN(parsedMs)) {
+    return { ok: false, message: `${fieldName} must be a valid timestamp or null` };
+  }
+
+  return { ok: true, value: new Date(parsedMs).toISOString() };
+}
+
+function validateOperationalLocationPatch(body) {
+  if (!isPlainObject(body)) {
+    return { ok: false, code: 'VALIDATION_ERROR', message: 'Payload must be an object' };
+  }
+
+  if (Object.keys(body).length === 0) {
+    return { ok: false, code: 'VALIDATION_ERROR', message: 'latitude and longitude are required' };
+  }
+
+  if (!hasOwn(body, 'latitude') || !hasOwn(body, 'longitude')) {
+    return { ok: false, code: 'VALIDATION_ERROR', message: 'latitude and longitude are required' };
+  }
+
+  if (typeof body.latitude !== 'number' || !Number.isFinite(body.latitude) || body.latitude < -90 || body.latitude > 90) {
+    return { ok: false, code: 'VALIDATION_ERROR', message: 'latitude must be a number between -90 and 90' };
+  }
+
+  if (typeof body.longitude !== 'number' || !Number.isFinite(body.longitude) || body.longitude < -180 || body.longitude > 180) {
+    return { ok: false, code: 'VALIDATION_ERROR', message: 'longitude must be a number between -180 and 180' };
+  }
+
+  if (
+    hasOwn(body, 'accuracyMeters')
+    && body.accuracyMeters !== null
+    && (typeof body.accuracyMeters !== 'number' || !Number.isFinite(body.accuracyMeters) || body.accuracyMeters < 0)
+  ) {
+    return { ok: false, code: 'VALIDATION_ERROR', message: 'accuracyMeters must be a number >= 0 or null' };
+  }
+
+  const source = hasOwn(body, 'source')
+    ? normalizeOptionalString('source', body.source)
+    : { ok: true, value: null };
+  if (!source.ok) {
+    return { ok: false, code: 'VALIDATION_ERROR', message: source.message };
+  }
+
+  if (source.value !== null && source.value.length > 100) {
+    return { ok: false, code: 'VALIDATION_ERROR', message: 'source must be at most 100 characters' };
+  }
+
+  const capturedAt = hasOwn(body, 'capturedAt')
+    ? normalizeOptionalTimestamp('capturedAt', body.capturedAt)
+    : { ok: true, value: null };
+  if (!capturedAt.ok) {
+    return { ok: false, code: 'VALIDATION_ERROR', message: capturedAt.message };
+  }
+
+  return {
+    ok: true,
+    data: {
+      latitude: body.latitude,
+      longitude: body.longitude,
+      accuracyMeters: hasOwn(body, 'accuracyMeters') ? body.accuracyMeters : null,
+      source: source.value,
+      capturedAt: capturedAt.value,
+    },
+  };
+}
+
+module.exports = {
+  validateOperationalLocationPatch,
+};

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -11,6 +11,7 @@ const { gatheringAreasRouter } = require('../modules/gathering-areas/routes');
 const { notificationsRouter } = require('../modules/notifications/routes');
 const { announcementsRouter } = require('../modules/announcements/routes');
 const { safetyStatusRouter } = require('../modules/safety-status/routes');
+const { operationalLocationRouter } = require('../modules/operational-location/routes');
 
 const apiRouter = express.Router();
 
@@ -19,7 +20,7 @@ apiRouter.get('/', (_request, response) => {
     service: 'api',
     status: 'ok',
     name: 'Neighborhood Emergency Preparedness Hub API',
-    modules: ['auth', 'admin', 'profiles', 'help-requests', 'availability', 'assignments', 'location', 'gathering-areas', 'notifications', 'announcements', 'safety-status'],
+    modules: ['auth', 'admin', 'profiles', 'help-requests', 'availability', 'assignments', 'location', 'gathering-areas', 'notifications', 'announcements', 'safety-status', 'operational-location'],
   });
 });
 
@@ -34,6 +35,7 @@ apiRouter.use('/gathering-areas', gatheringAreasRouter);
 apiRouter.use('/notifications', notificationsRouter);
 apiRouter.use('/announcements', announcementsRouter);
 apiRouter.use('/safety-status', safetyStatusRouter);
+apiRouter.use('/operational-location', operationalLocationRouter);
 
 module.exports = {
   apiRouter,

--- a/backend/tests/integration/modules/operational-location/operational-location.integration.test.js
+++ b/backend/tests/integration/modules/operational-location/operational-location.integration.test.js
@@ -1,0 +1,439 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+const { operationalLocationRouter } = require('../../../../src/modules/operational-location/routes');
+const { query } = require('../../../../src/db/pool');
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/operational-location', operationalLocationRouter);
+  return app;
+}
+
+function buildAuthToken(userId) {
+  return jwt.sign(
+    {
+      userId,
+      email: `${userId}@example.com`,
+      isAdmin: false,
+      adminRole: null,
+    },
+    process.env.JWT_SECRET || 'dev-secret-123',
+    { expiresIn: '1h' },
+  );
+}
+
+async function seedActiveUser(userId, email = `${userId}@example.com`) {
+  await query(
+    `
+      INSERT INTO users (
+        user_id,
+        email,
+        password_hash,
+        is_email_verified,
+        is_deleted,
+        accepted_terms
+      )
+      VALUES ($1, $2, 'hash', TRUE, FALSE, TRUE);
+    `,
+    [userId, email],
+  );
+}
+
+async function seedProfileLocationAndPrivacy(userId) {
+  const profileId = `prf_${userId}`;
+
+  await query(
+    `
+      INSERT INTO user_profiles (profile_id, user_id, first_name, last_name, phone_number)
+      VALUES ($1, $2, 'Profile', 'Location', '5301234567');
+    `,
+    [profileId, userId],
+  );
+
+  await query(
+    `
+      INSERT INTO location_profiles (
+        location_profile_id,
+        profile_id,
+        address,
+        city,
+        country,
+        latitude,
+        longitude
+      )
+      VALUES ($1, $2, 'Residential address', 'Istanbul', 'Turkey', 40.99, 29.01);
+    `,
+    [`loc_${userId}`, profileId],
+  );
+
+  await query(
+    `
+      INSERT INTO privacy_settings (
+        settings_id,
+        profile_id,
+        profile_visibility,
+        health_info_visibility,
+        location_visibility,
+        location_sharing_enabled
+      )
+      VALUES ($1, $2, 'PUBLIC', 'PRIVATE', 'EMERGENCY_ONLY', TRUE);
+    `,
+    [`priv_${userId}`, profileId],
+  );
+
+  return profileId;
+}
+
+async function getProfileLocationRow(profileId) {
+  const result = await query(
+    `
+      SELECT
+        address,
+        city,
+        country,
+        latitude,
+        longitude
+      FROM location_profiles
+      WHERE profile_id = $1;
+    `,
+    [profileId],
+  );
+
+  return result.rows[0];
+}
+
+async function getProfileRow(profileId) {
+  const result = await query(
+    `
+      SELECT
+        first_name,
+        last_name,
+        phone_number
+      FROM user_profiles
+      WHERE profile_id = $1;
+    `,
+    [profileId],
+  );
+
+  return result.rows[0];
+}
+
+async function getPrivacyRow(profileId) {
+  const result = await query(
+    `
+      SELECT
+        profile_visibility,
+        health_info_visibility,
+        location_visibility,
+        location_sharing_enabled
+      FROM privacy_settings
+      WHERE profile_id = $1;
+    `,
+    [profileId],
+  );
+
+  return result.rows[0];
+}
+
+beforeEach(async () => {
+  await query(`
+    TRUNCATE TABLE
+      user_operational_locations,
+      user_safety_statuses,
+      messages,
+      assignments,
+      availability_records,
+      resources,
+      volunteers,
+      request_locations,
+      help_requests,
+      news_announcements,
+      reports,
+      expertise,
+      privacy_settings,
+      location_profiles,
+      health_info,
+      physical_info,
+      user_profiles,
+      admins,
+      users
+    RESTART IDENTITY CASCADE;
+  `);
+});
+
+describe('operational-location integration', () => {
+  test('PATCH /api/operational-location/me stores the authenticated user operational location', async () => {
+    const app = createTestApp();
+    const userId = 'user_op_patch';
+    await seedActiveUser(userId);
+
+    const response = await request(app)
+      .patch('/api/operational-location/me')
+      .set('Authorization', `Bearer ${buildAuthToken(userId)}`)
+      .send({
+        latitude: 41.0123,
+        longitude: 29.0456,
+        accuracyMeters: 20,
+        source: 'DEVICE_GPS',
+        capturedAt: '2026-05-04T07:00:00Z',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      userId,
+      latitude: 41.0123,
+      longitude: 29.0456,
+      accuracyMeters: 20,
+      source: 'DEVICE_GPS',
+    });
+    expect(response.body.capturedAt).toBeTruthy();
+    expect(response.body.updatedAt).toBeTruthy();
+
+    const stored = await query('SELECT user_id FROM user_operational_locations WHERE user_id = $1;', [userId]);
+    expect(stored.rows).toHaveLength(1);
+  });
+
+  test('GET /api/operational-location/me returns the authenticated user latest operational location', async () => {
+    const app = createTestApp();
+    const userId = 'user_op_get';
+    await seedActiveUser(userId);
+
+    await request(app)
+      .patch('/api/operational-location/me')
+      .set('Authorization', `Bearer ${buildAuthToken(userId)}`)
+      .send({
+        latitude: 41.0123,
+        longitude: 29.0456,
+        accuracyMeters: null,
+        source: null,
+        capturedAt: null,
+      })
+      .expect(200);
+
+    const response = await request(app)
+      .get('/api/operational-location/me')
+      .set('Authorization', `Bearer ${buildAuthToken(userId)}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      userId,
+      latitude: 41.0123,
+      longitude: 29.0456,
+      accuracyMeters: null,
+      source: null,
+      capturedAt: null,
+    });
+    expect(response.body.updatedAt).toBeTruthy();
+  });
+
+  test('GET /api/operational-location/me returns 404 when no operational location exists', async () => {
+    const app = createTestApp();
+    const userId = 'user_op_missing';
+    await seedActiveUser(userId);
+
+    const response = await request(app)
+      .get('/api/operational-location/me')
+      .set('Authorization', `Bearer ${buildAuthToken(userId)}`);
+
+    expect(response.status).toBe(404);
+    expect(response.body.code).toBe('NOT_FOUND');
+  });
+
+  test('PATCH /api/operational-location/me updates the existing row instead of duplicating', async () => {
+    const app = createTestApp();
+    const userId = 'user_op_update';
+    await seedActiveUser(userId);
+    const token = buildAuthToken(userId);
+
+    await request(app)
+      .patch('/api/operational-location/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ latitude: 41.0123, longitude: 29.0456 })
+      .expect(200);
+
+    const response = await request(app)
+      .patch('/api/operational-location/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        latitude: 40.99,
+        longitude: 28.95,
+        accuracyMeters: 5,
+        source: 'NETWORK',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      userId,
+      latitude: 40.99,
+      longitude: 28.95,
+      accuracyMeters: 5,
+      source: 'NETWORK',
+    });
+
+    const countResult = await query(
+      'SELECT COUNT(*)::int AS count FROM user_operational_locations WHERE user_id = $1;',
+      [userId],
+    );
+    expect(countResult.rows[0].count).toBe(1);
+  });
+
+  test('PATCH /api/operational-location/me rejects invalid latitude and longitude', async () => {
+    const app = createTestApp();
+    const userId = 'user_op_invalid_coordinates';
+    await seedActiveUser(userId);
+    const token = buildAuthToken(userId);
+
+    const badLatitude = await request(app)
+      .patch('/api/operational-location/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ latitude: -91, longitude: 29.0456 });
+
+    expect(badLatitude.status).toBe(400);
+    expect(badLatitude.body.code).toBe('VALIDATION_ERROR');
+
+    const badLongitude = await request(app)
+      .patch('/api/operational-location/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ latitude: 41.0123, longitude: 181 });
+
+    expect(badLongitude.status).toBe(400);
+    expect(badLongitude.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('PATCH /api/operational-location/me rejects missing latitude or longitude', async () => {
+    const app = createTestApp();
+    const userId = 'user_op_missing_coordinates';
+    await seedActiveUser(userId);
+    const token = buildAuthToken(userId);
+
+    const missingLatitude = await request(app)
+      .patch('/api/operational-location/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ longitude: 29.0456 });
+
+    expect(missingLatitude.status).toBe(400);
+    expect(missingLatitude.body.code).toBe('VALIDATION_ERROR');
+
+    const missingLongitude = await request(app)
+      .patch('/api/operational-location/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ latitude: 41.0123 });
+
+    expect(missingLongitude.status).toBe(400);
+    expect(missingLongitude.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('PATCH /api/operational-location/me rejects empty and null payloads', async () => {
+    const app = createTestApp();
+    const userId = 'user_op_empty_payload';
+    await seedActiveUser(userId);
+    const token = buildAuthToken(userId);
+
+    const emptyResponse = await request(app)
+      .patch('/api/operational-location/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(emptyResponse.status).toBe(400);
+    expect(emptyResponse.body.code).toBe('VALIDATION_ERROR');
+
+    const nullResponse = await request(app)
+      .patch('/api/operational-location/me')
+      .set('Authorization', `Bearer ${token}`)
+      .set('Content-Type', 'application/json')
+      .send('null');
+
+    expect(nullResponse.status).toBe(400);
+  });
+
+  test('GET and PATCH /api/operational-location/me require authentication', async () => {
+    const app = createTestApp();
+
+    const getResponse = await request(app)
+      .get('/api/operational-location/me');
+
+    expect(getResponse.status).toBe(401);
+
+    const patchResponse = await request(app)
+      .patch('/api/operational-location/me')
+      .send({ latitude: 41.0123, longitude: 29.0456 });
+
+    expect(patchResponse.status).toBe(401);
+  });
+
+  test('PATCH /api/operational-location/me does not modify profile residential location', async () => {
+    const app = createTestApp();
+    const userId = 'user_op_profile_location';
+    await seedActiveUser(userId);
+    const profileId = await seedProfileLocationAndPrivacy(userId);
+    const beforeProfile = await getProfileRow(profileId);
+    const beforeLocation = await getProfileLocationRow(profileId);
+
+    await request(app)
+      .patch('/api/operational-location/me')
+      .set('Authorization', `Bearer ${buildAuthToken(userId)}`)
+      .send({
+        latitude: 41.2,
+        longitude: 29.2,
+        accuracyMeters: 8,
+        source: 'DEVICE_GPS',
+      })
+      .expect(200);
+
+    const afterProfile = await getProfileRow(profileId);
+    const afterLocation = await getProfileLocationRow(profileId);
+    expect(afterProfile).toEqual(beforeProfile);
+    expect(afterLocation).toEqual(beforeLocation);
+  });
+
+  test('PATCH /api/operational-location/me does not modify profile privacy settings', async () => {
+    const app = createTestApp();
+    const userId = 'user_op_privacy';
+    await seedActiveUser(userId);
+    const profileId = await seedProfileLocationAndPrivacy(userId);
+    const beforePrivacy = await getPrivacyRow(profileId);
+
+    await request(app)
+      .patch('/api/operational-location/me')
+      .set('Authorization', `Bearer ${buildAuthToken(userId)}`)
+      .send({
+        latitude: 41.2,
+        longitude: 29.2,
+        source: 'DEVICE_GPS',
+      })
+      .expect(200);
+
+    const afterPrivacy = await getPrivacyRow(profileId);
+    expect(afterPrivacy).toEqual(beforePrivacy);
+  });
+
+  test('user B cannot retrieve user A operational location through /me', async () => {
+    const app = createTestApp();
+    const userA = 'user_op_owner_a';
+    const userB = 'user_op_owner_b';
+    await seedActiveUser(userA);
+    await seedActiveUser(userB);
+
+    await request(app)
+      .patch('/api/operational-location/me')
+      .set('Authorization', `Bearer ${buildAuthToken(userA)}`)
+      .send({
+        latitude: 41.0123,
+        longitude: 29.0456,
+        source: 'DEVICE_GPS',
+      })
+      .expect(200);
+
+    const response = await request(app)
+      .get('/api/operational-location/me')
+      .set('Authorization', `Bearer ${buildAuthToken(userB)}`);
+
+    expect(response.status).toBe(404);
+    expect(response.body.userId).not.toBe(userA);
+  });
+});

--- a/backend/tests/unit/modules/operational-location/validators.test.js
+++ b/backend/tests/unit/modules/operational-location/validators.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const {
+  validateOperationalLocationPatch,
+} = require('../../../../src/modules/operational-location/validators');
+
+describe('operational-location validators', () => {
+  test('accepts valid operational location payload', () => {
+    const result = validateOperationalLocationPatch({
+      latitude: 41.0123,
+      longitude: 29.0456,
+      accuracyMeters: 20,
+      source: 'DEVICE_GPS',
+      capturedAt: '2026-05-04T07:00:00Z',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({
+      latitude: 41.0123,
+      longitude: 29.0456,
+      accuracyMeters: 20,
+      source: 'DEVICE_GPS',
+      capturedAt: '2026-05-04T07:00:00.000Z',
+    });
+  });
+
+  test('rejects missing latitude or longitude', () => {
+    expect(validateOperationalLocationPatch({ latitude: 41.0123 }).ok).toBe(false);
+    expect(validateOperationalLocationPatch({ longitude: 29.0456 }).ok).toBe(false);
+  });
+
+  test('rejects invalid coordinate ranges', () => {
+    expect(validateOperationalLocationPatch({ latitude: 91, longitude: 29.0456 }).ok).toBe(false);
+    expect(validateOperationalLocationPatch({ latitude: 41.0123, longitude: -181 }).ok).toBe(false);
+  });
+
+  test('rejects null and empty payloads', () => {
+    expect(validateOperationalLocationPatch(null).ok).toBe(false);
+    expect(validateOperationalLocationPatch({}).ok).toBe(false);
+  });
+
+  test('rejects invalid optional fields', () => {
+    expect(validateOperationalLocationPatch({
+      latitude: 41.0123,
+      longitude: 29.0456,
+      accuracyMeters: -1,
+    }).ok).toBe(false);
+
+    expect(validateOperationalLocationPatch({
+      latitude: 41.0123,
+      longitude: 29.0456,
+      source: 123,
+    }).ok).toBe(false);
+
+    expect(validateOperationalLocationPatch({
+      latitude: 41.0123,
+      longitude: 29.0456,
+      capturedAt: 'not-a-date',
+    }).ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds backend support for a separate **operational location** concept, as defined in #430 under the residential vs. operational location separation epic.

Operational location represents the user's latest current/device location for emergency-related flows, while residential/profile location remains manually managed through the profile APIs.

## Changes

- Added a new `user_operational_locations` table through a backend migration
- Added authenticated operational location endpoints:
  - `GET /api/operational-location/me`
  - `PATCH /api/operational-location/me`
- Added backend module files for operational location:
  - routes
  - controller
  - service
  - repository
  - validators
- Added validation for:
  - required latitude/longitude
  - coordinate ranges
  - optional accuracy
  - optional source
  - optional captured timestamp
- Registered the new router under `/api/operational-location`
- Added backend tests for:
  - authenticated update/read behavior
  - unauthenticated access
  - invalid payloads and coordinates
  - upsert behavior
  - isolation from profile/residential location
  - isolation from privacy settings
  - `/me` only returning the authenticated user’s own operational location

## Important Behavior

Operational location is intentionally stored separately from residential/profile location.

Updating operational location does **not** modify:

- `user_profiles`
- `location_profiles`
- `privacy_settings`

This keeps current GPS/device updates from overwriting the user’s manually maintained residential/community location.

## Testing

- Added unit tests for operational location validation
- Added integration tests for the new API behavior
- Verified the endpoint behavior through the backend test suite

Closes #430 