### PR TITLE
fix: implement fallback content mechanism during API failures

### DIFF
--- a/web/e2e/gathering-areas.spec.js
+++ b/web/e2e/gathering-areas.spec.js
@@ -115,7 +115,7 @@ test('keeps map/list selection stable when features share same id but different 
   await expect(page.locator('.gathering-areas-selected-meta').first()).toContainText('Shelter');
 });
 
-test('shows empty and error states for gathering areas retrieval', async ({ page }) => {
+test('shows empty and fallback states for gathering areas retrieval', async ({ page }) => {
   await mockGeolocation(page);
 
   let requestCount = 0;
@@ -157,8 +157,10 @@ test('shows empty and error states for gathering areas retrieval', async ({ page
 
   await page.getByRole('button', { name: 'Retry Results' }).click();
 
-  await expect(page.getByText('Gathering areas provider is unavailable')).toBeVisible();
-  await expect(page.getByText('Could not load nearby results.')).toBeVisible();
+  await expect(page.getByText(/Live gathering areas could not be refreshed/)).toBeVisible();
+  await expect(page.getByRole('button', { name: /Demo central assembly area/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry gathering areas' })).toBeVisible();
+  await expect(page.getByText('Could not load nearby results.')).toHaveCount(0);
   await expect(page.getByText('No nearby areas in the current result.')).toHaveCount(0);
   await expect(page.getByRole('button', { name: 'Retry Results' })).toBeVisible();
 });

--- a/web/e2e/gathering-areas.spec.js
+++ b/web/e2e/gathering-areas.spec.js
@@ -165,6 +165,58 @@ test('shows empty and fallback states for gathering areas retrieval', async ({ p
   await expect(page.getByRole('button', { name: 'Retry Results' })).toBeVisible();
 });
 
+test('shows backend fallback warning while rendering non-empty fallback gathering areas', async ({ page }) => {
+  await mockGeolocation(page);
+
+  await page.route('**/api/gathering-areas/nearby**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        center: { lat: 41.009, lon: 28.97 },
+        radius: 2000,
+        source: 'fallback',
+        meta: {
+          requestedLimit: 20,
+          returnedCount: 1,
+          fallbackReason: 'Overpass provider timed out.',
+        },
+        collection: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [28.976, 41.011],
+              },
+              properties: {
+                id: 'backend-fallback-assembly',
+                osmType: 'fallback',
+                name: 'Backend fallback assembly point',
+                category: 'assembly_point',
+                distanceMeters: 180,
+                rawTags: {
+                  address: 'Backend fallback address',
+                },
+              },
+            },
+          ],
+        },
+      }),
+    });
+  });
+
+  await page.goto('/gathering-areas');
+
+  await expect(page.getByText('Using backend fallback gathering areas')).toBeVisible();
+  await expect(page.getByText(/Overpass provider timed out/)).toBeVisible();
+  await expect(page.getByText(/Retry to refresh live results/)).toBeVisible();
+  await expect(page.getByRole('button', { name: /Backend fallback assembly point/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry gathering areas' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry Results' })).toBeVisible();
+});
+
 test('does not show false empty state while geolocation is still pending', async ({ page }) => {
   await mockGeolocationPending(page);
 

--- a/web/e2e/news-fallback.spec.js
+++ b/web/e2e/news-fallback.spec.js
@@ -1,0 +1,27 @@
+const { test, expect } = require('@playwright/test');
+const { resetDatabase } = require('./helpers/db');
+
+test.beforeEach(async () => {
+  await resetDatabase();
+});
+
+test('shows demo announcements with retry context when news API is unavailable', async ({ page }) => {
+  await page.route('**/api/announcements**', async (route) => {
+    await route.fulfill({
+      status: 503,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 'ANNOUNCEMENTS_UNAVAILABLE',
+        message: 'Announcements service is unavailable',
+      }),
+    });
+  });
+
+  await page.goto('/news');
+
+  await expect(page.getByText('Using fallback news')).toBeVisible();
+  await expect(page.getByText(/Announcements could not be refreshed/)).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry news' })).toBeVisible();
+  await expect(page.getByText('Last updated:')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Know your nearest gathering area' })).toBeVisible();
+});

--- a/web/src/app/gathering-areas/page.tsx
+++ b/web/src/app/gathering-areas/page.tsx
@@ -388,16 +388,25 @@ export default function GatheringAreasPage() {
                         `The live provider failed${response.meta.providerErrorCode ? ` (${response.meta.providerErrorCode})` : ""}. Showing the backend's cached result.`
                     );
                     setLastUpdated("");
-                } else if (response.source === "fallback" && mapped.length === 0) {
-                    const fallbackAreas = getFallbackMapFeatures();
+                } else if (response.source === "fallback") {
+                    const fallbackAreas = mapped.length ? mapped : getFallbackMapFeatures();
                     const savedAt = new Date().toISOString();
+                    const fallbackReason =
+                        response.meta.fallbackReason || "The live gathering-area provider is unavailable.";
 
-                    setCenter(DEFAULT_CENTER);
-                    setLocationNote("Live provider unavailable. Showing demo gathering areas around Istanbul.");
+                    if (!mapped.length) {
+                        setCenter(DEFAULT_CENTER);
+                        setLocationNote("Live provider unavailable. Showing demo gathering areas around Istanbul.");
+                    } else {
+                        setLocationNote("Live provider unavailable. Showing backend fallback gathering areas.");
+                    }
                     setAreas(fallbackAreas);
-                    setDataNoticeTitle("Using demo gathering areas");
+                    void hydrateMissingAddresses(fallbackAreas, currentRequestId);
+                    setDataNoticeTitle(mapped.length ? "Using backend fallback gathering areas" : "Using demo gathering areas");
                     setDataNotice(
-                        `${response.meta.fallbackReason || "The live gathering-area provider is unavailable."} Showing demo Istanbul areas and guidance so the page remains usable.`
+                        mapped.length
+                            ? `${fallbackReason} Showing fallback gathering areas so the page remains usable. Retry to refresh live results.`
+                            : `${fallbackReason} Showing demo Istanbul areas and guidance so the page remains usable.`
                     );
                     setLastUpdated(savedAt);
                     setFetchState("fallback");

--- a/web/src/app/gathering-areas/page.tsx
+++ b/web/src/app/gathering-areas/page.tsx
@@ -3,10 +3,11 @@
 import * as React from "react";
 import { AppShell } from "@/components/layout/AppShell";
 import { SectionCard } from "@/components/ui/display/SectionCard";
+import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
 import { GatheringAreasMap } from "@/components/feature/location/GatheringAreasMap";
 import { fetchNearbyGatheringAreas } from "@/lib/gatheringAreas";
 import { reverseLocation } from "@/lib/location";
-import type { GatheringAreaFeature } from "@/types/location";
+import type { GatheringAreaFeature, NearbyGatheringAreasResponse } from "@/types/location";
 import type { GatheringAreaMapFeature } from "@/components/feature/location/LeafletGatheringAreasMap";
 
 const DEFAULT_CENTER = {
@@ -18,7 +19,70 @@ const DEFAULT_RADIUS = 2000;
 const DEFAULT_LIMIT = 20;
 const SEARCH_RADIUS_KM = DEFAULT_RADIUS / 1000;
 const ADDRESS_UNAVAILABLE = "Address unavailable";
-type FetchState = "idle" | "loading" | "success" | "empty" | "error";
+const GATHERING_AREAS_CACHE_KEY = "neph.nearbyGatheringAreas.cache.v1";
+type FetchState = "idle" | "loading" | "success" | "empty" | "error" | "fallback";
+
+type GatheringAreasCache = {
+    response: NearbyGatheringAreasResponse;
+    savedAt: string;
+};
+
+const FALLBACK_GATHERING_AREA_FEATURES: GatheringAreaFeature[] = [
+    {
+        type: "Feature",
+        geometry: {
+            type: "Point",
+            coordinates: [28.9784, 41.0082],
+        },
+        properties: {
+            id: "demo-sultanahmet-assembly",
+            osmType: "fallback",
+            name: "Demo central assembly area",
+            category: "assembly_point",
+            distanceMeters: 0,
+            rawTags: {
+                address: "Sultanahmet area, Istanbul",
+                description: "Demo fallback area shown when the live gathering-area provider is unavailable.",
+            },
+        },
+    },
+    {
+        type: "Feature",
+        geometry: {
+            type: "Point",
+            coordinates: [28.9924, 41.0422],
+        },
+        properties: {
+            id: "demo-taksim-support",
+            osmType: "fallback",
+            name: "Demo community support point",
+            category: "shelter",
+            distanceMeters: 4100,
+            rawTags: {
+                address: "Taksim area, Istanbul",
+                description: "Demo fallback point for presentation and outage guidance.",
+            },
+        },
+    },
+    {
+        type: "Feature",
+        geometry: {
+            type: "Point",
+            coordinates: [29.0304, 40.9903],
+        },
+        properties: {
+            id: "demo-kadikoy-assembly",
+            osmType: "fallback",
+            name: "Demo Kadıköy assembly area",
+            category: "assembly_point",
+            distanceMeters: 4800,
+            rawTags: {
+                address: "Kadıköy coastline area, Istanbul",
+                description: "Demo fallback area; verify official instructions during a real emergency.",
+            },
+        },
+    },
+];
 
 function formatCategoryLabel(category: string) {
     const normalized = (category || "").trim().toLowerCase();
@@ -137,6 +201,72 @@ function mapFeature(feature: GatheringAreaFeature): GatheringAreaMapFeature | nu
     };
 }
 
+function readCachedGatheringAreas(): GatheringAreasCache | null {
+    try {
+        const raw = window.localStorage.getItem(GATHERING_AREAS_CACHE_KEY);
+        if (!raw) {
+            return null;
+        }
+
+        const parsed = JSON.parse(raw) as Partial<GatheringAreasCache>;
+        if (!parsed.response || typeof parsed.savedAt !== "string") {
+            return null;
+        }
+
+        return {
+            response: parsed.response,
+            savedAt: parsed.savedAt,
+        };
+    } catch {
+        return null;
+    }
+}
+
+function cacheGatheringAreas(response: NearbyGatheringAreasResponse, savedAt: string) {
+    try {
+        window.localStorage.setItem(
+            GATHERING_AREAS_CACHE_KEY,
+            JSON.stringify({ response, savedAt })
+        );
+    } catch {
+        // Cache is best-effort only.
+    }
+}
+
+function formatLastUpdated(value: string) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return date.toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+    });
+}
+
+function describeGatheringAreaFailure(rawMessage: string) {
+    if (/could not reach the server/i.test(rawMessage)) {
+        return "the live gathering-area service did not respond";
+    }
+
+    if (rawMessage === "Internal Server Error") {
+        return "the gathering-area service returned an unexpected error";
+    }
+
+    return rawMessage || "the gathering-area service did not respond";
+}
+
+function mapFeatures(features: GatheringAreaFeature[]) {
+    return features
+        .map(mapFeature)
+        .filter((item): item is GatheringAreaMapFeature => item !== null);
+}
+
+function getFallbackMapFeatures() {
+    return mapFeatures(FALLBACK_GATHERING_AREA_FEATURES);
+}
+
 export default function GatheringAreasPage() {
     const [center, setCenter] = React.useState(DEFAULT_CENTER);
     const [areas, setAreas] = React.useState<GatheringAreaMapFeature[]>([]);
@@ -146,6 +276,9 @@ export default function GatheringAreasPage() {
     const [resolvingLocation, setResolvingLocation] = React.useState(true);
     const [error, setError] = React.useState("");
     const [locationNote, setLocationNote] = React.useState("Resolving your current location...");
+    const [dataNotice, setDataNotice] = React.useState("");
+    const [dataNoticeTitle, setDataNoticeTitle] = React.useState("");
+    const [lastUpdated, setLastUpdated] = React.useState("");
     const requestIdRef = React.useRef(0);
     const reverseAddressCacheRef = React.useRef<Map<string, string>>(new Map());
 
@@ -227,6 +360,8 @@ export default function GatheringAreasPage() {
             try {
                 setFetchState("loading");
                 setError("");
+                setDataNotice("");
+                setDataNoticeTitle("");
 
                 const response = await fetchNearbyGatheringAreas({
                     latitude: sourceCenter.latitude,
@@ -239,9 +374,39 @@ export default function GatheringAreasPage() {
                     return;
                 }
 
-                const mapped = response.collection.features
-                    .map(mapFeature)
-                    .filter((item): item is GatheringAreaMapFeature => item !== null);
+                const mapped = mapFeatures(response.collection.features);
+
+                if (response.source === "overpass") {
+                    const savedAt = new Date().toISOString();
+                    cacheGatheringAreas(response, savedAt);
+                    setLastUpdated(savedAt);
+                }
+
+                if (response.source === "stale_cache") {
+                    setDataNoticeTitle("Using backend cached gathering areas");
+                    setDataNotice(
+                        `The live provider failed${response.meta.providerErrorCode ? ` (${response.meta.providerErrorCode})` : ""}. Showing the backend's cached result.`
+                    );
+                    setLastUpdated("");
+                } else if (response.source === "fallback" && mapped.length === 0) {
+                    const fallbackAreas = getFallbackMapFeatures();
+                    const savedAt = new Date().toISOString();
+
+                    setCenter(DEFAULT_CENTER);
+                    setLocationNote("Live provider unavailable. Showing demo gathering areas around Istanbul.");
+                    setAreas(fallbackAreas);
+                    setDataNoticeTitle("Using demo gathering areas");
+                    setDataNotice(
+                        `${response.meta.fallbackReason || "The live gathering-area provider is unavailable."} Showing demo Istanbul areas and guidance so the page remains usable.`
+                    );
+                    setLastUpdated(savedAt);
+                    setFetchState("fallback");
+                    setSelectedAreaId(fallbackAreas[0]?.featureKey || null);
+                    return;
+                } else {
+                    setDataNotice("");
+                    setDataNoticeTitle("");
+                }
 
                 setAreas(mapped);
                 void hydrateMissingAddresses(mapped, currentRequestId);
@@ -267,15 +432,40 @@ export default function GatheringAreasPage() {
                         ? err.message
                         : "Could not load gathering areas right now.";
 
-                const uiMessage =
-                    rawMessage === "Internal Server Error"
-                        ? "Gathering areas service is temporarily unavailable. Please try again shortly."
-                        : rawMessage;
+                const uiMessage = describeGatheringAreaFailure(rawMessage);
 
-                setError(uiMessage);
-                setAreas([]);
-                setSelectedAreaId(null);
-                setFetchState("error");
+                const cached = readCachedGatheringAreas();
+                const cachedAreas = cached
+                    ? mapFeatures(cached.response.collection.features)
+                    : [];
+
+                if (cached && cachedAreas.length) {
+                    setCenter({
+                        latitude: cached.response.center.lat,
+                        longitude: cached.response.center.lon,
+                    });
+                    setLocationNote("Showing cached gathering areas from your last successful lookup.");
+                    setAreas(cachedAreas);
+                    setSelectedAreaId(cachedAreas[0].featureKey);
+                    setError("");
+                    setDataNoticeTitle("Using cached gathering areas");
+                    setDataNotice(`Live gathering areas could not be refreshed (${uiMessage}). Showing your last saved result.`);
+                    setLastUpdated(cached.savedAt);
+                    setFetchState("fallback");
+                    return;
+                }
+
+                const fallbackAreas = getFallbackMapFeatures();
+                const savedAt = new Date().toISOString();
+                setCenter(DEFAULT_CENTER);
+                setLocationNote("Live provider unavailable. Showing demo gathering areas around Istanbul.");
+                setAreas(fallbackAreas);
+                setSelectedAreaId(fallbackAreas[0]?.featureKey || null);
+                setError("");
+                setDataNoticeTitle("Using demo gathering areas");
+                setDataNotice(`Live gathering areas could not be refreshed (${uiMessage}). Showing demo Istanbul areas and guidance.`);
+                setLastUpdated(savedAt);
+                setFetchState(fallbackAreas.length ? "fallback" : "error");
             } finally {
                 if (currentRequestId !== requestIdRef.current) {
                     return;
@@ -335,6 +525,10 @@ export default function GatheringAreasPage() {
     const isLoading = fetchState === "loading";
     const isError = fetchState === "error";
     const isEmpty = fetchState === "empty";
+    const isFallback = fetchState === "fallback";
+    const searchContextLine = isFallback
+        ? "Fallback content may not match your exact location; follow official guidance during a real emergency."
+        : `Searching within ${SEARCH_RADIUS_KM} km of your current location.`;
 
     const selectedArea =
         areas.find((item) => item.featureKey === selectedAreaId) ||
@@ -417,7 +611,16 @@ export default function GatheringAreasPage() {
                                 <p className="gathering-areas-overlay-title">Nearby Results</p>
 
                                 <div className="gathering-areas-list">
-                                    {isError ? (
+                                    {isLoading ? (
+                                        <>
+                                            {[0, 1, 2].map((index) => (
+                                                <div key={index} className="gathering-areas-item-skeleton">
+                                                    <span />
+                                                    <span />
+                                                </div>
+                                            ))}
+                                        </>
+                                    ) : isError ? (
                                         <p className="gathering-areas-empty-detail">
                                             Could not load nearby results.
                                         </p>
@@ -451,20 +654,48 @@ export default function GatheringAreasPage() {
 
                     <div className="gathering-areas-context-note">
                         <p className="gathering-areas-context-line">{locationNote}</p>
-                        <p className="gathering-areas-context-line">
-                            Searching within {SEARCH_RADIUS_KM} km of your current location.
-                        </p>
+                        <p className="gathering-areas-context-line">{searchContextLine}</p>
                     </div>
 
                     {isLoading ? (
                         <div className="gathering-areas-status-box">
-                            <p>Loading nearby gathering areas...</p>
+                            <p className="gathering-areas-status-title">Loading nearby gathering areas...</p>
+                            <div className="gathering-areas-loading-skeleton" aria-hidden="true">
+                                <span />
+                                <span />
+                            </div>
+                        </div>
+                    ) : null}
+
+                    {dataNotice ? (
+                        <div className={isFallback ? "gathering-areas-status-box is-warning" : "gathering-areas-status-box"}>
+                            <div>
+                                <p className="gathering-areas-status-title">
+                                    {dataNoticeTitle || "Gathering areas status"}
+                                </p>
+                                <p>{dataNotice}</p>
+                                {lastUpdated ? (
+                                    <p>Last updated: {formatLastUpdated(lastUpdated)}</p>
+                                ) : (
+                                    <p>Last updated: cached by backend; exact timestamp unavailable.</p>
+                                )}
+                            </div>
+                            <PrimaryButton className="w-auto" onClick={resolveCurrentLocationAndLoad}>
+                                Retry gathering areas
+                            </PrimaryButton>
+                        </div>
+                    ) : lastUpdated && areas.length ? (
+                        <div className="gathering-areas-status-box">
+                            <p>Last updated: {formatLastUpdated(lastUpdated)}</p>
                         </div>
                     ) : null}
 
                     {error ? (
                         <div className="gathering-areas-status-box is-error">
                             <p>{error}</p>
+                            <PrimaryButton className="w-auto" onClick={resolveCurrentLocationAndLoad}>
+                                Retry gathering areas
+                            </PrimaryButton>
                         </div>
                     ) : null}
 

--- a/web/src/app/home/page.tsx
+++ b/web/src/app/home/page.tsx
@@ -15,6 +15,7 @@ import {
     FALLBACK_ANNOUNCEMENTS,
     announcementToNewsItem,
     fetchAnnouncements,
+    readCachedAnnouncements,
     type NewsItem,
 } from "@/lib/news";
 
@@ -112,11 +113,21 @@ export default function HomePage() {
             setPreviewNews(announcements.map(announcementToNewsItem));
             setNewsUpdatedAt(new Date().toISOString());
         } catch (err) {
-            setPreviewNews(FALLBACK_ANNOUNCEMENTS.slice(0, 3).map(announcementToNewsItem));
-            setNewsUpdatedAt(FALLBACK_ANNOUNCEMENTS[0]?.createdAt || "");
+            const cached = readCachedAnnouncements();
+            const cachedAnnouncements = cached?.announcements.slice(0, 3) || [];
+            const hasCachedAnnouncements = cachedAnnouncements.length > 0;
+            const fallbackAnnouncements = hasCachedAnnouncements
+                ? cachedAnnouncements
+                : FALLBACK_ANNOUNCEMENTS.slice(0, 3);
+            const sourceLabel = hasCachedAnnouncements
+                ? "cached announcements"
+                : "demo announcements";
+
+            setPreviewNews(fallbackAnnouncements.map(announcementToNewsItem));
+            setNewsUpdatedAt(hasCachedAnnouncements && cached ? cached.savedAt : FALLBACK_ANNOUNCEMENTS[0]?.createdAt || "");
             setUsingFallbackNews(true);
             setNewsError(
-                `Latest announcements could not be refreshed (${describeNewsPreviewFailure(err)}). Showing demo announcements.`
+                `Latest announcements could not be refreshed (${describeNewsPreviewFailure(err)}). Showing ${sourceLabel}.`
             );
         } finally {
             setNewsLoading(false);

--- a/web/src/app/home/page.tsx
+++ b/web/src/app/home/page.tsx
@@ -11,7 +11,12 @@ import {
     defaultEmergencyContacts,
     type EmergencyContact,
 } from "../../lib/emergencyNumbers";
-import { announcementToNewsItem, fetchAnnouncements, type NewsItem } from "@/lib/news";
+import {
+    FALLBACK_ANNOUNCEMENTS,
+    announcementToNewsItem,
+    fetchAnnouncements,
+    type NewsItem,
+} from "@/lib/news";
 
 type HeroSlide = {
     title: string;
@@ -59,12 +64,35 @@ const heroSlides: HeroSlide[] = [
     },
 ];
 
+function describeNewsPreviewFailure(err: unknown) {
+    const rawDetail = err instanceof Error ? err.message : "";
+    if (/could not reach the server/i.test(rawDetail)) {
+        return "the live announcements service did not respond";
+    }
+
+    return rawDetail || "the announcements API did not respond";
+}
+
+function formatLastUpdated(value: string) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return date.toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+    });
+}
+
 export default function HomePage() {
     const router = useRouter();
     const [activeSlide, setActiveSlide] = React.useState(0);
     const [previewNews, setPreviewNews] = React.useState<NewsItem[]>([]);
     const [newsLoading, setNewsLoading] = React.useState(true);
     const [newsError, setNewsError] = React.useState("");
+    const [newsUpdatedAt, setNewsUpdatedAt] = React.useState("");
+    const [usingFallbackNews, setUsingFallbackNews] = React.useState(false);
 
     React.useEffect(() => {
         const timer = setInterval(() => {
@@ -74,38 +102,30 @@ export default function HomePage() {
         return () => clearInterval(timer);
     }, []);
 
-    React.useEffect(() => {
-        let isMounted = true;
+    const loadPreviewNews = React.useCallback(async () => {
+        setNewsLoading(true);
+        setNewsError("");
+        setUsingFallbackNews(false);
 
-        async function loadPreviewNews() {
-            setNewsLoading(true);
-            setNewsError("");
-
-            try {
-                const announcements = await fetchAnnouncements({ limit: 3 });
-                if (!isMounted) {
-                    return;
-                }
-                setPreviewNews(announcements.map(announcementToNewsItem));
-            } catch (err) {
-                if (!isMounted) {
-                    return;
-                }
-                setPreviewNews([]);
-                setNewsError(err instanceof Error ? err.message : "Could not load latest announcements.");
-            } finally {
-                if (isMounted) {
-                    setNewsLoading(false);
-                }
-            }
+        try {
+            const announcements = await fetchAnnouncements({ limit: 3 });
+            setPreviewNews(announcements.map(announcementToNewsItem));
+            setNewsUpdatedAt(new Date().toISOString());
+        } catch (err) {
+            setPreviewNews(FALLBACK_ANNOUNCEMENTS.slice(0, 3).map(announcementToNewsItem));
+            setNewsUpdatedAt(FALLBACK_ANNOUNCEMENTS[0]?.createdAt || "");
+            setUsingFallbackNews(true);
+            setNewsError(
+                `Latest announcements could not be refreshed (${describeNewsPreviewFailure(err)}). Showing demo announcements.`
+            );
+        } finally {
+            setNewsLoading(false);
         }
-
-        void loadPreviewNews();
-
-        return () => {
-            isMounted = false;
-        };
     }, []);
+
+    React.useEffect(() => {
+        void loadPreviewNews();
+    }, [loadPreviewNews]);
 
     const currentSlide = heroSlides[activeSlide];
     const previewContacts = defaultEmergencyContacts.slice(0, 3);
@@ -167,27 +187,63 @@ export default function HomePage() {
                         />
 
                         {newsLoading ? (
-                            <div className="admin-empty-state">
-                                <p>Loading latest announcements...</p>
+                            <div className="home-news-list" aria-label="Loading latest announcements">
+                                {[0, 1, 2].map((index) => (
+                                    <div key={index} className="home-news-card news-item-skeleton">
+                                        <span className="news-skeleton-line is-chip" />
+                                        <span className="news-skeleton-line is-title" />
+                                        <span className="news-skeleton-line is-short" />
+                                    </div>
+                                ))}
                             </div>
                         ) : newsError ? (
-                            <div className="admin-empty-state">
-                                <p className="admin-error-text">{newsError}</p>
-                            </div>
+                            <>
+                                <div className={usingFallbackNews ? "news-status-box is-warning" : "news-status-box is-error"}>
+                                    <div>
+                                        <p className="news-status-title">Using fallback news preview</p>
+                                        <p className="news-status-copy">{newsError}</p>
+                                        {newsUpdatedAt ? (
+                                            <p className="news-status-copy">
+                                                Last updated: {formatLastUpdated(newsUpdatedAt)}
+                                            </p>
+                                        ) : null}
+                                    </div>
+                                    <PrimaryButton className="w-auto" onClick={() => void loadPreviewNews()}>
+                                        Retry latest news
+                                    </PrimaryButton>
+                                </div>
+
+                                <div className="home-news-list">
+                                    {previewNews.map((item) => (
+                                        <article key={item.id} className="home-news-card">
+                                            <p className="home-news-category">{item.category}</p>
+                                            <h3 className="home-news-title">{item.title}</h3>
+                                            <p className="home-news-summary">{item.summary}</p>
+                                        </article>
+                                    ))}
+                                </div>
+                            </>
                         ) : previewNews.length === 0 ? (
                             <div className="admin-empty-state">
                                 <p>No announcements have been published yet.</p>
                             </div>
                         ) : (
-                            <div className="home-news-list">
-                                {previewNews.map((item) => (
-                                    <article key={item.id} className="home-news-card">
-                                        <p className="home-news-category">{item.category}</p>
-                                        <h3 className="home-news-title">{item.title}</h3>
-                                        <p className="home-news-summary">{item.summary}</p>
-                                    </article>
-                                ))}
-                            </div>
+                            <>
+                                {newsUpdatedAt ? (
+                                    <p className="news-status-copy">
+                                        Last updated: {formatLastUpdated(newsUpdatedAt)}
+                                    </p>
+                                ) : null}
+                                <div className="home-news-list">
+                                    {previewNews.map((item) => (
+                                        <article key={item.id} className="home-news-card">
+                                            <p className="home-news-category">{item.category}</p>
+                                            <h3 className="home-news-title">{item.title}</h3>
+                                            <p className="home-news-summary">{item.summary}</p>
+                                        </article>
+                                    ))}
+                                </div>
+                            </>
                         )}
 
                         <div className="home-news-action-wrap">

--- a/web/src/app/news/[announcementId]/page.tsx
+++ b/web/src/app/news/[announcementId]/page.tsx
@@ -8,13 +8,12 @@ import { SectionCard } from "@/components/ui/display/SectionCard";
 import { SectionHeader } from "@/components/ui/display/SectionHeader";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
 import {
+    ANNOUNCEMENTS_CACHE_KEY,
     FALLBACK_ANNOUNCEMENTS,
     fetchAnnouncement,
     formatAnnouncementDate,
     type Announcement,
 } from "@/lib/news";
-
-const ANNOUNCEMENTS_CACHE_KEY = "neph.publicAnnouncements.cache.v1";
 
 function readAnnouncementId(param: string | string[] | undefined) {
     if (Array.isArray(param)) {

--- a/web/src/app/news/[announcementId]/page.tsx
+++ b/web/src/app/news/[announcementId]/page.tsx
@@ -7,7 +7,14 @@ import { AppShell } from "@/components/layout/AppShell";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { SectionHeader } from "@/components/ui/display/SectionHeader";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
-import { fetchAnnouncement, formatAnnouncementDate, type Announcement } from "@/lib/news";
+import {
+    FALLBACK_ANNOUNCEMENTS,
+    fetchAnnouncement,
+    formatAnnouncementDate,
+    type Announcement,
+} from "@/lib/news";
+
+const ANNOUNCEMENTS_CACHE_KEY = "neph.publicAnnouncements.cache.v1";
 
 function readAnnouncementId(param: string | string[] | undefined) {
     if (Array.isArray(param)) {
@@ -17,12 +24,36 @@ function readAnnouncementId(param: string | string[] | undefined) {
     return param || "";
 }
 
+function findCachedAnnouncement(announcementId: string) {
+    try {
+        const raw = window.localStorage.getItem(ANNOUNCEMENTS_CACHE_KEY);
+        if (!raw) {
+            return null;
+        }
+
+        const parsed = JSON.parse(raw) as { announcements?: Announcement[] };
+        return parsed.announcements?.find((item) => item.id === announcementId) || null;
+    } catch {
+        return null;
+    }
+}
+
+function describeAnnouncementFailure(err: unknown) {
+    const rawDetail = err instanceof Error ? err.message : "";
+    if (/could not reach the server/i.test(rawDetail)) {
+        return "the live announcements service did not respond";
+    }
+
+    return rawDetail || "the announcement API did not respond";
+}
+
 export default function NewsDetailPage() {
     const params = useParams<{ announcementId?: string | string[] }>();
     const announcementId = readAnnouncementId(params.announcementId);
     const [announcement, setAnnouncement] = React.useState<Announcement | null>(null);
     const [loading, setLoading] = React.useState(true);
     const [error, setError] = React.useState("");
+    const [usingFallback, setUsingFallback] = React.useState(false);
 
     const loadAnnouncement = React.useCallback(async () => {
         if (!announcementId) {
@@ -34,13 +65,26 @@ export default function NewsDetailPage() {
 
         setLoading(true);
         setError("");
+        setUsingFallback(false);
 
         try {
             const nextAnnouncement = await fetchAnnouncement(announcementId);
             setAnnouncement(nextAnnouncement);
         } catch (err) {
-            setError(err instanceof Error ? err.message : "Could not load announcement.");
-            setAnnouncement(null);
+            const fallback =
+                findCachedAnnouncement(announcementId) ||
+                FALLBACK_ANNOUNCEMENTS.find((item) => item.id === announcementId) ||
+                null;
+
+            if (fallback) {
+                const detail = describeAnnouncementFailure(err);
+                setAnnouncement(fallback);
+                setUsingFallback(true);
+                setError(`Announcement could not be refreshed (${detail}). Showing cached/demo content.`);
+            } else {
+                setError(`Announcement could not be refreshed (${describeAnnouncementFailure(err)}).`);
+                setAnnouncement(null);
+            }
         } finally {
             setLoading(false);
         }
@@ -59,16 +103,47 @@ export default function NewsDetailPage() {
                     </Link>
 
                     {loading ? (
-                        <div className="admin-empty-state">
-                            <p>Loading announcement...</p>
+                        <div className="news-detail-card" aria-label="Loading announcement">
+                            <div className="news-item-card news-item-skeleton">
+                                <span className="news-skeleton-line is-chip" />
+                                <span className="news-skeleton-line is-title" />
+                                <span className="news-skeleton-line" />
+                                <span className="news-skeleton-line" />
+                            </div>
                         </div>
                     ) : error ? (
-                        <div className="admin-empty-state">
-                            <p className="admin-error-text">{error}</p>
-                            <PrimaryButton className="w-auto" onClick={() => void loadAnnouncement()}>
-                                Retry
-                            </PrimaryButton>
-                        </div>
+                        <>
+                            <div className={usingFallback ? "news-status-box is-warning" : "news-status-box is-error"}>
+                                <div>
+                                    <p className="news-status-title">
+                                        {usingFallback ? "Using fallback announcement" : "Announcement load failed"}
+                                    </p>
+                                    <p className="news-status-copy">{error}</p>
+                                </div>
+                                <PrimaryButton className="w-auto" onClick={() => void loadAnnouncement()}>
+                                    Retry announcement
+                                </PrimaryButton>
+                            </div>
+
+                            {!announcement ? null : (
+                                <article className="news-detail-card">
+                                    <div className="news-item-meta-row">
+                                        <span className="news-item-category-chip">Announcement</span>
+                                        <span className="news-item-date">
+                                            {formatAnnouncementDate(announcement.createdAt)}
+                                        </span>
+                                    </div>
+
+                                    <SectionHeader
+                                        className="news-detail-header"
+                                        title={announcement.title}
+                                        subtitle="Official public announcement from the emergency coordination team."
+                                    />
+
+                                    <p className="news-detail-content">{announcement.content}</p>
+                                </article>
+                            )}
+                        </>
                     ) : announcement ? (
                         <article className="news-detail-card">
                             <div className="news-item-meta-row">

--- a/web/src/app/news/page.tsx
+++ b/web/src/app/news/page.tsx
@@ -9,49 +9,11 @@ import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
 import {
     FALLBACK_ANNOUNCEMENTS,
     announcementToNewsItem,
+    cacheAnnouncements,
     fetchAnnouncements,
-    type Announcement,
+    readCachedAnnouncements,
     type NewsItem,
 } from "@/lib/news";
-
-const ANNOUNCEMENTS_CACHE_KEY = "neph.publicAnnouncements.cache.v1";
-
-type AnnouncementCache = {
-    announcements: Announcement[];
-    savedAt: string;
-};
-
-function readCachedAnnouncements(): AnnouncementCache | null {
-    try {
-        const raw = window.localStorage.getItem(ANNOUNCEMENTS_CACHE_KEY);
-        if (!raw) {
-            return null;
-        }
-
-        const parsed = JSON.parse(raw) as Partial<AnnouncementCache>;
-        if (!Array.isArray(parsed.announcements) || typeof parsed.savedAt !== "string") {
-            return null;
-        }
-
-        return {
-            announcements: parsed.announcements,
-            savedAt: parsed.savedAt,
-        };
-    } catch {
-        return null;
-    }
-}
-
-function cacheAnnouncements(announcements: Announcement[], savedAt: string) {
-    try {
-        window.localStorage.setItem(
-            ANNOUNCEMENTS_CACHE_KEY,
-            JSON.stringify({ announcements, savedAt })
-        );
-    } catch {
-        // Cache is best-effort only.
-    }
-}
 
 function formatLastUpdated(value: string) {
     const date = new Date(value);

--- a/web/src/app/news/page.tsx
+++ b/web/src/app/news/page.tsx
@@ -6,12 +6,79 @@ import { AppShell } from "@/components/layout/AppShell";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { SectionHeader } from "@/components/ui/display/SectionHeader";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
-import { announcementToNewsItem, fetchAnnouncements, type NewsItem } from "@/lib/news";
+import {
+    FALLBACK_ANNOUNCEMENTS,
+    announcementToNewsItem,
+    fetchAnnouncements,
+    type Announcement,
+    type NewsItem,
+} from "@/lib/news";
+
+const ANNOUNCEMENTS_CACHE_KEY = "neph.publicAnnouncements.cache.v1";
+
+type AnnouncementCache = {
+    announcements: Announcement[];
+    savedAt: string;
+};
+
+function readCachedAnnouncements(): AnnouncementCache | null {
+    try {
+        const raw = window.localStorage.getItem(ANNOUNCEMENTS_CACHE_KEY);
+        if (!raw) {
+            return null;
+        }
+
+        const parsed = JSON.parse(raw) as Partial<AnnouncementCache>;
+        if (!Array.isArray(parsed.announcements) || typeof parsed.savedAt !== "string") {
+            return null;
+        }
+
+        return {
+            announcements: parsed.announcements,
+            savedAt: parsed.savedAt,
+        };
+    } catch {
+        return null;
+    }
+}
+
+function cacheAnnouncements(announcements: Announcement[], savedAt: string) {
+    try {
+        window.localStorage.setItem(
+            ANNOUNCEMENTS_CACHE_KEY,
+            JSON.stringify({ announcements, savedAt })
+        );
+    } catch {
+        // Cache is best-effort only.
+    }
+}
+
+function formatLastUpdated(value: string) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return date.toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+    });
+}
+
+function buildFailureMessage(err: unknown, sourceLabel: string) {
+    const rawDetail = err instanceof Error ? err.message : "";
+    const detail = /could not reach the server/i.test(rawDetail)
+        ? "the live announcements service did not respond"
+        : rawDetail || "the announcements API did not respond";
+    return `Announcements could not be refreshed (${detail}). Showing ${sourceLabel} instead.`;
+}
 
 export default function NewsPage() {
     const [items, setItems] = React.useState<NewsItem[]>([]);
     const [loading, setLoading] = React.useState(true);
     const [error, setError] = React.useState("");
+    const [lastUpdated, setLastUpdated] = React.useState("");
+    const [sourceLabel, setSourceLabel] = React.useState("live announcements");
 
     const loadAnnouncements = React.useCallback(async () => {
         setLoading(true);
@@ -19,10 +86,25 @@ export default function NewsPage() {
 
         try {
             const announcements = await fetchAnnouncements({ limit: 100 });
+            const savedAt = new Date().toISOString();
+            cacheAnnouncements(announcements, savedAt);
             setItems(announcements.map(announcementToNewsItem));
+            setLastUpdated(savedAt);
+            setSourceLabel("live announcements");
         } catch (err) {
-            setError(err instanceof Error ? err.message : "Could not load announcements.");
-            setItems([]);
+            const cached = readCachedAnnouncements();
+
+            if (cached && cached.announcements.length) {
+                setItems(cached.announcements.map(announcementToNewsItem));
+                setLastUpdated(cached.savedAt);
+                setSourceLabel("cached announcements");
+                setError(buildFailureMessage(err, "cached announcements"));
+            } else {
+                setItems(FALLBACK_ANNOUNCEMENTS.map(announcementToNewsItem));
+                setLastUpdated(FALLBACK_ANNOUNCEMENTS[0]?.createdAt || "");
+                setSourceLabel("demo announcements");
+                setError(buildFailureMessage(err, "demo announcements"));
+            }
         } finally {
             setLoading(false);
         }
@@ -42,42 +124,65 @@ export default function NewsPage() {
                     />
 
                     {loading ? (
-                        <div className="admin-empty-state">
-                            <p>Loading announcements...</p>
-                        </div>
-                    ) : error ? (
-                        <div className="admin-empty-state">
-                            <p className="admin-error-text">{error}</p>
-                            <PrimaryButton className="w-auto" onClick={() => void loadAnnouncements()}>
-                                Retry
-                            </PrimaryButton>
-                        </div>
-                    ) : items.length === 0 ? (
-                        <div className="admin-empty-state">
-                            <p>No announcements have been published yet.</p>
-                        </div>
-                    ) : (
-                        <div className="news-list">
-                            {items.map((item) => (
-                                <article key={item.id} className="news-item-card">
-                                    <div className="news-item-meta-row">
-                                        <span className="news-item-category-chip">
-                                            {item.category}
-                                        </span>
-                                        <span className="news-item-date">{item.publishedAt}</span>
-                                    </div>
-
-                                    <h2 className="news-item-title">{item.title}</h2>
-                                    <p className="news-item-summary">{item.summary}</p>
-                                    <Link
-                                        className="news-read-more-link"
-                                        href={`/news/${encodeURIComponent(item.id)}`}
-                                    >
-                                        {item.hasMore ? "Read full announcement" : "Open announcement"}
-                                    </Link>
-                                </article>
+                        <div className="news-list" aria-label="Loading announcements">
+                            {[0, 1, 2].map((index) => (
+                                <div key={index} className="news-item-card news-item-skeleton">
+                                    <span className="news-skeleton-line is-chip" />
+                                    <span className="news-skeleton-line is-title" />
+                                    <span className="news-skeleton-line" />
+                                    <span className="news-skeleton-line is-short" />
+                                </div>
                             ))}
                         </div>
+                    ) : (
+                        <>
+                            <div className={error ? "news-status-box is-warning" : "news-status-box"}>
+                                <div>
+                                    <p className="news-status-title">
+                                        {error ? "Using fallback news" : "Announcements are up to date"}
+                                    </p>
+                                    <p className="news-status-copy">
+                                        {error || `Showing ${sourceLabel}.`}
+                                    </p>
+                                    {lastUpdated ? (
+                                        <p className="news-status-copy">
+                                            Last updated: {formatLastUpdated(lastUpdated)}
+                                        </p>
+                                    ) : null}
+                                </div>
+                                <PrimaryButton className="w-auto" onClick={() => void loadAnnouncements()}>
+                                    Retry news
+                                </PrimaryButton>
+                            </div>
+
+                            {items.length === 0 ? (
+                                <div className="admin-empty-state">
+                                    <p>No announcements have been published yet.</p>
+                                </div>
+                            ) : (
+                                <div className="news-list">
+                                    {items.map((item) => (
+                                        <article key={item.id} className="news-item-card">
+                                            <div className="news-item-meta-row">
+                                                <span className="news-item-category-chip">
+                                                    {item.category}
+                                                </span>
+                                                <span className="news-item-date">{item.publishedAt}</span>
+                                            </div>
+
+                                            <h2 className="news-item-title">{item.title}</h2>
+                                            <p className="news-item-summary">{item.summary}</p>
+                                            <Link
+                                                className="news-read-more-link"
+                                                href={`/news/${encodeURIComponent(item.id)}`}
+                                            >
+                                                {item.hasMore ? "Read full announcement" : "Open announcement"}
+                                            </Link>
+                                        </article>
+                                    ))}
+                                </div>
+                            )}
+                        </>
                     )}
                 </SectionCard>
             </div>

--- a/web/src/lib/news.ts
+++ b/web/src/lib/news.ts
@@ -26,6 +26,33 @@ type AnnouncementResponse = {
     announcement: Announcement;
 };
 
+export const FALLBACK_ANNOUNCEMENTS: Announcement[] = [
+    {
+        id: "seed_announcement_gathering_area",
+        adminId: "seed",
+        title: "Know your nearest gathering area",
+        content:
+            "Check the gathering areas page and keep your location information up to date so emergency guidance can stay relevant.",
+        createdAt: "2026-04-29T12:10:00.000Z",
+    },
+    {
+        id: "seed_announcement_volunteer_expansion",
+        adminId: "seed",
+        title: "Community safety volunteers are expanding",
+        content:
+            "New volunteer coordination improvements are being prepared to help communities respond faster during emergencies.",
+        createdAt: "2026-04-29T12:05:00.000Z",
+    },
+    {
+        id: "seed_announcement_preparedness_checklist",
+        adminId: "seed",
+        title: "Preparedness checklist updated",
+        content:
+            "Review your household emergency bag, contact list, medication details, and nearest gathering area before an emergency occurs.",
+        createdAt: "2026-04-29T12:00:00.000Z",
+    },
+];
+
 function buildAnnouncementsPath(options: { limit?: number } = {}) {
     const params = new URLSearchParams();
     if (typeof options.limit === "number") {

--- a/web/src/lib/news.ts
+++ b/web/src/lib/news.ts
@@ -26,6 +26,13 @@ type AnnouncementResponse = {
     announcement: Announcement;
 };
 
+export const ANNOUNCEMENTS_CACHE_KEY = "neph.publicAnnouncements.cache.v1";
+
+export type AnnouncementCache = {
+    announcements: Announcement[];
+    savedAt: string;
+};
+
 export const FALLBACK_ANNOUNCEMENTS: Announcement[] = [
     {
         id: "seed_announcement_gathering_area",
@@ -97,6 +104,46 @@ export function announcementToNewsItem(announcement: Announcement): NewsItem {
         publishedAt: formatAnnouncementDate(announcement.createdAt),
         category: "Announcement",
     };
+}
+
+export function readCachedAnnouncements(): AnnouncementCache | null {
+    if (typeof window === "undefined") {
+        return null;
+    }
+
+    try {
+        const raw = window.localStorage.getItem(ANNOUNCEMENTS_CACHE_KEY);
+        if (!raw) {
+            return null;
+        }
+
+        const parsed = JSON.parse(raw) as Partial<AnnouncementCache>;
+        if (!Array.isArray(parsed.announcements) || typeof parsed.savedAt !== "string") {
+            return null;
+        }
+
+        return {
+            announcements: parsed.announcements,
+            savedAt: parsed.savedAt,
+        };
+    } catch {
+        return null;
+    }
+}
+
+export function cacheAnnouncements(announcements: Announcement[], savedAt: string) {
+    if (typeof window === "undefined") {
+        return;
+    }
+
+    try {
+        window.localStorage.setItem(
+            ANNOUNCEMENTS_CACHE_KEY,
+            JSON.stringify({ announcements, savedAt })
+        );
+    } catch {
+        // Cache is best-effort only.
+    }
 }
 
 export async function fetchAnnouncements(options: { limit?: number } = {}) {

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -676,11 +676,88 @@ textarea::placeholder {
     gap: 16px;
 }
 
+.news-status-box {
+    margin-top: 16px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--surface-soft);
+    padding: 14px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.news-status-box.is-warning {
+    border-color: var(--primary-soft-200);
+    background: var(--primary-soft-100);
+}
+
+.news-status-box.is-error {
+    border-color: var(--error);
+    background: #fff5f5;
+}
+
+.news-status-title {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.news-status-copy {
+    margin: 4px 0 0;
+    font-size: 0.84rem;
+    line-height: 1.5;
+    color: var(--text-secondary);
+}
+
 .news-item-card {
     border: 1px solid var(--border-subtle);
     border-radius: 20px;
     background: var(--surface-card);
     padding: 20px;
+}
+
+.news-item-skeleton {
+    display: grid;
+    gap: 10px;
+}
+
+.news-skeleton-line,
+.gathering-areas-loading-skeleton span,
+.gathering-areas-item-skeleton span {
+    display: block;
+    height: 12px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, #f1f1f4 25%, #e8e8ee 50%, #f1f1f4 75%);
+    background-size: 200% 100%;
+    animation: skeleton-shimmer 1200ms ease-in-out infinite;
+}
+
+.news-skeleton-line.is-chip {
+    width: 110px;
+    height: 22px;
+}
+
+.news-skeleton-line.is-title {
+    width: min(360px, 82%);
+    height: 20px;
+}
+
+.news-skeleton-line.is-short {
+    width: min(260px, 64%);
+}
+
+@keyframes skeleton-shimmer {
+    0% {
+        background-position: 200% 0;
+    }
+
+    100% {
+        background-position: -200% 0;
+    }
 }
 
 .news-item-meta-row {
@@ -1305,10 +1382,37 @@ textarea::placeholder {
     color: var(--text-secondary);
 }
 
+.gathering-areas-status-box p {
+    margin: 0;
+}
+
+.gathering-areas-status-title {
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
 .gathering-areas-status-box.is-error {
     border-color: var(--primary-soft-200);
     background: var(--primary-soft-100);
     color: var(--primary-700);
+}
+
+.gathering-areas-status-box.is-warning {
+    border-color: var(--primary-soft-200);
+    background: var(--primary-soft-100);
+}
+
+.gathering-areas-loading-skeleton {
+    display: grid;
+    gap: 8px;
+}
+
+.gathering-areas-loading-skeleton span:first-child {
+    width: min(420px, 86%);
+}
+
+.gathering-areas-loading-skeleton span:last-child {
+    width: min(280px, 62%);
 }
 
 .gathering-areas-selected-card {
@@ -1355,6 +1459,23 @@ textarea::placeholder {
     border-radius: var(--radius-md);
     background: var(--surface-card);
     padding: 10px 12px;
+}
+
+.gathering-areas-item-skeleton {
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-card);
+    padding: 12px;
+    display: grid;
+    gap: 8px;
+}
+
+.gathering-areas-item-skeleton span:first-child {
+    width: 80%;
+}
+
+.gathering-areas-item-skeleton span:last-child {
+    width: 56%;
 }
 
 .gathering-areas-item:hover {

--- a/web/src/types/location.ts
+++ b/web/src/types/location.ts
@@ -95,10 +95,13 @@ export type NearbyGatheringAreasResponse = {
         lon: number;
     };
     radius: number;
-    source: "overpass";
+    source: "overpass" | "stale_cache" | "fallback";
     meta: {
         requestedLimit: number;
         returnedCount: number;
+        stale?: boolean;
+        providerErrorCode?: string;
+        fallbackReason?: string;
     };
     collection: GatheringAreaFeatureCollection;
 };


### PR DESCRIPTION
- Improves public outage UX for news, home previews, and gathering areas by replacing hard server-error states with skeleton loading, retry actions, last-updated context, and cached/demo fallback content. Gathering areas now stays usable during backend/provider failures with cached results or demo guidance instead of blank failure states.

Resolves #388 