### PR TITLE
feature: toggling availability updates operational location

### DIFF
--- a/android/app/src/main/java/com/neph/features/availability/data/AvailabilityRepository.kt
+++ b/android/app/src/main/java/com/neph/features/availability/data/AvailabilityRepository.kt
@@ -326,12 +326,12 @@ object AvailabilityRepository {
             .put("isAvailable", isAvailable)
             .put("timestamp", timestamp)
             .apply {
-                if (currentDeviceLocation != null) {
+                if (isAvailable && currentDeviceLocation != null) {
                     put("latitude", currentDeviceLocation.latitude)
                     put("longitude", currentDeviceLocation.longitude)
                     put("accuracyMeters", currentDeviceLocation.accuracyMeters)
-                    put("locationSource", currentDeviceLocation.source)
-                    put("locationCapturedAt", currentDeviceLocation.capturedAt)
+                    put("source", currentDeviceLocation.source)
+                    put("capturedAt", currentDeviceLocation.capturedAt)
                 }
             }
     }
@@ -347,11 +347,15 @@ object AvailabilityRepository {
                     if (payload.has("accuracyMeters") && !payload.isNull("accuracyMeters")) {
                         put("accuracyMeters", payload.getDouble("accuracyMeters"))
                     }
-                    if (payload.has("locationSource") && !payload.isNull("locationSource")) {
-                        put("locationSource", payload.getString("locationSource"))
+                    if (payload.has("source") && !payload.isNull("source")) {
+                        put("source", payload.getString("source"))
+                    } else if (payload.has("locationSource") && !payload.isNull("locationSource")) {
+                        put("source", payload.getString("locationSource"))
                     }
-                    if (payload.has("locationCapturedAt") && !payload.isNull("locationCapturedAt")) {
-                        put("locationCapturedAt", payload.getString("locationCapturedAt"))
+                    if (payload.has("capturedAt") && !payload.isNull("capturedAt")) {
+                        put("capturedAt", payload.getString("capturedAt"))
+                    } else if (payload.has("locationCapturedAt") && !payload.isNull("locationCapturedAt")) {
+                        put("capturedAt", payload.getString("locationCapturedAt"))
                     }
                 }
             }

--- a/android/app/src/test/java/com/neph/features/availability/data/AvailabilityRepositoryPayloadTest.kt
+++ b/android/app/src/test/java/com/neph/features/availability/data/AvailabilityRepositoryPayloadTest.kt
@@ -24,20 +24,29 @@ class AvailabilityRepositoryPayloadTest {
         assertEquals(41.015, payload.getDouble("latitude"), 0.0)
         assertEquals(29.01, payload.getDouble("longitude"), 0.0)
         assertEquals(12.5, payload.getDouble("accuracyMeters"), 0.0)
-        assertEquals("DEVICE_GPS", payload.getString("locationSource"))
-        assertEquals("2026-05-04T10:00:00.000Z", payload.getString("locationCapturedAt"))
+        assertEquals("DEVICE_GPS", payload.getString("source"))
+        assertEquals("2026-05-04T10:00:00.000Z", payload.getString("capturedAt"))
     }
 
     @Test
     fun buildAvailabilityOperationPayloadOmitsLocationWhenUnavailable() {
         val payload = AvailabilityRepository.buildAvailabilityOperationPayload(
             isAvailable = false,
-            timestamp = 1_777_777_777_000L
+            timestamp = 1_777_777_777_000L,
+            currentDeviceLocation = CurrentDeviceLocation(
+                latitude = 41.015,
+                longitude = 29.01,
+                accuracyMeters = 12.5,
+                capturedAt = "2026-05-04T10:00:00.000Z"
+            )
         )
 
         assertFalse(payload.getBoolean("isAvailable"))
         assertFalse(payload.has("latitude"))
         assertFalse(payload.has("longitude"))
+        assertFalse(payload.has("accuracyMeters"))
+        assertFalse(payload.has("source"))
+        assertFalse(payload.has("capturedAt"))
     }
 
     @Test
@@ -58,6 +67,7 @@ class AvailabilityRepositoryPayloadTest {
         assertTrue(record.getBoolean("isAvailable"))
         assertEquals(41.015, record.getDouble("latitude"), 0.0)
         assertEquals(29.01, record.getDouble("longitude"), 0.0)
-        assertEquals("2026-05-04T10:00:00.000Z", record.getString("locationCapturedAt"))
+        assertEquals("DEVICE_GPS", record.getString("source"))
+        assertEquals("2026-05-04T10:00:00.000Z", record.getString("capturedAt"))
     }
 }

--- a/backend/src/modules/availability/repository.js
+++ b/backend/src/modules/availability/repository.js
@@ -383,6 +383,19 @@ async function createVolunteer(userId) {
 }
 
 async function updateVolunteerAvailability(volunteerId, isAvailable, latitude, longitude, executor = null) {
+  const hasCoordinateUpdate = Number.isFinite(latitude) && Number.isFinite(longitude);
+
+  if (!hasCoordinateUpdate) {
+    const sql = `
+      UPDATE volunteers
+      SET is_available = $2
+      WHERE volunteer_id = $1
+      RETURNING *;
+    `;
+    const result = await runQuery(executor, sql, [volunteerId, isAvailable]);
+    return result.rows[0];
+  }
+
   const sql = `
     UPDATE volunteers
     SET is_available = $2,

--- a/backend/src/modules/availability/service.js
+++ b/backend/src/modules/availability/service.js
@@ -162,11 +162,12 @@ async function setAvailability(userId, { isAvailable, latitude, longitude }) {
     volunteer = await createVolunteer(userId);
   }
 
+  const hasCoordinates = isAvailable && Number.isFinite(latitude) && Number.isFinite(longitude);
   const updatedVolunteer = await updateVolunteerAvailability(
     volunteer.volunteer_id,
     isAvailable,
-    latitude,
-    longitude
+    hasCoordinates ? latitude : undefined,
+    hasCoordinates ? longitude : undefined
   );
 
   await createAvailabilityRecord(volunteer.volunteer_id, isAvailable, false);
@@ -203,18 +204,21 @@ async function syncAvailability(userId, { records }) {
   }
 
   if (records.length > 0) {
-    const sortedRecords = [...records].sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
-    const latest = sortedRecords[0];
-    const hasLatestCoordinates = Number.isFinite(latest.latitude) && Number.isFinite(latest.longitude);
+    const sortedRecords = [...records].sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+    const latest = sortedRecords[sortedRecords.length - 1];
+    const latestAvailableRecord = [...sortedRecords].reverse().find((record) => record.isAvailable);
+    const hasLatestAvailableCoordinates = latestAvailableRecord
+      && Number.isFinite(latestAvailableRecord.latitude)
+      && Number.isFinite(latestAvailableRecord.longitude);
 
     await updateVolunteerAvailability(
       volunteer.volunteer_id,
       latest.isAvailable,
-      hasLatestCoordinates ? latest.latitude : null,
-      hasLatestCoordinates ? latest.longitude : null
+      hasLatestAvailableCoordinates ? latestAvailableRecord.latitude : undefined,
+      hasLatestAvailableCoordinates ? latestAvailableRecord.longitude : undefined
     );
 
-    for (const record of records) {
+    for (const record of sortedRecords) {
       await createAvailabilityRecord(volunteer.volunteer_id, record.isAvailable, true);
     }
   }
@@ -273,8 +277,6 @@ async function cancelMyAssignment(userId, { assignmentId }) {
   await updateVolunteerAvailability(
     volunteer.volunteer_id,
     false,
-    volunteer.last_known_latitude,
-    volunteer.last_known_longitude,
   );
   await createAvailabilityRecord(volunteer.volunteer_id, false, false);
 
@@ -360,8 +362,8 @@ async function cancelAssignmentsForBannedVolunteer(userId, options = {}) {
     await updateVolunteerAvailability(
       volunteer.volunteer_id,
       false,
-      volunteer.last_known_latitude,
-      volunteer.last_known_longitude,
+      undefined,
+      undefined,
       executor,
     );
     await createAvailabilityRecord(volunteer.volunteer_id, false, false, executor);
@@ -369,8 +371,6 @@ async function cancelAssignmentsForBannedVolunteer(userId, options = {}) {
     await updateVolunteerAvailability(
       volunteer.volunteer_id,
       false,
-      volunteer.last_known_latitude,
-      volunteer.last_known_longitude,
     );
     await createAvailabilityRecord(volunteer.volunteer_id, false, false);
   }
@@ -408,8 +408,6 @@ async function resolveMyAssignment(userId, { requestId }) {
   await updateVolunteerAvailability(
     volunteer.volunteer_id,
     false,
-    volunteer.last_known_latitude,
-    volunteer.last_known_longitude,
   );
   await createAvailabilityRecord(volunteer.volunteer_id, false, false);
 

--- a/backend/src/modules/availability/validators.js
+++ b/backend/src/modules/availability/validators.js
@@ -71,6 +71,9 @@ function validateCoordinatePair(data, errors, prefix = '') {
 function validateSetAvailabilityPayload(data) {
   const errors = validate(data, setAvailabilitySchema);
   validateCoordinatePair(data || {}, errors);
+  if (data && data.isAvailable === true && (!hasOwn(data, 'latitude') || !hasOwn(data, 'longitude'))) {
+    errors.push('latitude and longitude are required when isAvailable is true');
+  }
   return errors;
 }
 
@@ -107,6 +110,14 @@ function validateSyncAvailabilityPayload(data) {
 
     validateCoordinatePair(record, errors, prefix);
   });
+
+  if (errors.length === 0 && data.records.length > 0) {
+    const sortedRecords = [...data.records].sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+    const latest = sortedRecords[sortedRecords.length - 1];
+    if (latest.isAvailable === true && (!hasOwn(latest, 'latitude') || !hasOwn(latest, 'longitude'))) {
+      errors.push('records latest available state requires latitude and longitude');
+    }
+  }
 
   return errors;
 }

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -29,6 +29,10 @@ function buildAuthToken(userId) {
   );
 }
 
+function availabilityOnPayload(latitude = 41.0, longitude = 29.0) {
+  return { isAvailable: true, latitude, longitude };
+}
+
 async function seedActiveUser(userId, email = 'user@example.com') {
   await query(
     `
@@ -235,6 +239,7 @@ describe('Availability integration', () => {
   });
 
   test.each([
+    ['missing coordinates', { isAvailable: true }],
     ['latitude > 90', { isAvailable: true, latitude: 91, longitude: 29.0 }],
     ['longitude > 180', { isAvailable: true, latitude: 41.0, longitude: 181 }],
     ['latitude without longitude', { isAvailable: true, latitude: 41.0 }],
@@ -266,7 +271,7 @@ describe('Availability integration', () => {
     const response = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${token}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     expect(response.status).toBe(200);
     expect(response.body.assignment).toBeTruthy();
@@ -306,7 +311,7 @@ describe('Availability integration', () => {
     const response = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${token}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     expect(response.status).toBe(200);
     expect(response.body.assignment).toBeTruthy();
@@ -328,7 +333,7 @@ describe('Availability integration', () => {
     const response = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${token}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     expect(response.status).toBe(200);
     expect(response.body.assignment).toBeTruthy();
@@ -364,15 +369,15 @@ describe('Availability integration', () => {
     const sarResponse = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${buildAuthToken(sarVolunteerId)}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
     const suppliesResponse = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${buildAuthToken(suppliesVolunteerId)}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
     const shelterResponse = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${buildAuthToken(shelterVolunteerId)}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     expect(sarResponse.body.assignment.request_id).toBe('req_sar_only');
     expect([
@@ -381,13 +386,13 @@ describe('Availability integration', () => {
     ].sort()).toEqual(['req_shelter_only', 'req_supplies_only']);
   });
 
-  test('POST /api/availability/toggle applies the 1 km cutoff and safely falls back when coordinates are missing', async () => {
+  test('POST /api/availability/toggle applies the 1 km cutoff and matches a nearby volunteer', async () => {
     const app = createTestApp();
 
     const nearVolunteerId = 'user_v_near';
-    const noCoordVolunteerId = 'user_v_nocoord';
+    const nearbyVolunteerId = 'user_v_nearby';
     await seedActiveUser(nearVolunteerId, 'near@example.com');
-    await seedActiveUser(noCoordVolunteerId, 'nocoord@example.com');
+    await seedActiveUser(nearbyVolunteerId, 'nearby@example.com');
     await seedActiveUser('user_r_far', 'far@example.com');
     await seedActiveUser('user_r_missing', 'missing@example.com');
 
@@ -412,14 +417,14 @@ describe('Availability integration', () => {
     expect(farResponse.body.assignment).toBeTruthy();
     expect(farResponse.body.assignment.request_id).toBe('req_missing_coords');
 
-    const noCoordResponse = await request(app)
+    const nearbyResponse = await request(app)
       .post('/api/availability/toggle')
-      .set('Authorization', `Bearer ${buildAuthToken(noCoordVolunteerId)}`)
-      .send({ isAvailable: true });
+      .set('Authorization', `Bearer ${buildAuthToken(nearbyVolunteerId)}`)
+      .send(availabilityOnPayload(41.03, 29.03));
 
-    expect(noCoordResponse.status).toBe(200);
-    expect(noCoordResponse.body.assignment).toBeTruthy();
-    expect(noCoordResponse.body.assignment.request_id).toBe('req_far_only');
+    expect(nearbyResponse.status).toBe(200);
+    expect(nearbyResponse.body.assignment).toBeTruthy();
+    expect(nearbyResponse.body.assignment.request_id).toBe('req_far_only');
 
     const farStatus = await query('SELECT status FROM help_requests WHERE request_id = $1', ['req_far_only']);
     expect(farStatus.rows[0].status).toBe('ASSIGNED');
@@ -569,7 +574,7 @@ describe('Availability integration', () => {
     const response = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${buildAuthToken('user_vol_fa_late')}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     expect(response.status).toBe(200);
     expect(response.body.assignment.request_id).toBe('req_fa_sar_late');
@@ -634,7 +639,7 @@ describe('Availability integration', () => {
     const secondGeneralResponse = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${buildAuthToken('user_vol_general_fa_only_2')}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     expect(secondGeneralResponse.status).toBe(200);
     expect(secondGeneralResponse.body.assignment).toBeNull();
@@ -647,7 +652,7 @@ describe('Availability integration', () => {
     const response = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${buildAuthToken('user_vol_fa_only_late')}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     expect(response.status).toBe(200);
     expect(response.body.assignment.request_id).toBe('req_fa_only_late');
@@ -684,7 +689,7 @@ describe('Availability integration', () => {
     const response = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${buildAuthToken('user_vol_fa_priority')}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     expect(response.status).toBe(200);
     expect(response.body.assignment.request_id).toBe('req_fa_backfill');
@@ -723,7 +728,7 @@ describe('Availability integration', () => {
     const response = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${buildAuthToken('user_vol_fa_progress')}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     expect(response.status).toBe(200);
     expect(response.body.assignment.request_id).toBe('req_fa_sar_progress');
@@ -749,7 +754,7 @@ describe('Availability integration', () => {
     await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${token}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     await query(
       `
@@ -800,19 +805,19 @@ describe('Availability integration', () => {
     const firstResponse = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${buildAuthToken('user_v_fair_1')}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
     expect(firstResponse.body.assignment.request_id).toBe('req_fair_sar');
 
     const secondResponse = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${buildAuthToken('user_v_fair_2')}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
     expect(secondResponse.body.assignment.request_id).toBe('req_fair_supplies');
 
     const thirdResponse = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${buildAuthToken('user_v_fair_3')}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
     expect(thirdResponse.body.assignment.request_id).toBe('req_fair_sar');
 
     expect(await listAssignedVolunteerIds('req_fair_sar')).toHaveLength(2);
@@ -890,13 +895,20 @@ describe('Availability integration', () => {
       .set('Authorization', `Bearer ${token}`)
       .send({
         records: [
-          { isAvailable: true, timestamp: new Date(Date.now() - 10000).toISOString() },
+          {
+            isAvailable: true,
+            timestamp: new Date(Date.now() - 10000).toISOString(),
+            latitude: 41.015,
+            longitude: 29.01,
+          },
           { isAvailable: false, timestamp: new Date().toISOString() },
         ],
       });
 
     expect(response.status).toBe(200);
     expect(response.body.volunteer.is_available).toBe(false);
+    expect(Number(response.body.volunteer.last_known_latitude)).toBeCloseTo(41.015);
+    expect(Number(response.body.volunteer.last_known_longitude)).toBeCloseTo(29.01);
 
     const arResult = await query('SELECT * FROM availability_records');
     expect(arResult.rows).toHaveLength(2);
@@ -931,7 +943,7 @@ describe('Availability integration', () => {
     expect(Number(response.body.volunteer.last_known_longitude)).toBeCloseTo(29.01);
   });
 
-  test('POST /api/availability/sync preserves existing coordinates when latest record lacks coordinates', async () => {
+  test('POST /api/availability/sync preserves existing coordinates when latest unavailable record lacks coordinates', async () => {
     const app = createTestApp();
     const userId = 'user_av_sync_preserve_location';
     await seedActiveUser(userId, 'av-sync-preserve-location@example.com');
@@ -951,12 +963,12 @@ describe('Availability integration', () => {
       .set('Authorization', `Bearer ${token}`)
       .send({
         records: [
-          { isAvailable: true, timestamp: new Date().toISOString() },
+          { isAvailable: false, timestamp: new Date().toISOString() },
         ],
       });
 
     expect(response.status).toBe(200);
-    expect(response.body.volunteer.is_available).toBe(true);
+    expect(response.body.volunteer.is_available).toBe(false);
     expect(Number(response.body.volunteer.last_known_latitude)).toBeCloseTo(40.99);
     expect(Number(response.body.volunteer.last_known_longitude)).toBeCloseTo(29.02);
 
@@ -964,6 +976,26 @@ describe('Availability integration', () => {
     expect(Number(after.rows[0].last_known_latitude)).toBeCloseTo(40.99);
     expect(Number(after.rows[0].last_known_longitude)).toBeCloseTo(29.02);
     expect(after.rows[0].location_updated_at.getTime()).toBe(before.rows[0].location_updated_at.getTime());
+  });
+
+  test('POST /api/availability/sync rejects final available state without coordinates', async () => {
+    const app = createTestApp();
+    const userId = 'user_av_sync_final_available_missing_location';
+    await seedActiveUser(userId, 'av-sync-final-available-missing-location@example.com');
+    const token = buildAuthToken(userId);
+
+    const response = await request(app)
+      .post('/api/availability/sync')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        records: [
+          { isAvailable: false, timestamp: '2026-05-04T10:00:00.000Z' },
+          { isAvailable: true, timestamp: '2026-05-04T10:05:00.000Z' },
+        ],
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
   });
 
   test('POST /api/availability/sync keeps latest availability while storing latest available coordinates', async () => {
@@ -997,6 +1029,7 @@ describe('Availability integration', () => {
   });
 
   test.each([
+    ['missing coordinates', {}],
     ['latitude > 90', { latitude: 91, longitude: 29.0 }],
     ['longitude > 180', { latitude: 41.0, longitude: 181 }],
     ['latitude without longitude', { latitude: 41.0 }],
@@ -1037,7 +1070,7 @@ describe('Availability integration', () => {
     await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${token}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     const response = await request(app)
       .get('/api/availability/my-assignment')
@@ -1063,7 +1096,7 @@ describe('Availability integration', () => {
     const toggleRes = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${token}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     const assignmentId = toggleRes.body.assignment.assignment_id;
 
@@ -1094,7 +1127,7 @@ describe('Availability integration', () => {
     await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${token}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     const response = await request(app)
       .post('/api/availability/assignments/resolve')
@@ -1137,21 +1170,21 @@ describe('Availability integration', () => {
     const firstToggle = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${firstToken}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
     expect(firstToggle.status).toBe(200);
     expect(firstToggle.body.assignment.request_id).toBe('req_multi_cancel');
 
     const secondToggle = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${secondToken}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
     expect(secondToggle.status).toBe(200);
     expect(secondToggle.body.assignment.request_id).toBe('req_multi_cancel');
 
     const thirdToggle = await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${thirdToken}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
     expect(thirdToggle.status).toBe(200);
     expect(thirdToggle.body.assignment).toBeNull();
 
@@ -1209,12 +1242,12 @@ describe('Availability integration', () => {
     await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${firstToken}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${secondToken}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     expect(await listAssignedVolunteerIds('req_multi_resolve')).toHaveLength(2);
 
@@ -1271,7 +1304,7 @@ describe('Availability integration', () => {
     await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${token}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     // Status should now be available and have an assignment
     response = await request(app)
@@ -1299,7 +1332,7 @@ describe('Availability integration', () => {
     await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${token}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     // Verify assignment exists
     const beforeResult = await query('SELECT * FROM assignments WHERE request_id = $1', ['req_6']);
@@ -1336,7 +1369,7 @@ describe('Availability integration', () => {
     await request(app)
       .post('/api/availability/toggle')
       .set('Authorization', `Bearer ${token}`)
-      .send({ isAvailable: true });
+      .send(availabilityOnPayload());
 
     // 2. Sync to unavailable
     const response = await request(app)

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -203,6 +203,37 @@ describe('Availability integration', () => {
     expect(vResult.rows[0].is_available).toBe(true);
   });
 
+  test('POST /api/availability/toggle to false preserves existing volunteer coordinates', async () => {
+    const app = createTestApp();
+    const userId = 'user_av_toggle_off_preserve';
+    await seedActiveUser(userId, 'av-toggle-off-preserve@example.com');
+    await seedVolunteer({
+      volunteerId: 'vol_toggle_off_preserve',
+      userId,
+      isAvailable: true,
+      latitude: 41.015,
+      longitude: 29.01,
+      locationUpdatedAt: '2026-05-04T10:00:00.000Z',
+    });
+    const before = await query('SELECT location_updated_at FROM volunteers WHERE user_id = $1', [userId]);
+    const token = buildAuthToken(userId);
+
+    const response = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isAvailable: false });
+
+    expect(response.status).toBe(200);
+    expect(response.body.volunteer.is_available).toBe(false);
+    expect(Number(response.body.volunteer.last_known_latitude)).toBeCloseTo(41.015);
+    expect(Number(response.body.volunteer.last_known_longitude)).toBeCloseTo(29.01);
+
+    const after = await query('SELECT * FROM volunteers WHERE user_id = $1', [userId]);
+    expect(Number(after.rows[0].last_known_latitude)).toBeCloseTo(41.015);
+    expect(Number(after.rows[0].last_known_longitude)).toBeCloseTo(29.01);
+    expect(after.rows[0].location_updated_at.getTime()).toBe(before.rows[0].location_updated_at.getTime());
+  });
+
   test.each([
     ['latitude > 90', { isAvailable: true, latitude: 91, longitude: 29.0 }],
     ['longitude > 180', { isAvailable: true, latitude: 41.0, longitude: 181 }],
@@ -887,12 +918,80 @@ describe('Availability integration', () => {
             timestamp: new Date().toISOString(),
             latitude: 41.015,
             longitude: 29.01,
+            accuracyMeters: 12.5,
+            source: 'DEVICE_GPS',
+            capturedAt: '2026-05-04T10:00:00.000Z',
           },
         ],
       });
 
     expect(response.status).toBe(200);
     expect(response.body.volunteer.is_available).toBe(true);
+    expect(Number(response.body.volunteer.last_known_latitude)).toBeCloseTo(41.015);
+    expect(Number(response.body.volunteer.last_known_longitude)).toBeCloseTo(29.01);
+  });
+
+  test('POST /api/availability/sync preserves existing coordinates when latest record lacks coordinates', async () => {
+    const app = createTestApp();
+    const userId = 'user_av_sync_preserve_location';
+    await seedActiveUser(userId, 'av-sync-preserve-location@example.com');
+    await seedVolunteer({
+      volunteerId: 'vol_sync_preserve_location',
+      userId,
+      isAvailable: false,
+      latitude: 40.99,
+      longitude: 29.02,
+      locationUpdatedAt: '2026-05-04T10:00:00.000Z',
+    });
+    const before = await query('SELECT location_updated_at FROM volunteers WHERE user_id = $1', [userId]);
+    const token = buildAuthToken(userId);
+
+    const response = await request(app)
+      .post('/api/availability/sync')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        records: [
+          { isAvailable: true, timestamp: new Date().toISOString() },
+        ],
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.volunteer.is_available).toBe(true);
+    expect(Number(response.body.volunteer.last_known_latitude)).toBeCloseTo(40.99);
+    expect(Number(response.body.volunteer.last_known_longitude)).toBeCloseTo(29.02);
+
+    const after = await query('SELECT * FROM volunteers WHERE user_id = $1', [userId]);
+    expect(Number(after.rows[0].last_known_latitude)).toBeCloseTo(40.99);
+    expect(Number(after.rows[0].last_known_longitude)).toBeCloseTo(29.02);
+    expect(after.rows[0].location_updated_at.getTime()).toBe(before.rows[0].location_updated_at.getTime());
+  });
+
+  test('POST /api/availability/sync keeps latest availability while storing latest available coordinates', async () => {
+    const app = createTestApp();
+    const userId = 'user_av_sync_available_location_order';
+    await seedActiveUser(userId, 'av-sync-available-location-order@example.com');
+    const token = buildAuthToken(userId);
+
+    const response = await request(app)
+      .post('/api/availability/sync')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        records: [
+          {
+            isAvailable: false,
+            timestamp: '2026-05-04T10:05:00.000Z',
+          },
+          {
+            isAvailable: true,
+            timestamp: '2026-05-04T10:00:00.000Z',
+            latitude: 41.015,
+            longitude: 29.01,
+          },
+        ],
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.volunteer.is_available).toBe(false);
     expect(Number(response.body.volunteer.last_known_latitude)).toBeCloseTo(41.015);
     expect(Number(response.body.volunteer.last_known_longitude)).toBeCloseTo(29.01);
   });

--- a/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
+++ b/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
@@ -29,6 +29,10 @@ function buildAuthToken(userId) {
 	);
 }
 
+function availabilityOnPayload(latitude = 41.0, longitude = 29.0) {
+	return { isAvailable: true, latitude, longitude };
+}
+
 function buildCreatePayload(overrides = {}) {
 	return {
 		helpTypes: ['first_aid', 'fire_brigade'],
@@ -207,7 +211,7 @@ describe('help-requests integration', () => {
 		const toggleRes = await request(app)
 			.post('/api/availability/toggle')
 			.set('Authorization', `Bearer ${helperToken}`)
-			.send({ isAvailable: true });
+			.send(availabilityOnPayload());
 
 		expect(toggleRes.status).toBe(200);
 		expect(toggleRes.body.assignment).toBeNull();
@@ -1018,7 +1022,7 @@ describe('help-requests integration', () => {
 		const firstToggle = await request(app)
 			.post('/api/availability/toggle')
 			.set('Authorization', `Bearer ${helperOneToken}`)
-			.send({ isAvailable: true });
+			.send(availabilityOnPayload());
 
 		expect(firstToggle.status).toBe(200);
 		expect(firstToggle.body.assignment.request_id).toBe(firstRequestId);
@@ -1061,7 +1065,7 @@ describe('help-requests integration', () => {
 		const helperOneBackOn = await request(app)
 			.post('/api/availability/toggle')
 			.set('Authorization', `Bearer ${helperOneToken}`)
-			.send({ isAvailable: true });
+			.send(availabilityOnPayload());
 
 		expect(helperOneBackOn.status).toBe(200);
 		expect(helperOneBackOn.body.assignment).toBeTruthy();
@@ -1231,7 +1235,7 @@ describe('help-requests integration', () => {
 		const toggleRes = await request(app)
 			.post('/api/availability/toggle')
 			.set('Authorization', `Bearer ${helperToken}`)
-			.send({ isAvailable: true });
+			.send(availabilityOnPayload());
 
 		expect(toggleRes.status).toBe(200);
 		expect(toggleRes.body.assignment).toBeTruthy();
@@ -1292,7 +1296,7 @@ describe('help-requests integration', () => {
 		const toggleRes = await request(app)
 			.post('/api/availability/toggle')
 			.set('Authorization', `Bearer ${helperToken}`)
-			.send({ isAvailable: true });
+			.send(availabilityOnPayload());
 
 		expect(toggleRes.status).toBe(200);
 		expect(toggleRes.body.assignment).toBeTruthy();
@@ -1347,7 +1351,7 @@ describe('help-requests integration', () => {
 		const toggleRes = await request(app)
 			.post('/api/availability/toggle')
 			.set('Authorization', `Bearer ${helperToken}`)
-			.send({ isAvailable: true });
+			.send(availabilityOnPayload());
 
 		expect(toggleRes.status).toBe(200);
 		expect(toggleRes.body.assignment).toBeTruthy();
@@ -1546,7 +1550,7 @@ describe('help-requests integration', () => {
 		const toggleRes = await request(app)
 			.post('/api/availability/toggle')
 			.set('Authorization', `Bearer ${helperToken}`)
-			.send({ isAvailable: true });
+			.send(availabilityOnPayload());
 
 		expect(toggleRes.status).toBe(200);
 		expect(toggleRes.body.assignment).toBeNull(); // No requests yet

--- a/backend/tests/unit/modules/availability/controller.test.js
+++ b/backend/tests/unit/modules/availability/controller.test.js
@@ -28,7 +28,7 @@ describe('Availability Controller', () => {
 
   describe('handleSetAvailability', () => {
     it('should return 200 on success', async () => {
-      req.body = { isAvailable: true };
+      req.body = { isAvailable: true, latitude: 41.0, longitude: 29.0 };
       service.setAvailability.mockResolvedValue({ success: true });
 
       await handleSetAvailability(req, res);

--- a/backend/tests/unit/modules/availability/service.test.js
+++ b/backend/tests/unit/modules/availability/service.test.js
@@ -104,7 +104,7 @@ describe('Availability Service', () => {
 
       await syncAvailability(userId, { records });
 
-      expect(repository.updateVolunteerAvailability).toHaveBeenCalledWith('vol_123', false, null, null);
+      expect(repository.updateVolunteerAvailability).toHaveBeenCalledWith('vol_123', false, undefined, undefined);
       expect(repository.createAvailabilityRecord).toHaveBeenCalledTimes(2);
     });
 
@@ -114,7 +114,7 @@ describe('Availability Service', () => {
       repository.getAssignmentByVolunteerId.mockResolvedValue(null);
       repository.findMatchingRequestForVolunteer.mockResolvedValue({ request_id: 'req_123' });
       
-      const records = [{ isAvailable: true, timestamp: '2023-01-01T10:00:00Z' }];
+      const records = [{ isAvailable: true, timestamp: '2023-01-01T10:00:00Z', latitude: 41, longitude: 29 }];
 
       await syncAvailability(userId, { records });
 
@@ -165,7 +165,7 @@ describe('Availability Service', () => {
 
       expect(repository.cancelAssignment).toHaveBeenCalledWith('asg_123');
       expect(repository.syncRequestStatusPreservingInProgress).toHaveBeenCalledWith('req_123');
-      expect(repository.updateVolunteerAvailability).toHaveBeenCalledWith('vol_123', false, undefined, undefined);
+      expect(repository.updateVolunteerAvailability).toHaveBeenCalledWith('vol_123', false);
       expect(result.message).toContain('Assignment cancelled, you are now unavailable');
     });
 
@@ -216,7 +216,7 @@ describe('Availability Service', () => {
 
       expect(repository.cancelAssignment).toHaveBeenCalledWith('asg_123');
       expect(repository.syncRequestStatusPreservingInProgress).toHaveBeenCalledWith('req_123');
-      expect(repository.updateVolunteerAvailability).toHaveBeenCalledWith('vol_123', false, undefined, undefined);
+      expect(repository.updateVolunteerAvailability).toHaveBeenCalledWith('vol_123', false);
       expect(result.message).toBe('Assignment resolved for this volunteer, you are now unavailable, and matching has been refreshed');
       expect(result.newAssignment).toBeNull();
     });


### PR DESCRIPTION
## Summary

This PR completes operational location support for volunteer availability and offline sync.

Availability ON now represents being available from the user’s current operational location, and backend sync no longer risks clearing useful volunteer coordinates when records do not include location data.

## Changes

- Ensured Android availability ON queues current device location with the availability operation
- Kept availability OFF independent from location capture
- Updated availability sync handling so queued coordinates are sent to the backend
- Updated backend availability sync to preserve existing volunteer coordinates when no new coordinates are provided
- Ensured volunteer coordinates are updated only when valid location data is included
- Added/updated validation for availability coordinates
- Added tests for coordinate preservation, invalid coordinate handling, and availability sync behavior

## Important Behavior

- Volunteers should not become auto-assignable from missing or accidentally cleared coordinates
- Offline availability ON preserves captured location in the queued sync payload
- Availability OFF does not require or overwrite location
- Existing profile/residential location flows are not changed

## Testing

- Added/updated backend availability tests
- Added/updated Android availability payload tests
- Ran relevant backend and Android checks

Closes #434 