### PR TITLE
fix: contextual location permission ux

### DIFF
--- a/android/app/src/main/java/com/neph/MainActivity.kt
+++ b/android/app/src/main/java/com/neph/MainActivity.kt
@@ -10,21 +10,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.rememberNavController
 import com.neph.core.NephAppContext
 import com.neph.core.database.NephDatabaseProvider
 import com.neph.core.sync.OfflineSyncScheduler
 import com.neph.features.availability.data.AvailabilityRepository
 import com.neph.features.auth.data.AuthSessionStore
-import com.neph.features.profile.data.AppLaunchLocationUpdater
 import com.neph.features.profile.data.ProfileRepository
 import com.neph.features.notifications.data.PushTokenSync
 import com.neph.features.requesthelp.data.RequestHelpRepository
 import com.neph.navigation.AppNavGraph
 import com.neph.navigation.Routes
 import com.neph.ui.theme.NephTheme
-import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,9 +36,6 @@ class MainActivity : ComponentActivity() {
         PushTokenSync.syncCurrentToken()
         OfflineSyncScheduler.schedulePeriodicSync(applicationContext)
         OfflineSyncScheduler.enqueueSync(applicationContext, reason = "app-start")
-        lifecycleScope.launch {
-            AppLaunchLocationUpdater.updateOnAppLaunch(applicationContext)
-        }
         setContent {
             NephApp()
         }

--- a/android/app/src/main/java/com/neph/features/availability/data/AvailabilityRepository.kt
+++ b/android/app/src/main/java/com/neph/features/availability/data/AvailabilityRepository.kt
@@ -12,6 +12,7 @@ import com.neph.core.sync.OfflineSyncScheduler
 import com.neph.core.sync.SyncEntityType
 import com.neph.core.sync.SyncOperationType
 import com.neph.core.sync.SyncStatus
+import com.neph.features.profile.data.CurrentDeviceLocation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -140,7 +141,8 @@ object AvailabilityRepository {
 
     suspend fun setAvailability(
         isAvailable: Boolean,
-        token: String?
+        token: String?,
+        currentDeviceLocation: CurrentDeviceLocation? = null
     ): AvailabilityState {
         ensureInitialized()
         val now = System.currentTimeMillis()
@@ -158,10 +160,11 @@ object AvailabilityRepository {
                 entityType = SyncEntityType.AVAILABILITY,
                 entityId = AvailabilityEntity.CURRENT_KEY,
                 operationType = SyncOperationType.SET_AVAILABILITY,
-                payloadJson = JSONObject()
-                    .put("isAvailable", isAvailable)
-                    .put("timestamp", now)
-                    .toString(),
+                payloadJson = buildAvailabilityOperationPayload(
+                    isAvailable = isAvailable,
+                    timestamp = now,
+                    currentDeviceLocation = currentDeviceLocation.takeIf { isAvailable }
+                ).toString(),
                 createdAtEpochMillis = now
             )
         )
@@ -210,9 +213,7 @@ object AvailabilityRepository {
             operations.sortedBy { it.createdAtEpochMillis }.forEach { operation ->
                 val payload = JSONObject(operation.payloadJson)
                 put(
-                    JSONObject()
-                        .put("isAvailable", payload.optBoolean("isAvailable"))
-                        .put("timestamp", payload.optLong("timestamp").toIsoLikeString())
+                    buildAvailabilitySyncRecord(payload)
                 )
             }
         }
@@ -314,6 +315,46 @@ object AvailabilityRepository {
         val formatter = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.US)
         formatter.timeZone = java.util.TimeZone.getTimeZone("UTC")
         return formatter.format(java.util.Date(this))
+    }
+
+    internal fun buildAvailabilityOperationPayload(
+        isAvailable: Boolean,
+        timestamp: Long,
+        currentDeviceLocation: CurrentDeviceLocation? = null
+    ): JSONObject {
+        return JSONObject()
+            .put("isAvailable", isAvailable)
+            .put("timestamp", timestamp)
+            .apply {
+                if (currentDeviceLocation != null) {
+                    put("latitude", currentDeviceLocation.latitude)
+                    put("longitude", currentDeviceLocation.longitude)
+                    put("accuracyMeters", currentDeviceLocation.accuracyMeters)
+                    put("locationSource", currentDeviceLocation.source)
+                    put("locationCapturedAt", currentDeviceLocation.capturedAt)
+                }
+            }
+    }
+
+    internal fun buildAvailabilitySyncRecord(payload: JSONObject): JSONObject {
+        return JSONObject()
+            .put("isAvailable", payload.optBoolean("isAvailable"))
+            .put("timestamp", payload.optLong("timestamp").toIsoLikeString())
+            .apply {
+                if (payload.has("latitude") && payload.has("longitude")) {
+                    put("latitude", payload.getDouble("latitude"))
+                    put("longitude", payload.getDouble("longitude"))
+                    if (payload.has("accuracyMeters") && !payload.isNull("accuracyMeters")) {
+                        put("accuracyMeters", payload.getDouble("accuracyMeters"))
+                    }
+                    if (payload.has("locationSource") && !payload.isNull("locationSource")) {
+                        put("locationSource", payload.getString("locationSource"))
+                    }
+                    if (payload.has("locationCapturedAt") && !payload.isNull("locationCapturedAt")) {
+                        put("locationCapturedAt", payload.getString("locationCapturedAt"))
+                    }
+                }
+            }
     }
 
     private fun ensureInitialized() {

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -1,7 +1,5 @@
 package com.neph.features.gatheringareas.presentation
 
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -36,6 +34,7 @@ import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
 import com.neph.ui.layout.AppDrawerScaffold
+import com.neph.ui.location.rememberForegroundLocationPermissionRequester
 import com.neph.ui.map.NephMapIntegration
 import com.neph.ui.map.formatMapCoordinate
 import com.neph.ui.theme.LocalNephSpacing
@@ -158,10 +157,8 @@ fun GatheringAreasScreen(
         }
     }
 
-    val locationPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestMultiplePermissions()
-    ) { grants ->
-        if (grants.values.any { it }) {
+    val locationPermissionRequester = rememberForegroundLocationPermissionRequester { result ->
+        if (result.granted) {
             requestCurrentLocationAndRefresh()
         } else {
             errorMessage = ""
@@ -218,10 +215,10 @@ fun GatheringAreasScreen(
                     SecondaryButton(
                         text = "Use Current Location",
                         onClick = {
-                            if (DeviceLocationProvider.hasLocationPermission(context)) {
+                            if (locationPermissionRequester.refreshPermissionState()) {
                                 requestCurrentLocationAndRefresh()
                             } else {
-                                locationPermissionLauncher.launch(DeviceLocationProvider.RequiredLocationPermissions)
+                                locationPermissionRequester.requestPermission()
                             }
                         },
                         enabled = !loading

--- a/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
+++ b/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.neph.features.home.presentation
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -28,6 +29,7 @@ import com.neph.features.availability.data.AvailabilityAccessPolicy
 import com.neph.features.availability.data.AvailabilityRepository
 import com.neph.features.availability.presentation.AvailableToHelpCard
 import com.neph.features.availability.presentation.AvailabilitySyncIndicator
+import com.neph.features.profile.data.CurrentLocationShareWarning
 import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.features.profile.data.ProfileRepository
 import com.neph.features.requesthelp.data.EmergencyDraftRequirementsException
@@ -39,6 +41,7 @@ import com.neph.ui.components.buttons.SecondaryButton
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
 import com.neph.ui.layout.AppDrawerScaffold
+import com.neph.ui.location.rememberForegroundLocationPermissionRequester
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
 import kotlinx.coroutines.CancellationException
@@ -75,8 +78,20 @@ fun HomeScreen(
     var showMarkSafeLocationConsentDialog by remember { mutableStateOf(false) }
     var emergencyInfo by remember { mutableStateOf("") }
     var emergencyError by remember { mutableStateOf("") }
+    var locationPermissionInfo by remember { mutableStateOf("") }
+    var locationPermissionGranted by remember {
+        mutableStateOf(DeviceLocationProvider.hasLocationPermission(context))
+    }
+    var pendingLocationPermissionAction by remember { mutableStateOf<((Boolean) -> Unit)?>(null) }
 
-    fun handleAvailabilityChange(nextValue: Boolean) {
+    val locationPermissionRequester = rememberForegroundLocationPermissionRequester { result ->
+        locationPermissionGranted = result.granted
+        val action = pendingLocationPermissionAction
+        pendingLocationPermissionAction = null
+        action?.invoke(result.granted)
+    }
+
+    fun syncAvailabilityChange(nextValue: Boolean) {
         availabilityError = ""
         availabilityInfo = ""
         availabilitySyncIndicator = AvailabilitySyncIndicator.NONE
@@ -123,6 +138,80 @@ fun HomeScreen(
             } finally {
                 availabilityLoading = false
             }
+        }
+    }
+
+    fun enableAvailabilityWithCurrentLocation() {
+        availabilityError = ""
+        availabilityInfo = ""
+        availabilitySyncIndicator = AvailabilitySyncIndicator.NONE
+        availabilityLoading = true
+
+        scope.launch {
+            try {
+                val locationAttempt = DeviceLocationProvider.captureCurrentLocationForSharing(
+                    context = context,
+                    sharingEnabled = true
+                )
+                if (locationAttempt.location == null) {
+                    availabilityError = when (locationAttempt.warning) {
+                        CurrentLocationShareWarning.PERMISSION_DENIED ->
+                            "Location permission is required before you can become available to help."
+
+                        CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
+                        null -> "Current location is unavailable. Availability was not enabled."
+                    }
+                    availabilitySyncIndicator = AvailabilitySyncIndicator.FAILED
+                    availabilityLoading = false
+                    return@launch
+                }
+
+                availabilityLoading = false
+                syncAvailabilityChange(true)
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                availabilityError = "Current location is unavailable. Availability was not enabled."
+                availabilitySyncIndicator = AvailabilitySyncIndicator.FAILED
+                availabilityLoading = false
+            }
+        }
+    }
+
+    fun handleAvailabilityChange(nextValue: Boolean) {
+        if (!nextValue) {
+            syncAvailabilityChange(false)
+            return
+        }
+
+        availabilityError = ""
+        availabilityInfo = ""
+        availabilitySyncIndicator = AvailabilitySyncIndicator.NONE
+
+        if (!AvailabilityAccessPolicy.canAccess(sessionToken)) {
+            availabilityError = "Please log in to manage your availability."
+            availabilitySyncIndicator = AvailabilitySyncIndicator.FAILED
+            if (AvailabilityAccessPolicy.shouldRedirectToLogin()) {
+                onNavigateToLogin()
+            }
+            return
+        }
+
+        pendingLocationPermissionAction = { granted ->
+            if (granted) {
+                enableAvailabilityWithCurrentLocation()
+            } else {
+                availabilityError = "Location permission is required before you can become available to help."
+                availabilitySyncIndicator = AvailabilitySyncIndicator.FAILED
+            }
+        }
+
+        if (locationPermissionRequester.refreshPermissionState()) {
+            val action = pendingLocationPermissionAction
+            pendingLocationPermissionAction = null
+            action?.invoke(true)
+        } else {
+            locationPermissionRequester.requestPermission()
         }
     }
 
@@ -207,7 +296,10 @@ fun HomeScreen(
         showMarkSafeLocationConsentDialog = true
     }
 
-    fun handleMarkSafe(shareLocation: Boolean) {
+    fun handleMarkSafeWithOptionalLocation(
+        shareLocation: Boolean,
+        permissionDeniedBeforeCapture: Boolean = false
+    ) {
         val safeSessionToken = sessionToken
         if (!isAuthenticated || safeSessionToken.isNullOrBlank()) {
             showMarkSafeLocationConsentDialog = false
@@ -220,7 +312,7 @@ fun HomeScreen(
         markSafeLoading = true
         scope.launch {
             try {
-                val locationAttempt = if (shareLocation) {
+                val locationAttempt = if (shareLocation && !permissionDeniedBeforeCapture) {
                     DeviceLocationProvider.captureCurrentLocationForSharing(
                         context = context,
                         sharingEnabled = true
@@ -236,8 +328,12 @@ fun HomeScreen(
                 )
                 emergencyInfo = if (sharedLocation != null) {
                     "You are marked safe. Your current location was shared with your safety status."
+                } else if (shareLocation && permissionDeniedBeforeCapture) {
+                    "You are marked safe. Location was not shared because permission was denied."
+                } else if (shareLocation && locationAttempt?.warning == CurrentLocationShareWarning.PERMISSION_DENIED) {
+                    "You are marked safe. Location was not shared because permission was denied."
                 } else if (shareLocation) {
-                    "You are marked safe. Location was not shared because permission or location was unavailable."
+                    "You are marked safe. Location was not shared because current location was unavailable."
                 } else {
                     "You are marked safe. Your location was not shared."
                 }
@@ -256,6 +352,28 @@ fun HomeScreen(
             } finally {
                 markSafeLoading = false
             }
+        }
+    }
+
+    fun handleMarkSafe(shareLocation: Boolean) {
+        if (!shareLocation) {
+            handleMarkSafeWithOptionalLocation(shareLocation = false)
+            return
+        }
+
+        pendingLocationPermissionAction = { granted ->
+            handleMarkSafeWithOptionalLocation(
+                shareLocation = true,
+                permissionDeniedBeforeCapture = !granted
+            )
+        }
+
+        if (locationPermissionRequester.refreshPermissionState()) {
+            val action = pendingLocationPermissionAction
+            pendingLocationPermissionAction = null
+            action?.invoke(true)
+        } else {
+            locationPermissionRequester.requestPermission()
         }
     }
 
@@ -305,6 +423,39 @@ fun HomeScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(spacing.md)
         ) {
+            if (!locationPermissionGranted) {
+                SectionCard(
+                    modifier = Modifier.clickable {
+                        pendingLocationPermissionAction = { granted ->
+                            locationPermissionGranted = granted
+                            locationPermissionInfo = if (granted) {
+                                ""
+                            } else {
+                                "Location permission was not enabled. You can still use NEPH with manual location entry."
+                            }
+                        }
+                        locationPermissionRequester.requestPermission()
+                    }
+                ) {
+                    Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                        SectionHeader(
+                            title = "Enable location for faster emergency actions",
+                            subtitle = "Allow NEPH to use your location while the app is open so Request Help and volunteer matching can work faster."
+                        )
+                    }
+                }
+            }
+
+            if (locationPermissionInfo.isNotBlank()) {
+                Text(
+                    text = locationPermissionInfo,
+                    modifier = Modifier.fillMaxWidth(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
+            }
+
             if (isAuthenticated) {
                 AvailableToHelpCard(
                     isAvailable = availabilityState.isAvailable,

--- a/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
+++ b/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.collectAsState
@@ -19,9 +20,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import com.neph.core.network.ApiException
 import com.neph.features.auth.data.AuthRepository
 import com.neph.features.auth.data.AuthSessionStore
@@ -29,6 +33,7 @@ import com.neph.features.availability.data.AvailabilityAccessPolicy
 import com.neph.features.availability.data.AvailabilityRepository
 import com.neph.features.availability.presentation.AvailableToHelpCard
 import com.neph.features.availability.presentation.AvailabilitySyncIndicator
+import com.neph.features.profile.data.CurrentDeviceLocation
 import com.neph.features.profile.data.CurrentLocationShareWarning
 import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.features.profile.data.ProfileRepository
@@ -91,7 +96,24 @@ fun HomeScreen(
         action?.invoke(result.granted)
     }
 
-    fun syncAvailabilityChange(nextValue: Boolean) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner, context) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                locationPermissionGranted = DeviceLocationProvider.hasLocationPermission(context)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    fun syncAvailabilityChange(
+        nextValue: Boolean,
+        currentDeviceLocation: CurrentDeviceLocation? = null
+    ) {
         availabilityError = ""
         availabilityInfo = ""
         availabilitySyncIndicator = AvailabilitySyncIndicator.NONE
@@ -113,7 +135,8 @@ fun HomeScreen(
                 availabilitySyncIndicator = AvailabilitySyncIndicator.SYNCING
                 AvailabilityRepository.setAvailability(
                     isAvailable = nextValue,
-                    token = sessionToken
+                    token = sessionToken,
+                    currentDeviceLocation = currentDeviceLocation
                 )
                 AvailabilityRepository.syncPendingAvailabilityNow(sessionToken)
                 availabilitySyncIndicator = AvailabilitySyncIndicator.SYNCED
@@ -167,7 +190,10 @@ fun HomeScreen(
                 }
 
                 availabilityLoading = false
-                syncAvailabilityChange(true)
+                syncAvailabilityChange(
+                    nextValue = true,
+                    currentDeviceLocation = locationAttempt.location
+                )
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (_: Exception) {

--- a/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
@@ -15,9 +15,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import com.neph.core.network.ApiException
 import com.neph.features.auth.util.countryCodeOptions
+import com.neph.features.profile.data.CurrentLocationShareWarning
+import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.features.profile.data.LocationData
 import com.neph.features.profile.data.LocationTreeRepository
 import com.neph.features.profile.data.ProfileData
@@ -47,6 +50,7 @@ import com.neph.ui.components.inputs.AppTextArea
 import com.neph.ui.components.inputs.AppTextField
 import com.neph.ui.components.selection.AppCheckbox
 import com.neph.ui.layout.AppScaffold
+import com.neph.ui.location.rememberForegroundLocationPermissionRequester
 import com.neph.ui.map.MapPickerDialog
 import com.neph.ui.map.MapPickerSelection
 import com.neph.ui.map.LocationSelectionMapAction
@@ -83,6 +87,10 @@ fun EditProfileScreen(
     var mapActionInfo by rememberSaveable { mutableStateOf("") }
     var mapPickerOpen by rememberSaveable { mutableStateOf(false) }
     var mapPickerLoading by rememberSaveable { mutableStateOf(false) }
+    var mapCenterLoading by rememberSaveable { mutableStateOf(false) }
+    var mapCenterInfo by rememberSaveable { mutableStateOf("") }
+    var mapCenterLatitude by rememberSaveable { mutableStateOf<Double?>(null) }
+    var mapCenterLongitude by rememberSaveable { mutableStateOf<Double?>(null) }
     var mapPickerSelection by remember { mutableStateOf<MapPickerSelection?>(null) }
 
     var countryCode by rememberSaveable { mutableStateOf(initialPhoneParts.countryCode) }
@@ -98,6 +106,7 @@ fun EditProfileScreen(
 
     val scope = rememberCoroutineScope()
     val spacing = LocalNephSpacing.current
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         try {
@@ -195,6 +204,51 @@ fun EditProfileScreen(
                 mapPickerLoading = false
                 mapPickerOpen = false
             }
+        }
+    }
+
+    fun centerProfileMapOnCurrentLocation() {
+        if (mapCenterLoading) return
+
+        mapCenterLoading = true
+        mapCenterInfo = ""
+
+        scope.launch {
+            try {
+                val attempt = DeviceLocationProvider.captureCurrentLocationForSharing(
+                    context = context,
+                    sharingEnabled = true
+                )
+                val location = attempt.location
+                if (location == null) {
+                    mapCenterInfo = when (attempt.warning) {
+                        CurrentLocationShareWarning.PERMISSION_DENIED ->
+                            "Location permission is denied. The map was not centered."
+
+                        CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
+                        null -> "Current location is unavailable. The map was not centered."
+                    }
+                    return@launch
+                }
+
+                mapCenterLatitude = location.latitude
+                mapCenterLongitude = location.longitude
+                mapCenterInfo = "Map centered on your current location. Choose a point to update your residential location."
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                mapCenterInfo = "Current location is unavailable. The map was not centered."
+            } finally {
+                mapCenterLoading = false
+            }
+        }
+    }
+
+    val mapLocationPermissionRequester = rememberForegroundLocationPermissionRequester { result ->
+        if (result.granted) {
+            centerProfileMapOnCurrentLocation()
+        } else {
+            mapCenterInfo = "Location permission is denied. The map was not centered."
         }
     }
 
@@ -508,9 +562,21 @@ fun EditProfileScreen(
                             title = "Select Home Location on Map",
                             initialLatitude = mapPickerSelection?.latitude,
                             initialLongitude = mapPickerSelection?.longitude,
+                            centerLatitude = mapCenterLatitude,
+                            centerLongitude = mapCenterLongitude,
+                            showCenterOnCurrentLocation = true,
+                            centerActionLoading = mapCenterLoading,
+                            centerActionMessage = mapCenterInfo,
                             loading = mapPickerLoading,
                             onDismiss = { if (!mapPickerLoading) mapPickerOpen = false },
-                            onConfirm = ::handleMapSelection
+                            onConfirm = ::handleMapSelection,
+                            onCenterOnCurrentLocation = {
+                                if (mapLocationPermissionRequester.refreshPermissionState()) {
+                                    centerProfileMapOnCurrentLocation()
+                                } else {
+                                    mapLocationPermissionRequester.requestPermission()
+                                }
+                            }
                         )
                     }
                 }

--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -1,7 +1,5 @@
 package com.neph.features.requesthelp.presentation
 
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -75,6 +73,7 @@ import com.neph.ui.components.inputs.AppTextField
 import com.neph.ui.components.selection.AppCheckbox
 import com.neph.ui.components.selection.AppMultiSelectChipGroup
 import com.neph.ui.layout.AppScaffold
+import com.neph.ui.location.rememberForegroundLocationPermissionRequester
 import com.neph.ui.map.MapPickerDialog
 import com.neph.ui.map.MapPickerSelection
 import com.neph.ui.map.LocationSelectionMapAction
@@ -452,9 +451,7 @@ fun RequestHelpScreen(
     var mapPickerLoading by rememberSaveable { mutableStateOf(false) }
     var mapPickerSelection by remember { mutableStateOf<MapPickerSelection?>(null) }
     var checkingActiveRequest by remember { mutableStateOf(isLoggedIn) }
-    var guestLocationAutoFillLoading by remember { mutableStateOf(false) }
-    var guestLocationPermissionHandled by rememberSaveable { mutableStateOf(false) }
-    val guestFormInteractionStarted = !isLoggedIn && formState != RequestHelpFormState()
+    var currentLocationLoading by remember { mutableStateOf(false) }
 
     LaunchedEffect(draftLocalId) {
         val nextDraftLocalId = draftLocalId.orEmpty()
@@ -468,10 +465,10 @@ fun RequestHelpScreen(
         }
     }
 
-    fun triggerGuestLocationAutofill() {
+    fun applyCurrentLocationToForm() {
         scope.launch {
-            if (guestLocationAutoFillLoading) return@launch
-            guestLocationAutoFillLoading = true
+            if (currentLocationLoading) return@launch
+            currentLocationLoading = true
             try {
                 val attempt = DeviceLocationProvider.captureCurrentLocationForSharing(
                     context = context,
@@ -527,7 +524,7 @@ fun RequestHelpScreen(
             } catch (_: Exception) {
                 infoMessage = "Could not retrieve your current location. You can continue with manual location entry."
             } finally {
-                guestLocationAutoFillLoading = false
+                currentLocationLoading = false
             }
         }
     }
@@ -580,11 +577,9 @@ fun RequestHelpScreen(
         }
     }
 
-    val locationPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestMultiplePermissions()
-    ) { grants ->
-        if (grants.values.any { it }) {
-            triggerGuestLocationAutofill()
+    val locationPermissionRequester = rememberForegroundLocationPermissionRequester { result ->
+        if (result.granted) {
+            applyCurrentLocationToForm()
         } else {
             infoMessage = "Location permission is denied. You can continue with manual location entry."
         }
@@ -651,21 +646,6 @@ fun RequestHelpScreen(
         } finally {
             checkingActiveRequest = false
         }
-    }
-
-    LaunchedEffect(isLoggedIn, guestFormInteractionStarted, guestLocationPermissionHandled) {
-        if (isLoggedIn || guestLocationPermissionHandled || !guestFormInteractionStarted) {
-            return@LaunchedEffect
-        }
-
-        guestLocationPermissionHandled = true
-
-        if (DeviceLocationProvider.hasLocationPermission(context)) {
-            triggerGuestLocationAutofill()
-            return@LaunchedEffect
-        }
-
-        locationPermissionLauncher.launch(DeviceLocationProvider.RequiredLocationPermissions)
     }
 
     fun handleSubmit() {
@@ -846,23 +826,21 @@ fun RequestHelpScreen(
                         HelperText(text = "Loading location options...")
                     }
 
-                    if (!isLoggedIn && guestLocationAutoFillLoading) {
+                    if (currentLocationLoading) {
                         HelperText(text = "Detecting your current location. You can continue filling the form while this runs.")
                     }
 
-                    if (!isLoggedIn) {
-                        SecondaryButton(
-                            text = "Use Current Location",
-                            onClick = {
-                                if (DeviceLocationProvider.hasLocationPermission(context)) {
-                                    triggerGuestLocationAutofill()
-                                } else {
-                                    locationPermissionLauncher.launch(DeviceLocationProvider.RequiredLocationPermissions)
-                                }
-                            },
-                            enabled = !guestLocationAutoFillLoading
-                        )
-                    }
+                    SecondaryButton(
+                        text = "Use Current Location",
+                        onClick = {
+                            if (locationPermissionRequester.refreshPermissionState()) {
+                                applyCurrentLocationToForm()
+                            } else {
+                                locationPermissionRequester.requestPermission()
+                            }
+                        },
+                        enabled = !currentLocationLoading
+                    )
 
                     LocationSelector(
                         country = formState.country,

--- a/android/app/src/main/java/com/neph/ui/location/ForegroundLocationPermissionRequester.kt
+++ b/android/app/src/main/java/com/neph/ui/location/ForegroundLocationPermissionRequester.kt
@@ -1,0 +1,69 @@
+package com.neph.ui.location
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import com.neph.features.profile.data.DeviceLocationProvider
+
+data class ForegroundLocationPermissionResult(
+    val granted: Boolean
+)
+
+@Stable
+class ForegroundLocationPermissionRequester internal constructor(
+    val isGranted: Boolean,
+    private val onRequest: () -> Unit,
+    private val onRefresh: () -> Boolean
+) {
+    fun requestPermission() {
+        onRequest()
+    }
+
+    fun refreshPermissionState(): Boolean {
+        return onRefresh()
+    }
+}
+
+@Composable
+fun rememberForegroundLocationPermissionRequester(
+    onPermissionResult: (ForegroundLocationPermissionResult) -> Unit
+): ForegroundLocationPermissionRequester {
+    val context = LocalContext.current
+    val latestOnPermissionResult by rememberUpdatedState(onPermissionResult)
+    var isGranted by remember {
+        mutableStateOf(DeviceLocationProvider.hasLocationPermission(context))
+    }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { grants ->
+        val granted = DeviceLocationProvider.hasLocationPermission(context) || grants.values.any { it }
+        isGranted = granted
+        latestOnPermissionResult(ForegroundLocationPermissionResult(granted = granted))
+    }
+
+    return ForegroundLocationPermissionRequester(
+        isGranted = isGranted,
+        onRequest = {
+            val alreadyGranted = DeviceLocationProvider.hasLocationPermission(context)
+            isGranted = alreadyGranted
+            if (alreadyGranted) {
+                latestOnPermissionResult(ForegroundLocationPermissionResult(granted = true))
+            } else {
+                launcher.launch(DeviceLocationProvider.RequiredLocationPermissions)
+            }
+        },
+        onRefresh = {
+            val granted = DeviceLocationProvider.hasLocationPermission(context)
+            isGranted = granted
+            granted
+        }
+    )
+}

--- a/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
+++ b/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
@@ -47,11 +47,19 @@ fun MapPickerDialog(
     title: String = "Select Location on Map",
     initialLatitude: Double? = null,
     initialLongitude: Double? = null,
+    centerLatitude: Double? = null,
+    centerLongitude: Double? = null,
+    showCenterOnCurrentLocation: Boolean = false,
+    centerActionLoading: Boolean = false,
+    centerActionMessage: String = "",
     loading: Boolean = false,
     onDismiss: () -> Unit,
-    onConfirm: (MapPickerSelection) -> Unit
+    onConfirm: (MapPickerSelection) -> Unit,
+    onCenterOnCurrentLocation: (() -> Unit)? = null
 ) {
     val spacing = LocalNephSpacing.current
+    val effectiveInitialLatitude = centerLatitude ?: initialLatitude
+    val effectiveInitialLongitude = centerLongitude ?: initialLongitude
     var selection by remember(initialLatitude, initialLongitude) {
         mutableStateOf<MapPickerSelection?>(null)
     }
@@ -79,8 +87,8 @@ fun MapPickerDialog(
                 HelperText(text = "Tap on the map to place a pin, then confirm the selection.")
 
                 MapPickerMap(
-                    initialLatitude = initialLatitude,
-                    initialLongitude = initialLongitude,
+                    initialLatitude = effectiveInitialLatitude,
+                    initialLongitude = effectiveInitialLongitude,
                     onLocationSelected = { lat, lon ->
                         selection = MapPickerSelection(lat, lon)
                     },
@@ -106,6 +114,22 @@ fun MapPickerDialog(
 
                 if (loading) {
                     HelperText(text = "Resolving selected coordinates...")
+                }
+
+                if (showCenterOnCurrentLocation && onCenterOnCurrentLocation != null) {
+                    SecondaryButton(
+                        text = "Center on my location",
+                        onClick = onCenterOnCurrentLocation,
+                        enabled = !loading && !centerActionLoading
+                    )
+                }
+
+                if (centerActionLoading) {
+                    HelperText(text = "Finding your current location...")
+                }
+
+                if (centerActionMessage.isNotBlank()) {
+                    HelperText(text = centerActionMessage)
                 }
 
                 PrimaryButton(

--- a/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
+++ b/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
@@ -60,7 +60,7 @@ fun MapPickerDialog(
     val spacing = LocalNephSpacing.current
     val effectiveInitialLatitude = centerLatitude ?: initialLatitude
     val effectiveInitialLongitude = centerLongitude ?: initialLongitude
-    var selection by remember(initialLatitude, initialLongitude) {
+    var selection by remember(initialLatitude, initialLongitude, centerLatitude, centerLongitude) {
         mutableStateOf<MapPickerSelection?>(null)
     }
     var mapReady by remember { mutableStateOf(false) }

--- a/android/app/src/test/java/com/neph/features/availability/data/AvailabilityRepositoryPayloadTest.kt
+++ b/android/app/src/test/java/com/neph/features/availability/data/AvailabilityRepositoryPayloadTest.kt
@@ -1,0 +1,63 @@
+package com.neph.features.availability.data
+
+import com.neph.features.profile.data.CurrentDeviceLocation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AvailabilityRepositoryPayloadTest {
+    @Test
+    fun buildAvailabilityOperationPayloadIncludesLocationWhenAvailable() {
+        val payload = AvailabilityRepository.buildAvailabilityOperationPayload(
+            isAvailable = true,
+            timestamp = 1_777_777_777_000L,
+            currentDeviceLocation = CurrentDeviceLocation(
+                latitude = 41.015,
+                longitude = 29.01,
+                accuracyMeters = 12.5,
+                capturedAt = "2026-05-04T10:00:00.000Z"
+            )
+        )
+
+        assertTrue(payload.getBoolean("isAvailable"))
+        assertEquals(41.015, payload.getDouble("latitude"), 0.0)
+        assertEquals(29.01, payload.getDouble("longitude"), 0.0)
+        assertEquals(12.5, payload.getDouble("accuracyMeters"), 0.0)
+        assertEquals("DEVICE_GPS", payload.getString("locationSource"))
+        assertEquals("2026-05-04T10:00:00.000Z", payload.getString("locationCapturedAt"))
+    }
+
+    @Test
+    fun buildAvailabilityOperationPayloadOmitsLocationWhenUnavailable() {
+        val payload = AvailabilityRepository.buildAvailabilityOperationPayload(
+            isAvailable = false,
+            timestamp = 1_777_777_777_000L
+        )
+
+        assertFalse(payload.getBoolean("isAvailable"))
+        assertFalse(payload.has("latitude"))
+        assertFalse(payload.has("longitude"))
+    }
+
+    @Test
+    fun buildAvailabilitySyncRecordCarriesQueuedCoordinates() {
+        val payload = AvailabilityRepository.buildAvailabilityOperationPayload(
+            isAvailable = true,
+            timestamp = 1_777_777_777_000L,
+            currentDeviceLocation = CurrentDeviceLocation(
+                latitude = 41.015,
+                longitude = 29.01,
+                accuracyMeters = null,
+                capturedAt = "2026-05-04T10:00:00.000Z"
+            )
+        )
+
+        val record = AvailabilityRepository.buildAvailabilitySyncRecord(payload)
+
+        assertTrue(record.getBoolean("isAvailable"))
+        assertEquals(41.015, record.getDouble("latitude"), 0.0)
+        assertEquals(29.01, record.getDouble("longitude"), 0.0)
+        assertEquals("2026-05-04T10:00:00.000Z", record.getString("locationCapturedAt"))
+    }
+}

--- a/backend/src/modules/availability/controller.js
+++ b/backend/src/modules/availability/controller.js
@@ -8,13 +8,13 @@ const {
 } = require('./service');
 const {
   validate,
-  setAvailabilitySchema,
-  syncAvailabilitySchema,
   resolveRequestSchema,
+  validateSetAvailabilityPayload,
+  validateSyncAvailabilityPayload,
 } = require('./validators');
 
 async function handleSetAvailability(req, res) {
-  const errors = validate(req.body, setAvailabilitySchema);
+  const errors = validateSetAvailabilityPayload(req.body);
   if (errors.length > 0) {
     return res.status(400).json({ code: 'VALIDATION_ERROR', errors });
   }
@@ -29,7 +29,7 @@ async function handleSetAvailability(req, res) {
 }
 
 async function handleSyncAvailability(req, res) {
-  const errors = validate(req.body, syncAvailabilitySchema);
+  const errors = validateSyncAvailabilityPayload(req.body);
   if (errors.length > 0) {
     return res.status(400).json({ code: 'VALIDATION_ERROR', errors });
   }

--- a/backend/src/modules/availability/service.js
+++ b/backend/src/modules/availability/service.js
@@ -205,12 +205,13 @@ async function syncAvailability(userId, { records }) {
   if (records.length > 0) {
     const sortedRecords = [...records].sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
     const latest = sortedRecords[0];
+    const hasLatestCoordinates = Number.isFinite(latest.latitude) && Number.isFinite(latest.longitude);
 
     await updateVolunteerAvailability(
       volunteer.volunteer_id,
       latest.isAvailable,
-      null,
-      null
+      hasLatestCoordinates ? latest.latitude : null,
+      hasLatestCoordinates ? latest.longitude : null
     );
 
     for (const record of records) {

--- a/backend/src/modules/availability/validators.js
+++ b/backend/src/modules/availability/validators.js
@@ -22,6 +22,8 @@ const syncAvailabilitySchema = {
       properties: {
         isAvailable: { type: 'boolean', required: true },
         timestamp: { type: 'string', required: true },
+        latitude: { type: 'number', required: false },
+        longitude: { type: 'number', required: false },
       },
     },
   },

--- a/backend/src/modules/availability/validators.js
+++ b/backend/src/modules/availability/validators.js
@@ -36,6 +36,81 @@ const resolveRequestSchema = {
   },
 };
 
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasOwn(object, key) {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function validateCoordinatePair(data, errors, prefix = '') {
+  const latitudeKey = prefix ? `${prefix}.latitude` : 'latitude';
+  const longitudeKey = prefix ? `${prefix}.longitude` : 'longitude';
+  const latitudeProvided = hasOwn(data, 'latitude');
+  const longitudeProvided = hasOwn(data, 'longitude');
+
+  if (latitudeProvided !== longitudeProvided) {
+    errors.push(`${latitudeKey} and ${longitudeKey} must be provided together`);
+    return;
+  }
+
+  if (!latitudeProvided) {
+    return;
+  }
+
+  if (typeof data.latitude !== 'number' || !Number.isFinite(data.latitude) || data.latitude < -90 || data.latitude > 90) {
+    errors.push(`${latitudeKey} must be a finite number between -90 and 90`);
+  }
+
+  if (typeof data.longitude !== 'number' || !Number.isFinite(data.longitude) || data.longitude < -180 || data.longitude > 180) {
+    errors.push(`${longitudeKey} must be a finite number between -180 and 180`);
+  }
+}
+
+function validateSetAvailabilityPayload(data) {
+  const errors = validate(data, setAvailabilitySchema);
+  validateCoordinatePair(data || {}, errors);
+  return errors;
+}
+
+function validateSyncAvailabilityPayload(data) {
+  const errors = [];
+
+  if (!isPlainObject(data)) {
+    return ['payload must be an object'];
+  }
+
+  if (!Array.isArray(data.records)) {
+    return ['records must be an array'];
+  }
+
+  data.records.forEach((record, index) => {
+    const prefix = `records[${index}]`;
+
+    if (!isPlainObject(record)) {
+      errors.push(`${prefix} must be an object`);
+      return;
+    }
+
+    if (!hasOwn(record, 'isAvailable') || record.isAvailable === null) {
+      errors.push(`${prefix}.isAvailable is required`);
+    } else if (typeof record.isAvailable !== 'boolean') {
+      errors.push(`${prefix}.isAvailable must be a boolean`);
+    }
+
+    if (!hasOwn(record, 'timestamp') || record.timestamp === null) {
+      errors.push(`${prefix}.timestamp is required`);
+    } else if (typeof record.timestamp !== 'string') {
+      errors.push(`${prefix}.timestamp must be a string`);
+    }
+
+    validateCoordinatePair(record, errors, prefix);
+  });
+
+  return errors;
+}
+
 // Simple validator function to match the project's style
 function validate(data, schema) {
   const errors = [];
@@ -68,4 +143,6 @@ module.exports = {
   syncAvailabilitySchema,
   resolveRequestSchema,
   validate,
+  validateSetAvailabilityPayload,
+  validateSyncAvailabilityPayload,
 };

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -203,6 +203,26 @@ describe('Availability integration', () => {
     expect(vResult.rows[0].is_available).toBe(true);
   });
 
+  test.each([
+    ['latitude > 90', { isAvailable: true, latitude: 91, longitude: 29.0 }],
+    ['longitude > 180', { isAvailable: true, latitude: 41.0, longitude: 181 }],
+    ['latitude without longitude', { isAvailable: true, latitude: 41.0 }],
+    ['longitude without latitude', { isAvailable: true, longitude: 29.0 }],
+  ])('POST /api/availability/toggle rejects invalid coordinates: %s', async (_caseName, payload) => {
+    const app = createTestApp();
+    const userId = `user_av_toggle_invalid_${_caseName.replace(/\W+/g, '_')}`;
+    await seedActiveUser(userId, `${userId}@example.com`);
+    const token = buildAuthToken(userId);
+
+    const response = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${token}`)
+      .send(payload);
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+  });
+
   test('POST /api/availability/toggle matches a request if available', async () => {
     const app = createTestApp();
     const volunteerUserId = 'user_v_1';
@@ -875,6 +895,34 @@ describe('Availability integration', () => {
     expect(response.body.volunteer.is_available).toBe(true);
     expect(Number(response.body.volunteer.last_known_latitude)).toBeCloseTo(41.015);
     expect(Number(response.body.volunteer.last_known_longitude)).toBeCloseTo(29.01);
+  });
+
+  test.each([
+    ['latitude > 90', { latitude: 91, longitude: 29.0 }],
+    ['longitude > 180', { latitude: 41.0, longitude: 181 }],
+    ['latitude without longitude', { latitude: 41.0 }],
+    ['longitude without latitude', { longitude: 29.0 }],
+  ])('POST /api/availability/sync rejects invalid coordinates: %s', async (_caseName, coordinateFields) => {
+    const app = createTestApp();
+    const userId = `user_av_sync_invalid_${_caseName.replace(/\W+/g, '_')}`;
+    await seedActiveUser(userId, `${userId}@example.com`);
+    const token = buildAuthToken(userId);
+
+    const response = await request(app)
+      .post('/api/availability/sync')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        records: [
+          {
+            isAvailable: true,
+            timestamp: new Date().toISOString(),
+            ...coordinateFields,
+          },
+        ],
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
   });
 
   test('GET /api/availability/my-assignment returns current assignment', async () => {

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -851,6 +851,32 @@ describe('Availability integration', () => {
     expect(arResult.rows).toHaveLength(2);
   });
 
+  test('POST /api/availability/sync stores latest available coordinates on volunteer', async () => {
+    const app = createTestApp();
+    const userId = 'user_av_sync_location';
+    await seedActiveUser(userId, 'av-sync-location@example.com');
+    const token = buildAuthToken(userId);
+
+    const response = await request(app)
+      .post('/api/availability/sync')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        records: [
+          {
+            isAvailable: true,
+            timestamp: new Date().toISOString(),
+            latitude: 41.015,
+            longitude: 29.01,
+          },
+        ],
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.volunteer.is_available).toBe(true);
+    expect(Number(response.body.volunteer.last_known_latitude)).toBeCloseTo(41.015);
+    expect(Number(response.body.volunteer.last_known_longitude)).toBeCloseTo(29.01);
+  });
+
   test('GET /api/availability/my-assignment returns current assignment', async () => {
     const app = createTestApp();
     const volunteerUserId = 'user_v_2';


### PR DESCRIPTION
## Summary

This PR implements contextual foreground location permission handling on Android.

Location permission is now requested only after the user starts a location-dependent action, instead of being requested automatically during unrelated flows.

## Changes

- Added/reused shared foreground location permission handling for Android flows
- Added an optional Home card to enable foreground location permission
- Updated Request Help current-location flow to request permission only after `Use Current Location`
- Updated Available to Help flow so turning availability ON requires usable current location
- Updated Safety Check-in so location permission is requested only when the user chooses to share location
- Updated profile map behavior so current-location permission only centers the map and does not save profile location
- Added fallback messages for denied or unavailable location states

## Important Behavior

- The app does not request location permission on launch or resume
- Normal profile editing does not request location permission
- The app does not request background / always location permission
- Granting permission does not automatically update profile location, create a request, enable availability, or trigger assignment

## Testing

- Verified relevant Android build/checks
- Verified location-dependent flows where applicable

Closes #432 