### PR TITLE
fix: Android profile residential location handling

### DIFF
--- a/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
@@ -1,8 +1,6 @@
 package com.neph.features.auth.presentation
 
 import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,12 +21,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import com.neph.core.network.ApiException
 import com.neph.features.auth.util.countryCodeOptions
-import com.neph.features.profile.data.CurrentLocationShareWarning
-import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.features.profile.data.LocationData
 import com.neph.features.profile.data.LocationTreeRepository
 import com.neph.features.profile.data.ProfileRepository
-import com.neph.features.profile.data.ProfileRepository.LocationSharingInitializationRequiredException
 import com.neph.features.profile.data.bloodTypeOptions
 import com.neph.features.profile.data.calculateAgeFromDateOfBirth
 import com.neph.features.profile.data.combinePhoneNumber
@@ -52,13 +47,10 @@ import com.neph.ui.components.inputs.AppDropdown
 import com.neph.ui.components.inputs.AppTextArea
 import com.neph.ui.components.inputs.AppTextField
 import com.neph.ui.components.selection.AppCheckbox
-import com.neph.ui.components.selection.AppToggleSwitch
 import com.neph.ui.layout.AuthScaffold
 import com.neph.ui.map.MapPickerDialog
 import com.neph.ui.map.MapPickerSelection
 import com.neph.ui.map.LocationSelectionMapAction
-import com.neph.ui.map.SharedCoordinatesMapAction
-import com.neph.ui.map.formatMapCoordinate
 import com.neph.ui.map.resolveMapPickerLocationUpdate
 import com.neph.ui.theme.LocalNephSpacing
 import kotlinx.coroutines.CancellationException
