### PR TITLE
feat: add stale location guard and availability expiry

### DIFF
--- a/backend/migrations/20260505_120000__add_volunteer_availability_session_metadata.sql
+++ b/backend/migrations/20260505_120000__add_volunteer_availability_session_metadata.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+ALTER TABLE volunteers
+  ADD COLUMN IF NOT EXISTS available_until TIMESTAMP,
+  ADD COLUMN IF NOT EXISTS availability_confirmed_at TIMESTAMP,
+  ADD COLUMN IF NOT EXISTS last_location_accuracy_meters DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS last_location_source VARCHAR(100);
+
+ALTER TABLE volunteers
+  ADD CONSTRAINT chk_volunteer_last_location_accuracy
+  CHECK (
+    last_location_accuracy_meters IS NULL
+    OR last_location_accuracy_meters >= 0
+  )
+  NOT VALID;
+
+ALTER TABLE volunteers
+  VALIDATE CONSTRAINT chk_volunteer_last_location_accuracy;
+
+CREATE INDEX IF NOT EXISTS idx_volunteers_matching_availability_session
+  ON volunteers (is_available, available_until, location_updated_at);
+
+COMMIT;

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -58,6 +58,10 @@ const env = {
     guestMatchingEnabled: (process.env.HELP_REQUEST_GUEST_MATCHING_ENABLED || 'false').toLowerCase() === 'true',
     guestTokenTtl: process.env.HELP_REQUEST_GUEST_TOKEN_TTL || '2h',
   },
