### PR TITLE
feat: cache nearby visible users for offline access

### DIFF
--- a/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
+++ b/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
@@ -15,10 +15,11 @@ import com.neph.BuildConfig
         OperationalLocationEntity::class,
         SafetyStatusEntity::class,
         AssignedRequestEntity::class,
+        NearbyVisibleUserEntity::class,
         SyncOperationEntity::class,
         SyncMetadataEntity::class
     ],
-    version = 8,
+    version = 9,
     exportSchema = false
 )
 abstract class NephDatabase : RoomDatabase() {
@@ -27,6 +28,7 @@ abstract class NephDatabase : RoomDatabase() {
     abstract fun operationalLocationDao(): OperationalLocationDao
     abstract fun safetyStatusDao(): SafetyStatusDao
     abstract fun assignedRequestDao(): AssignedRequestDao
+    abstract fun nearbyVisibleUserDao(): NearbyVisibleUserDao
     abstract fun syncOperationDao(): SyncOperationDao
     abstract fun syncMetadataDao(): SyncMetadataDao
 }
@@ -119,6 +121,31 @@ object NephDatabaseProvider {
             database.execSQL("ALTER TABLE availability_state ADD COLUMN pauseReason TEXT NOT NULL DEFAULT 'NONE'")
         }
     }
+    private val Migration8To9 = object : Migration(8, 9) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS nearby_visible_users (
+                    cacheOwnerUserId TEXT NOT NULL,
+                    userId TEXT NOT NULL,
+                    displayName TEXT,
+                    safetyStatus TEXT NOT NULL,
+                    statusUpdatedAt TEXT,
+                    latitude REAL,
+                    longitude REAL,
+                    locationCapturedAt TEXT,
+                    visibilityScope TEXT,
+                    fetchedAtEpochMillis INTEGER NOT NULL,
+                    expiresAtEpochMillis INTEGER NOT NULL,
+                    PRIMARY KEY(cacheOwnerUserId, userId)
+                )
+                """.trimIndent()
+            )
+            database.execSQL("CREATE INDEX IF NOT EXISTS index_nearby_visible_users_cacheOwnerUserId ON nearby_visible_users (cacheOwnerUserId)")
+            database.execSQL("CREATE INDEX IF NOT EXISTS index_nearby_visible_users_safetyStatus ON nearby_visible_users (safetyStatus)")
+            database.execSQL("CREATE INDEX IF NOT EXISTS index_nearby_visible_users_fetchedAtEpochMillis ON nearby_visible_users (fetchedAtEpochMillis)")
+        }
+    }
 
     fun initialize(context: Context) {
         getInstance(context)
@@ -137,7 +164,8 @@ object NephDatabaseProvider {
                 Migration4To5,
                 Migration5To6,
                 Migration6To7,
-                Migration7To8
+                Migration7To8,
+                Migration8To9
             )
                 .build()
                 .also { instance = it }

--- a/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
@@ -121,6 +121,48 @@ interface AssignedRequestDao {
 }
 
 @Dao
+interface NearbyVisibleUserDao {
+    @Query(
+        """
+        SELECT * FROM nearby_visible_users
+        WHERE cacheOwnerUserId = :cacheOwnerUserId
+        ORDER BY fetchedAtEpochMillis DESC, displayName ASC, userId ASC
+        """
+    )
+    fun observeByCacheOwner(cacheOwnerUserId: String): Flow<List<NearbyVisibleUserEntity>>
+
+    @Query(
+        """
+        SELECT * FROM nearby_visible_users
+        WHERE cacheOwnerUserId = :cacheOwnerUserId
+        ORDER BY fetchedAtEpochMillis DESC, displayName ASC, userId ASC
+        """
+    )
+    suspend fun getByCacheOwner(cacheOwnerUserId: String): List<NearbyVisibleUserEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(users: List<NearbyVisibleUserEntity>)
+
+    @Query(
+        """
+        DELETE FROM nearby_visible_users
+        WHERE cacheOwnerUserId = :cacheOwnerUserId
+          AND userId NOT IN (:visibleUserIds)
+        """
+    )
+    suspend fun deleteUsersNotIn(cacheOwnerUserId: String, visibleUserIds: List<String>)
+
+    @Query("DELETE FROM nearby_visible_users WHERE cacheOwnerUserId = :cacheOwnerUserId")
+    suspend fun clearByCacheOwner(cacheOwnerUserId: String)
+
+    @Query("DELETE FROM nearby_visible_users WHERE expiresAtEpochMillis <= :nowEpochMillis")
+    suspend fun deleteExpired(nowEpochMillis: Long)
+
+    @Query("DELETE FROM nearby_visible_users")
+    suspend fun clearAll()
+}
+
+@Dao
 interface SyncOperationDao {
     @Query(
         """

