### PR TITLE
fix: make gathering areas resilient to provider failures

### DIFF
--- a/backend/src/modules/gathering-areas/service.js
+++ b/backend/src/modules/gathering-areas/service.js
@@ -5,37 +5,7 @@ const DEFAULT_STALE_CACHE_TTL_MS = 60 * 60 * 1000;
 const DEFAULT_CACHE_MAX_ENTRIES = 500;
 const DEFAULT_OVERPASS_USER_AGENT = 'NEPH-Backend/1.0 (+https://github.com/bounswe/bounswe2026group6)';
 const CACHE_COORDINATE_DECIMALS = 4;
-
-const FALLBACK_GATHERING_AREAS = [
-  {
-    id: 'fallback-istanbul-kadikoy-1',
-    name: 'Curated Kadikoy Assembly Area',
-    lat: 41.0105,
-    lon: 29.0105,
-    category: 'assembly_point',
-  },
-  {
-    id: 'fallback-istanbul-besiktas-1',
-    name: 'Curated Besiktas Assembly Area',
-    lat: 41.0438,
-    lon: 29.0094,
-    category: 'assembly_point',
-  },
-  {
-    id: 'fallback-ankara-cankaya-1',
-    name: 'Curated Cankaya Shelter Area',
-    lat: 39.9208,
-    lon: 32.8541,
-    category: 'shelter',
-  },
-  {
-    id: 'fallback-izmir-konak-1',
-    name: 'Curated Konak Assembly Area',
-    lat: 38.4192,
-    lon: 27.1287,
-    category: 'assembly_point',
-  },
-];
+const FALLBACK_REASON = 'No verified backend fallback gathering-area data is available';
 
 const nearbyCache = new Map();
 
@@ -177,6 +147,14 @@ function isObject(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+function isProviderFailure(error) {
+  return Boolean(error && [
+    'OVERPASS_TIMEOUT',
+    'OVERPASS_UNAVAILABLE',
+    'OVERPASS_INVALID_PAYLOAD',
+  ].includes(error.code));
+}
+
 function toRadians(value) {
   return (value * Math.PI) / 180;
 }
@@ -260,33 +238,10 @@ function toFeatureCollection(elements, limit, center) {
   };
 }
 