+  volunteerMatching: {
+    locationMaxAgeMinutes: readNumber(process.env.VOLUNTEER_LOCATION_MAX_AGE_MINUTES, 120),
+    availabilityTtlMinutes: readNumber(process.env.VOLUNTEER_AVAILABILITY_TTL_MINUTES, 360),
+  },
 };
 
 module.exports = {

--- a/backend/src/modules/availability/repository.js
+++ b/backend/src/modules/availability/repository.js
@@ -436,24 +436,31 @@ async function updateVolunteerAvailability(
   const ttlMinutes = Number.isFinite(options.availabilityTtlMinutes) && options.availabilityTtlMinutes > 0
     ? Math.floor(options.availabilityTtlMinutes)
     : env.volunteerMatching.availabilityTtlMinutes;
+  const locationTimestamp = typeof options.locationTimestamp === 'string' && options.locationTimestamp.trim() !== ''
+    ? options.locationTimestamp
+    : null;
 
   const sql = `
+    WITH availability_event AS (
+      SELECT COALESCE($8::timestamp, CURRENT_TIMESTAMP) AS occurred_at
+    )
     UPDATE volunteers
     SET is_available = $2,
         last_known_latitude = $3,
         last_known_longitude = $4,
-        location_updated_at = CURRENT_TIMESTAMP,
-        availability_confirmed_at = CURRENT_TIMESTAMP,
-        available_until = CURRENT_TIMESTAMP + ($7::int * INTERVAL '1 minute'),
+        location_updated_at = availability_event.occurred_at,
+        availability_confirmed_at = availability_event.occurred_at,
+        available_until = availability_event.occurred_at + ($7::int * INTERVAL '1 minute'),
         last_location_accuracy_meters = $5,
         last_location_source = $6
+    FROM availability_event
     WHERE volunteer_id = $1
     RETURNING *;
   `;
   const result = await runQuery(
     resolvedExecutor,
     sql,
-    [volunteerId, isAvailable, latitude, longitude, accuracyMeters, locationSource, ttlMinutes],
+    [volunteerId, isAvailable, latitude, longitude, accuracyMeters, locationSource, ttlMinutes, locationTimestamp],
   );
   return result.rows[0];
 }

--- a/backend/src/modules/availability/repository.js
+++ b/backend/src/modules/availability/repository.js
@@ -67,6 +67,16 @@ function getConfiguredMatchRadiusMeters() {
   return DEFAULT_MAX_MATCH_DISTANCE_METERS;
 }
 
+function getConfiguredVolunteerLocationMaxAgeMinutes() {
+  const configuredValue = Number(process.env.VOLUNTEER_LOCATION_MAX_AGE_MINUTES);
+
+  if (Number.isFinite(configuredValue) && configuredValue > 0) {
+    return Math.floor(configuredValue);
+  }
+
+  return env.volunteerMatching.locationMaxAgeMinutes;
+}
+
 function toCoordinateValue(value) {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value;
@@ -382,30 +392,69 @@ async function createVolunteer(userId) {
   return result.rows[0];
 }
 
-async function updateVolunteerAvailability(volunteerId, isAvailable, latitude, longitude, executor = null) {
-  const hasCoordinateUpdate = Number.isFinite(latitude) && Number.isFinite(longitude);
+function resolveAvailabilityUpdateOptions(optionsOrExecutor, executor) {
+  if (optionsOrExecutor && typeof optionsOrExecutor.query === 'function') {
+    return {
+      options: {},
+      executor: optionsOrExecutor,
+    };
+  }
+
+  return {
+    options: optionsOrExecutor || {},
+    executor,
+  };
+}
+
+async function updateVolunteerAvailability(
+  volunteerId,
+  isAvailable,
+  latitude,
+  longitude,
+  optionsOrExecutor = null,
+  executor = null,
+) {
+  const { options, executor: resolvedExecutor } = resolveAvailabilityUpdateOptions(optionsOrExecutor, executor);
+  const hasCoordinateUpdate = isAvailable && Number.isFinite(latitude) && Number.isFinite(longitude);
 
   if (!hasCoordinateUpdate) {
     const sql = `
       UPDATE volunteers
-      SET is_available = $2
+      SET is_available = $2,
+          available_until = CASE WHEN $2 THEN available_until ELSE NULL END
       WHERE volunteer_id = $1
       RETURNING *;
     `;
-    const result = await runQuery(executor, sql, [volunteerId, isAvailable]);
+    const result = await runQuery(resolvedExecutor, sql, [volunteerId, isAvailable]);
     return result.rows[0];
   }
+
+  const accuracyMeters = Number.isFinite(options.accuracyMeters) ? options.accuracyMeters : null;
+  const locationSource = typeof options.source === 'string' && options.source.trim() !== ''
+    ? options.source.trim()
+    : null;
+  const ttlMinutes = Number.isFinite(options.availabilityTtlMinutes) && options.availabilityTtlMinutes > 0
+    ? Math.floor(options.availabilityTtlMinutes)
+    : env.volunteerMatching.availabilityTtlMinutes;
 
   const sql = `
     UPDATE volunteers
     SET is_available = $2,
         last_known_latitude = $3,
         last_known_longitude = $4,
-        location_updated_at = CURRENT_TIMESTAMP
+        location_updated_at = CURRENT_TIMESTAMP,
+        availability_confirmed_at = CURRENT_TIMESTAMP,
+        available_until = CURRENT_TIMESTAMP + ($7::int * INTERVAL '1 minute'),
+        last_location_accuracy_meters = $5,
+        last_location_source = $6
     WHERE volunteer_id = $1
     RETURNING *;
   `;
-  const result = await runQuery(executor, sql, [volunteerId, isAvailable, latitude, longitude]);
+  const result = await runQuery(
+    resolvedExecutor,
+    sql,
+    [volunteerId, isAvailable, latitude, longitude, accuracyMeters, locationSource, ttlMinutes],
+  );
   return result.rows[0];
 }
 
@@ -433,6 +482,7 @@ async function findPendingRequests() {
 }
 
 async function findAvailableVolunteersForMatching() {
+  const locationMaxAgeMinutes = getConfiguredVolunteerLocationMaxAgeMinutes();
   const sql = `
     SELECT
       v.*,
@@ -445,6 +495,12 @@ async function findAvailableVolunteersForMatching() {
       WHERE e.profile_id = up.profile_id
     ) expertise_context ON TRUE
     WHERE v.is_available = TRUE
+      AND v.last_known_latitude IS NOT NULL
+      AND v.last_known_longitude IS NOT NULL
+      AND v.location_updated_at IS NOT NULL
+      AND v.location_updated_at >= CURRENT_TIMESTAMP - ($1::int * INTERVAL '1 minute')
+      AND v.available_until IS NOT NULL
+      AND v.available_until > CURRENT_TIMESTAMP
       AND NOT EXISTS (
         SELECT 1 FROM assignments a
         JOIN help_requests hr ON a.request_id = hr.request_id
@@ -454,7 +510,7 @@ async function findAvailableVolunteersForMatching() {
       )
     ORDER BY v.location_updated_at DESC NULLS LAST, v.volunteer_id ASC;
   `;
-  const result = await query(sql);
+  const result = await query(sql, [locationMaxAgeMinutes]);
   return result.rows.map(buildVolunteerMatchContext);
 }
 
@@ -561,6 +617,7 @@ function selectBestVolunteerForRequest(requestRow, volunteerRows) {
 }
 
 async function findMatchingRequestForVolunteer(volunteerId) {
+  const locationMaxAgeMinutes = getConfiguredVolunteerLocationMaxAgeMinutes();
   const volunteerSql = `
     SELECT
       v.*,
@@ -573,9 +630,16 @@ async function findMatchingRequestForVolunteer(volunteerId) {
       WHERE e.profile_id = up.profile_id
     ) expertise_context ON TRUE
     WHERE v.volunteer_id = $1
+      AND v.is_available = TRUE
+      AND v.last_known_latitude IS NOT NULL
+      AND v.last_known_longitude IS NOT NULL
+      AND v.location_updated_at IS NOT NULL
+      AND v.location_updated_at >= CURRENT_TIMESTAMP - ($2::int * INTERVAL '1 minute')
+      AND v.available_until IS NOT NULL
+      AND v.available_until > CURRENT_TIMESTAMP
     LIMIT 1;
   `;
-  const vResult = await query(volunteerSql, [volunteerId]);
+  const vResult = await query(volunteerSql, [volunteerId, locationMaxAgeMinutes]);
   const volunteer = vResult.rows[0] ? buildVolunteerMatchContext(vResult.rows[0]) : null;
 
   if (!volunteer) return null;
@@ -621,6 +685,7 @@ async function findMatchingVolunteerForRequest(requestId) {
 }
 
 async function createAssignment(volunteerId, requestId) {
+  const locationMaxAgeMinutes = getConfiguredVolunteerLocationMaxAgeMinutes();
   const assignmentId = makeId('asg');
   const sql = `
     INSERT INTO assignments (assignment_id, volunteer_id, request_id, assigned_at, is_cancelled)
@@ -629,6 +694,12 @@ async function createAssignment(volunteerId, requestId) {
     JOIN help_requests hr ON hr.request_id = $3::VARCHAR(64)
     WHERE v.volunteer_id = $2::VARCHAR(64)
       AND v.is_available = TRUE
+      AND v.last_known_latitude IS NOT NULL
+      AND v.last_known_longitude IS NOT NULL
+      AND v.location_updated_at IS NOT NULL
+      AND v.location_updated_at >= CURRENT_TIMESTAMP - ($4::int * INTERVAL '1 minute')
+      AND v.available_until IS NOT NULL
+      AND v.available_until > CURRENT_TIMESTAMP
       AND hr.status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS')
       AND NOT EXISTS (
         SELECT 1
@@ -641,7 +712,7 @@ async function createAssignment(volunteerId, requestId) {
     ON CONFLICT (volunteer_id) WHERE is_cancelled = FALSE DO NOTHING
     RETURNING *;
   `;
-  const result = await query(sql, [assignmentId, volunteerId, requestId]);
+  const result = await query(sql, [assignmentId, volunteerId, requestId, locationMaxAgeMinutes]);
   return result.rows[0] || null;
 }
 

--- a/backend/src/modules/availability/service.js
+++ b/backend/src/modules/availability/service.js
@@ -17,6 +17,7 @@ const {
   findRequestOwnerByRequestId,
 } = require('./repository');
 const { createNotification } = require('../notifications/service');
+const { env } = require('../../config/env');
 
 async function notifyVolunteerTaskAssigned(volunteerUserId, requestId, actorUserId) {
   if (!volunteerUserId || !requestId) {
@@ -151,23 +152,112 @@ async function runAssignmentCycle() {
   return createdAssignments;
 }
 
+function getConfiguredAvailabilityTtlMinutes() {
+  const configuredValue = Number(process.env.VOLUNTEER_AVAILABILITY_TTL_MINUTES);
+
+  if (Number.isFinite(configuredValue) && configuredValue > 0) {
+    return Math.floor(configuredValue);
+  }
+
+  return env.volunteerMatching.availabilityTtlMinutes;
+}
+
+function getConfiguredLocationMaxAgeMinutes() {
+  const configuredValue = Number(process.env.VOLUNTEER_LOCATION_MAX_AGE_MINUTES);
+
+  if (Number.isFinite(configuredValue) && configuredValue > 0) {
+    return Math.floor(configuredValue);
+  }
+
+  return env.volunteerMatching.locationMaxAgeMinutes;
+}
+
+function buildLocationSessionOptions(input) {
+  return {
+    accuracyMeters: Number.isFinite(input.accuracyMeters) ? input.accuracyMeters : null,
+    source: typeof input.source === 'string' ? input.source : null,
+    availabilityTtlMinutes: getConfiguredAvailabilityTtlMinutes(),
+  };
+}
+
+function parseDatabaseTimestamp(value) {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return new Date(Date.UTC(
+      value.getFullYear(),
+      value.getMonth(),
+      value.getDate(),
+      value.getHours(),
+      value.getMinutes(),
+      value.getSeconds(),
+      value.getMilliseconds(),
+    ));
+  }
+
+  const rawValue = String(value);
+  const parsed = new Date(/[zZ]$|[+-]\d{2}:\d{2}$/.test(rawValue) ? rawValue : `${rawValue}Z`);
+  return Number.isFinite(parsed.getTime()) ? parsed : null;
+}
+
+function buildAvailabilitySessionStatus(volunteer) {
+  const now = Date.now();
+  const locationUpdatedAt = volunteer && volunteer.location_updated_at
+    ? parseDatabaseTimestamp(volunteer.location_updated_at)
+    : null;
+  const availableUntil = volunteer && volunteer.available_until
+    ? parseDatabaseTimestamp(volunteer.available_until)
+    : null;
+  const locationMaxAgeMinutes = getConfiguredLocationMaxAgeMinutes();
+  const isLocationFresh = Boolean(
+    locationUpdatedAt
+    && Number.isFinite(locationUpdatedAt.getTime())
+    && now - locationUpdatedAt.getTime() <= locationMaxAgeMinutes * 60 * 1000,
+  );
+  const isAvailabilitySessionActive = Boolean(
+    volunteer
+    && volunteer.is_available
+    && availableUntil
+    && Number.isFinite(availableUntil.getTime())
+    && availableUntil.getTime() > now,
+  );
+
+  return {
+    availableUntil: volunteer ? volunteer.available_until || null : null,
+    availabilityConfirmedAt: volunteer ? volunteer.availability_confirmed_at || null : null,
+    locationUpdatedAt: volunteer ? volunteer.location_updated_at || null : null,
+    locationMaxAgeMinutes,
+    availabilityTtlMinutes: getConfiguredAvailabilityTtlMinutes(),
+    isLocationFresh,
+    isAvailabilitySessionActive,
+    availabilitySessionExpired: Boolean(volunteer && volunteer.is_available && !isAvailabilitySessionActive),
+  };
+}
+
 async function syncRequestStatusFromAssignments(requestId) {
   await syncRequestStatusPreservingInProgress(requestId);
   return findActiveAssignmentsByRequestId(requestId);
 }
 
-async function setAvailability(userId, { isAvailable, latitude, longitude }) {
+async function setAvailability(userId, input) {
+  const { isAvailable, latitude, longitude } = input;
   let volunteer = await findVolunteerByUserId(userId);
   if (!volunteer) {
     volunteer = await createVolunteer(userId);
   }
 
   const hasCoordinates = isAvailable && Number.isFinite(latitude) && Number.isFinite(longitude);
+  const locationOptions = hasCoordinates
+    ? buildLocationSessionOptions(input)
+    : {};
   const updatedVolunteer = await updateVolunteerAvailability(
     volunteer.volunteer_id,
     isAvailable,
     hasCoordinates ? latitude : undefined,
-    hasCoordinates ? longitude : undefined
+    hasCoordinates ? longitude : undefined,
+    locationOptions,
   );
 
   await createAvailabilityRecord(volunteer.volunteer_id, isAvailable, false);
@@ -206,16 +296,16 @@ async function syncAvailability(userId, { records }) {
   if (records.length > 0) {
     const sortedRecords = [...records].sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
     const latest = sortedRecords[sortedRecords.length - 1];
-    const latestAvailableRecord = [...sortedRecords].reverse().find((record) => record.isAvailable);
-    const hasLatestAvailableCoordinates = latestAvailableRecord
-      && Number.isFinite(latestAvailableRecord.latitude)
-      && Number.isFinite(latestAvailableRecord.longitude);
+    const latestHasAvailableCoordinates = latest.isAvailable
+      && Number.isFinite(latest.latitude)
+      && Number.isFinite(latest.longitude);
 
     await updateVolunteerAvailability(
       volunteer.volunteer_id,
       latest.isAvailable,
-      hasLatestAvailableCoordinates ? latestAvailableRecord.latitude : undefined,
-      hasLatestAvailableCoordinates ? latestAvailableRecord.longitude : undefined
+      latestHasAvailableCoordinates ? latest.latitude : undefined,
+      latestHasAvailableCoordinates ? latest.longitude : undefined,
+      latestHasAvailableCoordinates ? buildLocationSessionOptions(latest) : {},
     );
 
     for (const record of sortedRecords) {
@@ -425,7 +515,8 @@ async function getAvailabilityStatus(userId) {
     return {
       isAvailable: false,
       volunteer: null,
-      assignment: null
+      assignment: null,
+      ...buildAvailabilitySessionStatus(null),
     };
   }
 
@@ -434,7 +525,8 @@ async function getAvailabilityStatus(userId) {
   return {
     isAvailable: volunteer.is_available,
     volunteer,
-    assignment
+    assignment,
+    ...buildAvailabilitySessionStatus(volunteer),
   };
 }
 

--- a/backend/src/modules/availability/service.js
+++ b/backend/src/modules/availability/service.js
@@ -223,6 +223,12 @@ function buildAvailabilitySessionStatus(volunteer) {
     && Number.isFinite(availableUntil.getTime())
     && availableUntil.getTime() > now,
   );
+  const effectiveIsAvailable = Boolean(
+    volunteer
+    && volunteer.is_available
+    && isAvailabilitySessionActive
+    && isLocationFresh,
+  );
 
   return {
     availableUntil: volunteer ? volunteer.available_until || null : null,
@@ -230,6 +236,7 @@ function buildAvailabilitySessionStatus(volunteer) {
     locationUpdatedAt: volunteer ? volunteer.location_updated_at || null : null,
     locationMaxAgeMinutes,
     availabilityTtlMinutes: getConfiguredAvailabilityTtlMinutes(),
+    effectiveIsAvailable,
     isLocationFresh,
     isAvailabilitySessionActive,
     availabilitySessionExpired: Boolean(volunteer && volunteer.is_available && !isAvailabilitySessionActive),

--- a/backend/src/modules/availability/service.js
+++ b/backend/src/modules/availability/service.js
@@ -180,6 +180,17 @@ function buildLocationSessionOptions(input) {
   };
 }
 
+function getSyncRecordEventTimestamp(record) {
+  const rawTimestamp = record.capturedAt || record.timestamp;
+  const parsed = rawTimestamp ? new Date(rawTimestamp) : null;
+
+  if (!parsed || !Number.isFinite(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed.toISOString();
+}
+
 function parseDatabaseTimestamp(value) {
   if (!value) {
     return null;
@@ -211,6 +222,13 @@ function buildAvailabilitySessionStatus(volunteer) {
     ? parseDatabaseTimestamp(volunteer.available_until)
     : null;
   const locationMaxAgeMinutes = getConfiguredLocationMaxAgeMinutes();
+  const hasUsableLocation = Boolean(
+    volunteer
+    && volunteer.last_known_latitude !== null
+    && volunteer.last_known_latitude !== undefined
+    && volunteer.last_known_longitude !== null
+    && volunteer.last_known_longitude !== undefined,
+  );
   const isLocationFresh = Boolean(
     locationUpdatedAt
     && Number.isFinite(locationUpdatedAt.getTime())
@@ -227,7 +245,8 @@ function buildAvailabilitySessionStatus(volunteer) {
     volunteer
     && volunteer.is_available
     && isAvailabilitySessionActive
-    && isLocationFresh,
+    && isLocationFresh
+    && hasUsableLocation,
   );
 
   return {
@@ -237,6 +256,7 @@ function buildAvailabilitySessionStatus(volunteer) {
     locationMaxAgeMinutes,
     availabilityTtlMinutes: getConfiguredAvailabilityTtlMinutes(),
     effectiveIsAvailable,
+    hasUsableLocation,
     isLocationFresh,
     isAvailabilitySessionActive,
     availabilitySessionExpired: Boolean(volunteer && volunteer.is_available && !isAvailabilitySessionActive),
@@ -312,7 +332,12 @@ async function syncAvailability(userId, { records }) {
       latest.isAvailable,
       latestHasAvailableCoordinates ? latest.latitude : undefined,
       latestHasAvailableCoordinates ? latest.longitude : undefined,
-      latestHasAvailableCoordinates ? buildLocationSessionOptions(latest) : {},
+      latestHasAvailableCoordinates
+        ? {
+            ...buildLocationSessionOptions(latest),
+            locationTimestamp: getSyncRecordEventTimestamp(latest),
+          }
+        : {},
     );
 
     for (const record of sortedRecords) {

--- a/backend/src/modules/availability/validators.js
+++ b/backend/src/modules/availability/validators.js
@@ -1,3 +1,5 @@
+const { env } = require('../../config/env');
+
 const setAvailabilitySchema = {
   isAvailable: {
     type: 'boolean',
@@ -34,6 +36,7 @@ const syncAvailabilitySchema = {
         longitude: { type: 'number', required: false },
         accuracyMeters: { type: 'number', required: false },
         source: { type: 'string', required: false },
+        capturedAt: { type: 'string', required: false },
       },
     },
   },
@@ -52,6 +55,45 @@ function isPlainObject(value) {
 
 function hasOwn(object, key) {
   return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function getConfiguredLocationMaxAgeMinutes() {
+  const configuredValue = Number(process.env.VOLUNTEER_LOCATION_MAX_AGE_MINUTES);
+
+  if (Number.isFinite(configuredValue) && configuredValue > 0) {
+    return Math.floor(configuredValue);
+  }
+
+  return env.volunteerMatching.locationMaxAgeMinutes;
+}
+
+function parseEventTimestamp(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed : null;
+}
+
+function isStaleEventTimestamp(value) {
+  const parsed = parseEventTimestamp(value);
+
+  if (!parsed) {
+    return false;
+  }
+
+  return Date.now() - parsed.getTime() > getConfiguredLocationMaxAgeMinutes() * 60 * 1000;
+}
+
+function validateTimestampValue(data, key, errors, prefix = '') {
+  if (!hasOwn(data, key) || data[key] === null) {
+    return;
+  }
+
+  if (typeof data[key] !== 'string' || !parseEventTimestamp(data[key])) {
+    errors.push(`${prefix ? `${prefix}.` : ''}${key} must be a valid ISO timestamp string`);
+  }
 }
 
 function validateCoordinatePair(data, errors, prefix = '') {
@@ -142,8 +184,11 @@ function validateSyncAvailabilityPayload(data) {
       errors.push(`${prefix}.timestamp is required`);
     } else if (typeof record.timestamp !== 'string') {
       errors.push(`${prefix}.timestamp must be a string`);
+    } else {
+      validateTimestampValue(record, 'timestamp', errors, prefix);
     }
 
+    validateTimestampValue(record, 'capturedAt', errors, prefix);
     validateCoordinatePair(record, errors, prefix);
     validateLocationMetadata(record, errors, prefix);
   });
@@ -153,6 +198,9 @@ function validateSyncAvailabilityPayload(data) {
     const latest = sortedRecords[sortedRecords.length - 1];
     if (latest.isAvailable === true && (!hasOwn(latest, 'latitude') || !hasOwn(latest, 'longitude'))) {
       errors.push('records latest available state requires latitude and longitude');
+    }
+    if (latest.isAvailable === true && isStaleEventTimestamp(latest.capturedAt || latest.timestamp)) {
+      errors.push('records latest available location is stale');
     }
   }
 

--- a/backend/src/modules/availability/validators.js
+++ b/backend/src/modules/availability/validators.js
@@ -1,5 +1,7 @@
 const { env } = require('../../config/env');
 
+const FUTURE_EVENT_CLOCK_SKEW_MINUTES = 5;
+
 const setAvailabilitySchema = {
   isAvailable: {
     type: 'boolean',
@@ -86,6 +88,16 @@ function isStaleEventTimestamp(value) {
   return Date.now() - parsed.getTime() > getConfiguredLocationMaxAgeMinutes() * 60 * 1000;
 }
 
+function isFutureEventTimestamp(value) {
+  const parsed = parseEventTimestamp(value);
+
+  if (!parsed) {
+    return false;
+  }
+
+  return parsed.getTime() - Date.now() > FUTURE_EVENT_CLOCK_SKEW_MINUTES * 60 * 1000;
+}
+
 function validateTimestampValue(data, key, errors, prefix = '') {
   if (!hasOwn(data, key) || data[key] === null) {
     return;
@@ -93,6 +105,11 @@ function validateTimestampValue(data, key, errors, prefix = '') {
 
   if (typeof data[key] !== 'string' || !parseEventTimestamp(data[key])) {
     errors.push(`${prefix ? `${prefix}.` : ''}${key} must be a valid ISO timestamp string`);
+    return;
+  }
+
+  if (isFutureEventTimestamp(data[key])) {
+    errors.push(`${prefix ? `${prefix}.` : ''}${key} must not be more than ${FUTURE_EVENT_CLOCK_SKEW_MINUTES} minutes in the future`);
   }
 }
 

--- a/backend/src/modules/availability/validators.js
+++ b/backend/src/modules/availability/validators.js
@@ -11,6 +11,14 @@ const setAvailabilitySchema = {
     type: 'number',
     required: false,
   },
+  accuracyMeters: {
+    type: 'number',
+    required: false,
+  },
+  source: {
+    type: 'string',
+    required: false,
+  },
 };
 
 const syncAvailabilitySchema = {
@@ -24,6 +32,8 @@ const syncAvailabilitySchema = {
         timestamp: { type: 'string', required: true },
         latitude: { type: 'number', required: false },
         longitude: { type: 'number', required: false },
+        accuracyMeters: { type: 'number', required: false },
+        source: { type: 'string', required: false },
       },
     },
   },
@@ -68,9 +78,35 @@ function validateCoordinatePair(data, errors, prefix = '') {
   }
 }
 
+function validateLocationMetadata(data, errors, prefix = '') {
+  const accuracyKey = prefix ? `${prefix}.accuracyMeters` : 'accuracyMeters';
+  const sourceKey = prefix ? `${prefix}.source` : 'source';
+
+  if (
+    hasOwn(data, 'accuracyMeters')
+    && data.accuracyMeters !== null
+    && (
+      typeof data.accuracyMeters !== 'number'
+      || !Number.isFinite(data.accuracyMeters)
+      || data.accuracyMeters < 0
+    )
+  ) {
+    errors.push(`${accuracyKey} must be a finite number greater than or equal to 0`);
+  }
+
+  if (
+    hasOwn(data, 'source')
+    && data.source !== null
+    && (typeof data.source !== 'string' || data.source.length > 100)
+  ) {
+    errors.push(`${sourceKey} must be a string of at most 100 characters`);
+  }
+}
+
 function validateSetAvailabilityPayload(data) {
   const errors = validate(data, setAvailabilitySchema);
   validateCoordinatePair(data || {}, errors);
+  validateLocationMetadata(data || {}, errors);
   if (data && data.isAvailable === true && (!hasOwn(data, 'latitude') || !hasOwn(data, 'longitude'))) {
     errors.push('latitude and longitude are required when isAvailable is true');
   }
@@ -109,6 +145,7 @@ function validateSyncAvailabilityPayload(data) {
     }
 
     validateCoordinatePair(record, errors, prefix);
+    validateLocationMetadata(record, errors, prefix);
   });
 
   if (errors.length === 0 && data.records.length > 0) {

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -33,6 +33,10 @@ function availabilityOnPayload(latitude = 41.0, longitude = 29.0) {
   return { isAvailable: true, latitude, longitude };
 }
 
+function minutesFromNow(minutes) {
+  return new Date(Date.now() + minutes * 60 * 1000).toISOString();
+}
+
 async function seedActiveUser(userId, email = 'user@example.com') {
   await query(
     `
@@ -54,9 +58,10 @@ async function seedVolunteer({
   volunteerId,
   userId,
   isAvailable = true,
-  latitude = null,
-  longitude = null,
-  locationUpdatedAt = '2026-04-23T08:00:00.000Z',
+  latitude = 41.0,
+  longitude = 29.0,
+  locationUpdatedAt = new Date().toISOString(),
+  availableUntil = isAvailable ? minutesFromNow(360) : null,
 }) {
   await query(
     `
@@ -66,11 +71,22 @@ async function seedVolunteer({
         is_available,
         last_known_latitude,
         last_known_longitude,
-        location_updated_at
+        location_updated_at,
+        available_until,
+        availability_confirmed_at
       )
-      VALUES ($1, $2, $3, $4, $5, $6);
+      VALUES (
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        $6::timestamp,
+        $7::timestamp,
+        CASE WHEN $3 THEN $6::timestamp ELSE NULL END
+      );
     `,
-    [volunteerId, userId, isAvailable, latitude, longitude, locationUpdatedAt],
+    [volunteerId, userId, isAvailable, latitude, longitude, locationUpdatedAt, availableUntil],
   );
 }
 
@@ -201,10 +217,15 @@ describe('Availability integration', () => {
     expect(response.status).toBe(200);
     expect(response.body.volunteer.is_available).toBe(true);
     expect(response.body.volunteer.user_id).toBe(userId);
+    expect(response.body.volunteer.available_until).toBeTruthy();
+    expect(response.body.volunteer.availability_confirmed_at).toBeTruthy();
+    expect(response.body.volunteer.location_updated_at).toBeTruthy();
 
     const vResult = await query('SELECT * FROM volunteers WHERE user_id = $1', [userId]);
     expect(vResult.rows).toHaveLength(1);
     expect(vResult.rows[0].is_available).toBe(true);
+    expect(vResult.rows[0].available_until).toBeTruthy();
+    expect(vResult.rows[0].availability_confirmed_at).toBeTruthy();
   });
 
   test('POST /api/availability/toggle to false preserves existing volunteer coordinates', async () => {
@@ -217,7 +238,7 @@ describe('Availability integration', () => {
       isAvailable: true,
       latitude: 41.015,
       longitude: 29.01,
-      locationUpdatedAt: '2026-05-04T10:00:00.000Z',
+      locationUpdatedAt: minutesFromNow(-10),
     });
     const before = await query('SELECT location_updated_at FROM volunteers WHERE user_id = $1', [userId]);
     const token = buildAuthToken(userId);
@@ -236,6 +257,12 @@ describe('Availability integration', () => {
     expect(Number(after.rows[0].last_known_latitude)).toBeCloseTo(41.015);
     expect(Number(after.rows[0].last_known_longitude)).toBeCloseTo(29.01);
     expect(after.rows[0].location_updated_at.getTime()).toBe(before.rows[0].location_updated_at.getTime());
+    expect(after.rows[0].available_until).toBeNull();
+
+    await seedActiveUser('user_req_toggle_off_preserve', 'req-toggle-off-preserve@example.com');
+    await seedHelpRequest('req_toggle_off_preserve', 'user_req_toggle_off_preserve');
+    expect(await tryToAssignRequest('req_toggle_off_preserve')).toBe(false);
+    expect(await listAssignedVolunteerIds('req_toggle_off_preserve')).toEqual([]);
   });
 
   test.each([
@@ -257,6 +284,56 @@ describe('Availability integration', () => {
 
     expect(response.status).toBe(400);
     expect(response.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  test('POST /api/availability/toggle refresh while available extends session expiry', async () => {
+    const app = createTestApp();
+    const userId = 'user_av_refresh_extends';
+    await seedActiveUser(userId, 'av-refresh-extends@example.com');
+    const token = buildAuthToken(userId);
+
+    await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ isAvailable: true, latitude: 41.0, longitude: 29.0 });
+
+    await query(
+      `
+        UPDATE volunteers
+        SET available_until = CURRENT_TIMESTAMP + INTERVAL '5 minutes'
+        WHERE user_id = $1;
+      `,
+      [userId],
+    );
+    const before = await query('SELECT available_until FROM volunteers WHERE user_id = $1', [userId]);
+
+    const response = await request(app)
+      .post('/api/availability/toggle')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        isAvailable: true,
+        latitude: 41.001,
+        longitude: 29.001,
+        accuracyMeters: 8,
+        source: 'DEVICE_GPS',
+      });
+
+    expect(response.status).toBe(200);
+
+    const after = await query(
+      `
+        SELECT
+          available_until,
+          last_location_accuracy_meters,
+          last_location_source
+        FROM volunteers
+        WHERE user_id = $1;
+      `,
+      [userId],
+    );
+    expect(after.rows[0].available_until.getTime()).toBeGreaterThan(before.rows[0].available_until.getTime());
+    expect(Number(after.rows[0].last_location_accuracy_meters)).toBeCloseTo(8);
+    expect(after.rows[0].last_location_source).toBe('DEVICE_GPS');
   });
 
   test('POST /api/availability/toggle matches a request if available', async () => {
@@ -430,6 +507,100 @@ describe('Availability integration', () => {
     expect(farStatus.rows[0].status).toBe('ASSIGNED');
   });
 
+  test('tryToAssignRequest assigns a fresh nearby volunteer', async () => {
+    await seedActiveUser('user_r_fresh_nearby', 'fresh-nearby-requester@example.com');
+    await seedActiveUser('user_vol_fresh_nearby', 'fresh-nearby-volunteer@example.com');
+    await seedHelpRequest('req_fresh_nearby', 'user_r_fresh_nearby', {
+      needType: 'food',
+      helpTypes: ['food'],
+      latitude: 41.0,
+      longitude: 29.0,
+    });
+    await seedVolunteer({
+      volunteerId: 'vol_fresh_nearby',
+      userId: 'user_vol_fresh_nearby',
+      isAvailable: true,
+      latitude: 41.0005,
+      longitude: 29.0005,
+      locationUpdatedAt: minutesFromNow(-5),
+    });
+
+    const assigned = await tryToAssignRequest('req_fresh_nearby');
+
+    expect(assigned).toBe(true);
+    expect(await listAssignedVolunteerIds('req_fresh_nearby')).toEqual(['vol_fresh_nearby']);
+  });
+
+  test('tryToAssignRequest skips a volunteer with a 2-day-old location', async () => {
+    await seedActiveUser('user_r_stale_location', 'stale-location-requester@example.com');
+    await seedActiveUser('user_vol_stale_location', 'stale-location-volunteer@example.com');
+    await seedHelpRequest('req_stale_location', 'user_r_stale_location');
+    await seedVolunteer({
+      volunteerId: 'vol_stale_location',
+      userId: 'user_vol_stale_location',
+      isAvailable: true,
+      locationUpdatedAt: minutesFromNow(-2 * 24 * 60),
+    });
+
+    const assigned = await tryToAssignRequest('req_stale_location');
+
+    expect(assigned).toBe(false);
+    expect(await listAssignedVolunteerIds('req_stale_location')).toEqual([]);
+  });
+
+  test('tryToAssignRequest skips a volunteer with null coordinates', async () => {
+    await seedActiveUser('user_r_null_coords', 'null-coords-requester@example.com');
+    await seedActiveUser('user_vol_null_coords', 'null-coords-volunteer@example.com');
+    await seedHelpRequest('req_null_coords', 'user_r_null_coords');
+    await seedVolunteer({
+      volunteerId: 'vol_null_coords',
+      userId: 'user_vol_null_coords',
+      isAvailable: true,
+      latitude: null,
+      longitude: null,
+    });
+
+    const assigned = await tryToAssignRequest('req_null_coords');
+
+    expect(assigned).toBe(false);
+    expect(await listAssignedVolunteerIds('req_null_coords')).toEqual([]);
+  });
+
+  test('tryToAssignRequest skips a volunteer with null location_updated_at', async () => {
+    await seedActiveUser('user_r_null_location_updated', 'null-location-updated-requester@example.com');
+    await seedActiveUser('user_vol_null_location_updated', 'null-location-updated-volunteer@example.com');
+    await seedHelpRequest('req_null_location_updated', 'user_r_null_location_updated');
+    await seedVolunteer({
+      volunteerId: 'vol_null_location_updated',
+      userId: 'user_vol_null_location_updated',
+      isAvailable: true,
+      locationUpdatedAt: null,
+    });
+
+    const assigned = await tryToAssignRequest('req_null_location_updated');
+
+    expect(assigned).toBe(false);
+    expect(await listAssignedVolunteerIds('req_null_location_updated')).toEqual([]);
+  });
+
+  test('tryToAssignRequest skips an expired available volunteer', async () => {
+    await seedActiveUser('user_r_expired_session', 'expired-session-requester@example.com');
+    await seedActiveUser('user_vol_expired_session', 'expired-session-volunteer@example.com');
+    await seedHelpRequest('req_expired_session', 'user_r_expired_session');
+    await seedVolunteer({
+      volunteerId: 'vol_expired_session',
+      userId: 'user_vol_expired_session',
+      isAvailable: true,
+      locationUpdatedAt: minutesFromNow(-5),
+      availableUntil: minutesFromNow(-1),
+    });
+
+    const assigned = await tryToAssignRequest('req_expired_session');
+
+    expect(assigned).toBe(false);
+    expect(await listAssignedVolunteerIds('req_expired_session')).toEqual([]);
+  });
+
   test('tryToAssignRequest expands SAR requests up to affectedPeopleCount + 1 after initial coverage', async () => {
     await seedActiveUser('user_r_sar_growth', 'sar-growth@example.com');
     await seedHelpRequest('req_sar_growth', 'user_r_sar_growth', {
@@ -445,7 +616,7 @@ describe('Availability integration', () => {
         volunteerId,
         userId,
         isAvailable: true,
-        locationUpdatedAt: `2026-04-23T08:0${index}:00.000Z`,
+        locationUpdatedAt: minutesFromNow(-10 + index),
       });
     }
 
@@ -504,7 +675,7 @@ describe('Availability integration', () => {
         volunteerId,
         userId,
         isAvailable: true,
-        locationUpdatedAt: `2026-04-23T08:1${index}:00.000Z`,
+        locationUpdatedAt: minutesFromNow(-10 + index),
       });
     }
 
@@ -539,7 +710,7 @@ describe('Availability integration', () => {
         volunteerId,
         userId,
         isAvailable: true,
-        locationUpdatedAt: `2026-04-23T08:2${index}:00.000Z`,
+        locationUpdatedAt: minutesFromNow(-10 + index),
       });
     }
 
@@ -907,8 +1078,8 @@ describe('Availability integration', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.volunteer.is_available).toBe(false);
-    expect(Number(response.body.volunteer.last_known_latitude)).toBeCloseTo(41.015);
-    expect(Number(response.body.volunteer.last_known_longitude)).toBeCloseTo(29.01);
+    expect(response.body.volunteer.last_known_latitude).toBeNull();
+    expect(response.body.volunteer.last_known_longitude).toBeNull();
 
     const arResult = await query('SELECT * FROM availability_records');
     expect(arResult.rows).toHaveLength(2);
@@ -941,6 +1112,10 @@ describe('Availability integration', () => {
     expect(response.body.volunteer.is_available).toBe(true);
     expect(Number(response.body.volunteer.last_known_latitude)).toBeCloseTo(41.015);
     expect(Number(response.body.volunteer.last_known_longitude)).toBeCloseTo(29.01);
+    expect(response.body.volunteer.available_until).toBeTruthy();
+    expect(response.body.volunteer.availability_confirmed_at).toBeTruthy();
+    expect(Number(response.body.volunteer.last_location_accuracy_meters)).toBeCloseTo(12.5);
+    expect(response.body.volunteer.last_location_source).toBe('DEVICE_GPS');
   });
 
   test('POST /api/availability/sync preserves existing coordinates when latest unavailable record lacks coordinates', async () => {
@@ -953,7 +1128,7 @@ describe('Availability integration', () => {
       isAvailable: false,
       latitude: 40.99,
       longitude: 29.02,
-      locationUpdatedAt: '2026-05-04T10:00:00.000Z',
+      locationUpdatedAt: minutesFromNow(-10),
     });
     const before = await query('SELECT location_updated_at FROM volunteers WHERE user_id = $1', [userId]);
     const token = buildAuthToken(userId);
@@ -998,7 +1173,7 @@ describe('Availability integration', () => {
     expect(response.body.code).toBe('VALIDATION_ERROR');
   });
 
-  test('POST /api/availability/sync keeps latest availability while storing latest available coordinates', async () => {
+  test('POST /api/availability/sync keeps latest unavailable state without refreshing old available coordinates', async () => {
     const app = createTestApp();
     const userId = 'user_av_sync_available_location_order';
     await seedActiveUser(userId, 'av-sync-available-location-order@example.com');
@@ -1024,8 +1199,8 @@ describe('Availability integration', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.volunteer.is_available).toBe(false);
-    expect(Number(response.body.volunteer.last_known_latitude)).toBeCloseTo(41.015);
-    expect(Number(response.body.volunteer.last_known_longitude)).toBeCloseTo(29.01);
+    expect(response.body.volunteer.last_known_latitude).toBeNull();
+    expect(response.body.volunteer.last_known_longitude).toBeNull();
   });
 
   test.each([
@@ -1299,6 +1474,11 @@ describe('Availability integration', () => {
     expect(response.status).toBe(200);
     expect(response.body.isAvailable).toBe(false);
     expect(response.body.volunteer).toBeNull();
+    expect(response.body.availableUntil).toBeNull();
+    expect(response.body.availabilityConfirmedAt).toBeNull();
+    expect(response.body.locationUpdatedAt).toBeNull();
+    expect(response.body.isLocationFresh).toBe(false);
+    expect(response.body.isAvailabilitySessionActive).toBe(false);
 
     // Toggle to available
     await request(app)
@@ -1317,6 +1497,14 @@ describe('Availability integration', () => {
     expect(response.body.volunteer.user_id).toBe(volunteerUserId);
     expect(response.body.assignment).toBeTruthy();
     expect(response.body.assignment.request_id).toBe('req_5');
+    expect(response.body.availableUntil).toBeTruthy();
+    expect(response.body.availabilityConfirmedAt).toBeTruthy();
+    expect(response.body.locationUpdatedAt).toBeTruthy();
+    expect(response.body.locationMaxAgeMinutes).toBe(120);
+    expect(response.body.availabilityTtlMinutes).toBe(360);
+    expect(response.body.isLocationFresh).toBe(true);
+    expect(response.body.isAvailabilitySessionActive).toBe(true);
+    expect(response.body.availabilitySessionExpired).toBe(false);
   });
 
   test('POST /api/availability/toggle to false cancels active assignment', async () => {

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -1477,6 +1477,7 @@ describe('Availability integration', () => {
     expect(response.body.availableUntil).toBeNull();
     expect(response.body.availabilityConfirmedAt).toBeNull();
     expect(response.body.locationUpdatedAt).toBeNull();
+    expect(response.body.effectiveIsAvailable).toBe(false);
     expect(response.body.isLocationFresh).toBe(false);
     expect(response.body.isAvailabilitySessionActive).toBe(false);
 
@@ -1502,9 +1503,33 @@ describe('Availability integration', () => {
     expect(response.body.locationUpdatedAt).toBeTruthy();
     expect(response.body.locationMaxAgeMinutes).toBe(120);
     expect(response.body.availabilityTtlMinutes).toBe(360);
+    expect(response.body.effectiveIsAvailable).toBe(true);
     expect(response.body.isLocationFresh).toBe(true);
     expect(response.body.isAvailabilitySessionActive).toBe(true);
     expect(response.body.availabilitySessionExpired).toBe(false);
+  });
+
+  test('GET /api/availability/status reports expired availability as not effectively available', async () => {
+    const app = createTestApp();
+    const userId = 'user_v_status_expired';
+    await seedActiveUser(userId, 'status-expired@example.com');
+    await seedVolunteer({
+      volunteerId: 'vol_status_expired',
+      userId,
+      isAvailable: true,
+      locationUpdatedAt: minutesFromNow(-10),
+      availableUntil: minutesFromNow(-1),
+    });
+    const token = buildAuthToken(userId);
+
+    const response = await request(app)
+      .get('/api/availability/status')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.isAvailable).toBe(true);
+    expect(response.body.effectiveIsAvailable).toBe(false);
+    expect(response.body.availabilitySessionExpired).toBe(true);
   });
 
   test('POST /api/availability/toggle to false cancels active assignment', async () => {

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -1165,6 +1165,51 @@ describe('Availability integration', () => {
     expect(await tryToAssignRequest(`req_sync_stale_${_caseName}`)).toBe(false);
   });
 
+  test.each([
+    ['capturedAt', { capturedAt: minutesFromNow(10) }],
+    ['timestamp', { timestamp: minutesFromNow(10) }],
+  ])('POST /api/availability/sync rejects future final available location based on %s', async (_caseName, timeFields) => {
+    const app = createTestApp();
+    const userId = `user_av_sync_future_${_caseName}`;
+    await seedActiveUser(userId, `${userId}@example.com`);
+    await seedVolunteer({
+      volunteerId: `vol_sync_future_${_caseName}`,
+      userId,
+      isAvailable: false,
+      latitude: 40.99,
+      longitude: 29.02,
+      locationUpdatedAt: minutesFromNow(-15),
+    });
+    const before = await query('SELECT * FROM volunteers WHERE user_id = $1', [userId]);
+    const token = buildAuthToken(userId);
+    const timestamp = timeFields.timestamp || new Date().toISOString();
+
+    const response = await request(app)
+      .post('/api/availability/sync')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        records: [
+          {
+            isAvailable: true,
+            timestamp,
+            latitude: 41.015,
+            longitude: 29.01,
+            ...timeFields,
+          },
+        ],
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+
+    const after = await query('SELECT * FROM volunteers WHERE user_id = $1', [userId]);
+    expect(after.rows[0].is_available).toBe(false);
+    expect(after.rows[0].location_updated_at.getTime()).toBe(before.rows[0].location_updated_at.getTime());
+    expect(after.rows[0].availability_confirmed_at).toBeNull();
+    expect(after.rows[0].available_until).toBeNull();
+    expect(Number(after.rows[0].last_known_latitude)).toBeCloseTo(40.99);
+  });
+
   test('POST /api/availability/sync preserves existing coordinates when latest unavailable record lacks coordinates', async () => {
     const app = createTestApp();
     const userId = 'user_av_sync_preserve_location';

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -1103,7 +1103,7 @@ describe('Availability integration', () => {
             longitude: 29.01,
             accuracyMeters: 12.5,
             source: 'DEVICE_GPS',
-            capturedAt: '2026-05-04T10:00:00.000Z',
+            capturedAt: minutesFromNow(-10),
           },
         ],
       });
@@ -1116,6 +1116,53 @@ describe('Availability integration', () => {
     expect(response.body.volunteer.availability_confirmed_at).toBeTruthy();
     expect(Number(response.body.volunteer.last_location_accuracy_meters)).toBeCloseTo(12.5);
     expect(response.body.volunteer.last_location_source).toBe('DEVICE_GPS');
+  });
+
+  test.each([
+    ['capturedAt', { capturedAt: minutesFromNow(-2 * 24 * 60) }],
+    ['timestamp', { timestamp: minutesFromNow(-2 * 24 * 60) }],
+  ])('POST /api/availability/sync rejects stale final available location based on %s', async (_caseName, timeFields) => {
+    const app = createTestApp();
+    const userId = `user_av_sync_stale_${_caseName}`;
+    await seedActiveUser(userId, `${userId}@example.com`);
+    await seedVolunteer({
+      volunteerId: `vol_sync_stale_${_caseName}`,
+      userId,
+      isAvailable: false,
+      latitude: 40.99,
+      longitude: 29.02,
+      locationUpdatedAt: minutesFromNow(-15),
+    });
+    const before = await query('SELECT * FROM volunteers WHERE user_id = $1', [userId]);
+    const token = buildAuthToken(userId);
+    const timestamp = timeFields.timestamp || new Date().toISOString();
+
+    const response = await request(app)
+      .post('/api/availability/sync')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        records: [
+          {
+            isAvailable: true,
+            timestamp,
+            latitude: 41.015,
+            longitude: 29.01,
+            ...timeFields,
+          },
+        ],
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_ERROR');
+
+    const after = await query('SELECT * FROM volunteers WHERE user_id = $1', [userId]);
+    expect(after.rows[0].is_available).toBe(false);
+    expect(after.rows[0].location_updated_at.getTime()).toBe(before.rows[0].location_updated_at.getTime());
+    expect(Number(after.rows[0].last_known_latitude)).toBeCloseTo(40.99);
+
+    await seedActiveUser(`user_req_sync_stale_${_caseName}`, `req-sync-stale-${_caseName}@example.com`);
+    await seedHelpRequest(`req_sync_stale_${_caseName}`, `user_req_sync_stale_${_caseName}`);
+    expect(await tryToAssignRequest(`req_sync_stale_${_caseName}`)).toBe(false);
   });
 
   test('POST /api/availability/sync preserves existing coordinates when latest unavailable record lacks coordinates', async () => {
@@ -1530,6 +1577,33 @@ describe('Availability integration', () => {
     expect(response.body.isAvailable).toBe(true);
     expect(response.body.effectiveIsAvailable).toBe(false);
     expect(response.body.availabilitySessionExpired).toBe(true);
+  });
+
+  test('GET /api/availability/status reports fresh active availability without coordinates as not effectively available', async () => {
+    const app = createTestApp();
+    const userId = 'user_v_status_null_coords';
+    await seedActiveUser(userId, 'status-null-coords@example.com');
+    await seedVolunteer({
+      volunteerId: 'vol_status_null_coords',
+      userId,
+      isAvailable: true,
+      latitude: null,
+      longitude: null,
+      locationUpdatedAt: minutesFromNow(-10),
+      availableUntil: minutesFromNow(60),
+    });
+    const token = buildAuthToken(userId);
+
+    const response = await request(app)
+      .get('/api/availability/status')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.isAvailable).toBe(true);
+    expect(response.body.isAvailabilitySessionActive).toBe(true);
+    expect(response.body.isLocationFresh).toBe(true);
+    expect(response.body.hasUsableLocation).toBe(false);
+    expect(response.body.effectiveIsAvailable).toBe(false);
   });
 
   test('POST /api/availability/toggle to false cancels active assignment', async () => {

--- a/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
+++ b/backend/tests/integration/modules/help-requests/help-requests.integration.test.js
@@ -33,6 +33,10 @@ function availabilityOnPayload(latitude = 41.0, longitude = 29.0) {
 	return { isAvailable: true, latitude, longitude };
 }
 
+function minutesFromNow(minutes) {
+	return new Date(Date.now() + minutes * 60 * 1000).toISOString();
+}
+
 function buildCreatePayload(overrides = {}) {
 	return {
 		helpTypes: ['first_aid', 'fire_brigade'],
@@ -80,9 +84,10 @@ async function seedVolunteer({
 	volunteerId,
 	userId,
 	isAvailable = true,
-	latitude = null,
-	longitude = null,
-	locationUpdatedAt = '2026-04-23T08:00:00.000Z',
+	latitude = 41.0,
+	longitude = 29.0,
+	locationUpdatedAt = new Date().toISOString(),
+	availableUntil = isAvailable ? minutesFromNow(360) : null,
 }) {
 	await query(
 		`
@@ -92,11 +97,22 @@ async function seedVolunteer({
 				is_available,
 				last_known_latitude,
 				last_known_longitude,
-				location_updated_at
+				location_updated_at,
+				available_until,
+				availability_confirmed_at
 			)
-			VALUES ($1, $2, $3, $4, $5, $6);
+			VALUES (
+				$1,
+				$2,
+				$3,
+				$4,
+				$5,
+				$6::timestamp,
+				$7::timestamp,
+				CASE WHEN $3 THEN $6::timestamp ELSE NULL END
+			);
 		`,
-		[volunteerId, userId, isAvailable, latitude, longitude, locationUpdatedAt],
+		[volunteerId, userId, isAvailable, latitude, longitude, locationUpdatedAt, availableUntil],
 	);
 }
 
@@ -1589,14 +1605,14 @@ describe('help-requests integration', () => {
 			userId: medicalHelperId,
 			latitude: 41.043,
 			longitude: 29.009,
-			locationUpdatedAt: '2026-04-23T08:00:00.000Z',
+			locationUpdatedAt: minutesFromNow(-10),
 		});
 		await seedVolunteer({
 			volunteerId: 'vol_general_helper',
 			userId: generalHelperId,
 			latitude: 41.0431,
 			longitude: 29.0091,
-			locationUpdatedAt: '2026-04-23T08:10:00.000Z',
+			locationUpdatedAt: minutesFromNow(-5),
 		});
 		await seedVolunteerProfile(medicalHelperId, '["First Aid","Logistics"]');
 
@@ -1713,12 +1729,12 @@ describe('help-requests integration', () => {
 		await seedVolunteer({
 			volunteerId: 'vol_combo_fallback_a',
 			userId: firstHelperId,
-			locationUpdatedAt: '2026-04-23T08:00:00.000Z',
+			locationUpdatedAt: minutesFromNow(-10),
 		});
 		await seedVolunteer({
 			volunteerId: 'vol_combo_fallback_b',
 			userId: secondHelperId,
-			locationUpdatedAt: '2026-04-23T08:00:00.000Z',
+			locationUpdatedAt: minutesFromNow(-10),
 		});
 
 		const response = await request(app)

--- a/backend/tests/unit/modules/availability/service.test.js
+++ b/backend/tests/unit/modules/availability/service.test.js
@@ -41,7 +41,13 @@ describe('Availability Service', () => {
       const result = await setAvailability(userId, { isAvailable: true, latitude: 41, longitude: 29 });
 
       expect(repository.createVolunteer).toHaveBeenCalledWith(userId);
-      expect(repository.updateVolunteerAvailability).toHaveBeenCalledWith('vol_123', true, 41, 29);
+      expect(repository.updateVolunteerAvailability).toHaveBeenCalledWith(
+        'vol_123',
+        true,
+        41,
+        29,
+        expect.objectContaining({ availabilityTtlMinutes: expect.any(Number) }),
+      );
       expect(repository.createAvailabilityRecord).toHaveBeenCalled();
       expect(result.volunteer.is_available).toBe(true);
     });
@@ -55,7 +61,7 @@ describe('Availability Service', () => {
       repository.createAssignment.mockResolvedValue(assignment);
       repository.getAssignmentByVolunteerId.mockResolvedValueOnce(null).mockResolvedValueOnce(assignment);
 
-      const result = await setAvailability(userId, { isAvailable: true });
+      const result = await setAvailability(userId, { isAvailable: true, latitude: 41, longitude: 29 });
 
       expect(repository.findMatchingRequestForVolunteer).toHaveBeenCalledWith('vol_123');
       expect(repository.createAssignment).toHaveBeenCalledWith('vol_123', 'req_123');
@@ -71,7 +77,7 @@ describe('Availability Service', () => {
       repository.findMatchingRequestForVolunteer.mockResolvedValue({ request_id: 'req_123' });
       repository.createAssignment.mockResolvedValue(null);
 
-      const result = await setAvailability(userId, { isAvailable: true });
+      const result = await setAvailability(userId, { isAvailable: true, latitude: 41, longitude: 29 });
 
       expect(repository.createAssignment).toHaveBeenCalledWith('vol_123', 'req_123');
       expect(repository.markRequestAssignedIfPending).not.toHaveBeenCalled();
@@ -104,7 +110,7 @@ describe('Availability Service', () => {
 
       await syncAvailability(userId, { records });
 
-      expect(repository.updateVolunteerAvailability).toHaveBeenCalledWith('vol_123', false, undefined, undefined);
+      expect(repository.updateVolunteerAvailability).toHaveBeenCalledWith('vol_123', false, undefined, undefined, {});
       expect(repository.createAvailabilityRecord).toHaveBeenCalledTimes(2);
     });
 


### PR DESCRIPTION
## Summary

This PR adds stale-location and availability-session guards to volunteer matching.

Volunteer availability is now treated as a time-limited operational session instead of a permanent assignable state.

## Changes

- Added volunteer availability session metadata:
  - `available_until`
  - `availability_confirmed_at`
  - `last_location_accuracy_meters`
  - `last_location_source`
- Added configurable backend defaults for:
  - max assignable location age
  - availability session TTL
- Updated availability ON behavior to refresh session expiry and operational location metadata
- Updated matching eligibility to skip volunteers with:
  - expired availability sessions
  - stale operational locations
  - missing coordinates
  - missing `location_updated_at`
- Updated availability status response with session/freshness fields
- Added backend tests for stale location, expired availability, null location, and existing matching regressions

## Important Behavior

- Volunteers with old operational locations are no longer auto-assigned
- Expired availability sessions are ignored by matching
- Availability OFF still preserves existing location data
- Existing first-aid / SAR matching behavior remains intact

## Testing

- Added/updated backend unit tests
- Added/updated backend integration tests
- Ran relevant backend test commands

Closes #435 