@@ -104,7 +96,6 @@ fun CompleteProfileScreen(
     var district by rememberSaveable { mutableStateOf(existingProfile.district.orEmpty()) }
     var neighborhood by rememberSaveable { mutableStateOf(existingProfile.neighborhood.orEmpty()) }
     var extraAddress by rememberSaveable { mutableStateOf(existingProfile.extraAddress.orEmpty()) }
-    var shareLocation by rememberSaveable { mutableStateOf(existingProfile.shareLocation ?: false) }
     var profession by rememberSaveable { mutableStateOf(existingProfile.profession) }
     var expertise by rememberSaveable { mutableStateOf(existingProfile.expertise) }
     var loading by rememberSaveable { mutableStateOf(false) }
@@ -117,19 +108,6 @@ fun CompleteProfileScreen(
     var availableLocationData by remember { mutableStateOf<LocationData>(locationData) }
     var locationLoading by remember { mutableStateOf(true) }
     var locationInfo by rememberSaveable { mutableStateOf("") }
-    var syncedSharedLatitude by rememberSaveable { mutableStateOf(existingProfile.sharedLatitude) }
-    var syncedSharedLongitude by rememberSaveable { mutableStateOf(existingProfile.sharedLongitude) }
-    val locationPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestMultiplePermissions()
-    ) { grants ->
-        if (grants.values.any { it }) {
-            shareLocation = true
-            info = "Location permission granted. Current location will be shared when you save."
-        } else {
-            shareLocation = false
-            info = "Location permission denied. Current location sharing remains off."
-        }
-    }
 
     LaunchedEffect(Unit) {
         try {
@@ -264,51 +242,18 @@ fun CompleteProfileScreen(
                     district = district,
                     neighborhood = neighborhood,
                     extraAddress = extraAddress.takeIf(String::isNotBlank),
-                    shareLocation = shareLocation,
                     profession = profession?.trim()?.takeIf(String::isNotBlank),
                     expertise = parseListField(expertise.joinToString(", "))
                 )
-                val locationShareAttempt = DeviceLocationProvider.captureCurrentLocationForSharing(
-                    context = context,
-                    sharingEnabled = profileToSync.shareLocation == true
+                ProfileRepository.syncProfile(
+                    profile = profileToSync
                 )
-                val profileWithSharePolicy = when (locationShareAttempt.warning) {
-                    CurrentLocationShareWarning.PERMISSION_DENIED -> profileToSync.copy(shareLocation = false)
-                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> profileToSync
-                    null -> profileToSync
-                }
-
-                val syncedProfile = ProfileRepository.syncProfile(
-                    profile = profileWithSharePolicy,
-                    currentDeviceLocation = locationShareAttempt.location,
-                    forceClearSharedCoordinates = locationShareAttempt.warning == CurrentLocationShareWarning.LOCATION_UNAVAILABLE
-                )
-                shareLocation = syncedProfile.shareLocation ?: false
-                syncedSharedLatitude = syncedProfile.sharedLatitude
-                syncedSharedLongitude = syncedProfile.sharedLongitude
-
-                val completionMessage = when (locationShareAttempt.warning) {
-                    CurrentLocationShareWarning.PERMISSION_DENIED ->
-                        "Profile saved. Location permission is denied, so location sharing was turned off and stored coordinates were cleared."
-
-                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE ->
-                        "Profile saved. Current location is unavailable, so sharing remains on and stale coordinates were cleared."
-
-                    null -> {
-                        if (locationShareAttempt.location != null) {
-                            "Profile saved. Current location shared."
-                        } else {
-                            "Profile saved."
-                        }
-                    }
-                }
+                val completionMessage = "Profile saved."
 
                 info = completionMessage
                 Toast.makeText(context, completionMessage, Toast.LENGTH_LONG).show()
 
                 onComplete()
-            } catch (guardError: LocationSharingInitializationRequiredException) {
-                error = guardError.message ?: "To enable Share Current Location, save a valid current location first."
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (errorResponse: ApiException) {
@@ -462,7 +407,8 @@ fun CompleteProfileScreen(
                 }
             }
 
-            Text("Location", style = MaterialTheme.typography.titleMedium)
+            Text("Residential Location", style = MaterialTheme.typography.titleMedium)
+            HelperText(text = "This is your home/neighborhood location. It is not automatically updated by GPS.")
 
             if (locationLoading) {
                 HelperText(text = "Loading location options...")
@@ -498,16 +444,10 @@ fun CompleteProfileScreen(
             )
 
             SecondaryButton(
-                text = "Select Location on Map",
+                text = "Select Home Location on Map",
                 onClick = { mapPickerOpen = true },
                 enabled = !locationLoading && !loading
             )
-
-            mapPickerSelection?.let { selection ->
-                HelperText(
-                    text = "Selected coordinates: ${formatMapCoordinate(selection.latitude)}, ${formatMapCoordinate(selection.longitude)}"
-                )
-            }
 
             AppTextField(
                 value = extraAddress,
@@ -528,35 +468,11 @@ fun CompleteProfileScreen(
                 onOpenSuccess = { mapActionInfo = "" }
             )
 
-            SharedCoordinatesMapAction(
-                latitude = syncedSharedLatitude,
-                longitude = syncedSharedLongitude,
-                enabled = !loading,
-                onOpenFailure = { mapActionInfo = it },
-                onOpenSuccess = { mapActionInfo = "" }
-            )
-
-            AppToggleSwitch(
-                checked = shareLocation,
-                onCheckedChange = { shareEnabled ->
-                    if (!shareEnabled) {
-                        shareLocation = false
-                        return@AppToggleSwitch
-                    }
-
-                    if (DeviceLocationProvider.hasLocationPermission(context)) {
-                        shareLocation = true
-                    } else {
-                        locationPermissionLauncher.launch(DeviceLocationProvider.RequiredLocationPermissions)
-                    }
-                },
-                label = "Share Current Location"
-            )
-
             if (mapPickerOpen) {
                 MapPickerDialog(
-                    initialLatitude = mapPickerSelection?.latitude ?: syncedSharedLatitude,
-                    initialLongitude = mapPickerSelection?.longitude ?: syncedSharedLongitude,
+                    title = "Select Home Location on Map",
+                    initialLatitude = mapPickerSelection?.latitude,
+                    initialLongitude = mapPickerSelection?.longitude,
                     loading = mapPickerLoading,
                     onDismiss = { if (!mapPickerLoading) mapPickerOpen = false },
                     onConfirm = ::handleMapSelection

--- a/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
@@ -1,7 +1,5 @@
 package com.neph.features.profile.presentation
 
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,17 +15,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import com.neph.core.network.ApiException
 import com.neph.features.auth.util.countryCodeOptions
-import com.neph.features.profile.data.CurrentLocationShareWarning
-import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.features.profile.data.LocationData
 import com.neph.features.profile.data.LocationTreeRepository
 import com.neph.features.profile.data.ProfileData
 import com.neph.features.profile.data.ProfileRepository
-import com.neph.features.profile.data.ProfileRepository.LocationSharingInitializationRequiredException
 import com.neph.features.profile.data.bloodTypeOptions
 import com.neph.features.profile.data.calculateAgeFromDateOfBirth
 import com.neph.features.profile.data.combinePhoneNumber
@@ -52,13 +46,10 @@ import com.neph.ui.components.inputs.AppDropdown
 import com.neph.ui.components.inputs.AppTextArea
 import com.neph.ui.components.inputs.AppTextField
 import com.neph.ui.components.selection.AppCheckbox
-import com.neph.ui.components.selection.AppToggleSwitch
 import com.neph.ui.layout.AppScaffold
 import com.neph.ui.map.MapPickerDialog
 import com.neph.ui.map.MapPickerSelection
 import com.neph.ui.map.LocationSelectionMapAction
-import com.neph.ui.map.SharedCoordinatesMapAction
-import com.neph.ui.map.formatMapCoordinate
 import com.neph.ui.map.resolveMapPickerLocationUpdate
 import com.neph.ui.theme.LocalNephSpacing
 import kotlinx.coroutines.CancellationException
@@ -104,29 +95,13 @@ fun EditProfileScreen(
     var availableLocationData by remember { mutableStateOf<LocationData>(locationData) }
     var locationLoading by remember { mutableStateOf(true) }
     var locationInfo by rememberSaveable { mutableStateOf("") }
-    var syncedSharedLatitude by remember { mutableStateOf(profile.sharedLatitude) }
-    var syncedSharedLongitude by remember { mutableStateOf(profile.sharedLongitude) }
 
     val scope = rememberCoroutineScope()
     val spacing = LocalNephSpacing.current
-    val context = LocalContext.current
-    val locationPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestMultiplePermissions()
-    ) { grants ->
-        if (grants.values.any { it }) {
-            profile = profile.copy(shareLocation = true)
-            info = "Location permission granted. Current location will be shared when you save."
-        } else {
-            profile = profile.copy(shareLocation = false)
-            info = "Location permission denied. Current location sharing remains off."
-        }
-    }
 
     LaunchedEffect(Unit) {
         try {
             profile = ProfileRepository.fetchAndCacheRemoteProfile()
-            syncedSharedLatitude = profile.sharedLatitude
-            syncedSharedLongitude = profile.sharedLongitude
             val phoneParts = normalizePhoneParts(profile.phone)
             countryCode = phoneParts.countryCode
             phone = phoneParts.phone
@@ -139,8 +114,6 @@ fun EditProfileScreen(
             throw cancellationException
         } catch (_: ApiException) {
             profile = ProfileRepository.getProfile()
-            syncedSharedLatitude = profile.sharedLatitude
-            syncedSharedLongitude = profile.sharedLongitude
             val phoneParts = normalizePhoneParts(profile.phone)
             countryCode = phoneParts.countryCode
             phone = phoneParts.phone
@@ -151,8 +124,6 @@ fun EditProfileScreen(
             dateOfBirthText = profile.dateOfBirth.orEmpty()
         } catch (_: Exception) {
             profile = ProfileRepository.getProfile()
-            syncedSharedLatitude = profile.sharedLatitude
-            syncedSharedLongitude = profile.sharedLongitude
             val phoneParts = normalizePhoneParts(profile.phone)
             countryCode = phoneParts.countryCode
             phone = phoneParts.phone
@@ -283,23 +254,9 @@ fun EditProfileScreen(
                     dateOfBirth = normalizedDateOfBirth,
                     age = ageInt
                 )
-                val locationShareAttempt = DeviceLocationProvider.captureCurrentLocationForSharing(
-                    context = context,
-                    sharingEnabled = profileToSync.shareLocation == true
-                )
-                val profileWithSharePolicy = when (locationShareAttempt.warning) {
-                    CurrentLocationShareWarning.PERMISSION_DENIED -> profileToSync.copy(shareLocation = false)
-                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE -> profileToSync
-                    null -> profileToSync
-                }
-
                 profile = ProfileRepository.syncProfile(
-                    profile = profileWithSharePolicy,
-                    currentDeviceLocation = locationShareAttempt.location,
-                    forceClearSharedCoordinates = locationShareAttempt.warning == CurrentLocationShareWarning.LOCATION_UNAVAILABLE
+                    profile = profileToSync
                 )
-                syncedSharedLatitude = profile.sharedLatitude
-                syncedSharedLongitude = profile.sharedLongitude
 
                 val phoneParts = normalizePhoneParts(profile.phone)
                 countryCode = phoneParts.countryCode
@@ -309,24 +266,8 @@ fun EditProfileScreen(
                 heightText = profile.height.toEditableString()
                 weightText = profile.weight.toEditableString()
                 dateOfBirthText = profile.dateOfBirth.orEmpty()
-                info = when (locationShareAttempt.warning) {
-                    CurrentLocationShareWarning.PERMISSION_DENIED ->
-                        "Profile updated successfully. Location permission is denied, so location sharing was turned off and stored coordinates were cleared."
-
-                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE ->
-                        "Profile updated successfully. Current location is unavailable, so sharing remains on and stale coordinates were cleared."
-
-                    null -> {
-                        if (locationShareAttempt.location != null) {
-                            "Profile updated successfully. Current location shared."
-                        } else {
-                            "Profile updated successfully."
-                        }
-                    }
-                }
+                info = "Profile updated successfully."
                 onSave(profile)
-            } catch (guardError: LocationSharingInitializationRequiredException) {
-                error = guardError.message ?: "To enable Share Current Location, save a valid current location first."
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (errorResponse: ApiException) {
@@ -504,7 +445,10 @@ fun EditProfileScreen(
 
             SectionCard {
                 Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
-                    SectionHeader(title = "Location")
+                    SectionHeader(
+                        title = "Residential Location",
+                        subtitle = "This is your home/neighborhood location. It is not automatically updated by GPS."
+                    )
 
                     if (locationLoading) {
                         HelperText(text = "Loading location options...")
@@ -536,16 +480,10 @@ fun EditProfileScreen(
                     )
 
                     SecondaryButton(
-                        text = "Select Location on Map",
+                        text = "Select Home Location on Map",
                         onClick = { mapPickerOpen = true },
                         enabled = !locationLoading && !loading
                     )
-
-                    mapPickerSelection?.let { selection ->
-                        HelperText(
-                            text = "Selected coordinates: ${formatMapCoordinate(selection.latitude)}, ${formatMapCoordinate(selection.longitude)}"
-                        )
-                    }
 
                     AppTextField(
                         value = profile.extraAddress.orEmpty(),
@@ -565,35 +503,11 @@ fun EditProfileScreen(
                         onOpenSuccess = { mapActionInfo = "" }
                     )
 
-                    SharedCoordinatesMapAction(
-                        latitude = syncedSharedLatitude,
-                        longitude = syncedSharedLongitude,
-                        enabled = !loading,
-                        onOpenFailure = { mapActionInfo = it },
-                        onOpenSuccess = { mapActionInfo = "" }
-                    )
-
-                    AppToggleSwitch(
-                        checked = profile.shareLocation ?: false,
-                        onCheckedChange = { shareEnabled ->
-                            if (!shareEnabled) {
-                                profile = profile.copy(shareLocation = false)
-                                return@AppToggleSwitch
-                            }
-
-                            if (DeviceLocationProvider.hasLocationPermission(context)) {
-                                profile = profile.copy(shareLocation = true)
-                            } else {
-                                locationPermissionLauncher.launch(DeviceLocationProvider.RequiredLocationPermissions)
-                            }
-                        },
-                        label = "Share Current Location"
-                    )
-
                     if (mapPickerOpen) {
                         MapPickerDialog(
-                            initialLatitude = mapPickerSelection?.latitude ?: syncedSharedLatitude,
-                            initialLongitude = mapPickerSelection?.longitude ?: syncedSharedLongitude,
+                            title = "Select Home Location on Map",
+                            initialLatitude = mapPickerSelection?.latitude,
+                            initialLongitude = mapPickerSelection?.longitude,
                             loading = mapPickerLoading,
                             onDismiss = { if (!mapPickerLoading) mapPickerOpen = false },
                             onConfirm = ::handleMapSelection

--- a/android/app/src/main/java/com/neph/features/profile/presentation/components/LocationSelector.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/components/LocationSelector.kt
@@ -47,7 +47,7 @@ fun LocationSelector(
 
     AppDropdown(
         value = country,
-        onValueChange = { onCountryChange(it); onCityChange(""); onDistrictChange(""); onNeighborhoodChange("") },
+        onValueChange = onCountryChange,
         label = "Country",
         options = listOf(DropdownOption("Select Country", "")) + countryOptions,
         enabled = enabled,
@@ -59,7 +59,7 @@ fun LocationSelector(
 
     AppDropdown(
         value = city,
-        onValueChange = { onCityChange(it); onDistrictChange(""); onNeighborhoodChange("") },
+        onValueChange = onCityChange,
         label = "City",
         options = listOf(DropdownOption("Select City", "")) + cityOptions,
         enabled = enabled && country.isNotEmpty(),
@@ -71,7 +71,7 @@ fun LocationSelector(
 
     AppDropdown(
         value = district,
-        onValueChange = { onDistrictChange(it); onNeighborhoodChange("") },
+        onValueChange = onDistrictChange,
         label = "District",
         options = listOf(DropdownOption("Select District", "")) + districtOptions,
         enabled = enabled && city.isNotEmpty(),

--- a/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
+++ b/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
@@ -52,15 +52,8 @@ fun MapPickerDialog(
     onConfirm: (MapPickerSelection) -> Unit
 ) {
     val spacing = LocalNephSpacing.current
-    val initialSelection = remember(initialLatitude, initialLongitude) {
-        if (initialLatitude != null && initialLongitude != null) {
-            MapPickerSelection(initialLatitude, initialLongitude)
-        } else {
-            null
-        }
-    }
     var selection by remember(initialLatitude, initialLongitude) {
-        mutableStateOf(initialSelection)
+        mutableStateOf<MapPickerSelection?>(null)
     }
     var mapReady by remember { mutableStateOf(false) }
     var mapError by remember { mutableStateOf("") }
@@ -83,7 +76,7 @@ fun MapPickerDialog(
                     color = MaterialTheme.colorScheme.onSurface
                 )
 
-                HelperText(text = "Tap on the map to place a pin.")
+                HelperText(text = "Tap on the map to place a pin, then confirm the selection.")
 
                 MapPickerMap(
                     initialLatitude = initialLatitude,
@@ -324,10 +317,6 @@ private fun buildMapHtml(initialLatitude: Double?, initialLongitude: Double?): S
                             fillOpacity: 0.85
                         }).addTo(map);
                     }
-                }
-
-                if (${hasInitial.toString()}) {
-                    setMarker($formattedLat, $formattedLon);
                 }
 
                 map.on('click', function(e) {


### PR DESCRIPTION
## Summary
- Makes `LocationSelector` stateless so dependent dropdown resets are handled only by parent screens.
- Separates residential profile location from current/shared GPS location in Complete Profile and Edit Profile.
- Updates profile location UI copy to clarify home/neighborhood semantics.
- Prevents profile save from implicitly capturing current GPS.
- Updates map picker so opening the map only centers it; users must place and confirm a pin before fields update.

## Verification
- `./gradlew :app:compileDebugKotlin -x processDebugNavigationResources`
- `./gradlew :app:assembleDebug`

Closes [#429](https://github.com/bounswe/bounswe2026group6/issues/429)