### PR TITLE
fix: parse country-specific Android location tree

### DIFF
--- a/android/app/src/main/java/com/neph/features/profile/data/LocationTreeRepository.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/LocationTreeRepository.kt
@@ -40,7 +40,10 @@ object LocationTreeRepository {
             path = "/location/tree?countryCode=$normalizedCountryCode"
         )
 
-        val parsed = parseLocationTreeResponse(response)
+        val parsed = parseLocationTreeResponse(
+            response = response,
+            requestedCountryCode = normalizedCountryCode
+        )
         if (parsed.isEmpty()) {
             throw ApiException(
                 message = "Location options are unavailable right now.",
@@ -55,10 +58,21 @@ object LocationTreeRepository {
         return parsed
     }
 
-    internal fun parseLocationTreeResponse(response: JSONObject): LocationData {
+    internal fun parseLocationTreeResponse(
+        response: JSONObject,
+        requestedCountryCode: String = DefaultCountryCode
+    ): LocationData {
         val tree = response.optJSONObject("tree") ?: JSONObject()
         if (tree.length() == 0) {
             return emptyMap()
+        }
+
+        if (tree.optJSONObject("cities") != null || tree.has("label")) {
+            val normalizedCountryKey = requestedCountryCode.trim()
+                .lowercase()
+                .ifBlank { DefaultCountryCode.lowercase() }
+
+            return mapOf(normalizedCountryKey to parseCountry(requestedCountryCode, tree))
         }
 
         val countries = linkedMapOf<String, Country>()
@@ -70,49 +84,57 @@ object LocationTreeRepository {
                 continue
             }
 
-            val citiesJson = countryJson.optJSONObject("cities") ?: JSONObject()
-            val cities = linkedMapOf<String, City>()
-
-            for (cityKey in jsonKeys(citiesJson)) {
-                val cityJson = citiesJson.optJSONObject(cityKey) ?: continue
-                val normalizedCityKey = cityKey.trim().lowercase()
-                if (normalizedCityKey.isBlank()) {
-                    continue
-                }
-
-                val districtsJson = cityJson.optJSONObject("districts") ?: JSONObject()
-                val districts = linkedMapOf<String, District>()
-
-                for (districtKey in jsonKeys(districtsJson)) {
-                    val districtJson = districtsJson.optJSONObject(districtKey) ?: continue
-                    val normalizedDistrictKey = districtKey.trim().lowercase()
-                    if (normalizedDistrictKey.isBlank()) {
-                        continue
-                    }
-
-                    val neighborhoods = parseNeighborhoods(
-                        districtJson.optJSONArray("neighborhoods") ?: JSONArray()
-                    )
-
-                    districts[normalizedDistrictKey] = District(
-                        label = districtJson.optString("label").trim().ifBlank { districtKey },
-                        neighborhoods = neighborhoods
-                    )
-                }
-
-                cities[normalizedCityKey] = City(
-                    label = cityJson.optString("label").trim().ifBlank { cityKey },
-                    districts = districts
-                )
-            }
-
-            countries[normalizedCountryKey] = Country(
-                label = countryJson.optString("label").trim().ifBlank { countryKey },
-                cities = cities
-            )
+            countries[normalizedCountryKey] = parseCountry(countryKey, countryJson)
         }
 
         return countries
+    }
+
+    private fun parseCountry(countryKey: String, countryJson: JSONObject): Country {
+        return Country(
+            label = countryJson.optString("label").trim().ifBlank { countryKey },
+            cities = parseCities(countryJson.optJSONObject("cities") ?: JSONObject())
+        )
+    }
+
+    private fun parseCities(citiesJson: JSONObject): Map<String, City> {
+        val cities = linkedMapOf<String, City>()
+
+        for (cityKey in jsonKeys(citiesJson)) {
+            val cityJson = citiesJson.optJSONObject(cityKey) ?: continue
+            val normalizedCityKey = cityKey.trim().lowercase()
+            if (normalizedCityKey.isBlank()) {
+                continue
+            }
+
+            cities[normalizedCityKey] = City(
+                label = cityJson.optString("label").trim().ifBlank { cityKey },
+                districts = parseDistricts(cityJson.optJSONObject("districts") ?: JSONObject())
+            )
+        }
+
+        return cities
+    }
+
+    private fun parseDistricts(districtsJson: JSONObject): Map<String, District> {
+        val districts = linkedMapOf<String, District>()
+
+        for (districtKey in jsonKeys(districtsJson)) {
+            val districtJson = districtsJson.optJSONObject(districtKey) ?: continue
+            val normalizedDistrictKey = districtKey.trim().lowercase()
+            if (normalizedDistrictKey.isBlank()) {
+                continue
+            }
+
+            districts[normalizedDistrictKey] = District(
+                label = districtJson.optString("label").trim().ifBlank { districtKey },
+                neighborhoods = parseNeighborhoods(
+                    districtJson.optJSONArray("neighborhoods") ?: JSONArray()
+                )
+            )
+        }
+
+        return districts
     }
 
     private fun parseNeighborhoods(array: JSONArray): List<Neighborhood> {

--- a/android/app/src/test/java/com/neph/features/profile/data/LocationTreeRepositoryTest.kt
+++ b/android/app/src/test/java/com/neph/features/profile/data/LocationTreeRepositoryTest.kt
@@ -7,7 +7,56 @@ import org.junit.Test
 
 class LocationTreeRepositoryTest {
     @Test
-    fun parseLocationTreeResponse_mapsBackendTreeToAppLocationData() {
+    fun parseLocationTreeResponse_mapsCountrySpecificBackendTreeToRequestedCountry() {
+        val response = JSONObject(
+            """
+            {
+              "countryCode": "TR",
+              "tree": {
+                "label": "Turkey",
+                "cities": {
+                  "ankara": {
+                    "label": "Ankara",
+                    "districts": {
+                      "cankaya": {
+                        "label": "Çankaya",
+                        "neighborhoods": [
+                          { "label": "Anıttepe", "value": "AnitTepeCode" }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        val parsed = LocationTreeRepository.parseLocationTreeResponse(
+            response = response,
+            requestedCountryCode = "TR"
+        )
+
+        assertEquals(setOf("tr"), parsed.keys)
+        assertEquals("Turkey", parsed["tr"]?.label)
+        assertTrue(parsed["tr"]?.cities?.containsKey("ankara") == true)
+        assertEquals("Ankara", parsed["tr"]?.cities?.get("ankara")?.label)
+        assertTrue(parsed["tr"]?.cities?.get("ankara")?.districts?.containsKey("cankaya") == true)
+
+        val neighborhoods = parsed["tr"]
+            ?.cities
+            ?.get("ankara")
+            ?.districts
+            ?.get("cankaya")
+            ?.neighborhoods
+            .orEmpty()
+        assertEquals(1, neighborhoods.size)
+        assertEquals("Anıttepe", neighborhoods.first().label)
+        assertEquals("AnitTepeCode", neighborhoods.first().value)
+    }
+
+    @Test
+    fun parseLocationTreeResponse_keepsCountryKeyedBackendTreeBehavior() {
         val response = JSONObject(
             """
             {
@@ -52,5 +101,29 @@ class LocationTreeRepositoryTest {
         assertEquals(1, neighborhoods.size)
         assertEquals("Anıttepe", neighborhoods.first().label)
         assertEquals("AnitTepeCode", neighborhoods.first().value)
+    }
+
+    @Test
+    fun parseLocationTreeResponse_returnsEmptyMapForEmptyOrMalformedTree() {
+        assertTrue(
+            LocationTreeRepository.parseLocationTreeResponse(
+                JSONObject("""{ "tree": {} }""")
+            ).isEmpty()
+        )
+
+        assertTrue(
+            LocationTreeRepository.parseLocationTreeResponse(
+                JSONObject(
+                    """
+                    {
+                      "tree": {
+                        "TR": "Turkey",
+                        "cities": "not-a-city-map"
+                      }
+                    }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        )
     }
 }


### PR DESCRIPTION
## Summary

Fixes Android location tree parsing for the Edit Profile residential location dropdown.

The backend `/location/tree?countryCode=TR` endpoint can return a country-specific tree in this shape:

`{ "tree": { "label": "Turkey", "cities": { ... } } }`

Android previously expected the tree to always be keyed by country code:

`{ "tree": { "TR": { "label": "Turkey", "cities": { ... } } } }`

Because of this mismatch, the parser treated `cities` as a country option, causing the Country dropdown to show `cities` instead of `Turkey`.

## Changes

- Updated Android location tree parsing to support country-specific backend responses.
- Preserved support for the existing country-keyed tree shape.
- Ensured country-specific responses are normalized under the requested country code.
- Added focused unit tests for:
  - country-specific `/location/tree?countryCode=TR` response shape
  - existing country-keyed response shape
  - empty tree fallback behavior

## Expected Behavior

- Edit Profile → Residential Location shows `Turkey` in the Country dropdown.
- City, district, and neighborhood dropdowns populate correctly.
- Existing fallback/static location data behavior remains unchanged.

## Testing

- Android unit tests were run for the affected parser behavior.

Closes #450