-function toFallbackFeatureCollection(params) {
-  const features = FALLBACK_GATHERING_AREAS
-    .map((area) => {
-      const distanceMeters = Math.round(calculateDistanceMeters(params.lat, params.lon, area.lat, area.lon));
-      return {
-        type: 'Feature',
-        geometry: {
-          type: 'Point',
-          coordinates: [area.lon, area.lat],
-        },
-        properties: {
-          id: area.id,
-          osmType: 'fallback',
-          name: area.name,
-          category: area.category,
-          distanceMeters,
-          rawTags: {},
-        },
-      };
-    })
-    .filter((feature) => feature.properties.distanceMeters <= params.radius)
-    .sort((left, right) => left.properties.distanceMeters - right.properties.distanceMeters)
-    .slice(0, params.limit);
-
+function toFallbackFeatureCollection() {
   return {
     type: 'FeatureCollection',
-    features,
+    features: [],
   };
 }
 
@@ -412,6 +367,10 @@ async function getNearbyGatheringAreas(params) {
     writeToCache(cacheKey, result);
     return result;
   } catch (error) {
+    if (!isProviderFailure(error)) {
+      throw error;
+    }
+
     const staleCached = readStaleCache(cacheKey);
     if (staleCached) {
       return withSource(staleCached, 'stale_cache', {
@@ -420,7 +379,7 @@ async function getNearbyGatheringAreas(params) {
       });
     }
 
-    const collection = toFallbackFeatureCollection(params);
+    const collection = toFallbackFeatureCollection();
     return {
       center: {
         lat: params.lat,
@@ -432,6 +391,7 @@ async function getNearbyGatheringAreas(params) {
         requestedLimit: params.limit,
         returnedCount: collection.features.length,
         providerErrorCode: error.code,
+        fallbackReason: FALLBACK_REASON,
       },
       collection,
     };

--- a/backend/src/modules/gathering-areas/service.js
+++ b/backend/src/modules/gathering-areas/service.js
@@ -1,9 +1,41 @@
 const DEFAULT_OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
 const DEFAULT_TIMEOUT_MS = 6000;
 const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_STALE_CACHE_TTL_MS = 60 * 60 * 1000;
 const DEFAULT_CACHE_MAX_ENTRIES = 500;
 const DEFAULT_OVERPASS_USER_AGENT = 'NEPH-Backend/1.0 (+https://github.com/bounswe/bounswe2026group6)';
 const CACHE_COORDINATE_DECIMALS = 4;
+
+const FALLBACK_GATHERING_AREAS = [
+  {
+    id: 'fallback-istanbul-kadikoy-1',
+    name: 'Curated Kadikoy Assembly Area',
+    lat: 41.0105,
+    lon: 29.0105,
+    category: 'assembly_point',
+  },
+  {
+    id: 'fallback-istanbul-besiktas-1',
+    name: 'Curated Besiktas Assembly Area',
+    lat: 41.0438,
+    lon: 29.0094,
+    category: 'assembly_point',
+  },
+  {
+    id: 'fallback-ankara-cankaya-1',
+    name: 'Curated Cankaya Shelter Area',
+    lat: 39.9208,
+    lon: 32.8541,
+    category: 'shelter',
+  },
+  {
+    id: 'fallback-izmir-konak-1',
+    name: 'Curated Konak Assembly Area',
+    lat: 38.4192,
+    lon: 27.1287,
+    category: 'assembly_point',
+  },
+];
 
 const nearbyCache = new Map();
 
@@ -16,8 +48,15 @@ function readPositiveNumberEnv(value, fallback, { integer = false } = {}) {
   return integer ? Math.floor(parsed) : parsed;
 }
 
-function getOverpassUrl() {
-  return process.env.GATHERING_AREAS_OVERPASS_URL || DEFAULT_OVERPASS_URL;
+function getOverpassUrls() {
+  const configuredPrimaryUrl = (process.env.GATHERING_AREAS_OVERPASS_URL || '').trim();
+  const primaryUrl = configuredPrimaryUrl || DEFAULT_OVERPASS_URL;
+  const fallbackUrls = (process.env.GATHERING_AREAS_OVERPASS_FALLBACK_URLS || '')
+    .split(',')
+    .map((url) => url.trim())
+    .filter(Boolean);
+
+  return [...new Set([primaryUrl, ...fallbackUrls])];
 }
 
 function getOverpassUserAgent() {
@@ -33,6 +72,10 @@ function getCacheTtlMs() {
   return readPositiveNumberEnv(process.env.GATHERING_AREAS_CACHE_TTL_MS, DEFAULT_CACHE_TTL_MS);
 }
 
+function getStaleCacheTtlMs() {
+  return readPositiveNumberEnv(process.env.GATHERING_AREAS_STALE_CACHE_TTL_MS, DEFAULT_STALE_CACHE_TTL_MS);
+}
+
 function getCacheMaxEntries() {
   return readPositiveNumberEnv(process.env.GATHERING_AREAS_CACHE_MAX_ENTRIES, DEFAULT_CACHE_MAX_ENTRIES, { integer: true });
 }
@@ -41,13 +84,26 @@ function buildCacheKey({ lat, lon, radius, limit }) {
   return `${lat.toFixed(CACHE_COORDINATE_DECIMALS)}:${lon.toFixed(CACHE_COORDINATE_DECIMALS)}:${radius}:${limit}`;
 }
 
-function readFromCache(cacheKey) {
+function readFreshCache(cacheKey) {
   const entry = nearbyCache.get(cacheKey);
   if (!entry) {
     return null;
   }
 
   if (entry.expiresAt <= Date.now()) {
+    return null;
+  }
+
+  return entry.value;
+}
+
+function readStaleCache(cacheKey) {
+  const entry = nearbyCache.get(cacheKey);
+  if (!entry) {
+    return null;
+  }
+
+  if (entry.staleExpiresAt <= Date.now()) {
     nearbyCache.delete(cacheKey);
     return null;
   }
@@ -58,7 +114,7 @@ function readFromCache(cacheKey) {
 function pruneCache() {
   const now = Date.now();
   for (const [key, entry] of nearbyCache.entries()) {
-    if (entry.expiresAt <= now) {
+    if (entry.staleExpiresAt <= now) {
       nearbyCache.delete(key);
     }
   }
@@ -74,9 +130,14 @@ function pruneCache() {
 }
 
 function writeToCache(cacheKey, value) {
+  const now = Date.now();
+  const cacheTtlMs = getCacheTtlMs();
+  const staleCacheTtlMs = Math.max(cacheTtlMs, getStaleCacheTtlMs());
+
   nearbyCache.set(cacheKey, {
     value,
-    expiresAt: Date.now() + getCacheTtlMs(),
+    expiresAt: now + cacheTtlMs,
+    staleExpiresAt: now + staleCacheTtlMs,
   });
   pruneCache();
 }
@@ -199,12 +260,53 @@ function toFeatureCollection(elements, limit, center) {
   };
 }
 
-async function fetchNearbyFromOverpassWithQuery(params, queryText) {
+function toFallbackFeatureCollection(params) {
+  const features = FALLBACK_GATHERING_AREAS
+    .map((area) => {
+      const distanceMeters = Math.round(calculateDistanceMeters(params.lat, params.lon, area.lat, area.lon));
+      return {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [area.lon, area.lat],
+        },
+        properties: {
+          id: area.id,
+          osmType: 'fallback',
+          name: area.name,
+          category: area.category,
+          distanceMeters,
+          rawTags: {},
+        },
+      };
+    })
+    .filter((feature) => feature.properties.distanceMeters <= params.radius)
+    .sort((left, right) => left.properties.distanceMeters - right.properties.distanceMeters)
+    .slice(0, params.limit);
+
+  return {
+    type: 'FeatureCollection',
+    features,
+  };
+}
+
+function withSource(result, source, extraMeta = {}) {
+  return {
+    ...result,
+    source,
+    meta: {
+      ...result.meta,
+      ...extraMeta,
+    },
+  };
+}
+
+async function fetchNearbyFromOverpassUrl(queryText, url) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), getTimeoutMs());
 
   try {
-    const response = await fetch(getOverpassUrl(), {
+    const response = await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
@@ -249,9 +351,23 @@ async function fetchNearbyFromOverpassWithQuery(params, queryText) {
   }
 }
 
+async function fetchNearbyFromOverpassWithQuery(queryText) {
+  let lastError = null;
+
+  for (const url of getOverpassUrls()) {
+    try {
+      return await fetchNearbyFromOverpassUrl(queryText, url);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}
+
 async function fetchNearbyFromOverpass(params) {
   try {
-    return await fetchNearbyFromOverpassWithQuery(params, buildOverpassQuery(params));
+    return await fetchNearbyFromOverpassWithQuery(buildOverpassQuery(params));
   } catch (error) {
     const shouldRetryWithLightweightQuery =
       error &&
@@ -261,39 +377,65 @@ async function fetchNearbyFromOverpass(params) {
       throw error;
     }
 
-    return fetchNearbyFromOverpassWithQuery(params, buildOverpassLightweightQuery(params));
+    return fetchNearbyFromOverpassWithQuery(buildOverpassLightweightQuery(params));
   }
 }
 
 async function getNearbyGatheringAreas(params) {
   const cacheKey = buildCacheKey(params);
-  const cached = readFromCache(cacheKey);
+  const cached = readFreshCache(cacheKey);
   if (cached) {
     return cached;
   }
 
-  const payload = await fetchNearbyFromOverpass(params);
-  const collection = toFeatureCollection(payload.elements, params.limit, {
-    lat: params.lat,
-    lon: params.lon,
-  });
-
-  const result = {
-    center: {
+  try {
+    const payload = await fetchNearbyFromOverpass(params);
+    const collection = toFeatureCollection(payload.elements, params.limit, {
       lat: params.lat,
       lon: params.lon,
-    },
-    radius: params.radius,
-    source: 'overpass',
-    meta: {
-      requestedLimit: params.limit,
-      returnedCount: collection.features.length,
-    },
-    collection,
-  };
+    });
 
-  writeToCache(cacheKey, result);
-  return result;
+    const result = {
+      center: {
+        lat: params.lat,
+        lon: params.lon,
+      },
+      radius: params.radius,
+      source: 'overpass',
+      meta: {
+        requestedLimit: params.limit,
+        returnedCount: collection.features.length,
+      },
+      collection,
+    };
+
+    writeToCache(cacheKey, result);
+    return result;
+  } catch (error) {
+    const staleCached = readStaleCache(cacheKey);
+    if (staleCached) {
+      return withSource(staleCached, 'stale_cache', {
+        stale: true,
+        providerErrorCode: error.code,
+      });
+    }
+
+    const collection = toFallbackFeatureCollection(params);
+    return {
+      center: {
+        lat: params.lat,
+        lon: params.lon,
+      },
+      radius: params.radius,
+      source: 'fallback',
+      meta: {
+        requestedLimit: params.limit,
+        returnedCount: collection.features.length,
+        providerErrorCode: error.code,
+      },
+      collection,
+    };
+  }
 }
 
 function __resetNearbyCache() {

--- a/backend/tests/integration/modules/gathering-areas/gathering-areas.integration.test.js
+++ b/backend/tests/integration/modules/gathering-areas/gathering-areas.integration.test.js
@@ -237,6 +237,8 @@ describe('gathering-areas integration', () => {
 
     expect(first.status).toBe(200);
     expect(second.status).toBe(200);
+    expect(first.body.source).toBe('overpass');
+    expect(second.body.source).toBe('overpass');
     expect(second.body.collection.features).toHaveLength(1);
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });

--- a/backend/tests/integration/modules/gathering-areas/gathering-areas.integration.test.js
+++ b/backend/tests/integration/modules/gathering-areas/gathering-areas.integration.test.js
@@ -188,6 +188,8 @@ describe('gathering-areas integration', () => {
 
     expect(response.status).toBe(400);
     expect(response.body.code).toBe('VALIDATION_ERROR');
+    expect(response.body.source).toBeUndefined();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
   test('GET /api/gathering-areas/nearby validates radius and limit as positive integers', async () => {

--- a/backend/tests/integration/modules/gathering-areas/gathering-areas.provider-failures.integration.test.js
+++ b/backend/tests/integration/modules/gathering-areas/gathering-areas.provider-failures.integration.test.js
@@ -148,7 +148,7 @@ describe('gathering-areas integration - provider failures', () => {
     expect(second.body.collection.features[0].properties.name).toBe('Unavailable Cached Area');
   });
 
-  test('GET /api/gathering-areas/nearby returns fallback data when provider is unavailable and no cache exists', async () => {
+  test('GET /api/gathering-areas/nearby returns empty fallback when provider is unavailable and no cache exists', async () => {
     const app = createApp();
 
     global.fetch.mockResolvedValue({
@@ -164,14 +164,16 @@ describe('gathering-areas integration - provider failures', () => {
     expect(response.body.source).toBe('fallback');
     expect(response.body.meta).toMatchObject({
       requestedLimit: 10,
+      returnedCount: 0,
       providerErrorCode: 'OVERPASS_UNAVAILABLE',
     });
+    expect(response.body.meta.fallbackReason).toContain('No verified backend fallback');
     expect(response.body.collection.type).toBe('FeatureCollection');
-    expect(response.body.collection.features.length).toBeGreaterThan(0);
+    expect(response.body.collection.features).toHaveLength(0);
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
-  test('GET /api/gathering-areas/nearby returns fallback data when provider times out and no cache exists', async () => {
+  test('GET /api/gathering-areas/nearby returns empty fallback when provider times out and no cache exists', async () => {
     const app = createApp();
 
     const timeoutError = new Error('timeout');
@@ -185,25 +187,16 @@ describe('gathering-areas integration - provider failures', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.source).toBe('fallback');
-    expect(response.body.meta.providerErrorCode).toBe('OVERPASS_TIMEOUT');
+    expect(response.body.meta).toMatchObject({
+      returnedCount: 0,
+      providerErrorCode: 'OVERPASS_TIMEOUT',
+    });
+    expect(response.body.meta.fallbackReason).toContain('No verified backend fallback');
     expect(response.body.collection.type).toBe('FeatureCollection');
-  });
-
-  test('GET /api/gathering-areas/nearby returns empty fallback collection when no curated area is nearby', async () => {
-    const app = createApp();
-
-    global.fetch.mockRejectedValue(new Error('network down'));
-
-    const response = await request(app)
-      .get('/api/gathering-areas/nearby?lat=0&lon=0&radius=1500&limit=10');
-
-    expect(response.status).toBe(200);
-    expect(response.body.source).toBe('fallback');
-    expect(response.body.meta.returnedCount).toBe(0);
     expect(response.body.collection.features).toHaveLength(0);
   });
 
-  test('GET /api/gathering-areas/nearby returns fallback data on invalid provider payload', async () => {
+  test('GET /api/gathering-areas/nearby returns empty fallback on invalid provider payload', async () => {
     const app = createApp();
 
     global.fetch.mockResolvedValueOnce({
@@ -216,7 +209,12 @@ describe('gathering-areas integration - provider failures', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.source).toBe('fallback');
-    expect(response.body.meta.providerErrorCode).toBe('OVERPASS_INVALID_PAYLOAD');
+    expect(response.body.meta).toMatchObject({
+      returnedCount: 0,
+      providerErrorCode: 'OVERPASS_INVALID_PAYLOAD',
+    });
+    expect(response.body.meta.fallbackReason).toContain('No verified backend fallback');
+    expect(response.body.collection.features).toHaveLength(0);
   });
 
   test('GET /api/gathering-areas/nearby attempts fallback Overpass endpoint after primary fails', async () => {

--- a/backend/tests/integration/modules/gathering-areas/gathering-areas.provider-failures.integration.test.js
+++ b/backend/tests/integration/modules/gathering-areas/gathering-areas.provider-failures.integration.test.js
@@ -22,10 +22,31 @@ const { createApp } = require('../../../../src/app');
 const gatheringAreasService = require('../../../../src/modules/gathering-areas/service');
 
 const originalFetch = global.fetch;
+const originalEnv = {
+  GATHERING_AREAS_CACHE_TTL_MS: process.env.GATHERING_AREAS_CACHE_TTL_MS,
+  GATHERING_AREAS_STALE_CACHE_TTL_MS: process.env.GATHERING_AREAS_STALE_CACHE_TTL_MS,
+  GATHERING_AREAS_OVERPASS_URL: process.env.GATHERING_AREAS_OVERPASS_URL,
+  GATHERING_AREAS_OVERPASS_FALLBACK_URLS: process.env.GATHERING_AREAS_OVERPASS_FALLBACK_URLS,
+};
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
 
 beforeEach(() => {
+  restoreEnv();
   gatheringAreasService.__resetNearbyCache();
   global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  restoreEnv();
 });
 
 afterAll(() => {
@@ -33,10 +54,104 @@ afterAll(() => {
 });
 
 describe('gathering-areas integration - provider failures', () => {
-  test('GET /api/gathering-areas/nearby returns 503 when provider is unavailable', async () => {
+  test('GET /api/gathering-areas/nearby returns stale cache when provider times out', async () => {
     const app = createApp();
+    process.env.GATHERING_AREAS_CACHE_TTL_MS = '1';
+    process.env.GATHERING_AREAS_STALE_CACHE_TTL_MS = '60000';
 
     global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        elements: [
+          {
+            type: 'node',
+            id: 7001,
+            lat: 41.01,
+            lon: 29.01,
+            tags: {
+              name: 'Stale Cached Area',
+              emergency: 'assembly_point',
+            },
+          },
+        ],
+      }),
+    });
+
+    const first = await request(app)
+      .get('/api/gathering-areas/nearby?lat=41.01&lon=29.01&radius=1500&limit=10');
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const timeoutError = new Error('timeout');
+    timeoutError.name = 'AbortError';
+    global.fetch.mockRejectedValue(timeoutError);
+
+    const second = await request(app)
+      .get('/api/gathering-areas/nearby?lat=41.01&lon=29.01&radius=1500&limit=10');
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body.source).toBe('stale_cache');
+    expect(second.body.meta).toMatchObject({
+      requestedLimit: 10,
+      returnedCount: 1,
+      stale: true,
+      providerErrorCode: 'OVERPASS_TIMEOUT',
+    });
+    expect(second.body.collection.features[0].properties.name).toBe('Stale Cached Area');
+  });
+
+  test('GET /api/gathering-areas/nearby returns stale cache when provider is unavailable', async () => {
+    const app = createApp();
+    process.env.GATHERING_AREAS_CACHE_TTL_MS = '1';
+    process.env.GATHERING_AREAS_STALE_CACHE_TTL_MS = '60000';
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        elements: [
+          {
+            type: 'node',
+            id: 7002,
+            lat: 41.01,
+            lon: 29.01,
+            tags: {
+              name: 'Unavailable Cached Area',
+              amenity: 'shelter',
+            },
+          },
+        ],
+      }),
+    });
+
+    const first = await request(app)
+      .get('/api/gathering-areas/nearby?lat=41.01&lon=29.01&radius=1500&limit=10');
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    global.fetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    });
+
+    const second = await request(app)
+      .get('/api/gathering-areas/nearby?lat=41.01&lon=29.01&radius=1500&limit=10');
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body.source).toBe('stale_cache');
+    expect(second.body.meta).toMatchObject({
+      stale: true,
+      providerErrorCode: 'OVERPASS_UNAVAILABLE',
+    });
+    expect(second.body.collection.features[0].properties.name).toBe('Unavailable Cached Area');
+  });
+
+  test('GET /api/gathering-areas/nearby returns fallback data when provider is unavailable and no cache exists', async () => {
+    const app = createApp();
+
+    global.fetch.mockResolvedValue({
       ok: false,
       status: 503,
       json: async () => ({}),
@@ -45,34 +160,18 @@ describe('gathering-areas integration - provider failures', () => {
     const response = await request(app)
       .get('/api/gathering-areas/nearby?lat=41.01&lon=29.01&radius=1500&limit=10');
 
-    expect(response.status).toBe(503);
-    expect(response.body.code).toBe('OVERPASS_UNAVAILABLE');
-  });
-
-  test('GET /api/gathering-areas/nearby returns 503 when provider keeps returning 406', async () => {
-    const app = createApp();
-
-    global.fetch
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 406,
-        json: async () => ({}),
-      })
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 406,
-        json: async () => ({}),
-      });
-
-    const response = await request(app)
-      .get('/api/gathering-areas/nearby?lat=41.01&lon=29.01&radius=1500&limit=10');
-
-    expect(response.status).toBe(503);
-    expect(response.body.code).toBe('OVERPASS_UNAVAILABLE');
+    expect(response.status).toBe(200);
+    expect(response.body.source).toBe('fallback');
+    expect(response.body.meta).toMatchObject({
+      requestedLimit: 10,
+      providerErrorCode: 'OVERPASS_UNAVAILABLE',
+    });
+    expect(response.body.collection.type).toBe('FeatureCollection');
+    expect(response.body.collection.features.length).toBeGreaterThan(0);
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
-  test('GET /api/gathering-areas/nearby returns 504 when provider times out', async () => {
+  test('GET /api/gathering-areas/nearby returns fallback data when provider times out and no cache exists', async () => {
     const app = createApp();
 
     const timeoutError = new Error('timeout');
@@ -84,23 +183,27 @@ describe('gathering-areas integration - provider failures', () => {
     const response = await request(app)
       .get('/api/gathering-areas/nearby?lat=41.01&lon=29.01&radius=1500&limit=10');
 
-    expect(response.status).toBe(504);
-    expect(response.body.code).toBe('OVERPASS_TIMEOUT');
+    expect(response.status).toBe(200);
+    expect(response.body.source).toBe('fallback');
+    expect(response.body.meta.providerErrorCode).toBe('OVERPASS_TIMEOUT');
+    expect(response.body.collection.type).toBe('FeatureCollection');
   });
 
-  test('GET /api/gathering-areas/nearby returns 503 on provider network error', async () => {
+  test('GET /api/gathering-areas/nearby returns empty fallback collection when no curated area is nearby', async () => {
     const app = createApp();
 
-    global.fetch.mockRejectedValueOnce(new Error('network down'));
+    global.fetch.mockRejectedValue(new Error('network down'));
 
     const response = await request(app)
-      .get('/api/gathering-areas/nearby?lat=41.01&lon=29.01&radius=1500&limit=10');
+      .get('/api/gathering-areas/nearby?lat=0&lon=0&radius=1500&limit=10');
 
-    expect(response.status).toBe(503);
-    expect(response.body.code).toBe('OVERPASS_UNAVAILABLE');
+    expect(response.status).toBe(200);
+    expect(response.body.source).toBe('fallback');
+    expect(response.body.meta.returnedCount).toBe(0);
+    expect(response.body.collection.features).toHaveLength(0);
   });
 
-  test('GET /api/gathering-areas/nearby returns 503 on invalid provider payload', async () => {
+  test('GET /api/gathering-areas/nearby returns fallback data on invalid provider payload', async () => {
     const app = createApp();
 
     global.fetch.mockResolvedValueOnce({
@@ -111,22 +214,48 @@ describe('gathering-areas integration - provider failures', () => {
     const response = await request(app)
       .get('/api/gathering-areas/nearby?lat=41.01&lon=29.01&radius=1500&limit=10');
 
-    expect(response.status).toBe(503);
-    expect(response.body.code).toBe('OVERPASS_UNAVAILABLE');
+    expect(response.status).toBe(200);
+    expect(response.body.source).toBe('fallback');
+    expect(response.body.meta.providerErrorCode).toBe('OVERPASS_INVALID_PAYLOAD');
   });
 
-  test('GET /api/gathering-areas/nearby returns 503 when payload has no elements array', async () => {
+  test('GET /api/gathering-areas/nearby attempts fallback Overpass endpoint after primary fails', async () => {
     const app = createApp();
+    process.env.GATHERING_AREAS_OVERPASS_URL = 'https://overpass-primary.example/api';
+    process.env.GATHERING_AREAS_OVERPASS_FALLBACK_URLS = 'https://overpass-fallback.example/api';
 
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ note: 'bad payload shape' }),
-    });
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          elements: [
+            {
+              type: 'node',
+              id: 7101,
+              lat: 41.01,
+              lon: 29.01,
+              tags: {
+                name: 'Fallback Endpoint Area',
+                emergency: 'assembly_point',
+              },
+            },
+          ],
+        }),
+      });
 
     const response = await request(app)
       .get('/api/gathering-areas/nearby?lat=41.01&lon=29.01&radius=1500&limit=10');
 
-    expect(response.status).toBe(503);
-    expect(response.body.code).toBe('OVERPASS_UNAVAILABLE');
+    expect(response.status).toBe(200);
+    expect(response.body.source).toBe('overpass');
+    expect(response.body.collection.features[0].properties.name).toBe('Fallback Endpoint Area');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch.mock.calls[0][0]).toBe('https://overpass-primary.example/api');
+    expect(global.fetch.mock.calls[1][0]).toBe('https://overpass-fallback.example/api');
   });
 });

--- a/backend/tests/unit/modules/gathering-areas/service.test.js
+++ b/backend/tests/unit/modules/gathering-areas/service.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const gatheringAreasService = require('../../../../src/modules/gathering-areas/service');
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  gatheringAreasService.__resetNearbyCache();
+  global.fetch = jest.fn();
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+describe('gathering-areas service', () => {
+  test('getNearbyGatheringAreas rethrows unexpected internal errors instead of returning fallback', async () => {
+    const unexpectedError = new Error('unexpected transform failure');
+    const element = {
+      type: 'node',
+      id: 8101,
+      lat: 41.01,
+      lon: 29.01,
+    };
+
+    Object.defineProperty(element, 'tags', {
+      get() {
+        throw unexpectedError;
+      },
+    });
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ elements: [element] }),
+    });
+
+    await expect(gatheringAreasService.getNearbyGatheringAreas({
+      lat: 41.01,
+      lon: 29.01,
+      radius: 1500,
+      limit: 10,
+    })).rejects.toThrow('unexpected transform failure');
+  });
+});


### PR DESCRIPTION
## Summary

Makes the Gathering Areas backend more resilient when the live Overpass provider is unavailable or times out.

The Android current-location flow was already capturing device location correctly, but `/gathering-areas/nearby` could still fail when Overpass returned `OVERPASS_UNAVAILABLE` or `OVERPASS_TIMEOUT`. This PR keeps the fix backend-side and avoids hardcoding gathering areas in the Android app.

## Changes

- Added fallback Overpass endpoint support.
- Added stale cache fallback when the live provider fails.
- Added backend-side fallback response behavior when no usable live/cache data is available.
- Kept response source explicit:
  - `overpass`
  - `stale_cache`
  - `fallback`
- Preserved the existing nearby response shape.
- Added focused tests for provider failure paths and fallback behavior.

## Location Model Notes

- Gathering Areas continue to use the current/operational coordinates provided by the request.
- Profile/residential location is not used as a fallback for this flow.
- No Android hardcoded gathering area data was added.

## Testing

- Added/updated backend tests for Gathering Areas provider failure resilience.
- Ran the relevant backend test suite.

Closes #451