### PR TITLE
bug: Add exit confirmation on system back for Home/Welcome root routes

### DIFF
--- a/android/app/src/androidTest/java/com/neph/e2e/AndroidE2ETest.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/AndroidE2ETest.kt
@@ -1,9 +1,11 @@
 package com.neph.e2e
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
@@ -86,6 +88,32 @@ class AndroidE2ETest {
         composeRule.onNodeWithTag("reset_password_token").assertIsDisplayed()
     }
 
+    @Test
+    fun systemBack_onRootRoute_showsExitConfirmationDialog() {
+        waitForClickable("Continue as Guest")
+        pressSystemBack()
+
+        composeRule.onNodeWithText("Exit NEPH?").assertIsDisplayed()
+        composeRule.onNodeWithText("Cancel").assertIsDisplayed()
+        composeRule.onNodeWithText("Exit").assertIsDisplayed()
+
+        clickableNode("Cancel").performClick()
+        composeRule.onNodeWithText("Exit NEPH?").assertDoesNotExist()
+        composeRule.onNodeWithText("Continue as Guest").assertIsDisplayed()
+    }
+
+    @Test
+    fun systemBack_whenStackCanPop_navigatesBackWithoutExitDialog() {
+        waitForClickable("Log In")
+        clickableNode("Log In").performClick()
+        waitForTag("login_email")
+
+        pressSystemBack()
+
+        composeRule.onNodeWithText("Continue as Guest").assertIsDisplayed()
+        composeRule.onNodeWithText("Exit NEPH?").assertDoesNotExist()
+    }
+
     private fun openEmailFormIfNeeded(fieldTag: String) {
         composeRule.waitUntil(5_000) {
             hasTag(fieldTag) || hasClickableText("Continue with Email")
@@ -97,6 +125,12 @@ class AndroidE2ETest {
 
         clickableNode("Continue with Email").performClick()
         waitForTag(fieldTag)
+    }
+
+    private fun pressSystemBack() {
+        composeRule.activityRule.scenario.onActivity { activity ->
+            activity.onBackPressedDispatcher.onBackPressed()
+        }
     }
 
     private fun selectDropdown(fieldTag: String, optionTag: String) {

--- a/android/app/src/androidTest/java/com/neph/e2e/AndroidE2ETest.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/AndroidE2ETest.kt
@@ -1,11 +1,10 @@
 package com.neph.e2e
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
@@ -98,7 +97,7 @@ class AndroidE2ETest {
         composeRule.onNodeWithText("Exit").assertIsDisplayed()
 
         clickableNode("Cancel").performClick()
-        composeRule.onNodeWithText("Exit NEPH?").assertDoesNotExist()
+        composeRule.onAllNodesWithText("Exit NEPH?").assertCountEquals(0)
         composeRule.onNodeWithText("Continue as Guest").assertIsDisplayed()
     }
 
@@ -111,7 +110,7 @@ class AndroidE2ETest {
         pressSystemBack()
 
         composeRule.onNodeWithText("Continue as Guest").assertIsDisplayed()
-        composeRule.onNodeWithText("Exit NEPH?").assertDoesNotExist()
+        composeRule.onAllNodesWithText("Exit NEPH?").assertCountEquals(0)
     }
 
     private fun openEmailFormIfNeeded(fieldTag: String) {

--- a/android/app/src/androidTest/java/com/neph/e2e/AndroidE2ETest.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/AndroidE2ETest.kt
@@ -19,6 +19,7 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.rules.TestRule
 
+
 class AndroidE2ETest {
     private val fakeBackend = FakeNephBackend()
     private val environmentRule = NephE2ETestEnvironmentRule(fakeBackend)

--- a/android/app/src/main/java/com/neph/MainActivity.kt
+++ b/android/app/src/main/java/com/neph/MainActivity.kt
@@ -1,16 +1,27 @@
 package com.neph
 
 import android.Manifest
+import android.app.Activity
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.neph.core.NephAppContext
 import com.neph.core.database.NephDatabaseProvider
@@ -85,7 +96,46 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun NephApp() {
     NephTheme {
+        val activity = LocalContext.current as? Activity
         val navController = rememberNavController()
+        val currentBackStackEntry by navController.currentBackStackEntryAsState()
+        val currentRoute = currentBackStackEntry?.destination?.route
+        var showExitDialog by remember { mutableStateOf(false) }
+        val canPopBackStack = navController.previousBackStackEntry != null
+        val shouldConfirmExit = !canPopBackStack && (
+            currentRoute == Routes.Home.route || currentRoute == Routes.Welcome.route
+        )
+
+        BackHandler(enabled = canPopBackStack || shouldConfirmExit) {
+            if (canPopBackStack) {
+                navController.popBackStack()
+            } else if (shouldConfirmExit) {
+                showExitDialog = true
+            }
+        }
+
+        if (showExitDialog) {
+            AlertDialog(
+                onDismissRequest = { showExitDialog = false },
+                title = { Text("Exit NEPH?") },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            showExitDialog = false
+                            activity?.finish()
+                        }
+                    ) {
+                        Text("Exit")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showExitDialog = false }) {
+                        Text("Cancel")
+                    }
+                }
+            )
+        }
+
         AppNavGraph(
             navController = navController,
             startDestination = when {


### PR DESCRIPTION
### Summary
This PR fixes issue #449 by adding a root-level Android back handling flow that confirms before exiting the app on top-level routes.

### What Changed
- Added a root-level `BackHandler` in `NephApp` to handle system back presses.
- Preserved normal back navigation when the nav stack can pop.
- Added an exit confirmation dialog only when:
  - back stack cannot pop, and
  - current route is `Home` or `Welcome`.
- Dialog copy/actions match the issue:
  - Title: `Exit NEPH?`
  - Actions: `Cancel`, `Exit`
- Added/updated Android E2E tests:
  - verifies exit dialog appears on root-level back
  - verifies normal back navigation when stack can pop
- Fixed missing test import for `onAllNodes`.

### Why
Previously, pressing Android system back on top-level routes could close the app immediately without confirmation. This change ensures users are prompted before exit while keeping standard back behavior elsewhere.

### Scope Notes
- Exit confirmation is intentionally limited to top-level routes (`Home`, `Welcome`) per issue requirements.
- No behavior change for regular in-stack navigation.

### Testing
Added E2E coverage in:
- `android/app/src/androidTest/java/com/neph/e2e/AndroidE2ETest.kt`


Closes #449 