### PR TITLE
fix: Android privacy save cache merge

### DIFF
--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
@@ -275,21 +275,62 @@ object ProfileRepository {
             path = "/profiles/me/privacy",
             method = "PATCH",
             token = token,
-            body = JSONObject().apply {
-                put("profileVisibility", normalizeVisibility(profileVisibility))
-                put("healthInfoVisibility", normalizeVisibility(healthInfoVisibility))
-                put("locationVisibility", normalizeVisibility(locationVisibility))
-                put("locationSharingEnabled", locationSharingEnabled)
-            }
+            body = buildPrivacySettingsPatchPayload(
+                profileVisibility = profileVisibility,
+                healthInfoVisibility = healthInfoVisibility,
+                locationVisibility = locationVisibility,
+                locationSharingEnabled = locationSharingEnabled
+            )
         )
 
-        val updated = mapBackendProfile(
-            profileJson = response,
-            email = cachedProfile.email.orEmpty(),
-            cachedProfileSnapshot = cachedProfile
+        val updated = mergePrivacySettingsResponse(
+            cachedProfileSnapshot = cachedProfile,
+            response = response,
+            requestedProfileVisibility = profileVisibility,
+            requestedHealthInfoVisibility = healthInfoVisibility,
+            requestedLocationVisibility = locationVisibility,
+            requestedLocationSharingEnabled = locationSharingEnabled
         )
         saveProfile(updated)
         return updated
+    }
+
+    internal fun buildPrivacySettingsPatchPayload(
+        profileVisibility: String,
+        healthInfoVisibility: String,
+        locationVisibility: String,
+        locationSharingEnabled: Boolean
+    ): JSONObject {
+        return JSONObject().apply {
+            put("profileVisibility", normalizeVisibility(profileVisibility))
+            put("healthInfoVisibility", normalizeVisibility(healthInfoVisibility))
+            put("locationVisibility", normalizeVisibility(locationVisibility))
+            put("locationSharingEnabled", locationSharingEnabled)
+        }
+    }
+
+    internal fun mergePrivacySettingsResponse(
+        cachedProfileSnapshot: ProfileData,
+        response: JSONObject,
+        requestedProfileVisibility: String,
+        requestedHealthInfoVisibility: String,
+        requestedLocationVisibility: String,
+        requestedLocationSharingEnabled: Boolean
+    ): ProfileData {
+        val privacySettings = response.optJSONObject("privacySettings") ?: response
+        return cachedProfileSnapshot.copy(
+            profileVisibility = normalizeVisibility(
+                privacySettings.optStringOrNull("profileVisibility") ?: requestedProfileVisibility
+            ),
+            healthInfoVisibility = normalizeVisibility(
+                privacySettings.optStringOrNull("healthInfoVisibility") ?: requestedHealthInfoVisibility
+            ),
+            locationVisibility = normalizeVisibility(
+                privacySettings.optStringOrNull("locationVisibility") ?: requestedLocationVisibility
+            ),
+            shareLocation = privacySettings.optNullableBoolean("locationSharingEnabled")
+                ?: requestedLocationSharingEnabled
+        )
     }
 
     private suspend fun hasTrustedRemoteSharedCoordinates(token: String): Boolean {

--- a/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
+++ b/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
@@ -5,8 +5,86 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.json.JSONObject
 
 class ProfileRepositoryLocationPayloadTest {
+    @Test
+    fun buildPrivacySettingsPatchPayload_onlyIncludesPrivacyFields() {
+        val payload = ProfileRepository.buildPrivacySettingsPatchPayload(
+            profileVisibility = "public",
+            healthInfoVisibility = "EMERGENCY_ONLY",
+            locationVisibility = "unexpected-value",
+            locationSharingEnabled = true
+        )
+
+        assertEquals(4, payload.length())
+        assertEquals("PUBLIC", payload.getString("profileVisibility"))
+        assertEquals("EMERGENCY_ONLY", payload.getString("healthInfoVisibility"))
+        assertEquals("PRIVATE", payload.getString("locationVisibility"))
+        assertTrue(payload.getBoolean("locationSharingEnabled"))
+        assertFalse(payload.has("firstName"))
+        assertFalse(payload.has("medicalConditions"))
+        assertFalse(payload.has("latitude"))
+        assertFalse(payload.has("profession"))
+        assertFalse(payload.has("expertiseAreas"))
+    }
+
+    @Test
+    fun mergePrivacySettingsResponse_preservesUnrelatedCachedProfileFields() {
+        val cached = ProfileData(
+            firstName = "Ada",
+            lastName = "Lovelace",
+            fullName = "Ada Lovelace",
+            email = "ada@example.com",
+            phone = "+905551112233",
+            profession = "Engineer",
+            expertise = listOf("FIRST_AID"),
+            height = 165f,
+            weight = 58f,
+            bloodType = "A+",
+            gender = "FEMALE",
+            dateOfBirth = "1990-05-01",
+            age = 36,
+            medicalHistory = "asthma",
+            chronicDiseases = "diabetes",
+            allergies = "pollen",
+            country = "tr",
+            city = "istanbul",
+            district = "kadikoy",
+            neighborhood = "moda",
+            extraAddress = "Apt 4",
+            profileVisibility = "PRIVATE",
+            healthInfoVisibility = "PRIVATE",
+            locationVisibility = "PRIVATE",
+            shareLocation = false,
+            sharedLatitude = 41.043,
+            sharedLongitude = 29.009
+        )
+
+        val updated = ProfileRepository.mergePrivacySettingsResponse(
+            cachedProfileSnapshot = cached,
+            response = JSONObject().put(
+                "privacySettings",
+                JSONObject()
+                    .put("profileVisibility", "PUBLIC")
+                    .put("healthInfoVisibility", "EMERGENCY_ONLY")
+                    .put("locationVisibility", "PUBLIC")
+                    .put("locationSharingEnabled", true)
+            ),
+            requestedProfileVisibility = "PRIVATE",
+            requestedHealthInfoVisibility = "PRIVATE",
+            requestedLocationVisibility = "PRIVATE",
+            requestedLocationSharingEnabled = false
+        )
+
+        assertEquals(cached.copy(
+            profileVisibility = "PUBLIC",
+            healthInfoVisibility = "EMERGENCY_ONLY",
+            locationVisibility = "PUBLIC",
+            shareLocation = true
+        ), updated)
+    }
+
     @Test
     fun isFirstTimeShareEnableWithoutCoordinates_returnsTrue_whenEnablingWithoutSavedOrFreshCoordinates() {
         val previous = ProfileData(shareLocation = false, sharedLatitude = null, sharedLongitude = null)


### PR DESCRIPTION
This PR completes the fix for issue [#361](https://github.com/bounswe/bounswe2026group6/issues/361) by tightening the Android privacy-save path.

### Changes:

- Keeps Privacy & Security saves scoped to PATCH /profiles/me/privacy.
- Adds a dedicated privacy payload builder that only includes privacy fields.
- Updates privacy response handling to merge returned privacy settings into the cached profile instead of remapping a partial response as a full profile.
- Prevents unrelated cached profile data such as health, location, profession, expertise, and basic profile fields from being cleared after saving privacy settings.
- Adds unit tests for privacy-only payload generation and cache-preserving privacy response merge.