### PR TITLE
feat: use operational location snapshots for request help

### DIFF
--- a/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
+++ b/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
@@ -17,7 +17,7 @@ import com.neph.BuildConfig
         SyncOperationEntity::class,
         SyncMetadataEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 abstract class NephDatabase : RoomDatabase() {
@@ -76,6 +76,11 @@ object NephDatabaseProvider {
             )
         }
     }
+    private val Migration5To6 = object : Migration(5, 6) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL("ALTER TABLE help_requests ADD COLUMN coordinateAccuracyMeters REAL")
+        }
+    }
 
     fun initialize(context: Context) {
         getInstance(context)
@@ -87,7 +92,7 @@ object NephDatabaseProvider {
                 context.applicationContext,
                 NephDatabase::class.java,
                 DatabaseName
-            ).addMigrations(Migration1To2, Migration2To3, Migration3To4, Migration4To5)
+            ).addMigrations(Migration1To2, Migration2To3, Migration3To4, Migration4To5, Migration5To6)
                 .build()
                 .also { instance = it }
         }

--- a/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
@@ -36,6 +36,7 @@ data class HelpRequestEntity(
     val longitude: Double? = null,
     val coordinateSource: String? = null,
     val coordinateCapturedAt: String? = null,
+    val coordinateAccuracyMeters: Double? = null,
     val contactFullName: String,
     val contactPhone: String,
     val contactAlternativePhone: String?,

--- a/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
+++ b/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
@@ -39,6 +39,7 @@ import com.neph.features.profile.data.CurrentLocationShareWarning
 import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.features.profile.data.ProfileRepository
 import com.neph.features.requesthelp.data.EmergencyDraftRequirementsException
+import com.neph.features.requesthelp.data.RequestHelpReverseLocation
 import com.neph.features.requesthelp.data.RequestHelpRepository
 import com.neph.features.safetystatus.data.SafetyStatusRepository
 import com.neph.navigation.Routes
@@ -242,6 +243,14 @@ fun HomeScreen(
         }
     }
 