--- a/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
@@ -155,6 +155,29 @@ data class AssignedRequestEntity(
 )
 
 @Entity(
+    tableName = "nearby_visible_users",
+    primaryKeys = ["cacheOwnerUserId", "userId"],
+    indices = [
+        Index(value = ["cacheOwnerUserId"]),
+        Index(value = ["safetyStatus"]),
+        Index(value = ["fetchedAtEpochMillis"])
+    ]
+)
+data class NearbyVisibleUserEntity(
+    val cacheOwnerUserId: String,
+    val userId: String,
+    val displayName: String?,
+    val safetyStatus: String,
+    val statusUpdatedAt: String?,
+    val latitude: Double?,
+    val longitude: Double?,
+    val locationCapturedAt: String?,
+    val visibilityScope: String?,
+    val fetchedAtEpochMillis: Long,
+    val expiresAtEpochMillis: Long
+)
+
+@Entity(
     tableName = "sync_operations",
     indices = [
         Index(value = ["status", "createdAtEpochMillis"]),

--- a/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
+++ b/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
@@ -8,6 +8,7 @@ import com.neph.core.sync.OfflineSyncScheduler
 import com.neph.core.network.JsonHttpClient
 import com.neph.features.notifications.data.PushTokenSync
 import com.neph.features.notifications.data.NotificationsRepository
+import com.neph.features.nearbyusers.data.NearbyVisibleUsersRepository
 import com.neph.features.operationallocation.data.OperationalLocationRepository
 import com.neph.features.profile.data.ProfileData
 import com.neph.features.profile.data.ProfileRepository
@@ -79,6 +80,7 @@ object AuthRepository {
         }
 
         val user = response.optJSONObject("user")
+        val userId = user?.optString("userId")?.trim().orEmpty()
         val userEmail = user?.optString("email")?.ifBlank { normalizedEmail } ?: normalizedEmail
         val canReuseLocalProfileFields = previousProfile.email
             ?.trim()
@@ -90,7 +92,7 @@ object AuthRepository {
             SafetyStatusRepository.clearLocalCache()
         }
 
-        AuthSessionStore.saveAccessToken(accessToken, rememberMe)
+        AuthSessionStore.saveAccessToken(accessToken, rememberMe, userId = userId)
         PushTokenSync.syncCurrentToken()
         ProfileRepository.clearProfile()
         ProfileRepository.saveProfile(
@@ -139,7 +141,8 @@ object AuthRepository {
 
         val accessToken = response.optString("accessToken")
         if (accessToken.isNotBlank()) {
-            AuthSessionStore.saveAccessToken(accessToken, rememberMe = true)
+            val userId = response.optJSONObject("user")?.optString("userId")?.trim().orEmpty()
+            AuthSessionStore.saveAccessToken(accessToken, rememberMe = true, userId = userId)
             PushTokenSync.syncCurrentToken()
             NephAppContext.getOrNull()?.let { OfflineSyncScheduler.enqueueSync(it, reason = "email-verified") }
         }
@@ -212,6 +215,11 @@ object AuthRepository {
         AuthSessionStore.clearPendingVerificationEmail()
         ProfileRepository.clearProfile()
         ioScope.launch {
+            try {
+                NearbyVisibleUsersRepository.clearLocalCache()
+            } catch (error: Exception) {
+                Log.w("AuthRepository", "Failed to clear nearby visible users on logout", error)
+            }
             try {
                 OperationalLocationRepository.clearLocalCache()
             } catch (error: Exception) {

--- a/android/app/src/main/java/com/neph/features/auth/data/AuthSessionStore.kt
+++ b/android/app/src/main/java/com/neph/features/auth/data/AuthSessionStore.kt
@@ -2,24 +2,29 @@ package com.neph.features.auth.data
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Base64
 import com.neph.BuildConfig
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import org.json.JSONObject
 
 object AuthSessionStore {
     private const val PrefsName = "neph_auth"
     private const val AccessTokenKey = "access_token"
+    private const val CurrentUserIdKey = "current_user_id"
     private const val PendingVerificationEmailKey = "pending_verification_email"
     private const val GuestModeKey = "guest_mode"
 
     private lateinit var prefs: SharedPreferences
     private val accessTokenState = MutableStateFlow<String?>(null)
     private var sessionToken: String? = null
+    private var sessionUserId: String? = null
 
     fun initialize(context: Context) {
         if (!::prefs.isInitialized) {
             prefs = context.applicationContext.getSharedPreferences(PrefsName, Context.MODE_PRIVATE)
             sessionToken = prefs.getString(AccessTokenKey, null)
+            sessionUserId = prefs.getString(CurrentUserIdKey, null)
             accessTokenState.value = sessionToken
         }
     }
@@ -31,16 +36,39 @@ object AuthSessionStore {
         return sessionToken ?: prefs.getString(AccessTokenKey, null)
     }
 
-    fun saveAccessToken(token: String, rememberMe: Boolean) {
+    fun getCurrentUserId(): String? {
         ensureInitialized()
+        val storedUserId = sessionUserId ?: prefs.getString(CurrentUserIdKey, null)
+        if (!storedUserId.isNullOrBlank()) {
+            return storedUserId
+        }
+
+        val userIdFromToken = extractUserIdFromAccessToken(sessionToken ?: prefs.getString(AccessTokenKey, null))
+        if (!userIdFromToken.isNullOrBlank()) {
+            sessionUserId = userIdFromToken
+            prefs.edit().putString(CurrentUserIdKey, userIdFromToken).apply()
+        }
+        return userIdFromToken
+    }
+
+    fun saveAccessToken(token: String, rememberMe: Boolean, userId: String? = null) {
+        ensureInitialized()
+        val normalizedUserId = userId?.trim()?.takeIf { it.isNotBlank() }
         sessionToken = token
+        sessionUserId = normalizedUserId
         accessTokenState.value = token
         prefs.edit().apply {
             putBoolean(GuestModeKey, false)
             if (rememberMe) {
                 putString(AccessTokenKey, token)
+                if (normalizedUserId != null) {
+                    putString(CurrentUserIdKey, normalizedUserId)
+                } else {
+                    remove(CurrentUserIdKey)
+                }
             } else {
                 remove(AccessTokenKey)
+                remove(CurrentUserIdKey)
             }
         }.apply()
     }
@@ -48,8 +76,12 @@ object AuthSessionStore {
     fun clearAccessToken() {
         ensureInitialized()
         sessionToken = null
+        sessionUserId = null
         accessTokenState.value = null
-        prefs.edit().remove(AccessTokenKey).apply()
+        prefs.edit()
+            .remove(AccessTokenKey)
+            .remove(CurrentUserIdKey)
+            .apply()
     }
 
     fun setGuestMode(enabled: Boolean) {
@@ -91,6 +123,7 @@ object AuthSessionStore {
         }
 
         sessionToken = null
+        sessionUserId = null
         accessTokenState.value = null
     }
 
@@ -104,5 +137,19 @@ object AuthSessionStore {
         check(::prefs.isInitialized) {
             "AuthSessionStore must be initialized before use."
         }
+    }
+
+    private fun extractUserIdFromAccessToken(token: String?): String? {
+        val payload = token
+            ?.split('.')
+            ?.getOrNull(1)
+            ?: return null
+        return runCatching {
+            val decoded = Base64.decode(payload, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+            JSONObject(String(decoded, Charsets.UTF_8))
+                .optString("userId")
+                .trim()
+                .takeIf { it.isNotBlank() }
+        }.getOrNull()
     }
 }

--- a/android/app/src/main/java/com/neph/features/nearbyusers/data/NearbyVisibleUsersRepository.kt
+++ b/android/app/src/main/java/com/neph/features/nearbyusers/data/NearbyVisibleUsersRepository.kt
@@ -1,0 +1,172 @@
+package com.neph.features.nearbyusers.data
+
+import com.neph.core.database.NearbyVisibleUserEntity
+import com.neph.core.database.NephDatabaseProvider
+import com.neph.core.network.ApiException
+import com.neph.core.network.JsonHttpClient
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.CancellationException
+import org.json.JSONObject
+import kotlin.math.round
+
+data class NearbyVisibleUserUiModel(
+    val userId: String,
+    val displayName: String?,
+    val safetyStatus: String,
+    val statusUpdatedAt: String?,
+    val latitude: Double?,
+    val longitude: Double?,
+    val locationCapturedAt: String?,
+    val visibilityScope: String?,
+    val fetchedAtEpochMillis: Long,
+    val expiresAtEpochMillis: Long,
+    val isStale: Boolean
+) {
+    val hasLocation: Boolean
+        get() = latitude != null && longitude != null
+}
+
+data class NearbyVisibleUsersResult(
+    val users: List<NearbyVisibleUserUiModel>,
+    val fromCache: Boolean,
+    val isStale: Boolean,
+    val message: String?
+)
+
+object NearbyVisibleUsersRepository {
+    private const val CacheTtlMillis = 24L * 60L * 60L * 1000L
+    private const val StaleAfterMillis = 15L * 60L * 1000L
+
+    private val database get() = NephDatabaseProvider.requireInstance()
+
+    fun observeCachedUsers(cacheOwnerUserId: String): Flow<List<NearbyVisibleUserUiModel>> {
+        return database.nearbyVisibleUserDao()
+            .observeByCacheOwner(cacheOwnerUserId)
+            .map { entities -> entities.map { it.toUiModel(System.currentTimeMillis()) } }
+    }
+
+    suspend fun refreshNearbyVisibleUsers(token: String, cacheOwnerUserId: String): NearbyVisibleUsersResult {
+        val now = System.currentTimeMillis()
+        database.nearbyVisibleUserDao().deleteExpired(now)
+
+        return try {
+            val response = JsonHttpClient.request(
+                path = "/safety-status/visible?nearby=true",
+                token = token
+            )
+            val entities = parseVisibleSafetyStatuses(response, now, cacheOwnerUserId)
+            database.nearbyVisibleUserDao().clearByCacheOwner(cacheOwnerUserId)
+            if (entities.isNotEmpty()) {
+                database.nearbyVisibleUserDao().upsertAll(entities)
+            }
+            NearbyVisibleUsersResult(
+                users = entities.map { it.toUiModel(now, forceStale = false) },
+                fromCache = false,
+                isStale = false,
+                message = null
+            )
+        } catch (cancellationException: CancellationException) {
+            throw cancellationException
+        } catch (error: ApiException) {
+            if (error.status == 401) {
+                throw error
+            }
+            returnCachedUsers(cacheOwnerUserId, now)
+        } catch (error: Exception) {
+            returnCachedUsers(cacheOwnerUserId, now)
+        }
+    }
+
+    internal fun parseVisibleSafetyStatuses(
+        response: JSONObject,
+        now: Long,
+        cacheOwnerUserId: String
+    ): List<NearbyVisibleUserEntity> {
+        val items = response.optJSONArray("safetyStatuses") ?: return emptyList()
+        return buildList {
+            for (index in 0 until items.length()) {
+                items.optJSONObject(index)?.toNearbyVisibleUserEntity(now, cacheOwnerUserId)?.let(::add)
+            }
+        }.distinctBy { it.userId }
+    }
+
+    internal fun isEntityStale(entity: NearbyVisibleUserEntity, now: Long): Boolean {
+        return entity.expiresAtEpochMillis <= now || entity.fetchedAtEpochMillis + StaleAfterMillis <= now
+    }
+
+    private suspend fun returnCachedUsers(
+        cacheOwnerUserId: String,
+        now: Long
+    ): NearbyVisibleUsersResult {
+        val cached = database.nearbyVisibleUserDao()
+            .getByCacheOwner(cacheOwnerUserId)
+            .map { it.toUiModel(now, forceStale = true) }
+        return NearbyVisibleUsersResult(
+            users = cached,
+            fromCache = true,
+            isStale = cached.isNotEmpty(),
+            message = if (cached.isEmpty()) {
+                "Could not load nearby visible users. Please retry when you have a connection."
+            } else {
+                "Showing cached nearby users. This information may be stale."
+            }
+        )
+    }
+
+    suspend fun clearLocalCache(cacheOwnerUserId: String? = null) {
+        if (cacheOwnerUserId.isNullOrBlank()) {
+            database.nearbyVisibleUserDao().clearAll()
+        } else {
+            database.nearbyVisibleUserDao().clearByCacheOwner(cacheOwnerUserId)
+        }
+    }
+
+    private fun JSONObject.toNearbyVisibleUserEntity(now: Long, cacheOwnerUserId: String): NearbyVisibleUserEntity? {
+        val userId = optString("userId").trim()
+        if (userId.isBlank()) {
+            return null
+        }
+
+        val location = optJSONObject("location")
+        val latitude = location?.opt("latitude") as? Number
+        val longitude = location?.opt("longitude") as? Number
+
+        return NearbyVisibleUserEntity(
+            cacheOwnerUserId = cacheOwnerUserId,
+            userId = userId,
+            displayName = optString("displayName").takeIf { it.isNotBlank() && it != "null" },
+            safetyStatus = optString("status").ifBlank { "unknown" },
+            statusUpdatedAt = optString("updatedAt").takeIf { it.isNotBlank() && it != "null" },
+            latitude = latitude?.toDouble()?.roundToCoarseCoordinate(),
+            longitude = longitude?.toDouble()?.roundToCoarseCoordinate(),
+            locationCapturedAt = location?.optString("capturedAt")?.takeIf { it.isNotBlank() && it != "null" },
+            visibilityScope = optString("visibilityScope").takeIf { it.isNotBlank() && it != "null" },
+            fetchedAtEpochMillis = now,
+            expiresAtEpochMillis = now + CacheTtlMillis
+        )
+    }
+
+    private fun Double.roundToCoarseCoordinate(): Double {
+        return round(this * 1_000.0) / 1_000.0
+    }
+
+    private fun NearbyVisibleUserEntity.toUiModel(
+        now: Long,
+        forceStale: Boolean = false
+    ): NearbyVisibleUserUiModel {
+        return NearbyVisibleUserUiModel(
+            userId = userId,
+            displayName = displayName,
+            safetyStatus = safetyStatus,
+            statusUpdatedAt = statusUpdatedAt,
+            latitude = latitude,
+            longitude = longitude,
+            locationCapturedAt = locationCapturedAt,
+            visibilityScope = visibilityScope,
+            fetchedAtEpochMillis = fetchedAtEpochMillis,
+            expiresAtEpochMillis = expiresAtEpochMillis,
+            isStale = forceStale || isEntityStale(this, now)
+        )
+    }
+}

--- a/android/app/src/main/java/com/neph/features/nearbyusers/presentation/NearbyVisibleUsersScreen.kt
+++ b/android/app/src/main/java/com/neph/features/nearbyusers/presentation/NearbyVisibleUsersScreen.kt
@@ -1,0 +1,238 @@
+package com.neph.features.nearbyusers.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.neph.core.network.ApiException
+import com.neph.features.auth.data.AuthRepository
+import com.neph.features.auth.data.AuthSessionStore
+import com.neph.features.nearbyusers.data.NearbyVisibleUserUiModel
+import com.neph.features.nearbyusers.data.NearbyVisibleUsersRepository
+import com.neph.navigation.Routes
+import com.neph.ui.components.buttons.SecondaryButton
+import com.neph.ui.components.display.HelperText
+import com.neph.ui.components.display.SectionCard
+import com.neph.ui.components.display.SectionHeader
+import com.neph.ui.layout.AppDrawerScaffold
+import com.neph.ui.theme.LocalNephSpacing
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun NearbyVisibleUsersScreen(
+    onNavigateToRoute: (String) -> Unit,
+    onOpenSettings: () -> Unit,
+    onProfileClick: () -> Unit,
+    onNavigateToLogin: () -> Unit,
+    profileBadgeText: String,
+    modifier: Modifier = Modifier
+) {
+    val spacing = LocalNephSpacing.current
+    val scope = rememberCoroutineScope()
+    val token = AuthSessionStore.getAccessToken()
+    var users by remember { mutableStateOf<List<NearbyVisibleUserUiModel>>(emptyList()) }
+    var loading by remember { mutableStateOf(false) }
+    var message by remember { mutableStateOf("") }
+    var errorMessage by remember { mutableStateOf("") }
+    var showingCachedData by remember { mutableStateOf(false) }
+
+    fun loadNearbyUsers() {
+        val safeToken = token
+        val cacheOwnerUserId = AuthSessionStore.getCurrentUserId()
+        if (safeToken.isNullOrBlank() || cacheOwnerUserId.isNullOrBlank()) {
+            onNavigateToLogin()
+            return
+        }
+
+        loading = true
+        message = ""
+        errorMessage = ""
+        scope.launch {
+            try {
+                val result = NearbyVisibleUsersRepository.refreshNearbyVisibleUsers(
+                    token = safeToken,
+                    cacheOwnerUserId = cacheOwnerUserId
+                )
+                users = result.users
+                showingCachedData = result.fromCache || result.isStale
+                message = when {
+                    result.message != null -> result.message
+                    result.users.isEmpty() -> "No nearby visible users are available right now."
+                    result.fromCache -> "Showing cached nearby users. This information may be stale."
+                    else -> "Nearby visible users refreshed."
+                }
+            } catch (error: ApiException) {
+                if (error.status == 401) {
+                    AuthRepository.logout()
+                    errorMessage = "Session expired. Please log in again."
+                    onNavigateToLogin()
+                } else {
+                    errorMessage = error.message.ifBlank { "Could not load nearby visible users. Please retry." }
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                errorMessage = "Could not load nearby visible users. Please retry."
+            } finally {
+                loading = false
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        loadNearbyUsers()
+    }
+
+    AppDrawerScaffold(
+        title = "Nearby Users",
+        currentRoute = Routes.NearbyUsers.route,
+        onNavigateToRoute = onNavigateToRoute,
+        drawerItems = Routes.authenticatedDrawerItems,
+        modifier = modifier,
+        onOpenSettings = onOpenSettings,
+        onProfileClick = onProfileClick,
+        profileBadgeText = profileBadgeText,
+        profileLabel = "Profile",
+        contentMaxWidth = 560.dp,
+        contentAlignment = Alignment.TopCenter
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(spacing.md)
+        ) {
+            SectionCard {
+                Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                    SectionHeader(
+                        title = "Nearby Visible Users",
+                        subtitle = "Based on your residential/profile area, not your current GPS. Only users visible through privacy or trusted circle rules are cached."
+                    )
+                    SecondaryButton(
+                        text = "Refresh",
+                        onClick = { loadNearbyUsers() },
+                        enabled = !loading
+                    )
+                }
+            }
+
+            if (loading) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
+            }
+
+            if (showingCachedData) {
+                SectionCard {
+                    HelperText(text = "Cached data may be stale. Refresh when connectivity is available.")
+                }
+            }
+
+            if (message.isNotBlank()) {
+                SectionCard {
+                    HelperText(text = message)
+                }
+            }
+
+            if (errorMessage.isNotBlank()) {
+                SectionCard {
+                    Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                        HelperText(text = errorMessage)
+                        SecondaryButton(text = "Retry", onClick = { loadNearbyUsers() })
+                    }
+                }
+            }
+
+            users.forEach { user ->
+                NearbyVisibleUserRow(user = user)
+            }
+        }
+    }
+}
+
+@Composable
+private fun NearbyVisibleUserRow(user: NearbyVisibleUserUiModel) {
+    val spacing = LocalNephSpacing.current
+    SectionCard {
+        Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = user.displayName ?: user.userId,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Text(
+                        text = "Last update: ${user.statusUpdatedAt ?: "No response yet"}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                AssistChip(
+                    onClick = {},
+                    label = { Text(formatSafetyStatus(user.safetyStatus)) }
+                )
+            }
+
+            Text(
+                text = buildLocationLabel(user),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            if (user.isStale) {
+                Text(
+                    text = "Stale cache from ${formatEpoch(user.fetchedAtEpochMillis)}",
+                    modifier = Modifier.padding(top = 2.dp),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+    }
+}
+
+private fun buildLocationLabel(user: NearbyVisibleUserUiModel): String {
+    if (!user.hasLocation) {
+        return "Location not cached or not shared."
+    }
+
+    return "Approximate location: ${"%.3f".format(Locale.US, user.latitude)}, ${"%.3f".format(Locale.US, user.longitude)}"
+}
+
+private fun formatSafetyStatus(status: String): String {
+    return when (status.trim().lowercase()) {
+        "safe" -> "Safe"
+        "not_safe" -> "Needs help"
+        else -> "Unknown"
+    }
+}
+
+private fun formatEpoch(epochMillis: Long): String {
+    return SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US).format(Date(epochMillis))
+}

--- a/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
@@ -27,6 +27,7 @@ import com.neph.features.gatheringareas.presentation.GatheringAreasScreen
 import com.neph.features.helprequestmap.presentation.HelpRequestMapScreen
 import com.neph.features.home.presentation.HomeScreen
 import com.neph.features.myhelprequests.presentation.MyHelpRequestsScreen
+import com.neph.features.nearbyusers.presentation.NearbyVisibleUsersScreen
 import com.neph.features.news.presentation.NewsScreen
 import com.neph.features.notifications.presentation.NotificationsScreen
 import com.neph.features.privacysecurity.presentation.PrivacySecurityScreen
@@ -63,6 +64,7 @@ fun AppNavGraph(
             Routes.EditProfile.route,
             Routes.Settings.route,
             Routes.SafetyCircles.route,
+            Routes.NearbyUsers.route,
             Routes.PrivacySecurity.route
         )
 
@@ -321,6 +323,31 @@ fun AppNavGraph(
                 },
                 profileBadgeText = profileBadgeText,
                 isAuthenticated = authenticated
+            )
+        }
+
+        composable(Routes.NearbyUsers.route) {
+            if (!isAuthenticated()) {
+                LaunchedEffect(Unit) {
+                    navigateToLogin()
+                }
+                return@composable
+            }
+
+            val profileBadgeText = resolveProfileBadgeText(authenticated = true)
+
+            NearbyVisibleUsersScreen(
+                onNavigateToRoute = ::navigateToDrawerRoute,
+                onOpenSettings = {
+                    navigateToDrawerRoute(Routes.Settings.route)
+                },
+                onProfileClick = {
+                    navigateToDrawerRoute(Routes.Profile.route)
+                },
+                onNavigateToLogin = {
+                    navigateToLogin()
+                },
+                profileBadgeText = profileBadgeText
             )
         }
 

--- a/android/app/src/main/java/com/neph/navigation/Routes.kt
+++ b/android/app/src/main/java/com/neph/navigation/Routes.kt
@@ -11,6 +11,7 @@ sealed class Routes(
     data object AssignedRequest : Routes("assigned_request", "Assigned Request")
     data object EmergencyInfo : Routes("emergency_info", "Emergency Numbers")
     data object HelpRequestMap : Routes("help_request_map", "Help Request Map")
+    data object NearbyUsers : Routes("nearby_users", "Nearby Users")
     data object GatheringAreas : Routes("gathering_areas", "Gathering Areas")
     data object SafetyCircles : Routes("safety_circles", "Safety Circles")
     data object Notifications : Routes("notifications", "Notifications")
@@ -40,6 +41,7 @@ sealed class Routes(
             AssignedRequest,
             EmergencyInfo,
             HelpRequestMap,
+            NearbyUsers,
             GatheringAreas,
             SafetyCircles,
             Notifications

--- a/android/app/src/test/java/com/neph/features/nearbyusers/data/NearbyVisibleUsersRepositoryTest.kt
+++ b/android/app/src/test/java/com/neph/features/nearbyusers/data/NearbyVisibleUsersRepositoryTest.kt
@@ -1,0 +1,99 @@
+package com.neph.features.nearbyusers.data
+
+import com.neph.core.database.NearbyVisibleUserEntity
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NearbyVisibleUsersRepositoryTest {
+    @Test
+    fun parserStoresOnlyMinimalVisibleFields() {
+        val now = 1_000L
+        val response = JSONObject()
+            .put(
+                "safetyStatuses",
+                JSONArray()
+                    .put(
+                        JSONObject()
+                            .put("userId", "user-visible")
+                            .put("displayName", "Visible User")
+                            .put("status", "safe")
+                            .put("updatedAt", "2026-05-04T10:00:00.000Z")
+                            .put(
+                                "location",
+                                JSONObject()
+                                    .put("latitude", 41.04321)
+                                    .put("longitude", 29.00987)
+                                    .put("capturedAt", "2026-05-04T09:58:00.000Z")
+                            )
+                    )
+            )
+
+        val users = NearbyVisibleUsersRepository.parseVisibleSafetyStatuses(
+            response,
+            now,
+            cacheOwnerUserId = "viewer-1"
+        )
+
+        assertEquals(1, users.size)
+        assertEquals("viewer-1", users[0].cacheOwnerUserId)
+        assertEquals("user-visible", users[0].userId)
+        assertEquals("Visible User", users[0].displayName)
+        assertEquals("safe", users[0].safetyStatus)
+        assertEquals("2026-05-04T10:00:00.000Z", users[0].statusUpdatedAt)
+        assertEquals(41.043, users[0].latitude ?: 0.0, 0.0)
+        assertEquals(29.010, users[0].longitude ?: 0.0, 0.0)
+        assertEquals(now, users[0].fetchedAtEpochMillis)
+    }
+
+    @Test
+    fun parserDoesNotCacheLocationWhenBackendDoesNotExposeIt() {
+        val response = JSONObject()
+            .put(
+                "safetyStatuses",
+                JSONArray()
+                    .put(
+                        JSONObject()
+                            .put("userId", "user-private-location")
+                            .put("displayName", "Private Location")
+                            .put("status", "not_safe")
+                            .put("location", JSONObject.NULL)
+                    )
+            )
+
+        val user = NearbyVisibleUsersRepository.parseVisibleSafetyStatuses(
+            response,
+            now = 2_000L,
+            cacheOwnerUserId = "viewer-1"
+        ).single()
+
+        assertNull(user.latitude)
+        assertNull(user.longitude)
+        assertNull(user.locationCapturedAt)
+    }
+
+    @Test
+    fun stalePolicyMarksCacheStaleAfterRefreshWindowOrExpiry() {
+        val entity = NearbyVisibleUserEntity(
+            cacheOwnerUserId = "viewer-1",
+            userId = "user-stale",
+            displayName = "Stale User",
+            safetyStatus = "unknown",
+            statusUpdatedAt = null,
+            latitude = null,
+            longitude = null,
+            locationCapturedAt = null,
+            visibilityScope = null,
+            fetchedAtEpochMillis = 10_000L,
+            expiresAtEpochMillis = 20_000L
+        )
+
+        assertFalse(NearbyVisibleUsersRepository.isEntityStale(entity, now = 12_000L))
+        assertTrue(NearbyVisibleUsersRepository.isEntityStale(entity, now = 16 * 60 * 1000L + 10_000L))
+        assertTrue(NearbyVisibleUsersRepository.isEntityStale(entity, now = 20_000L))
+    }
+}

--- a/backend/src/modules/safety-status/controller.js
+++ b/backend/src/modules/safety-status/controller.js
@@ -13,6 +13,14 @@ function sendError(response, status, code, message, details) {
   return response.status(status).json(payload);
 }
 
+function parseVisibleStatusesQuery(query) {
+  const nearbyOnly = String(query.nearby || '').toLowerCase() === 'true';
+
+  return {
+    nearbyOnly,
+  };
+}
+
 async function handleGetMySafetyStatus(request, response) {
   try {
     const safetyStatus = await getMySafetyStatus(request.user.userId);
@@ -40,8 +48,10 @@ async function handlePatchMySafetyStatus(request, response) {
 
 async function handleGetVisibleSafetyStatuses(request, response) {
   try {
+    const query = parseVisibleStatusesQuery(request.query || {});
     const safetyStatuses = await getVisibleSafetyStatuses(request.user.userId, {
       isAdmin: Boolean(request.user.isAdmin),
+      nearbyOnly: query.nearbyOnly,
     });
     return response.status(200).json({ safetyStatuses });
   } catch (error) {

--- a/backend/src/modules/safety-status/repository.js
+++ b/backend/src/modules/safety-status/repository.js
@@ -41,7 +41,12 @@ function mapVisibleSafetyStatus(row, { isAdmin = false } = {}) {
   const canSeeLocation = Boolean(
     row.share_location_consent
     && row.location_sharing_enabled
-    && row.location_visibility !== 'PRIVATE'
+    && (
+      isAdmin
+      || row.is_self
+      || row.location_visibility === 'PUBLIC'
+      || (row.location_visibility === 'EMERGENCY_ONLY' && row.shares_safety_circle)
+    )
   );
 
   return {
@@ -158,9 +163,10 @@ async function upsertSafetyStatus(userId, input) {
   return mapSafetyStatus(result.rows[0]);
 }
 
-async function listVisibleSafetyStatuses(viewerUserId, { isAdmin = false } = {}) {
+async function listVisibleSafetyStatuses(viewerUserId, { isAdmin = false, nearbyOnly = false } = {}) {
   const result = await query(
     `
+      WITH visible_statuses AS (
       SELECT
         uss.user_id,
         uss.status,
@@ -176,10 +182,30 @@ async function listVisibleSafetyStatuses(viewerUserId, { isAdmin = false } = {})
         up.last_name,
         ps.profile_visibility,
         ps.location_visibility,
-        ps.location_sharing_enabled
+        ps.location_sharing_enabled,
+        target_lp.country,
+        target_lp.city,
+        target_lp.district,
+        target_lp.neighborhood,
+        viewer_lp.country AS viewer_country,
+        viewer_lp.city AS viewer_city,
+        viewer_lp.district AS viewer_district,
+        viewer_lp.neighborhood AS viewer_neighborhood,
+        uss.user_id = $1 AS is_self,
+        EXISTS (
+          SELECT 1
+          FROM safety_circle_members viewer_location_member
+          JOIN safety_circle_members target_location_member
+            ON target_location_member.circle_id = viewer_location_member.circle_id
+          WHERE viewer_location_member.user_id = $1
+            AND target_location_member.user_id = uss.user_id
+        ) AS shares_safety_circle
       FROM user_safety_statuses uss
       LEFT JOIN user_profiles up ON up.user_id = uss.user_id
       LEFT JOIN privacy_settings ps ON ps.profile_id = up.profile_id
+      LEFT JOIN location_profiles target_lp ON target_lp.profile_id = up.profile_id
+      LEFT JOIN user_profiles viewer_up ON viewer_up.user_id = $1
+      LEFT JOIN location_profiles viewer_lp ON viewer_lp.profile_id = viewer_up.profile_id
       WHERE uss.user_id = $1
         OR $2 = TRUE
         OR COALESCE(ps.profile_visibility::text, 'PRIVATE') = 'PUBLIC'
@@ -191,9 +217,22 @@ async function listVisibleSafetyStatuses(viewerUserId, { isAdmin = false } = {})
           WHERE viewer_member.user_id = $1
             AND visible_member.user_id = uss.user_id
         )
-      ORDER BY uss.updated_at DESC, uss.user_id ASC;
+      )
+      SELECT *
+      FROM visible_statuses
+      WHERE $3 = FALSE
+        OR (
+          user_id <> $1
+          AND NULLIF(TRIM(COALESCE(viewer_neighborhood, '')), '') IS NOT NULL
+          AND NULLIF(TRIM(COALESCE(neighborhood, '')), '') IS NOT NULL
+          AND LOWER(TRIM(COALESCE(viewer_country, ''))) = LOWER(TRIM(COALESCE(country, '')))
+          AND LOWER(TRIM(COALESCE(viewer_city, ''))) = LOWER(TRIM(COALESCE(city, '')))
+          AND LOWER(TRIM(COALESCE(viewer_district, ''))) = LOWER(TRIM(COALESCE(district, '')))
+          AND LOWER(TRIM(COALESCE(viewer_neighborhood, ''))) = LOWER(TRIM(COALESCE(neighborhood, '')))
+        )
+      ORDER BY updated_at DESC, user_id ASC;
     `,
-    [viewerUserId, isAdmin],
+    [viewerUserId, isAdmin, Boolean(nearbyOnly)],
   );
 
   return result.rows.map((row) => mapVisibleSafetyStatus(row, { isAdmin }));

--- a/backend/tests/integration/modules/safety-status/safety-status.integration.test.js
+++ b/backend/tests/integration/modules/safety-status/safety-status.integration.test.js
@@ -75,6 +75,32 @@ async function seedProfile(userId, options = {}) {
       Boolean(options.locationSharingEnabled),
     ],
   );
+
+  if (options.latitude !== undefined && options.longitude !== undefined) {
+    await query(
+      `
+        INSERT INTO location_profiles (
+          location_profile_id,
+          profile_id,
+          city,
+          district,
+          neighborhood,
+          latitude,
+          longitude
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7);
+      `,
+      [
+        `loc_${userId}`,
+        profileId,
+        options.city || 'Istanbul',
+        options.district || 'Besiktas',
+        options.neighborhood || 'Levazim',
+        options.latitude,
+        options.longitude,
+      ],
+    );
+  }
 }
 
 beforeEach(async () => {
@@ -91,6 +117,9 @@ beforeEach(async () => {
       news_announcements,
       reports,
       expertise,
+      safety_circle_invites,
+      safety_circle_members,
+      safety_circles,
       privacy_settings,
       location_profiles,
       health_info,
@@ -280,5 +309,171 @@ describe('safety-status integration', () => {
       status: 'not_safe',
     });
     expect(adminByUserId[privateId]).toBeTruthy();
+  });
+
+  test('GET /api/safety-status/visible nearby filters visible users by profile neighborhood and privacy', async () => {
+    const app = createTestApp();
+    const viewerId = 'user_nearby_viewer';
+    const nearId = 'user_nearby_public';
+    const farId = 'user_nearby_far';
+    const privateLocationId = 'user_nearby_private_location';
+    await seedActiveUser(viewerId);
+    await seedActiveUser(nearId);
+    await seedActiveUser(farId);
+    await seedActiveUser(privateLocationId);
+    await seedProfile(viewerId, {
+      profileVisibility: 'PRIVATE',
+      locationVisibility: 'EMERGENCY_ONLY',
+      locationSharingEnabled: true,
+      neighborhood: 'Levazim',
+      latitude: 41.043,
+      longitude: 29.009,
+    });
+    await seedProfile(nearId, {
+      firstName: 'Near',
+      lastName: 'Visible',
+      profileVisibility: 'PUBLIC',
+      locationVisibility: 'EMERGENCY_ONLY',
+      locationSharingEnabled: true,
+      neighborhood: 'Levazim',
+      latitude: 41.044,
+      longitude: 29.01,
+    });
+    await seedProfile(farId, {
+      firstName: 'Far',
+      lastName: 'Visible',
+      profileVisibility: 'PUBLIC',
+      locationVisibility: 'EMERGENCY_ONLY',
+      locationSharingEnabled: true,
+      neighborhood: 'Moda',
+      latitude: 40.19,
+      longitude: 29.06,
+    });
+    await seedProfile(privateLocationId, {
+      firstName: 'Private',
+      lastName: 'Location',
+      profileVisibility: 'PUBLIC',
+      locationVisibility: 'PRIVATE',
+      locationSharingEnabled: true,
+      neighborhood: 'Levazim',
+      latitude: 41.044,
+      longitude: 29.01,
+    });
+
+    for (const userId of [viewerId, nearId, farId, privateLocationId]) {
+      await request(app)
+        .patch('/api/safety-status/me')
+        .set('Authorization', `Bearer ${buildAuthToken(userId)}`)
+        .send({ status: userId === nearId ? 'safe' : 'not_safe' })
+        .expect(200);
+    }
+
+    const response = await request(app)
+      .get('/api/safety-status/visible?nearby=true')
+      .set('Authorization', `Bearer ${buildAuthToken(viewerId)}`);
+
+    expect(response.status).toBe(200);
+    const byUserId = Object.fromEntries(
+      response.body.safetyStatuses.map((item) => [item.userId, item]),
+    );
+    expect(byUserId[nearId]).toMatchObject({
+      displayName: 'Near Visible',
+      status: 'safe',
+    });
+    expect(byUserId[nearId]).not.toHaveProperty('neighborhood');
+    expect(byUserId[nearId]).not.toHaveProperty('district');
+    expect(byUserId[nearId]).not.toHaveProperty('city');
+    expect(byUserId[viewerId]).toBeUndefined();
+    expect(byUserId[farId]).toBeUndefined();
+    expect(byUserId[privateLocationId]).toMatchObject({
+      displayName: 'Private Location',
+      status: 'not_safe',
+      location: null,
+    });
+  });
+
+  test('GET /api/safety-status/visible nearby hides emergency-only location from non-circle viewers', async () => {
+    const app = createTestApp();
+    const viewerId = 'user_nearby_location_viewer';
+    const emergencyLocationId = 'user_nearby_location_emergency';
+    await seedActiveUser(viewerId);
+    await seedActiveUser(emergencyLocationId);
+    await seedProfile(viewerId, {
+      profileVisibility: 'PRIVATE',
+      locationVisibility: 'PRIVATE',
+      locationSharingEnabled: false,
+      neighborhood: 'Levazim',
+      latitude: 41.043,
+      longitude: 29.009,
+    });
+    await seedProfile(emergencyLocationId, {
+      firstName: 'Emergency',
+      lastName: 'Location',
+      profileVisibility: 'PUBLIC',
+      locationVisibility: 'EMERGENCY_ONLY',
+      locationSharingEnabled: true,
+      neighborhood: 'Levazim',
+      latitude: 41.044,
+      longitude: 29.01,
+    });
+
+    await request(app)
+      .patch('/api/safety-status/me')
+      .set('Authorization', `Bearer ${buildAuthToken(viewerId)}`)
+      .send({ status: 'safe' })
+      .expect(200);
+    await request(app)
+      .patch('/api/safety-status/me')
+      .set('Authorization', `Bearer ${buildAuthToken(emergencyLocationId)}`)
+      .send({
+        status: 'not_safe',
+        shareLocationConsent: true,
+        location: { latitude: 41.04444, longitude: 29.01001 },
+      })
+      .expect(200);
+
+    const nonCircleResponse = await request(app)
+      .get('/api/safety-status/visible?nearby=true')
+      .set('Authorization', `Bearer ${buildAuthToken(viewerId)}`);
+
+    expect(nonCircleResponse.status).toBe(200);
+    const nonCircleByUserId = Object.fromEntries(
+      nonCircleResponse.body.safetyStatuses.map((item) => [item.userId, item]),
+    );
+    expect(nonCircleByUserId[emergencyLocationId]).toMatchObject({
+      displayName: 'Emergency Location',
+      status: 'not_safe',
+      location: null,
+    });
+
+    await query(
+      `
+        INSERT INTO safety_circles (circle_id, owner_user_id, name)
+        VALUES ('circle_nearby_location', $1, 'Nearby Location Circle');
+      `,
+      [viewerId],
+    );
+    await query(
+      `
+        INSERT INTO safety_circle_members (circle_id, user_id, role)
+        VALUES
+          ('circle_nearby_location', $1, 'owner'),
+          ('circle_nearby_location', $2, 'member');
+      `,
+      [viewerId, emergencyLocationId],
+    );
+
+    const circleResponse = await request(app)
+      .get('/api/safety-status/visible?nearby=true')
+      .set('Authorization', `Bearer ${buildAuthToken(viewerId)}`);
+
+    expect(circleResponse.status).toBe(200);
+    const circleByUserId = Object.fromEntries(
+      circleResponse.body.safetyStatuses.map((item) => [item.userId, item]),
+    );
+    expect(circleByUserId[emergencyLocationId].location).toMatchObject({
+      latitude: 41.044,
+      longitude: 29.01,
+    });
   });
 });


### PR DESCRIPTION
**Closes**

- Closes #387
- Closes #438

**Summary**

Implements Android local caching for nearby visible users with privacy-first backend filtering.

**Changes**

- Adds `nearby=true` support to the visible safety statuses endpoint.
- Filters nearby users by shared residential/profile neighborhood context while preserving existing visibility/trusted-circle privacy rules.
- Does not expose `city`, `district`, or `neighborhood` fields in visible safety status responses.
- Includes nearby users based on profile-area visibility; exact/coarse location is returned only when location sharing allows it.
- Adds Android Room cache for nearby visible users.
- Scopes cached nearby users by the current viewer/cache owner to avoid cross-account cache leaks.
- Stores minimal cached fields only.
- Stores cache timestamps and expiration metadata.
- Shows cached users only for network/non-auth failures.
- Rethrows `401` auth errors so the screen can trigger logout/login handling.
- Labels offline/stale cached data in the Nearby Users screen.
- Avoids caching exact location unless the backend says location is visible.
- Adds Android cache tests and backend integration coverage.
- Rebases Android Room migration onto current development as DB version `9` with `Migration8To9`.
