### PR TITLE
feat: add offline safety check-in support

### DIFF
--- a/android/app/src/androidTest/java/com/neph/e2e/FakeNephBackend.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/FakeNephBackend.kt
@@ -58,13 +58,22 @@ data class FakeProfileState(
     var expertiseAreas: List<String> = emptyList()
 )
 
+data class FakeSafetyStatusState(
+    var status: String = "unknown",
+    var note: String? = null,
+    var shareLocationConsent: Boolean = false,
+    var location: JSONObject? = null,
+    var updatedAt: String? = null
+)
+
 private data class FakeUserState(
     val userId: String = "user-1",
     var email: String,
     var password: String,
     var verified: Boolean,
     var accessToken: String = "access-token-1",
-    var profile: FakeProfileState? = null
+    var profile: FakeProfileState? = null,
+    var safetyStatus: FakeSafetyStatusState = FakeSafetyStatusState()
 )
 
 private object MissingJsonField
@@ -87,6 +96,7 @@ private data class NormalizedLocationPatch(
 class FakeNephBackend {
     private var server: MockWebServer? = null
     private var userState: FakeUserState? = null
+    private var profileLocationPatchCount: Int = 0
 
     fun start() {
         if (server != null) return
@@ -109,6 +119,7 @@ class FakeNephBackend {
     @Synchronized
     fun reset() {
         userState = null
+        profileLocationPatchCount = 0
     }
 
     @Synchronized
@@ -124,6 +135,14 @@ class FakeNephBackend {
             profile = profile
         )
     }
+
+    @Synchronized
+    fun currentSafetyStatus(): FakeSafetyStatusState {
+        return requireUser().safetyStatus
+    }
+
+    @Synchronized
+    fun profileLocationPatchCount(): Int = profileLocationPatchCount
 
     private fun handleHttpRequest(request: RecordedRequest): MockResponse {
         val pathWithQuery = request.fakeBackendPathWithQuery()
@@ -179,6 +198,8 @@ class FakeNephBackend {
             route == "/profiles/me/physical" && method == "PATCH" -> handlePatchPhysical(token, body)
             route == "/profiles/me/health" && method == "PATCH" -> handlePatchHealth(token, body)
             route == "/profiles/me/location" && method == "PATCH" -> handlePatchLocation(token, body)
+            route == "/safety-status/me" && method == "GET" -> handleGetSafetyStatus(token)
+            route == "/safety-status/me" && method == "PATCH" -> handlePatchSafetyStatus(token, body)
             route == "/profiles/me/privacy" && method == "PATCH" -> handlePatchPrivacy(token, body)
             route == "/profiles/me/profession" && method == "PATCH" -> handlePatchProfession(token, body)
             route == "/profiles/me/expertise-areas" && method == "PUT" -> handlePutExpertise(token, body)
@@ -570,6 +591,7 @@ class FakeNephBackend {
 
     private fun handlePatchLocation(token: String?, body: JSONObject?): JSONObject {
         val user = requireAuthorizedUser(token)
+        profileLocationPatchCount += 1
         val profile = ensureProfile(user)
         val payload = body ?: JSONObject()
 
@@ -643,6 +665,36 @@ class FakeNephBackend {
         }
 
         return profileResponseJson(user, profile)
+    }
+
+    private fun handleGetSafetyStatus(token: String?): JSONObject {
+        val user = requireAuthorizedUser(token)
+        return JSONObject().put("safetyStatus", safetyStatusJson(user))
+    }
+
+    private fun handlePatchSafetyStatus(token: String?, body: JSONObject?): JSONObject {
+        val user = requireAuthorizedUser(token)
+        val payload = body ?: JSONObject()
+        val safetyStatus = user.safetyStatus
+
+        if (payload.has("status")) {
+            safetyStatus.status = payload.requiredString("status")
+        }
+        if (payload.has("note")) {
+            safetyStatus.note = payload.optStringOrNull("note")
+        }
+        if (payload.has("shareLocationConsent")) {
+            safetyStatus.shareLocationConsent = payload.optBoolean("shareLocationConsent", false)
+        }
+        if (payload.has("location")) {
+            safetyStatus.location = payload.optJSONObject("location")
+        }
+        if (!safetyStatus.shareLocationConsent) {
+            safetyStatus.location = null
+        }
+        safetyStatus.updatedAt = Instant.now().toString()
+
+        return JSONObject().put("safetyStatus", safetyStatusJson(user))
     }
 
     private fun handlePatchPrivacy(token: String?, body: JSONObject?): JSONObject {
@@ -769,6 +821,24 @@ class FakeNephBackend {
                     .put("lastUpdated", profile.locationLastUpdated ?: "2026-04-19T00:00:00Z")
             )
             .put("expertise", expertiseArray)
+    }
+
+    private fun safetyStatusJson(user: FakeUserState): JSONObject {
+        val safetyStatus = user.safetyStatus
+        return JSONObject()
+            .put("userId", user.userId)
+            .put("status", safetyStatus.status)
+            .putNullable("note", safetyStatus.note)
+            .put("shareLocationConsent", safetyStatus.shareLocationConsent)
+            .put(
+                "location",
+                if (safetyStatus.location == null) {
+                    JSONObject.NULL
+                } else {
+                    JSONObject(safetyStatus.location.toString())
+                }
+            )
+            .putNullable("updatedAt", safetyStatus.updatedAt)
     }
 
     private fun currentUserJson(user: FakeUserState): JSONObject {

--- a/android/app/src/androidTest/java/com/neph/e2e/SafetyStatusRepositoryAndroidTest.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/SafetyStatusRepositoryAndroidTest.kt
@@ -3,11 +3,18 @@ package com.neph.e2e
 import android.content.Context
 import com.neph.core.NephAppContext
 import com.neph.core.database.NephDatabaseProvider
+import com.neph.core.database.SafetyStatusEntity
+import com.neph.core.database.SyncOperationEntity
 import com.neph.core.sync.SyncEntityType
+import com.neph.core.sync.SyncOperationStatus
 import com.neph.core.sync.SyncOperationType
 import com.neph.core.sync.SyncStatus
+import com.neph.features.auth.data.AuthRepository
+import com.neph.features.auth.data.LoginDestination
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.profile.data.CurrentDeviceLocation
+import com.neph.features.profile.data.ProfileData
+import com.neph.features.profile.data.ProfileRepository
 import com.neph.features.safetystatus.data.SafetyStatusRepository
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -87,11 +94,86 @@ class SafetyStatusRepositoryAndroidTest {
         assertEquals(0, fakeBackend.profileLocationPatchCount())
     }
 
+    @Test
+    fun clearLocalCacheRemovesSafetyStatusAndPendingSyncOperation() = runBlocking {
+        SafetyStatusRepository.markSafe(
+            token = "expired-token",
+            location = sampleLocation(),
+            shareLocationConsent = true
+        )
+
+        assertEquals(SyncStatus.PENDING_UPDATE, SafetyStatusRepository.getSafetyStatusState().syncStatus)
+        assertEquals(1, pendingSafetyStatusOperationCount())
+        NephDatabaseProvider.requireInstance().syncOperationDao().upsert(
+            SyncOperationEntity(
+                entityType = SyncEntityType.SAFETY_STATUS,
+                entityId = SafetyStatusEntity.CURRENT_KEY,
+                operationType = SyncOperationType.SET_SAFETY_STATUS,
+                payloadJson = """{"status":"safe"}""",
+                createdAtEpochMillis = 1234L,
+                status = SyncOperationStatus.IN_PROGRESS
+            )
+        )
+
+        SafetyStatusRepository.clearLocalCache()
+
+        assertEquals("unknown", SafetyStatusRepository.getSafetyStatusState().status)
+        assertEquals(0, pendingSafetyStatusOperationCount())
+        assertNull(latestSafetyStatusOperation())
+    }
+
+    @Test
+    fun accountSwitchClearsQueuedSafetyStatusBeforeItCanSyncForNextUser() = runBlocking {
+        ProfileRepository.saveProfile(ProfileData(email = "user-a@example.com"))
+        SafetyStatusRepository.markSafe(
+            token = "expired-token",
+            location = sampleLocation(),
+            shareLocationConsent = true
+        )
+        assertEquals(1, pendingSafetyStatusOperationCount())
+
+        val destination = AuthRepository.login(
+            email = "safe.android@example.com",
+            password = "Passw0rd!",
+            rememberMe = true
+        )
+        SafetyStatusRepository.syncPendingSafetyStatusNow("access-token-1")
+
+        assertEquals(0, pendingSafetyStatusOperationCount())
+        assertEquals("unknown", SafetyStatusRepository.getSafetyStatusState().status)
+        assertEquals("unknown", fakeBackend.currentSafetyStatus().status)
+        assertNull(fakeBackend.currentSafetyStatus().location)
+        assertEquals(0, fakeBackend.profileLocationPatchCount())
+        assertEquals(LoginDestination.PROFILE, destination)
+    }
+
     private fun initializeSafetyStatusTestDependencies(context: Context) {
         NephAppContext.initialize(context)
         NephDatabaseProvider.initialize(context)
         AuthSessionStore.initialize(context)
+        ProfileRepository.initialize(context)
         SafetyStatusRepository.initialize(context)
+    }
+
+    private suspend fun pendingSafetyStatusOperationCount(): Int {
+        return NephDatabaseProvider.requireInstance()
+            .syncOperationDao()
+            .getPendingOperations()
+            .count {
+                it.entityType == SyncEntityType.SAFETY_STATUS &&
+                    it.entityId == SafetyStatusEntity.CURRENT_KEY &&
+                    it.operationType == SyncOperationType.SET_SAFETY_STATUS
+            }
+    }
+
+    private suspend fun latestSafetyStatusOperation(): SyncOperationEntity? {
+        return NephDatabaseProvider.requireInstance()
+            .syncOperationDao()
+            .getLatestPendingOperation(
+                entityType = SyncEntityType.SAFETY_STATUS,
+                entityId = SafetyStatusEntity.CURRENT_KEY,
+                operationType = SyncOperationType.SET_SAFETY_STATUS
+            )
     }
 
     private fun sampleLocation(): CurrentDeviceLocation {

--- a/android/app/src/androidTest/java/com/neph/e2e/SafetyStatusRepositoryAndroidTest.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/SafetyStatusRepositoryAndroidTest.kt
@@ -1,0 +1,106 @@
+package com.neph.e2e
+
+import android.content.Context
+import com.neph.core.NephAppContext
+import com.neph.core.database.NephDatabaseProvider
+import com.neph.core.sync.SyncEntityType
+import com.neph.core.sync.SyncOperationType
+import com.neph.core.sync.SyncStatus
+import com.neph.features.auth.data.AuthSessionStore
+import com.neph.features.profile.data.CurrentDeviceLocation
+import com.neph.features.safetystatus.data.SafetyStatusRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class SafetyStatusRepositoryAndroidTest {
+    private val fakeBackend = FakeNephBackend()
+
+    @get:Rule
+    val environmentRule = NephE2ETestEnvironmentRule(fakeBackend) { context, backend ->
+        backend.seedVerifiedUser(
+            email = "safe.android@example.com",
+            password = "Passw0rd!",
+            profile = FakeProfileState(firstName = "Safe", lastName = "Tester")
+        )
+        initializeSafetyStatusTestDependencies(context)
+        AuthSessionStore.saveAccessToken("access-token-1", rememberMe = true)
+    }
+
+    @Test
+    fun markSafeWithoutLocationSyncsAndDoesNotTouchProfileLocation() = runBlocking {
+        val state = SafetyStatusRepository.markSafe(
+            token = "access-token-1",
+            location = sampleLocation(),
+            shareLocationConsent = false
+        )
+
+        assertEquals(SyncStatus.SYNCED, state.syncStatus)
+        assertFalse(state.shareLocationConsent)
+        assertFalse(state.hasLocation)
+        assertEquals("safe", fakeBackend.currentSafetyStatus().status)
+        assertNull(fakeBackend.currentSafetyStatus().location)
+        assertEquals(0, fakeBackend.profileLocationPatchCount())
+    }
+
+    @Test
+    fun markSafeWithConsentSyncsOperationalLocationSnapshot() = runBlocking {
+        val state = SafetyStatusRepository.markSafe(
+            token = "access-token-1",
+            location = sampleLocation(),
+            shareLocationConsent = true
+        )
+
+        val syncedLocation = fakeBackend.currentSafetyStatus().location
+        assertEquals(SyncStatus.SYNCED, state.syncStatus)
+        assertTrue(state.shareLocationConsent)
+        assertEquals(41.043, state.latitude ?: 0.0, 0.0)
+        assertEquals(29.009, state.longitude ?: 0.0, 0.0)
+        assertEquals(41.043, syncedLocation?.getDouble("latitude") ?: 0.0, 0.0)
+        assertEquals(29.009, syncedLocation?.getDouble("longitude") ?: 0.0, 0.0)
+        assertEquals(0, fakeBackend.profileLocationPatchCount())
+    }
+
+    @Test
+    fun expiredTokenKeepsSafetyStatusQueuedForLaterSync() = runBlocking {
+        val state = SafetyStatusRepository.markSafe(
+            token = "expired-token",
+            location = null,
+            shareLocationConsent = false
+        )
+        val operation = NephDatabaseProvider.requireInstance()
+            .syncOperationDao()
+            .getPendingOperations()
+            .single {
+                it.entityType == SyncEntityType.SAFETY_STATUS &&
+                    it.operationType == SyncOperationType.SET_SAFETY_STATUS
+            }
+
+        assertEquals(SyncStatus.PENDING_UPDATE, state.syncStatus)
+        assertTrue(state.pendingError.orEmpty().contains("Session expired"))
+        assertEquals("current", operation.entityId)
+        assertTrue(operation.payloadJson.contains("\"status\":\"safe\""))
+        assertEquals(0, fakeBackend.profileLocationPatchCount())
+    }
+
+    private fun initializeSafetyStatusTestDependencies(context: Context) {
+        NephAppContext.initialize(context)
+        NephDatabaseProvider.initialize(context)
+        AuthSessionStore.initialize(context)
+        SafetyStatusRepository.initialize(context)
+    }
+
+    private fun sampleLocation(): CurrentDeviceLocation {
+        return CurrentDeviceLocation(
+            latitude = 41.043,
+            longitude = 29.009,
+            accuracyMeters = 12.5,
+            capturedAt = "2026-05-03T10:20:30.000Z",
+            source = "DEVICE_GPS"
+        )
+    }
+}

--- a/android/app/src/main/java/com/neph/MainActivity.kt
+++ b/android/app/src/main/java/com/neph/MainActivity.kt
@@ -22,6 +22,7 @@ import com.neph.features.operationallocation.data.OperationalLocationUpdater
 import com.neph.features.profile.data.ProfileRepository
 import com.neph.features.notifications.data.PushTokenSync
 import com.neph.features.requesthelp.data.RequestHelpRepository
+import com.neph.features.safetystatus.data.SafetyStatusRepository
 import com.neph.navigation.AppNavGraph
 import com.neph.navigation.Routes
 import com.neph.ui.theme.NephTheme
@@ -37,6 +38,7 @@ class MainActivity : ComponentActivity() {
         OperationalLocationRepository.initialize(applicationContext)
         ProfileRepository.initialize(applicationContext)
         RequestHelpRepository.initialize(applicationContext)
+        SafetyStatusRepository.initialize(applicationContext)
         requestNotificationPermissionIfNeeded()
         PushTokenSync.syncCurrentToken()
         OfflineSyncScheduler.schedulePeriodicSync(applicationContext)

--- a/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
+++ b/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
@@ -13,17 +13,19 @@ import com.neph.BuildConfig
         HelpRequestEntity::class,
         AvailabilityEntity::class,
         OperationalLocationEntity::class,
+        SafetyStatusEntity::class,
         AssignedRequestEntity::class,
         SyncOperationEntity::class,
         SyncMetadataEntity::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = false
 )
 abstract class NephDatabase : RoomDatabase() {
     abstract fun helpRequestDao(): HelpRequestDao
     abstract fun availabilityDao(): AvailabilityDao
     abstract fun operationalLocationDao(): OperationalLocationDao
+    abstract fun safetyStatusDao(): SafetyStatusDao
     abstract fun assignedRequestDao(): AssignedRequestDao
     abstract fun syncOperationDao(): SyncOperationDao
     abstract fun syncMetadataDao(): SyncMetadataDao
@@ -81,6 +83,34 @@ object NephDatabaseProvider {
             database.execSQL("ALTER TABLE help_requests ADD COLUMN coordinateAccuracyMeters REAL")
         }
     }
+    private val Migration6To7 = object : Migration(6, 7) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS safety_status (
+                    `key` TEXT NOT NULL PRIMARY KEY,
+                    status TEXT NOT NULL,
+                    note TEXT,
+                    shareLocationConsent INTEGER NOT NULL,
+                    latitude REAL,
+                    longitude REAL,
+                    accuracyMeters REAL,
+                    source TEXT,
+                    capturedAt TEXT,
+                    checkedAtEpochMillis INTEGER NOT NULL,
+                    updatedAtEpochMillis INTEGER NOT NULL,
+                    syncStatus TEXT NOT NULL,
+                    pendingError TEXT,
+                    lastSyncedAtEpochMillis INTEGER,
+                    serverUpdatedAt TEXT
+                )
+                """.trimIndent()
+            )
+            database.execSQL(
+                "CREATE INDEX IF NOT EXISTS index_safety_status_syncStatus ON safety_status (syncStatus)"
+            )
+        }
+    }
 
     fun initialize(context: Context) {
         getInstance(context)
@@ -92,7 +122,14 @@ object NephDatabaseProvider {
                 context.applicationContext,
                 NephDatabase::class.java,
                 DatabaseName
-            ).addMigrations(Migration1To2, Migration2To3, Migration3To4, Migration4To5, Migration5To6)
+            ).addMigrations(
+                Migration1To2,
+                Migration2To3,
+                Migration3To4,
+                Migration4To5,
+                Migration5To6,
+                Migration6To7
+            )
                 .build()
                 .also { instance = it }
         }

--- a/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
@@ -85,6 +85,18 @@ interface OperationalLocationDao {
 }
 
 @Dao
+interface SafetyStatusDao {
+    @Query("SELECT * FROM safety_status WHERE `key` = 'current' LIMIT 1")
+    fun observe(): Flow<SafetyStatusEntity?>
+
+    @Query("SELECT * FROM safety_status WHERE `key` = 'current' LIMIT 1")
+    suspend fun get(): SafetyStatusEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: SafetyStatusEntity)
+}
+
+@Dao
 interface AssignedRequestDao {
     @Query("SELECT * FROM assigned_requests WHERE locallyCancelled = 0 ORDER BY fetchedAtEpochMillis DESC LIMIT 1")
     fun observeCurrent(): Flow<AssignedRequestEntity?>

--- a/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
@@ -94,6 +94,9 @@ interface SafetyStatusDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(entity: SafetyStatusEntity)
+
+    @Query("DELETE FROM safety_status")
+    suspend fun clear()
 }
 
 @Dao

--- a/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
@@ -92,6 +92,32 @@ data class OperationalLocationEntity(
 }
 
 @Entity(
+    tableName = "safety_status",
+    indices = [Index(value = ["syncStatus"])]
+)
+data class SafetyStatusEntity(
+    @PrimaryKey val key: String = CURRENT_KEY,
+    val status: String,
+    val note: String?,
+    val shareLocationConsent: Boolean,
+    val latitude: Double?,
+    val longitude: Double?,
+    val accuracyMeters: Double?,
+    val source: String?,
+    val capturedAt: String?,
+    val checkedAtEpochMillis: Long,
+    val updatedAtEpochMillis: Long,
+    val syncStatus: String = SyncStatus.SYNCED,
+    val pendingError: String? = null,
+    val lastSyncedAtEpochMillis: Long? = null,
+    val serverUpdatedAt: String? = null
+) {
+    companion object {
+        const val CURRENT_KEY = "current"
+    }
+}
+
+@Entity(
     tableName = "assigned_requests",
     indices = [Index(value = ["requestId"]), Index(value = ["syncStatus"])]
 )

--- a/android/app/src/main/java/com/neph/core/sync/OfflineSyncCoordinator.kt
+++ b/android/app/src/main/java/com/neph/core/sync/OfflineSyncCoordinator.kt
@@ -9,6 +9,7 @@ import com.neph.features.assignedrequest.data.AssignedRequestRepository
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.availability.data.AvailabilityRepository
 import com.neph.features.requesthelp.data.RequestHelpRepository
+import com.neph.features.safetystatus.data.SafetyStatusRepository
 
 object OfflineSyncCoordinator {
     private const val Tag = "NephOfflineSync"
@@ -19,6 +20,7 @@ object OfflineSyncCoordinator {
         AuthSessionStore.initialize(appContext)
         AvailabilityRepository.initialize(appContext)
         RequestHelpRepository.initialize(appContext)
+        SafetyStatusRepository.initialize(appContext)
 
         val database = NephDatabaseProvider.requireInstance()
         recoverStaleInProgressOperations()
@@ -97,6 +99,7 @@ object OfflineSyncCoordinator {
                 SyncOperationType.UPDATE_HELP_REQUEST -> RequestHelpRepository.pushUpdateOperation(operation, token)
                 SyncOperationType.UPDATE_HELP_REQUEST_STATUS -> RequestHelpRepository.pushStatusOperation(operation, token)
                 SyncOperationType.CANCEL_ASSIGNMENT -> AssignedRequestRepository.pushCancelOperation(operation, token)
+                SyncOperationType.SET_SAFETY_STATUS -> SafetyStatusRepository.pushSafetyStatusOperation(operation, token)
             }
             false
         } catch (error: ApiException) {
@@ -216,7 +219,11 @@ object OfflineSyncCoordinator {
 
 
     private suspend fun operationRequiresAuthentication(operation: SyncOperationEntity): Boolean {
-        if (operation.entityType == SyncEntityType.AVAILABILITY || operation.entityType == SyncEntityType.ASSIGNED_REQUEST) {
+        if (
+            operation.entityType == SyncEntityType.AVAILABILITY ||
+            operation.entityType == SyncEntityType.ASSIGNED_REQUEST ||
+            operation.entityType == SyncEntityType.SAFETY_STATUS
+        ) {
             return true
         }
 
@@ -235,6 +242,7 @@ object OfflineSyncCoordinator {
                 RequestHelpRepository.refreshAuthenticatedHelpRequests(token)
                 AvailabilityRepository.refreshAssignmentState(token)
                 AssignedRequestRepository.fetchCurrentAssignment(token)
+                SafetyStatusRepository.refreshMySafetyStatus(token)
             }
             RequestHelpRepository.refreshGuestHelpRequests()
             false
@@ -279,6 +287,7 @@ object OfflineSyncCoordinator {
                 }
             }
             SyncEntityType.AVAILABILITY -> AvailabilityRepository.markSyncDeferred(displayMessage)
+            SyncEntityType.SAFETY_STATUS -> SafetyStatusRepository.markSyncDeferred(displayMessage)
         }
         return false
     }
@@ -298,6 +307,16 @@ object OfflineSyncCoordinator {
             lastAttemptAtEpochMillis = System.currentTimeMillis(),
             error = message
         )
+
+        when (operation.entityType) {
+            SyncEntityType.SAFETY_STATUS -> {
+                if (retry) {
+                    SafetyStatusRepository.markSyncDeferred(message)
+                } else {
+                    SafetyStatusRepository.markSyncFailed(message)
+                }
+            }
+        }
 
         if (!retry) {
             when (operation.entityType) {

--- a/android/app/src/main/java/com/neph/core/sync/SyncConstants.kt
+++ b/android/app/src/main/java/com/neph/core/sync/SyncConstants.kt
@@ -20,6 +20,7 @@ object SyncEntityType {
     const val HELP_REQUEST = "HELP_REQUEST"
     const val AVAILABILITY = "AVAILABILITY"
     const val ASSIGNED_REQUEST = "ASSIGNED_REQUEST"
+    const val SAFETY_STATUS = "SAFETY_STATUS"
 }
 
 object SyncOperationType {
@@ -28,6 +29,7 @@ object SyncOperationType {
     const val UPDATE_HELP_REQUEST_STATUS = "UPDATE_HELP_REQUEST_STATUS"
     const val SET_AVAILABILITY = "SET_AVAILABILITY"
     const val CANCEL_ASSIGNMENT = "CANCEL_ASSIGNMENT"
+    const val SET_SAFETY_STATUS = "SET_SAFETY_STATUS"
 }
 
 object LocalOwnerType {

--- a/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
+++ b/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
@@ -11,6 +11,7 @@ import com.neph.features.notifications.data.NotificationsRepository
 import com.neph.features.operationallocation.data.OperationalLocationRepository
 import com.neph.features.profile.data.ProfileData
 import com.neph.features.profile.data.ProfileRepository
+import com.neph.features.safetystatus.data.SafetyStatusRepository
 import org.json.JSONObject
 import java.net.URLEncoder
 import kotlinx.coroutines.CancellationException
@@ -86,6 +87,7 @@ object AuthRepository {
 
         if (!canReuseLocalProfileFields) {
             OperationalLocationRepository.clearLocalCache()
+            SafetyStatusRepository.clearLocalCache()
         }
 
         AuthSessionStore.saveAccessToken(accessToken, rememberMe)
@@ -214,6 +216,11 @@ object AuthRepository {
                 OperationalLocationRepository.clearLocalCache()
             } catch (error: Exception) {
                 Log.w("AuthRepository", "Failed to clear operational location on logout", error)
+            }
+            try {
+                SafetyStatusRepository.clearLocalCache()
+            } catch (error: Exception) {
+                Log.w("AuthRepository", "Failed to clear safety status on logout", error)
             }
         }
     }

--- a/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
+++ b/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.neph.core.network.ApiException
+import com.neph.core.sync.SyncStatus
 import com.neph.features.auth.data.AuthRepository
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.availability.data.AvailabilityAccessPolicy
@@ -42,6 +43,7 @@ import com.neph.features.requesthelp.data.EmergencyDraftRequirementsException
 import com.neph.features.requesthelp.data.RequestHelpReverseLocation
 import com.neph.features.requesthelp.data.RequestHelpRepository
 import com.neph.features.safetystatus.data.SafetyStatusRepository
+import com.neph.features.safetystatus.data.SafetyStatusState
 import com.neph.navigation.Routes
 import com.neph.ui.components.buttons.PrimaryButton
 import com.neph.ui.components.buttons.SecondaryButton
@@ -75,6 +77,8 @@ fun HomeScreen(
 
     val availabilityState by AvailabilityRepository.observeAvailabilityState()
         .collectAsState(initial = AvailabilityRepository.getAvailabilityState())
+    val safetyStatusState by SafetyStatusRepository.observeSafetyStatusState()
+        .collectAsState(initial = SafetyStatusState())
     var availabilityLoading by remember { mutableStateOf(false) }
     var availabilityError by remember { mutableStateOf("") }
     var availabilityInfo by remember { mutableStateOf("") }
@@ -379,22 +383,24 @@ fun HomeScreen(
                     null
                 }
                 val sharedLocation = locationAttempt?.location
-                SafetyStatusRepository.markSafe(
+                if (sharedLocation != null) {
+                    runCatching {
+                        OperationalLocationRepository.saveAndSyncIfAuthenticated(sharedLocation)
+                    }
+                }
+                val nextSafetyStatus = SafetyStatusRepository.markSafe(
                     token = safeSessionToken,
                     location = sharedLocation,
                     shareLocationConsent = shareLocation && sharedLocation != null
                 )
-                emergencyInfo = if (sharedLocation != null) {
-                    "You are marked safe. Your current location was shared with your safety status."
-                } else if (shareLocation && permissionDeniedBeforeCapture) {
-                    "You are marked safe. Location was not shared because permission was denied."
-                } else if (shareLocation && locationAttempt?.warning == CurrentLocationShareWarning.PERMISSION_DENIED) {
-                    "You are marked safe. Location was not shared because permission was denied."
-                } else if (shareLocation) {
-                    "You are marked safe. Location was not shared because current location was unavailable."
-                } else {
-                    "You are marked safe. Your location was not shared."
-                }
+                emergencyError = ""
+                emergencyInfo = buildMarkSafeFeedback(
+                    safetyStatus = nextSafetyStatus,
+                    shareLocation = shareLocation,
+                    sharedLocation = sharedLocation,
+                    locationWarning = locationAttempt?.warning,
+                    permissionDeniedBeforeCapture = permissionDeniedBeforeCapture
+                )
             } catch (error: ApiException) {
                 if (error.status == 401) {
                     AuthRepository.logout()
@@ -562,6 +568,21 @@ fun HomeScreen(
                             textAlign = TextAlign.Center
                         )
                     }
+
+                    val safetyStatusSyncMessage = buildSafetyStatusSyncMessage(safetyStatusState)
+                    if (!markSafeLoading && safetyStatusSyncMessage.isNotBlank()) {
+                        Text(
+                            text = safetyStatusSyncMessage,
+                            modifier = Modifier.fillMaxWidth(),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (safetyStatusState.isFailedSync) {
+                                MaterialTheme.colorScheme.error
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            },
+                            textAlign = TextAlign.Center
+                        )
+                    }
                 }
             }
 
@@ -604,6 +625,49 @@ fun HomeScreen(
             )
         }
     }
+}
+
+private fun buildMarkSafeFeedback(
+    safetyStatus: SafetyStatusState,
+    shareLocation: Boolean,
+    sharedLocation: CurrentDeviceLocation?,
+    locationWarning: CurrentLocationShareWarning?,
+    permissionDeniedBeforeCapture: Boolean
+): String {
+    val locationMessage = when {
+        sharedLocation != null -> "with location."
+        shareLocation && (permissionDeniedBeforeCapture || locationWarning == CurrentLocationShareWarning.PERMISSION_DENIED) ->
+            "without location because permission was denied."
+        shareLocation -> "without location because current location was unavailable."
+        else -> "without location."
+    }
+
+    return when {
+        safetyStatus.isFailedSync -> "Your safe status was saved on this device $locationMessage Sync failed; try again when you have connection."
+        safetyStatus.isPendingSync && safetyStatus.pendingError.requiresLoginForSync() ->
+            "Your safe status was saved on this device $locationMessage It will sync after you log in again."
+        safetyStatus.isPendingSync -> "Your safe status is queued $locationMessage It will sync when connection returns."
+        safetyStatus.syncStatus == SyncStatus.SYNCED -> "Safe status synced $locationMessage"
+        else -> "Your safe status was saved $locationMessage"
+    }
+}
+
+private fun buildSafetyStatusSyncMessage(safetyStatus: SafetyStatusState): String {
+    return when {
+        safetyStatus.isFailedSync -> safetyStatus.pendingError
+            ?.takeIf { it.isNotBlank() }
+            ?.let { "Safe status sync failed: $it" }
+            ?: "Safe status sync failed. Try again when you have connection."
+        safetyStatus.isPendingSync && safetyStatus.pendingError.requiresLoginForSync() ->
+            "Safe status saved locally. It will sync after you log in again."
+        safetyStatus.isPendingSync -> "Safe status saved locally and waiting to sync."
+        else -> ""
+    }
+}
+
+private fun String?.requiresLoginForSync(): Boolean {
+    val message = this?.lowercase().orEmpty()
+    return "login" in message || "session expired" in message
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/android/app/src/main/java/com/neph/features/safetystatus/data/SafetyStatusRepository.kt
+++ b/android/app/src/main/java/com/neph/features/safetystatus/data/SafetyStatusRepository.kt
@@ -62,6 +62,15 @@ object SafetyStatusRepository {
         return database.safetyStatusDao().get()?.toState() ?: SafetyStatusState()
     }
 
+    suspend fun clearLocalCache() {
+        database.safetyStatusDao().clear()
+        database.syncOperationDao().deleteOperations(
+            entityType = SyncEntityType.SAFETY_STATUS,
+            entityId = SafetyStatusEntity.CURRENT_KEY,
+            operationType = SyncOperationType.SET_SAFETY_STATUS
+        )
+    }
+
     suspend fun markSafe(
         token: String,
         note: String? = null,

--- a/android/app/src/main/java/com/neph/features/safetystatus/data/SafetyStatusRepository.kt
+++ b/android/app/src/main/java/com/neph/features/safetystatus/data/SafetyStatusRepository.kt
@@ -1,28 +1,96 @@
 package com.neph.features.safetystatus.data
 
+import android.content.Context
+import com.neph.core.NephAppContext
+import com.neph.core.database.NephDatabaseProvider
+import com.neph.core.database.SafetyStatusEntity
+import com.neph.core.database.SyncOperationEntity
+import com.neph.core.network.ApiException
 import com.neph.core.network.JsonHttpClient
+import com.neph.core.sync.OfflineSyncScheduler
+import com.neph.core.sync.SyncConflictPolicy
+import com.neph.core.sync.SyncEntityType
+import com.neph.core.sync.SyncOperationStatus
+import com.neph.core.sync.SyncOperationType
+import com.neph.core.sync.SyncStatus
+import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.profile.data.CurrentDeviceLocation
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import org.json.JSONObject
 
+data class SafetyStatusState(
+    val status: String = "unknown",
+    val note: String? = null,
+    val shareLocationConsent: Boolean = false,
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val accuracyMeters: Double? = null,
+    val source: String? = null,
+    val capturedAt: String? = null,
+    val checkedAtEpochMillis: Long? = null,
+    val syncStatus: String = SyncStatus.SYNCED,
+    val pendingError: String? = null,
+    val lastSyncedAtEpochMillis: Long? = null
+) {
+    val hasLocation: Boolean
+        get() = latitude != null && longitude != null
+
+    val isPendingSync: Boolean
+        get() = syncStatus == SyncStatus.PENDING_UPDATE
+
+    val isFailedSync: Boolean
+        get() = syncStatus == SyncStatus.FAILED || syncStatus == SyncStatus.CONFLICTED
+}
+
 object SafetyStatusRepository {
+    private val database get() = NephDatabaseProvider.requireInstance()
+
+    fun initialize(context: Context) {
+        val appContext = context.applicationContext
+        NephAppContext.initialize(appContext)
+        NephDatabaseProvider.initialize(appContext)
+    }
+
+    fun observeSafetyStatusState(): Flow<SafetyStatusState> {
+        return database.safetyStatusDao().observe().map { entity ->
+            entity?.toState() ?: SafetyStatusState()
+        }
+    }
+
+    suspend fun getSafetyStatusState(): SafetyStatusState {
+        return database.safetyStatusDao().get()?.toState() ?: SafetyStatusState()
+    }
+
     suspend fun markSafe(
         token: String,
         note: String? = null,
         location: CurrentDeviceLocation? = null,
         shareLocationConsent: Boolean = false
-    ) {
+    ): SafetyStatusState {
         val body = buildMarkSafePayload(
             note = note,
             location = location,
             shareLocationConsent = shareLocationConsent
         )
-
-        JsonHttpClient.request(
-            path = "/safety-status/me",
-            method = "PATCH",
-            token = token,
-            body = body
+        val now = System.currentTimeMillis()
+        val entity = buildPendingSafetyStatusEntity(
+            payload = body,
+            checkedAtEpochMillis = now,
+            existing = database.safetyStatusDao().get()
         )
+
+        database.safetyStatusDao().upsert(entity)
+        upsertSafetyStatusOperation(payload = body, now = now)
+        OfflineSyncScheduler.enqueueSync(NephAppContext.get(), reason = "safety-status-updated")
+
+        if (token.isBlank()) {
+            markSyncDeferred("Login required before your safety status can sync.")
+            return getSafetyStatusState()
+        }
+
+        syncPendingSafetyStatusNow(token)
+        return getSafetyStatusState()
     }
 
     internal fun buildMarkSafePayload(
@@ -54,5 +122,261 @@ object SafetyStatusRepository {
         }
 
         return body
+    }
+
+    suspend fun syncPendingSafetyStatusNow(token: String?) {
+        val operation = database.syncOperationDao().getLatestPendingOperation(
+            entityType = SyncEntityType.SAFETY_STATUS,
+            entityId = SafetyStatusEntity.CURRENT_KEY,
+            operationType = SyncOperationType.SET_SAFETY_STATUS
+        ) ?: return
+
+        pushSafetyStatusOperationWithPolicy(operation, token)
+    }
+
+    suspend fun refreshMySafetyStatus(token: String): SafetyStatusState {
+        if (token.isBlank()) return getSafetyStatusState()
+
+        val response = JsonHttpClient.request(
+            path = "/safety-status/me",
+            token = token
+        )
+        val safetyStatus = response.optJSONObject("safetyStatus") ?: return getSafetyStatusState()
+        val current = database.safetyStatusDao().get()
+        if (current?.syncStatus == SyncStatus.PENDING_UPDATE || current?.syncStatus == SyncStatus.FAILED) {
+            return current.toState()
+        }
+
+        val now = System.currentTimeMillis()
+        val synced = safetyStatus.toEntity(
+            checkedAtEpochMillis = current?.checkedAtEpochMillis ?: now,
+            now = now
+        )
+        database.safetyStatusDao().upsert(synced)
+        return synced.toState()
+    }
+
+    internal suspend fun pushSafetyStatusOperation(operation: SyncOperationEntity, token: String?) {
+        if (token.isNullOrBlank()) {
+            markSyncDeferred("Login required before your safety status can sync.")
+            return
+        }
+
+        val response = JsonHttpClient.request(
+            path = "/safety-status/me",
+            method = "PATCH",
+            token = token,
+            body = JSONObject(operation.payloadJson)
+        )
+        val safetyStatus = response.optJSONObject("safetyStatus")
+        val now = System.currentTimeMillis()
+        val synced = if (safetyStatus != null) {
+            safetyStatus.toEntity(
+                checkedAtEpochMillis = database.safetyStatusDao().get()?.checkedAtEpochMillis ?: now,
+                now = now
+            )
+        } else {
+            buildPendingSafetyStatusEntity(
+                payload = JSONObject(operation.payloadJson),
+                checkedAtEpochMillis = database.safetyStatusDao().get()?.checkedAtEpochMillis ?: now,
+                existing = database.safetyStatusDao().get()
+            ).copy(
+                syncStatus = SyncStatus.SYNCED,
+                pendingError = null,
+                updatedAtEpochMillis = now,
+                lastSyncedAtEpochMillis = now
+            )
+        }
+        database.safetyStatusDao().upsert(synced)
+        database.syncOperationDao().delete(operation.operationId)
+    }
+
+    internal suspend fun markSyncDeferred(message: String?) {
+        val now = System.currentTimeMillis()
+        val current = database.safetyStatusDao().get() ?: return
+        database.safetyStatusDao().upsert(
+            current.copy(
+                syncStatus = SyncStatus.PENDING_UPDATE,
+                pendingError = message,
+                updatedAtEpochMillis = now
+            )
+        )
+    }
+
+    internal suspend fun markSyncFailed(message: String?) {
+        val now = System.currentTimeMillis()
+        val current = database.safetyStatusDao().get() ?: return
+        database.safetyStatusDao().upsert(
+            current.copy(
+                syncStatus = SyncStatus.FAILED,
+                pendingError = message,
+                updatedAtEpochMillis = now
+            )
+        )
+    }
+
+    private suspend fun pushSafetyStatusOperationWithPolicy(
+        operation: SyncOperationEntity,
+        token: String?
+    ): Boolean {
+        if (token.isNullOrBlank()) {
+            database.syncOperationDao().updateStatus(
+                operationId = operation.operationId,
+                status = SyncOperationStatus.PENDING,
+                attemptCount = operation.attemptCount,
+                lastAttemptAtEpochMillis = operation.lastAttemptAtEpochMillis,
+                error = "Login required before your safety status can sync."
+            )
+            markSyncDeferred("Login required before your safety status can sync.")
+            return false
+        }
+
+        val attempt = operation.attemptCount + 1
+        val now = System.currentTimeMillis()
+        database.syncOperationDao().updateStatus(
+            operationId = operation.operationId,
+            status = SyncOperationStatus.IN_PROGRESS,
+            attemptCount = attempt,
+            lastAttemptAtEpochMillis = now,
+            error = null
+        )
+
+        return try {
+            pushSafetyStatusOperation(operation, token)
+            false
+        } catch (error: ApiException) {
+            if (error.status == 401) {
+                AuthSessionStore.clearAccessToken()
+                database.syncOperationDao().updateStatus(
+                    operationId = operation.operationId,
+                    status = SyncOperationStatus.PENDING,
+                    attemptCount = attempt,
+                    lastAttemptAtEpochMillis = now,
+                    error = "Session expired. Log in again to sync your safety status."
+                )
+                markSyncDeferred("Session expired. Log in again to sync your safety status.")
+                false
+            } else {
+                handleSafetyStatusSyncFailure(operation, attempt, error.message, error.status)
+            }
+        } catch (error: Exception) {
+            handleSafetyStatusSyncFailure(operation, attempt, error.message, status = 0)
+        }
+    }
+
+    private suspend fun handleSafetyStatusSyncFailure(
+        operation: SyncOperationEntity,
+        attempt: Int,
+        message: String?,
+        status: Int
+    ): Boolean {
+        val retry = SyncConflictPolicy.shouldRetryHttpStatus(status, attempt)
+        database.syncOperationDao().updateStatus(
+            operationId = operation.operationId,
+            status = if (retry) SyncOperationStatus.PENDING else SyncOperationStatus.FAILED,
+            attemptCount = attempt,
+            lastAttemptAtEpochMillis = System.currentTimeMillis(),
+            error = message
+        )
+
+        if (retry) {
+            markSyncDeferred(message)
+        } else {
+            markSyncFailed(message)
+        }
+
+        return retry
+    }
+
+    private suspend fun upsertSafetyStatusOperation(payload: JSONObject, now: Long) {
+        val existingOperation = database.syncOperationDao().getLatestPendingOperation(
+            entityType = SyncEntityType.SAFETY_STATUS,
+            entityId = SafetyStatusEntity.CURRENT_KEY,
+            operationType = SyncOperationType.SET_SAFETY_STATUS
+        )
+        database.syncOperationDao().upsert(
+            existingOperation?.copy(
+                payloadJson = payload.toString(),
+                status = SyncOperationStatus.PENDING,
+                attemptCount = 0,
+                lastAttemptAtEpochMillis = null,
+                error = null
+            ) ?: SyncOperationEntity(
+                entityType = SyncEntityType.SAFETY_STATUS,
+                entityId = SafetyStatusEntity.CURRENT_KEY,
+                operationType = SyncOperationType.SET_SAFETY_STATUS,
+                payloadJson = payload.toString(),
+                createdAtEpochMillis = now
+            )
+        )
+    }
+
+    internal fun buildPendingSafetyStatusEntity(
+        payload: JSONObject,
+        checkedAtEpochMillis: Long,
+        existing: SafetyStatusEntity? = null
+    ): SafetyStatusEntity {
+        val location = payload.optJSONObject("location")
+        return SafetyStatusEntity(
+            status = payload.optString("status").ifBlank { "safe" },
+            note = payload.optString("note").trim().takeIf { it.isNotBlank() },
+            shareLocationConsent = payload.optBoolean("shareLocationConsent", false),
+            latitude = location?.optDoubleOrNull("latitude"),
+            longitude = location?.optDoubleOrNull("longitude"),
+            accuracyMeters = location?.optDoubleOrNull("accuracyMeters"),
+            source = location?.optString("source")?.trim()?.takeIf { it.isNotBlank() },
+            capturedAt = location?.optString("capturedAt")?.trim()?.takeIf { it.isNotBlank() },
+            checkedAtEpochMillis = checkedAtEpochMillis,
+            updatedAtEpochMillis = checkedAtEpochMillis,
+            syncStatus = SyncStatus.PENDING_UPDATE,
+            pendingError = null,
+            lastSyncedAtEpochMillis = existing?.lastSyncedAtEpochMillis,
+            serverUpdatedAt = existing?.serverUpdatedAt
+        )
+    }
+
+    private fun JSONObject.toEntity(
+        checkedAtEpochMillis: Long,
+        now: Long
+    ): SafetyStatusEntity {
+        val location = optJSONObject("location")
+        return SafetyStatusEntity(
+            status = optString("status").ifBlank { "unknown" },
+            note = optString("note").trim().takeIf { it.isNotBlank() },
+            shareLocationConsent = optBoolean("shareLocationConsent", false),
+            latitude = location?.optDoubleOrNull("latitude"),
+            longitude = location?.optDoubleOrNull("longitude"),
+            accuracyMeters = location?.optDoubleOrNull("accuracyMeters"),
+            source = location?.optString("source")?.trim()?.takeIf { it.isNotBlank() },
+            capturedAt = location?.optString("capturedAt")?.trim()?.takeIf { it.isNotBlank() },
+            checkedAtEpochMillis = checkedAtEpochMillis,
+            updatedAtEpochMillis = now,
+            syncStatus = SyncStatus.SYNCED,
+            pendingError = null,
+            lastSyncedAtEpochMillis = now,
+            serverUpdatedAt = optString("updatedAt").trim().takeIf { it.isNotBlank() }
+        )
+    }
+
+    private fun SafetyStatusEntity.toState(): SafetyStatusState {
+        return SafetyStatusState(
+            status = status,
+            note = note,
+            shareLocationConsent = shareLocationConsent,
+            latitude = latitude,
+            longitude = longitude,
+            accuracyMeters = accuracyMeters,
+            source = source,
+            capturedAt = capturedAt,
+            checkedAtEpochMillis = checkedAtEpochMillis,
+            syncStatus = syncStatus,
+            pendingError = pendingError,
+            lastSyncedAtEpochMillis = lastSyncedAtEpochMillis
+        )
+    }
+
+    private fun JSONObject.optDoubleOrNull(key: String): Double? {
+        if (!has(key) || isNull(key)) return null
+        return optDouble(key, Double.NaN).takeIf { it.isFinite() }
     }
 }

--- a/android/app/src/test/java/com/neph/features/safetystatus/data/SafetyStatusRepositoryPayloadTest.kt
+++ b/android/app/src/test/java/com/neph/features/safetystatus/data/SafetyStatusRepositoryPayloadTest.kt
@@ -1,8 +1,10 @@
 package com.neph.features.safetystatus.data
 
+import com.neph.core.sync.SyncStatus
 import com.neph.features.profile.data.CurrentDeviceLocation
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -38,6 +40,49 @@ class SafetyStatusRepositoryPayloadTest {
         assertEquals(12.5, location.getDouble("accuracyMeters"), 0.0)
         assertEquals("DEVICE_GPS", location.getString("source"))
         assertEquals("2026-05-03T10:20:30.000Z", location.getString("capturedAt"))
+    }
+
+    @Test
+    fun pendingLocalStateIsQueuedWithoutLocationWhenConsentIsFalse() {
+        val payload = SafetyStatusRepository.buildMarkSafePayload(
+            note = "  Safe at school  ",
+            location = sampleLocation(),
+            shareLocationConsent = false
+        )
+
+        val entity = SafetyStatusRepository.buildPendingSafetyStatusEntity(
+            payload = payload,
+            checkedAtEpochMillis = 1_777_777_777_000L
+        )
+
+        assertEquals("safe", entity.status)
+        assertEquals("Safe at school", entity.note)
+        assertFalse(entity.shareLocationConsent)
+        assertNull(entity.latitude)
+        assertNull(entity.longitude)
+        assertEquals(SyncStatus.PENDING_UPDATE, entity.syncStatus)
+        assertEquals(1_777_777_777_000L, entity.checkedAtEpochMillis)
+    }
+
+    @Test
+    fun pendingLocalStateKeepsConsentedOperationalLocationSnapshot() {
+        val payload = SafetyStatusRepository.buildMarkSafePayload(
+            location = sampleLocation(),
+            shareLocationConsent = true
+        )
+
+        val entity = SafetyStatusRepository.buildPendingSafetyStatusEntity(
+            payload = payload,
+            checkedAtEpochMillis = 1_777_777_777_000L
+        )
+
+        assertTrue(entity.shareLocationConsent)
+        assertEquals(41.043, entity.latitude ?: 0.0, 0.0)
+        assertEquals(29.009, entity.longitude ?: 0.0, 0.0)
+        assertEquals(12.5, entity.accuracyMeters ?: 0.0, 0.0)
+        assertEquals("DEVICE_GPS", entity.source)
+        assertEquals("2026-05-03T10:20:30.000Z", entity.capturedAt)
+        assertEquals(SyncStatus.PENDING_UPDATE, entity.syncStatus)
     }
 
     private fun sampleLocation(): CurrentDeviceLocation {


### PR DESCRIPTION
## Summary

Implements offline-capable safety check-ins for Android.

This PR improves the "I am safe" flow so users can mark themselves safe even during weak or unavailable connectivity. Location sharing remains optional and is attached only as a consented operational location snapshot.

## Changes

- Adds local/offline support for safety status updates.
- Queues safety check-ins for later sync when network/auth state is unavailable.
- Syncs queued safety status updates to `/safety-status/me`.
- Preserves pending/synced/failed state for the latest safety check-in.
- Updates the Home safety check-in flow to handle:
  - safe without location
  - safe with location
  - permission denied
  - location unavailable
  - offline queued submission
- Uses foreground location permission only when the user explicitly chooses to share location.
- Best-effort updates operational location cache when location is captured.
- Ensures safety check-in does not update profile/residential location.

## Behavior

- Marking safe does not require location.
- If the user chooses to share location and permission is already granted, current location is captured directly.
- If permission is missing, the app requests foreground location permission in that context.
- If permission is denied, the user is still marked safe without location.
- If current location is unavailable, the user is still marked safe without location.
- If sync fails, the safety status remains queued or marked failed according to the offline sync policy.
- Profile/residential location is never modified by this flow.

## Testing

- Add/update tests for safety status payload creation.
- Add/update tests for local queued safety status behavior.
- Add/update tests for safety status sync success/failure handling.
- Verified that existing Request Help, Availability, Profile, and operational-location flows are not modified unexpectedly.

## Notes

- This PR does not request background/always location permission.
- Safety status location is treated as an event snapshot, not as profile/residential location.

Closes #437