+    fun RequestHelpReverseLocation?.hasCompleteEmergencyAdministrativeLocation(): Boolean {
+        return this != null &&
+            !country.isNullOrBlank() &&
+            !city.isNullOrBlank() &&
+            !district.isNullOrBlank() &&
+            !neighborhood.isNullOrBlank()
+    }
+
     fun handleRequestHelp() {
         availabilityError = ""
         availabilityInfo = ""
@@ -297,6 +306,11 @@ fun HomeScreen(
                         )
                     } else {
                         null
+                    }
+                    if (currentLocation != null && !reverseLocation.hasCompleteEmergencyAdministrativeLocation()) {
+                        RequestHelpRepository.storePendingCoordinateSnapshot(currentLocation)
+                        onRequestHelp(null)
+                        return@launch
                     }
                     val draft = RequestHelpRepository.createEmergencyDraft(
                         token = sessionToken,

--- a/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
+++ b/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
@@ -33,6 +33,7 @@ import com.neph.features.availability.data.AvailabilityAccessPolicy
 import com.neph.features.availability.data.AvailabilityRepository
 import com.neph.features.availability.presentation.AvailableToHelpCard
 import com.neph.features.availability.presentation.AvailabilitySyncIndicator
+import com.neph.features.operationallocation.data.OperationalLocationRepository
 import com.neph.features.profile.data.CurrentDeviceLocation
 import com.neph.features.profile.data.CurrentLocationShareWarning
 import com.neph.features.profile.data.DeviceLocationProvider
@@ -267,11 +268,28 @@ fun HomeScreen(
                 } else if (!isAuthenticated || sessionToken.isNullOrBlank()) {
                     onRequestHelp(null)
                 } else {
+                    if (!DeviceLocationProvider.hasLocationPermission(context)) {
+                        requestHelpLoading = false
+                        pendingLocationPermissionAction = { granted ->
+                            if (granted) {
+                                handleRequestHelp()
+                            } else {
+                                onRequestHelp(null)
+                            }
+                        }
+                        locationPermissionRequester.requestPermission()
+                        return@launch
+                    }
                     val locationAttempt = DeviceLocationProvider.captureCurrentLocationForSharing(
                         context = context,
                         sharingEnabled = true
                     )
                     val currentLocation = locationAttempt.location
+                    if (currentLocation != null) {
+                        runCatching {
+                            OperationalLocationRepository.saveAndSyncIfAuthenticated(currentLocation)
+                        }
+                    }
                     val reverseLocation = if (currentLocation != null) {
                         RequestHelpRepository.reverseGeocodeCurrentLocation(
                             latitude = currentLocation.latitude,

--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
@@ -207,7 +207,8 @@ object RequestHelpRepository {
     suspend fun updateHelpRequest(
         token: String?,
         localId: String,
-        submission: RequestHelpSubmission
+        submission: RequestHelpSubmission,
+        preserveExistingCoordinates: Boolean = true
     ): CreateHelpRequestResult {
         ensureInitialized()
 
@@ -215,7 +216,10 @@ object RequestHelpRepository {
         val existing = database.helpRequestDao().getByLocalId(localId)
             ?: return createHelpRequest(token = token, submission = submission)
         val ownerType = ownerTypeForToken(token)
-        val submissionWithPreservedLocation = submission.withPreservedCoordinates(existing)
+        val submissionWithPreservedLocation = submission.withPreservedCoordinates(
+            existing = existing,
+            preserveExistingCoordinates = preserveExistingCoordinates
+        )
         val updatedEntity = submissionWithPreservedLocation.toEntity(
             localId = existing.localId,
             ownerType = existing.ownerType,
@@ -826,7 +830,14 @@ internal fun JSONObject.toHelpRequestEntity(
     )
 }
 
-private fun RequestHelpSubmission.withPreservedCoordinates(existing: HelpRequestEntity): RequestHelpSubmission {
+internal fun RequestHelpSubmission.withPreservedCoordinates(
+    existing: HelpRequestEntity,
+    preserveExistingCoordinates: Boolean = true
+): RequestHelpSubmission {
+    if (!preserveExistingCoordinates) {
+        return this
+    }
+
     if (location.latitude != null && location.longitude != null) {
         return this
     }

--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
@@ -36,6 +36,7 @@ internal data class AssignedResponderSnapshot(
 
 private const val PendingHelpRequestStatus = "PENDING_SYNC"
 private const val ReverseGeocodeTimeoutMillis = 7000L
+private const val RequestHelpGpsCoordinateSource = "gps"
 
 data class RequestHelpLocationSubmission(
     val country: String,
@@ -46,7 +47,8 @@ data class RequestHelpLocationSubmission(
     val latitude: Double? = null,
     val longitude: Double? = null,
     val coordinateSource: String? = null,
-    val coordinateCapturedAt: String? = null
+    val coordinateCapturedAt: String? = null,
+    val coordinateAccuracyMeters: Double? = null
 )
 
 data class RequestHelpReverseLocation(
@@ -594,6 +596,7 @@ internal fun RequestHelpSubmission.toJson(): JSONObject {
                         JSONObject().apply {
                             put("latitude", location.latitude)
                             put("longitude", location.longitude)
+                            location.coordinateAccuracyMeters?.let { put("accuracyMeters", it) }
                             location.coordinateSource?.let { put("source", it) }
                             location.coordinateCapturedAt?.let { put("capturedAt", it) }
                         }
@@ -634,12 +637,9 @@ internal fun buildEmergencyDraftSubmission(
         ?: throw EmergencyDraftRequirementsException(
             "A real contact name is required before creating a quick emergency draft."
         )
-    val profileCoordinatesAllowed = profile.shareLocation == true
-        && profile.sharedLatitude != null
-        && profile.sharedLongitude != null
-    val latitude = currentLocation?.latitude ?: profile.sharedLatitude.takeIf { profileCoordinatesAllowed }
-    val longitude = currentLocation?.longitude ?: profile.sharedLongitude.takeIf { profileCoordinatesAllowed }
-    val coordinateSource = currentLocation?.source ?: latitude.takeIf { profileCoordinatesAllowed }?.let { "PROFILE_LAST_SHARED" }
+    val latitude = currentLocation?.latitude
+    val longitude = currentLocation?.longitude
+    val coordinateSource = currentLocation?.let { RequestHelpGpsCoordinateSource }
     val coordinateCapturedAt = currentLocation?.capturedAt
     val country = reverseLocation?.country?.trim()?.takeIf { it.isNotBlank() }
         ?: profile.country?.trim()?.takeIf { it.isNotBlank() }
@@ -684,7 +684,8 @@ internal fun buildEmergencyDraftSubmission(
             latitude = latitude,
             longitude = longitude,
             coordinateSource = coordinateSource,
-            coordinateCapturedAt = coordinateCapturedAt
+            coordinateCapturedAt = coordinateCapturedAt,
+            coordinateAccuracyMeters = currentLocation.accuracyMeters
         ),
         contact = RequestHelpContactSubmission(
             fullName = contactName,
@@ -722,6 +723,7 @@ internal fun RequestHelpSubmission.toEntity(
         longitude = location.longitude,
         coordinateSource = location.coordinateSource,
         coordinateCapturedAt = location.coordinateCapturedAt,
+        coordinateAccuracyMeters = location.coordinateAccuracyMeters,
         contactFullName = contact.fullName,
         contactPhone = contact.phone.toString(),
         contactAlternativePhone = contact.alternativePhone?.toString(),
@@ -785,6 +787,7 @@ internal fun JSONObject.toHelpRequestEntity(
         longitude = readLocationLongitude(location, existing),
         coordinateSource = readLocationCoordinateSource(location, existing),
         coordinateCapturedAt = readLocationCoordinateCapturedAt(location, existing),
+        coordinateAccuracyMeters = readLocationCoordinateAccuracyMeters(location, existing),
         contactFullName = contact.optString("fullName"),
         contactPhone = contact.opt("phone")?.toString().orEmpty(),
         contactAlternativePhone = contact.opt("alternativePhone")?.toString()?.takeIf { it.isNotBlank() && it != "null" },
@@ -823,7 +826,8 @@ private fun RequestHelpSubmission.withPreservedCoordinates(existing: HelpRequest
             latitude = existing.latitude,
             longitude = existing.longitude,
             coordinateSource = existing.coordinateSource,
-            coordinateCapturedAt = existing.coordinateCapturedAt
+            coordinateCapturedAt = existing.coordinateCapturedAt,
+            coordinateAccuracyMeters = existing.coordinateAccuracyMeters
         )
     )
 }
@@ -848,6 +852,11 @@ private fun readLocationCoordinateSource(location: JSONObject, existing: HelpReq
 private fun readLocationCoordinateCapturedAt(location: JSONObject, existing: HelpRequestEntity?): String? {
     return location.optJSONObject("coordinate")?.optString("capturedAt")?.takeIf { it.isNotBlank() }
         ?: existing?.coordinateCapturedAt
+}
+
+private fun readLocationCoordinateAccuracyMeters(location: JSONObject, existing: HelpRequestEntity?): Double? {
+    return location.optJSONObject("coordinate")?.optNullableDouble("accuracyMeters")
+        ?: existing?.coordinateAccuracyMeters
 }
 
 private fun JSONObject.optNullableDouble(key: String): Double? {

--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
@@ -79,6 +79,14 @@ data class RequestHelpSubmission(
     val consentGiven: Boolean
 )
 
+data class RequestHelpCoordinateSnapshot(
+    val latitude: Double,
+    val longitude: Double,
+    val coordinateSource: String,
+    val coordinateCapturedAt: String,
+    val coordinateAccuracyMeters: Double?
+)
+
 data class CreateHelpRequestResult(
     val requestId: String,
     val guestAccessToken: String? = null,
@@ -102,6 +110,7 @@ object RequestHelpRepository {
         "Waiting for the help request creation to sync before sending the status update."
 
     private lateinit var prefs: SharedPreferences
+    private var pendingCoordinateSnapshot: RequestHelpCoordinateSnapshot? = null
 
     private val database get() = NephDatabaseProvider.requireInstance()
 
@@ -173,6 +182,16 @@ object RequestHelpRepository {
     ): CreateHelpRequestResult {
         val submission = buildEmergencyDraftSubmission(profile, currentLocation, reverseLocation)
         return createHelpRequest(token = token, submission = submission)
+    }
+
+    fun storePendingCoordinateSnapshot(currentLocation: CurrentDeviceLocation) {
+        pendingCoordinateSnapshot = currentLocation.toRequestHelpCoordinateSnapshot()
+    }
+
+    fun consumePendingCoordinateSnapshot(): RequestHelpCoordinateSnapshot? {
+        return pendingCoordinateSnapshot.also {
+            pendingCoordinateSnapshot = null
+        }
     }
 
     suspend fun getLocalHelpRequest(localId: String): HelpRequestEntity? {
@@ -283,6 +302,7 @@ object RequestHelpRepository {
     fun resetForTesting() {
         requireDebugBuildForTestingReset()
 
+        pendingCoordinateSnapshot = null
         if (::prefs.isInitialized) {
             prefs.edit().clear().commit()
         }
@@ -642,13 +662,9 @@ internal fun buildEmergencyDraftSubmission(
     val coordinateSource = currentLocation?.let { RequestHelpGpsCoordinateSource }
     val coordinateCapturedAt = currentLocation?.capturedAt
     val country = reverseLocation?.country?.trim()?.takeIf { it.isNotBlank() }
-        ?: profile.country?.trim()?.takeIf { it.isNotBlank() }
     val city = reverseLocation?.city?.trim()?.takeIf { it.isNotBlank() }
-        ?: profile.city?.trim()?.takeIf { it.isNotBlank() }
     val district = reverseLocation?.district?.trim()?.takeIf { it.isNotBlank() }
-        ?: profile.district?.trim()?.takeIf { it.isNotBlank() }
     val neighborhood = reverseLocation?.neighborhood?.trim()?.takeIf { it.isNotBlank() }
-        ?: profile.neighborhood?.trim()?.takeIf { it.isNotBlank() }
 
     if (
         latitude == null ||
@@ -663,9 +679,7 @@ internal fun buildEmergencyDraftSubmission(
         )
     }
 
-    val extraAddress = reverseLocation?.extraAddress?.trim()?.takeIf { it.isNotBlank() }
-        ?: profile.extraAddress?.trim()?.takeIf { it.isNotBlank() }
-        ?: ""
+    val extraAddress = reverseLocation.extraAddress?.trim()?.takeIf { it.isNotBlank() } ?: ""
 
     return RequestHelpSubmission(
         helpTypes = listOf("other"),
@@ -857,6 +871,16 @@ private fun readLocationCoordinateCapturedAt(location: JSONObject, existing: Hel
 private fun readLocationCoordinateAccuracyMeters(location: JSONObject, existing: HelpRequestEntity?): Double? {
     return location.optJSONObject("coordinate")?.optNullableDouble("accuracyMeters")
         ?: existing?.coordinateAccuracyMeters
+}
+
+private fun CurrentDeviceLocation.toRequestHelpCoordinateSnapshot(): RequestHelpCoordinateSnapshot {
+    return RequestHelpCoordinateSnapshot(
+        latitude = latitude,
+        longitude = longitude,
+        coordinateSource = RequestHelpGpsCoordinateSource,
+        coordinateCapturedAt = capturedAt,
+        coordinateAccuracyMeters = accuracyMeters
+    )
 }
 
 private fun JSONObject.optNullableDouble(key: String): Double? {

--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -138,6 +138,7 @@ private data class RequestHelpFormState(
     val coordinateSource: String? = null,
     val coordinateCapturedAt: String? = null,
     val coordinateAccuracyMeters: Double? = null,
+    val locationWasManuallyChanged: Boolean = false,
     val fullName: String = "",
     val countryCode: String = "+90",
     val phoneNumber: String = "",
@@ -223,6 +224,7 @@ private fun HelpRequestEntity.toFormState(): RequestHelpFormState {
         coordinateSource = coordinateSource,
         coordinateCapturedAt = coordinateCapturedAt,
         coordinateAccuracyMeters = coordinateAccuracyMeters,
+        locationWasManuallyChanged = false,
         fullName = contactFullName,
         countryCode = phoneParts.countryCode,
         phoneNumber = phoneParts.phone,
@@ -334,7 +336,8 @@ private fun RequestHelpFormState.withoutCoordinateSnapshot(): RequestHelpFormSta
         longitude = null,
         coordinateSource = null,
         coordinateCapturedAt = null,
-        coordinateAccuracyMeters = null
+        coordinateAccuracyMeters = null,
+        locationWasManuallyChanged = true
     )
 }
 
@@ -460,6 +463,41 @@ internal fun resolveGuestLocationAutofillSelection(
     )
 }
 
+private fun resolveEventLocationAutofillSelection(
+    reverseLocation: RequestHelpReverseLocation,
+    locations: LocationData
+): GuestLocationAutofillSelection? {
+    val countryFromCode = reverseLocation.countryCode
+        ?.lowercase()
+        ?.takeIf { locations.containsKey(it) }
+        .orEmpty()
+    val countryFromLabel = findCountryKeyByLabel(reverseLocation.country, locations)
+    val country = countryFromCode.ifBlank { countryFromLabel }
+    if (country.isBlank()) return null
+
+    val city = findCityKeyByLabel(country, reverseLocation.city, locations)
+    if (city.isBlank()) return null
+
+    val district = findDistrictKeyByLabel(country, city, reverseLocation.district, locations)
+    if (district.isBlank()) return null
+
+    val neighborhood = findNeighborhoodValueByLabel(
+        country,
+        city,
+        district,
+        reverseLocation.neighborhood,
+        locations
+    )
+
+    return GuestLocationAutofillSelection(
+        country = country,
+        city = city,
+        district = district,
+        neighborhood = neighborhood,
+        shortAddress = reverseLocation.extraAddress?.takeIf { it.isNotBlank() }.orEmpty()
+    )
+}
+
 @Composable
 fun RequestHelpScreen(
     draftLocalId: String? = null,
@@ -512,7 +550,8 @@ fun RequestHelpScreen(
             longitude = snapshot.longitude,
             coordinateSource = snapshot.coordinateSource,
             coordinateCapturedAt = snapshot.coordinateCapturedAt,
-            coordinateAccuracyMeters = snapshot.coordinateAccuracyMeters
+            coordinateAccuracyMeters = snapshot.coordinateAccuracyMeters,
+            locationWasManuallyChanged = false
         )
     }
 
@@ -569,7 +608,8 @@ fun RequestHelpScreen(
                     longitude = location.longitude,
                     coordinateSource = RequestHelpGpsCoordinateSource,
                     coordinateCapturedAt = location.capturedAt,
-                    coordinateAccuracyMeters = location.accuracyMeters
+                    coordinateAccuracyMeters = location.accuracyMeters,
+                    locationWasManuallyChanged = false
                 )
                 capturedSnapshot = true
 
@@ -578,20 +618,33 @@ fun RequestHelpScreen(
                     longitude = location.longitude
                 )
                 if (reverseLocation == null) {
+                    formState = formState.copy(country = "", city = "", district = "", neighborhood = "", shortAddress = "")
                     infoMessage = "Current coordinates were saved for this request. Please complete the location fields manually."
                     return@launch
                 }
 
                 val previousFormState = formState
-                val autofill = resolveGuestLocationAutofillSelection(
-                    currentCountry = previousFormState.country,
-                    currentCity = previousFormState.city,
-                    currentDistrict = previousFormState.district,
-                    currentNeighborhood = previousFormState.neighborhood,
-                    currentShortAddress = previousFormState.shortAddress,
+                val autofill = resolveEventLocationAutofillSelection(
                     reverseLocation = reverseLocation,
                     locations = availableLocationData
                 )
+                if (autofill == null) {
+                    formState = previousFormState.copy(
+                        country = "",
+                        city = "",
+                        district = "",
+                        neighborhood = "",
+                        shortAddress = "",
+                        latitude = location.latitude,
+                        longitude = location.longitude,
+                        coordinateSource = RequestHelpGpsCoordinateSource,
+                        coordinateCapturedAt = location.capturedAt,
+                        coordinateAccuracyMeters = location.accuracyMeters,
+                        locationWasManuallyChanged = false
+                    )
+                    infoMessage = "Current coordinates were saved for this request. Please complete the location fields manually."
+                    return@launch
+                }
 
                 val nextFormState = previousFormState.copy(
                     country = autofill.country,
@@ -603,11 +656,12 @@ fun RequestHelpScreen(
                     longitude = location.longitude,
                     coordinateSource = RequestHelpGpsCoordinateSource,
                     coordinateCapturedAt = location.capturedAt,
-                    coordinateAccuracyMeters = location.accuracyMeters
+                    coordinateAccuracyMeters = location.accuracyMeters,
+                    locationWasManuallyChanged = false
                 )
                 if (nextFormState != previousFormState) {
                     formState = nextFormState
-                    infoMessage = "Current location applied without changing non-empty fields."
+                    infoMessage = "Current location applied. Please verify the emergency location fields."
                 } else {
                     infoMessage = "Current location detected. Existing location values were kept."
                 }
@@ -639,37 +693,57 @@ fun RequestHelpScreen(
                     longitude = selection.longitude,
                     coordinateSource = RequestHelpMapCoordinateSource,
                     coordinateCapturedAt = selectedCapturedAt,
-                    coordinateAccuracyMeters = null
+                    coordinateAccuracyMeters = null,
+                    locationWasManuallyChanged = false
                 )
                 val reverseLocation = RequestHelpRepository.reverseGeocodeCurrentLocation(
                     latitude = selection.latitude,
                     longitude = selection.longitude
                 )
-                val update = resolveMapPickerLocationUpdate(
-                    currentCountry = formState.country,
-                    currentCity = formState.city,
-                    currentDistrict = formState.district,
-                    currentNeighborhood = formState.neighborhood,
-                    currentExtraAddress = formState.shortAddress,
-                    reverseLocation = reverseLocation,
-                    locations = availableLocationData
-                )
+                val reverseUpdate = reverseLocation?.let {
+                    resolveMapPickerLocationUpdate(
+                        currentCountry = "",
+                        currentCity = "",
+                        currentDistrict = "",
+                        currentNeighborhood = "",
+                        currentExtraAddress = "",
+                        reverseLocation = it,
+                        locations = availableLocationData
+                    )
+                }
+                val mappedUpdate = reverseUpdate?.takeIf { it.country.isNotBlank() && it.city.isNotBlank() && it.district.isNotBlank() }
+                if (mappedUpdate == null) {
+                    formState = formState.copy(
+                        country = "",
+                        city = "",
+                        district = "",
+                        neighborhood = "",
+                        shortAddress = "",
+                        latitude = selection.latitude,
+                        longitude = selection.longitude,
+                        coordinateSource = RequestHelpMapCoordinateSource,
+                        coordinateCapturedAt = selectedCapturedAt,
+                        coordinateAccuracyMeters = null,
+                        locationWasManuallyChanged = false
+                    )
+                    mapActionMessage = "Could not resolve selected coordinates. You can continue with manual location entry."
+                    return@launch
+                }
                 formState = formState.copy(
-                    country = update.country,
-                    city = update.city,
-                    district = update.district,
-                    neighborhood = update.neighborhood,
-                    shortAddress = update.extraAddress,
+                    country = mappedUpdate.country,
+                    city = mappedUpdate.city,
+                    district = mappedUpdate.district,
+                    neighborhood = mappedUpdate.neighborhood,
+                    shortAddress = mappedUpdate.extraAddress,
                     latitude = selection.latitude,
                     longitude = selection.longitude,
                     coordinateSource = RequestHelpMapCoordinateSource,
                     coordinateCapturedAt = selectedCapturedAt,
-                    coordinateAccuracyMeters = null
+                    coordinateAccuracyMeters = null,
+                    locationWasManuallyChanged = false
                 )
                 mapActionMessage = when {
-                    reverseLocation == null ->
-                        "Could not resolve selected coordinates. You can continue with manual location entry."
-                    update.isMeaningfulMapping ->
+                    mappedUpdate.isMeaningfulMapping ->
                         "Selected location applied."
                     else ->
                         "Selected coordinates were detected. Please verify the location fields manually."
@@ -799,7 +873,8 @@ fun RequestHelpScreen(
                     RequestHelpRepository.updateHelpRequest(
                         token = sessionToken,
                         localId = activeDraftLocalId,
-                        submission = submission
+                        submission = submission,
+                        preserveExistingCoordinates = !formState.locationWasManuallyChanged
                     )
                 } else {
                     RequestHelpRepository.createHelpRequest(

--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -328,6 +328,20 @@ private fun shouldShowLowContextWarning(state: RequestHelpFormState): Boolean {
     return state.situationDescription.isBlank() && state.fullName.isBlank()
 }
 
+private fun RequestHelpFormState.withoutCoordinateSnapshot(): RequestHelpFormState {
+    return copy(
+        latitude = null,
+        longitude = null,
+        coordinateSource = null,
+        coordinateCapturedAt = null,
+        coordinateAccuracyMeters = null
+    )
+}
+
+private fun RequestHelpFormState.hasCoordinateSnapshot(): Boolean {
+    return latitude != null && longitude != null
+}
+
 private fun buildSubmission(
     state: RequestHelpFormState,
     locations: LocationData
@@ -481,6 +495,36 @@ fun RequestHelpScreen(
     var mapPickerSelection by remember { mutableStateOf<MapPickerSelection?>(null) }
     var checkingActiveRequest by remember { mutableStateOf(isLoggedIn) }
     var currentLocationLoading by remember { mutableStateOf(false) }
+
+    fun applyPendingCoordinateSnapshot(
+        baseState: RequestHelpFormState,
+        clearAdministrativeFields: Boolean
+    ): RequestHelpFormState {
+        val snapshot = RequestHelpRepository.consumePendingCoordinateSnapshot() ?: return baseState
+        infoMessage = "Current coordinates were saved for this request. Please complete the emergency location fields manually."
+        return baseState.copy(
+            country = if (clearAdministrativeFields) "" else baseState.country,
+            city = if (clearAdministrativeFields) "" else baseState.city,
+            district = if (clearAdministrativeFields) "" else baseState.district,
+            neighborhood = if (clearAdministrativeFields) "" else baseState.neighborhood,
+            shortAddress = if (clearAdministrativeFields) "" else baseState.shortAddress,
+            latitude = snapshot.latitude,
+            longitude = snapshot.longitude,
+            coordinateSource = snapshot.coordinateSource,
+            coordinateCapturedAt = snapshot.coordinateCapturedAt,
+            coordinateAccuracyMeters = snapshot.coordinateAccuracyMeters
+        )
+    }
+
+    fun updateManualLocation(nextState: RequestHelpFormState) {
+        val hadCoordinateSnapshot = formState.hasCoordinateSnapshot()
+        formState = nextState.withoutCoordinateSnapshot()
+        mapPickerSelection = null
+        mapActionMessage = ""
+        if (hadCoordinateSnapshot) {
+            infoMessage = "Coordinate snapshot cleared because the emergency location fields changed."
+        }
+    }
 
     LaunchedEffect(draftLocalId) {
         val nextDraftLocalId = draftLocalId.orEmpty()
@@ -679,7 +723,10 @@ fun RequestHelpScreen(
         }
 
         if (!isLoggedIn) {
-            formState = RequestHelpFormState()
+            formState = applyPendingCoordinateSnapshot(
+                baseState = RequestHelpFormState(),
+                clearAdministrativeFields = true
+            )
             checkingActiveRequest = false
             return@LaunchedEffect
         }
@@ -692,8 +739,10 @@ fun RequestHelpScreen(
             }
 
             val profile = ProfileRepository.fetchAndCacheRemoteProfile()
-            formState = buildPrefilledForm(profile)
-            infoMessage = ""
+            formState = applyPendingCoordinateSnapshot(
+                baseState = buildPrefilledForm(profile),
+                clearAdministrativeFields = true
+            )
         } catch (cancellationException: CancellationException) {
             throw cancellationException
         } catch (error: ApiException) {
@@ -703,11 +752,21 @@ fun RequestHelpScreen(
                 onNavigateToLogin()
                 return@LaunchedEffect
             }
-            formState = buildPrefilledForm(ProfileRepository.getProfile())
-            infoMessage = "Could not refresh profile details. Using saved information where available."
+            formState = applyPendingCoordinateSnapshot(
+                baseState = buildPrefilledForm(ProfileRepository.getProfile()),
+                clearAdministrativeFields = true
+            )
+            if (infoMessage.isBlank()) {
+                infoMessage = "Could not refresh profile details. Using saved information where available."
+            }
         } catch (_: Exception) {
-            formState = buildPrefilledForm(ProfileRepository.getProfile())
-            infoMessage = "Could not refresh profile details. Using saved information where available."
+            formState = applyPendingCoordinateSnapshot(
+                baseState = buildPrefilledForm(ProfileRepository.getProfile()),
+                clearAdministrativeFields = true
+            )
+            if (infoMessage.isBlank()) {
+                infoMessage = "Could not refresh profile details. Using saved information where available."
+            }
         } finally {
             checkingActiveRequest = false
         }
@@ -913,16 +972,22 @@ fun RequestHelpScreen(
                         district = formState.district,
                         neighborhood = formState.neighborhood,
                         onCountryChange = {
-                            formState = formState.copy(country = it, city = "", district = "", neighborhood = "")
+                            updateManualLocation(
+                                formState.copy(country = it, city = "", district = "", neighborhood = "")
+                            )
                         },
                         onCityChange = {
-                            formState = formState.copy(city = it, district = "", neighborhood = "")
+                            updateManualLocation(
+                                formState.copy(city = it, district = "", neighborhood = "")
+                            )
                         },
                         onDistrictChange = {
-                            formState = formState.copy(district = it, neighborhood = "")
+                            updateManualLocation(
+                                formState.copy(district = it, neighborhood = "")
+                            )
                         },
                         onNeighborhoodChange = {
-                            formState = formState.copy(neighborhood = it)
+                            updateManualLocation(formState.copy(neighborhood = it))
                         },
                         locationData = availableLocationData,
                         enabled = !locationLoading,
@@ -949,7 +1014,7 @@ fun RequestHelpScreen(
 
                     AppTextField(
                         value = formState.shortAddress,
-                        onValueChange = { formState = formState.copy(shortAddress = it) },
+                        onValueChange = { updateManualLocation(formState.copy(shortAddress = it)) },
                         label = "Short Address / Address Description (optional)",
                         error = fieldErrors.shortAddress
                     )

--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -54,6 +54,7 @@ import com.neph.features.profile.data.bloodTypeOptions
 import com.neph.features.profile.data.locationData
 import com.neph.features.profile.data.normalizeBloodType
 import com.neph.features.profile.data.normalizePhoneParts
+import com.neph.features.operationallocation.data.OperationalLocationRepository
 import com.neph.features.requesthelp.data.RequestHelpContactSubmission
 import com.neph.features.requesthelp.data.RequestHelpLocationSubmission
 import com.neph.features.profile.presentation.components.LocationSelector
@@ -83,6 +84,10 @@ import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 private val helpTypeOptions = listOf(
     "First Aid",
@@ -112,6 +117,9 @@ private val vulnerableGroupOptions = listOf(
     "Chronic Condition"
 )
 
+private const val RequestHelpGpsCoordinateSource = "gps"
+private const val RequestHelpMapCoordinateSource = "map_selection"
+
 private data class RequestHelpFormState(
     val helpTypes: List<String> = emptyList(),
     val otherHelpType: String = "",
@@ -125,6 +133,11 @@ private data class RequestHelpFormState(
     val district: String = "",
     val neighborhood: String = "",
     val shortAddress: String = "",
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val coordinateSource: String? = null,
+    val coordinateCapturedAt: String? = null,
+    val coordinateAccuracyMeters: Double? = null,
     val fullName: String = "",
     val countryCode: String = "+90",
     val phoneNumber: String = "",
@@ -205,6 +218,11 @@ private fun HelpRequestEntity.toFormState(): RequestHelpFormState {
         district = district,
         neighborhood = neighborhood,
         shortAddress = extraAddress,
+        latitude = latitude,
+        longitude = longitude,
+        coordinateSource = coordinateSource,
+        coordinateCapturedAt = coordinateCapturedAt,
+        coordinateAccuracyMeters = coordinateAccuracyMeters,
         fullName = contactFullName,
         countryCode = phoneParts.countryCode,
         phoneNumber = phoneParts.phone,
@@ -339,7 +357,12 @@ private fun buildSubmission(
                 state.neighborhood,
                 locations
             ).ifBlank { state.neighborhood.trim() },
-            extraAddress = state.shortAddress.trim()
+            extraAddress = state.shortAddress.trim(),
+            latitude = state.latitude,
+            longitude = state.longitude,
+            coordinateSource = state.coordinateSource,
+            coordinateCapturedAt = state.coordinateCapturedAt,
+            coordinateAccuracyMeters = state.coordinateAccuracyMeters
         ),
         contact = RequestHelpContactSubmission(
             fullName = state.fullName.trim(),
@@ -348,6 +371,12 @@ private fun buildSubmission(
         ),
         consentGiven = state.confirmationAccepted
     )
+}
+
+private fun currentIsoUtc(): String {
+    return SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }.format(Date())
 }
 
 internal data class GuestLocationAutofillSelection(
@@ -469,6 +498,7 @@ fun RequestHelpScreen(
         scope.launch {
             if (currentLocationLoading) return@launch
             currentLocationLoading = true
+            var capturedSnapshot = false
             try {
                 val attempt = DeviceLocationProvider.captureCurrentLocationForSharing(
                     context = context,
@@ -486,12 +516,25 @@ fun RequestHelpScreen(
                     return@launch
                 }
 
+                runCatching {
+                    OperationalLocationRepository.saveAndSyncIfAuthenticated(location)
+                }
+
+                formState = formState.copy(
+                    latitude = location.latitude,
+                    longitude = location.longitude,
+                    coordinateSource = RequestHelpGpsCoordinateSource,
+                    coordinateCapturedAt = location.capturedAt,
+                    coordinateAccuracyMeters = location.accuracyMeters
+                )
+                capturedSnapshot = true
+
                 val reverseLocation = RequestHelpRepository.reverseGeocodeCurrentLocation(
                     latitude = location.latitude,
                     longitude = location.longitude
                 )
                 if (reverseLocation == null) {
-                    infoMessage = "Could not resolve your current location. You can continue with manual location entry."
+                    infoMessage = "Current coordinates were saved for this request. Please complete the location fields manually."
                     return@launch
                 }
 
@@ -511,7 +554,12 @@ fun RequestHelpScreen(
                     city = autofill.city,
                     district = autofill.district,
                     neighborhood = autofill.neighborhood,
-                    shortAddress = autofill.shortAddress
+                    shortAddress = autofill.shortAddress,
+                    latitude = location.latitude,
+                    longitude = location.longitude,
+                    coordinateSource = RequestHelpGpsCoordinateSource,
+                    coordinateCapturedAt = location.capturedAt,
+                    coordinateAccuracyMeters = location.accuracyMeters
                 )
                 if (nextFormState != previousFormState) {
                     formState = nextFormState
@@ -522,7 +570,11 @@ fun RequestHelpScreen(
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (_: Exception) {
-                infoMessage = "Could not retrieve your current location. You can continue with manual location entry."
+                infoMessage = if (capturedSnapshot) {
+                    "Current coordinates were saved for this request. Please complete the location fields manually."
+                } else {
+                    "Could not retrieve your current location. You can continue with manual location entry."
+                }
             } finally {
                 currentLocationLoading = false
             }
@@ -536,7 +588,15 @@ fun RequestHelpScreen(
         mapActionMessage = ""
 
         scope.launch {
+            val selectedCapturedAt = currentIsoUtc()
             try {
+                formState = formState.copy(
+                    latitude = selection.latitude,
+                    longitude = selection.longitude,
+                    coordinateSource = RequestHelpMapCoordinateSource,
+                    coordinateCapturedAt = selectedCapturedAt,
+                    coordinateAccuracyMeters = null
+                )
                 val reverseLocation = RequestHelpRepository.reverseGeocodeCurrentLocation(
                     latitude = selection.latitude,
                     longitude = selection.longitude
@@ -555,7 +615,12 @@ fun RequestHelpScreen(
                     city = update.city,
                     district = update.district,
                     neighborhood = update.neighborhood,
-                    shortAddress = update.extraAddress
+                    shortAddress = update.extraAddress,
+                    latitude = selection.latitude,
+                    longitude = selection.longitude,
+                    coordinateSource = RequestHelpMapCoordinateSource,
+                    coordinateCapturedAt = selectedCapturedAt,
+                    coordinateAccuracyMeters = null
                 )
                 mapActionMessage = when {
                     reverseLocation == null ->
@@ -818,8 +883,8 @@ fun RequestHelpScreen(
             SectionCard {
                 Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
                     SectionHeader(
-                        title = "Location",
-                        subtitle = "Use the same location structure as your profile."
+                        title = "Emergency Location",
+                        subtitle = "Where do you need help right now? Profile location may prefill fields, but this request uses the event location you confirm here."
                     )
 
                     if (locationLoading) {
@@ -869,14 +934,16 @@ fun RequestHelpScreen(
                     )
 
                     SecondaryButton(
-                        text = "Select Location on Map",
+                        text = "Select Emergency Location on Map",
                         onClick = { mapPickerOpen = true },
                         enabled = !locationLoading && !loading
                     )
 
-                    mapPickerSelection?.let { selection ->
+                    val requestLatitude = formState.latitude
+                    val requestLongitude = formState.longitude
+                    if (requestLatitude != null && requestLongitude != null) {
                         HelperText(
-                            text = "Selected coordinates: ${formatMapCoordinate(selection.latitude)}, ${formatMapCoordinate(selection.longitude)}"
+                            text = "Request coordinate snapshot: ${formatMapCoordinate(requestLatitude)}, ${formatMapCoordinate(requestLongitude)}"
                         )
                     }
 
@@ -901,8 +968,8 @@ fun RequestHelpScreen(
 
                     if (mapPickerOpen) {
                         MapPickerDialog(
-                            initialLatitude = mapPickerSelection?.latitude,
-                            initialLongitude = mapPickerSelection?.longitude,
+                            initialLatitude = mapPickerSelection?.latitude ?: formState.latitude,
+                            initialLongitude = mapPickerSelection?.longitude ?: formState.longitude,
                             loading = mapPickerLoading,
                             onDismiss = { if (!mapPickerLoading) mapPickerOpen = false },
                             onConfirm = ::handleMapSelection

--- a/android/app/src/test/java/com/neph/features/requesthelp/data/RequestHelpOfflineMappingTest.kt
+++ b/android/app/src/test/java/com/neph/features/requesthelp/data/RequestHelpOfflineMappingTest.kt
@@ -163,6 +163,17 @@ class RequestHelpOfflineMappingTest {
     }
 
     @Test
+    fun emergencyDraftDoesNotMixCurrentCoordinatesWithProfileAdministrativeLocation() {
+        assertThrows(EmergencyDraftRequirementsException::class.java) {
+            buildEmergencyDraftSubmission(
+                profile = completeProfile(),
+                currentLocation = sampleCurrentLocation(),
+                reverseLocation = null
+            )
+        }
+    }
+
+    @Test
     fun emergencyDraftUsesVerifiedProfileAndCurrentLocationWithoutFakeValues() {
         val submission = buildEmergencyDraftSubmission(
             profile = completeProfile(),

--- a/android/app/src/test/java/com/neph/features/requesthelp/data/RequestHelpOfflineMappingTest.kt
+++ b/android/app/src/test/java/com/neph/features/requesthelp/data/RequestHelpOfflineMappingTest.kt
@@ -56,8 +56,9 @@ class RequestHelpOfflineMappingTest {
                 extraAddress = "Near park",
                 latitude = 40.987,
                 longitude = 29.025,
-                coordinateSource = "DEVICE_GPS",
-                coordinateCapturedAt = "2026-05-02T10:00:00.000Z"
+                coordinateSource = "gps",
+                coordinateCapturedAt = "2026-05-02T10:00:00.000Z",
+                coordinateAccuracyMeters = 18.5
             )
         )
         val json = submission.toJson()
@@ -71,12 +72,14 @@ class RequestHelpOfflineMappingTest {
         val location = json.getJSONObject("location")
         assertEquals(40.987, location.getDouble("latitude"), 0.0)
         assertEquals(29.025, location.getDouble("longitude"), 0.0)
-        assertEquals("DEVICE_GPS", location.getJSONObject("coordinate").getString("source"))
+        assertEquals(18.5, location.getJSONObject("coordinate").getDouble("accuracyMeters"), 0.0)
+        assertEquals("gps", location.getJSONObject("coordinate").getString("source"))
         assertEquals("2026-05-02T10:00:00.000Z", location.getJSONObject("coordinate").getString("capturedAt"))
         assertEquals(40.987, entity.latitude ?: 0.0, 0.0)
         assertEquals(29.025, entity.longitude ?: 0.0, 0.0)
-        assertEquals("DEVICE_GPS", entity.coordinateSource)
+        assertEquals("gps", entity.coordinateSource)
         assertEquals("2026-05-02T10:00:00.000Z", entity.coordinateCapturedAt)
+        assertEquals(18.5, entity.coordinateAccuracyMeters ?: 0.0, 0.0)
     }
 
     @Test
@@ -140,6 +143,26 @@ class RequestHelpOfflineMappingTest {
     }
 
     @Test
+    fun emergencyDraftDoesNotUseProfileSharedCoordinatesAsEventLocation() {
+        assertThrows(EmergencyDraftRequirementsException::class.java) {
+            buildEmergencyDraftSubmission(
+                profile = completeProfile().copy(
+                    shareLocation = true,
+                    sharedLatitude = 41.01,
+                    sharedLongitude = 29.02
+                ),
+                currentLocation = null,
+                reverseLocation = RequestHelpReverseLocation(
+                    country = "Turkey",
+                    city = "Istanbul",
+                    district = "Kadikoy",
+                    neighborhood = "Moda"
+                )
+            )
+        }
+    }
+
+    @Test
     fun emergencyDraftUsesVerifiedProfileAndCurrentLocationWithoutFakeValues() {
         val submission = buildEmergencyDraftSubmission(
             profile = completeProfile(),
@@ -162,7 +185,8 @@ class RequestHelpOfflineMappingTest {
         assertEquals("Besiktas assembly area", submission.location.extraAddress)
         assertEquals(41.043, submission.location.latitude ?: 0.0, 0.0)
         assertEquals(29.009, submission.location.longitude ?: 0.0, 0.0)
-        assertEquals("DEVICE_GPS", submission.location.coordinateSource)
+        assertEquals("gps", submission.location.coordinateSource)
+        assertEquals(12.0, submission.location.coordinateAccuracyMeters ?: 0.0, 0.0)
         assertTrue(submission.consentGiven)
     }
 

--- a/android/app/src/test/java/com/neph/features/requesthelp/data/RequestHelpOfflineMappingTest.kt
+++ b/android/app/src/test/java/com/neph/features/requesthelp/data/RequestHelpOfflineMappingTest.kt
@@ -83,6 +83,72 @@ class RequestHelpOfflineMappingTest {
     }
 
     @Test
+    fun draftUpdatePreservesExistingCoordinatesWhenLocationWasNotChanged() {
+        val existing = sampleSubmission().copy(
+            location = sampleSubmission().location.copy(
+                latitude = 40.987,
+                longitude = 29.025,
+                coordinateSource = "gps",
+                coordinateCapturedAt = "2026-05-02T10:00:00.000Z",
+                coordinateAccuracyMeters = 18.5
+            )
+        ).toEntity(
+            localId = "local-draft-with-coordinates",
+            ownerType = LocalOwnerType.AUTHENTICATED,
+            now = 1234L,
+            syncStatus = SyncStatus.PENDING_UPDATE
+        )
+
+        val updated = sampleSubmission().copy(
+            description = "Need water, medication, and blankets"
+        ).withPreservedCoordinates(
+            existing = existing,
+            preserveExistingCoordinates = true
+        )
+
+        assertEquals(40.987, updated.location.latitude ?: 0.0, 0.0)
+        assertEquals(29.025, updated.location.longitude ?: 0.0, 0.0)
+        assertEquals("gps", updated.location.coordinateSource)
+        assertEquals("2026-05-02T10:00:00.000Z", updated.location.coordinateCapturedAt)
+        assertEquals(18.5, updated.location.coordinateAccuracyMeters ?: 0.0, 0.0)
+    }
+
+    @Test
+    fun draftUpdateDoesNotRestoreCoordinatesWhenLocationWasManuallyChanged() {
+        val existing = sampleSubmission().copy(
+            location = sampleSubmission().location.copy(
+                latitude = 40.987,
+                longitude = 29.025,
+                coordinateSource = "map_selection",
+                coordinateCapturedAt = "2026-05-02T10:00:00.000Z",
+                coordinateAccuracyMeters = null
+            )
+        ).toEntity(
+            localId = "local-draft-with-stale-coordinates",
+            ownerType = LocalOwnerType.AUTHENTICATED,
+            now = 1234L,
+            syncStatus = SyncStatus.PENDING_UPDATE
+        )
+
+        val updated = sampleSubmission().copy(
+            location = sampleSubmission().location.copy(
+                district = "Besiktas",
+                neighborhood = "Akat",
+                extraAddress = "New emergency address"
+            )
+        ).withPreservedCoordinates(
+            existing = existing,
+            preserveExistingCoordinates = false
+        )
+
+        assertNull(updated.location.latitude)
+        assertNull(updated.location.longitude)
+        assertNull(updated.location.coordinateSource)
+        assertNull(updated.location.coordinateCapturedAt)
+        assertNull(updated.location.coordinateAccuracyMeters)
+    }
+
+    @Test
     fun remoteMappingPreservesLifecycleAndOperationalMetadata() {
         val entity = JSONObject().apply {
             put("id", "req_remote_1")


### PR DESCRIPTION
## Summary

Implements Android-side operational/current location snapshots for Request Help.

Request Help now treats location as the emergency/event location, not residential/profile location. Current location and map-selected coordinates are copied into the request payload as a snapshot so later device movement does not change the request location.

## Changes

- Added coordinate snapshot fields to Request Help form state
- Stores current GPS coordinates when Use Current Location succeeds
- Requests foreground location permission from Request Help when needed
- Reverse-geocodes current/map-selected coordinates when possible
- Preserves coordinates even when reverse geocoding fails
- Stores map-selected coordinates in form state and submission payload
- Includes coordinate source, capturedAt, and accuracyMeters in local/offline request data
- Preserves coordinates in draft edit/update flow unless changed
- Updates Request Help UI copy to clarify emergency/event location
- Removes profile shared-coordinate fallback from emergency draft creation
- Adds Room migration for request coordinate accuracy metadata

## Testing

- Ran targeted Request Help Android unit tests
- Ran Android debug Kotlin compile

Closes [#433](https://github.com/bounswe/bounswe2026group6/issues/433)
