### PR TITLE
feat: implement user account soft deletion and request state cleanup

### DIFF
--- a/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
@@ -58,6 +58,9 @@ interface HelpRequestDao {
 
     @Query("DELETE FROM help_requests WHERE localId = :localId")
     suspend fun deleteByLocalId(localId: String)
+
+    @Query("DELETE FROM help_requests WHERE ownerType = :ownerType")
+    suspend fun deleteByOwner(ownerType: String)
 }
 
 @Dao
@@ -70,6 +73,9 @@ interface AvailabilityDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(entity: AvailabilityEntity)
+
+    @Query("DELETE FROM availability_state")
+    suspend fun clear()
 }
 
 @Dao
@@ -202,6 +208,22 @@ interface SyncOperationDao {
 
     @Query("DELETE FROM sync_operations WHERE status = 'SYNCED'")
     suspend fun deleteSynced()
+
+    @Query("DELETE FROM sync_operations WHERE entityType = :entityType")
+    suspend fun deleteByEntityType(entityType: String)
+
+    @Query(
+        """
+        DELETE FROM sync_operations
+        WHERE entityType = :entityType
+          AND entityId IN (
+              SELECT localId
+              FROM help_requests
+              WHERE ownerType = :ownerType
+          )
+        """
+    )
+    suspend fun deleteHelpRequestOperationsForOwner(entityType: String, ownerType: String)
 }
 
 @Dao

--- a/android/app/src/main/java/com/neph/features/assignedrequest/data/AssignedRequestRepository.kt
+++ b/android/app/src/main/java/com/neph/features/assignedrequest/data/AssignedRequestRepository.kt
@@ -121,6 +121,11 @@ object AssignedRequestRepository {
         return pending.toUiModel()
     }
 
+    suspend fun clearLocalCache() {
+        database.assignedRequestDao().clearAll()
+        database.syncOperationDao().deleteByEntityType(SyncEntityType.ASSIGNED_REQUEST)
+    }
+
     suspend fun fetchAssignmentRoute(token: String, assignmentId: String): AssignmentRouteUiModel? {
         val response = JsonHttpClient.request(
             path = "/assignments/$assignmentId/route",

--- a/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
+++ b/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
@@ -4,13 +4,16 @@ import android.util.Log
 import com.google.firebase.messaging.FirebaseMessaging
 import com.neph.core.NephAppContext
 import com.neph.core.network.ApiException
-import com.neph.core.sync.OfflineSyncScheduler
 import com.neph.core.network.JsonHttpClient
+import com.neph.core.sync.OfflineSyncScheduler
+import com.neph.features.assignedrequest.data.AssignedRequestRepository
+import com.neph.features.availability.data.AvailabilityRepository
 import com.neph.features.notifications.data.PushTokenSync
 import com.neph.features.notifications.data.NotificationsRepository
 import com.neph.features.operationallocation.data.OperationalLocationRepository
 import com.neph.features.profile.data.ProfileData
 import com.neph.features.profile.data.ProfileRepository
+import com.neph.features.requesthelp.data.RequestHelpRepository
 import com.neph.features.safetystatus.data.SafetyStatusRepository
 import org.json.JSONObject
 import java.net.URLEncoder
@@ -226,7 +229,37 @@ object AuthRepository {
         )
 
         clearLocalAuthState()
+        clearDeletedAccountOfflineState()
         return response.optString("message").ifBlank { "Account deleted successfully." }
+    }
+
+    private suspend fun clearDeletedAccountOfflineState() {
+        clearDeletedAccountCache("authenticated help request cache") {
+            RequestHelpRepository.clearAuthenticatedLocalCache()
+        }
+        clearDeletedAccountCache("assigned request cache") {
+            AssignedRequestRepository.clearLocalCache()
+        }
+        clearDeletedAccountCache("availability cache") {
+            AvailabilityRepository.clearLocalCache()
+        }
+        clearDeletedAccountCache("operational location cache") {
+            OperationalLocationRepository.clearLocalCache()
+        }
+        clearDeletedAccountCache("safety status cache") {
+            SafetyStatusRepository.clearLocalCache()
+        }
+    }
+
+    private suspend fun clearDeletedAccountCache(
+        cacheName: String,
+        clear: suspend () -> Unit
+    ) {
+        try {
+            clear()
+        } catch (error: Exception) {
+            Log.w("AuthRepository", "Failed to clear $cacheName after account deletion", error)
+        }
     }
 
     private fun clearLocalAuthState() {

--- a/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
+++ b/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
@@ -208,6 +208,28 @@ object AuthRepository {
                 }
         }
 
+        clearLocalAuthState()
+    }
+
+    suspend fun deleteAccount(): String {
+        val accessToken = AuthSessionStore.getAccessToken()
+            ?: throw ApiException(
+                message = "Please log in again before deleting your account.",
+                status = 401,
+                code = "UNAUTHORIZED"
+            )
+
+        val response = JsonHttpClient.request(
+            path = "/auth/me",
+            method = "DELETE",
+            token = accessToken
+        )
+
+        clearLocalAuthState()
+        return response.optString("message").ifBlank { "Account deleted successfully." }
+    }
+
+    private fun clearLocalAuthState() {
         AuthSessionStore.clearAccessToken()
         AuthSessionStore.clearPendingVerificationEmail()
         ProfileRepository.clearProfile()

--- a/android/app/src/main/java/com/neph/features/availability/data/AvailabilityRepository.kt
+++ b/android/app/src/main/java/com/neph/features/availability/data/AvailabilityRepository.kt
@@ -107,6 +107,16 @@ object AvailabilityRepository {
         }
     }
 
+    suspend fun clearLocalCache() {
+        NephAppContext.getOrNull()?.let(::initialize)
+        cachedState = AvailabilityState()
+        if (::prefs.isInitialized) {
+            prefs.edit().clear().apply()
+        }
+        database.availabilityDao().clear()
+        database.syncOperationDao().deleteByEntityType(SyncEntityType.AVAILABILITY)
+    }
+
     private fun requireDebugBuildForTestingReset() {
         check(BuildConfig.DEBUG) {
             "AvailabilityRepository.resetForTesting() is only available in debug/e2e test builds."

--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
@@ -312,6 +312,17 @@ object RequestHelpRepository {
         }
     }
 
+    suspend fun clearAuthenticatedLocalCache() {
+        NephAppContext.getOrNull()?.let(::initialize)
+        pendingCoordinateSnapshot = null
+
+        database.syncOperationDao().deleteHelpRequestOperationsForOwner(
+            entityType = SyncEntityType.HELP_REQUEST,
+            ownerType = LocalOwnerType.AUTHENTICATED
+        )
+        database.helpRequestDao().deleteByOwner(LocalOwnerType.AUTHENTICATED)
+    }
+
     private fun requireDebugBuildForTestingReset() {
         check(BuildConfig.DEBUG) {
             "RequestHelpRepository.resetForTesting() is only available in debug/e2e test builds."

--- a/android/app/src/main/java/com/neph/features/settings/presentation/SettingsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/settings/presentation/SettingsScreen.kt
@@ -3,18 +3,28 @@ package com.neph.features.settings.presentation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.neph.features.auth.data.AuthRepository
 import com.neph.navigation.Routes
+import com.neph.ui.components.buttons.PrimaryButton
 import com.neph.ui.components.buttons.SecondaryButton
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
 import com.neph.ui.layout.AppDrawerScaffold
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
+import kotlinx.coroutines.launch
 
 @Composable
 fun SettingsScreen(
@@ -22,9 +32,66 @@ fun SettingsScreen(
     onProfileClick: () -> Unit,
     profileBadgeText: String,
     onNavigateToPrivacySecurity: () -> Unit,
-    onLogout: () -> Unit
+    onLogout: () -> Unit,
+    onAccountDeleted: () -> Unit
 ) {
     val spacing = LocalNephSpacing.current
+    val coroutineScope = rememberCoroutineScope()
+    var showDeleteDialog by remember { mutableStateOf(false) }
+    var deletingAccount by remember { mutableStateOf(false) }
+    var deleteError by remember { mutableStateOf<String?>(null) }
+
+    fun deleteAccount() {
+        deletingAccount = true
+        deleteError = null
+
+        coroutineScope.launch {
+            try {
+                AuthRepository.deleteAccount()
+                showDeleteDialog = false
+                onAccountDeleted()
+            } catch (error: Exception) {
+                deleteError = error.message ?: "Could not delete your account. Please try again."
+                showDeleteDialog = false
+            } finally {
+                deletingAccount = false
+            }
+        }
+    }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                if (!deletingAccount) {
+                    showDeleteDialog = false
+                }
+            },
+            title = {
+                Text(text = "Delete account?")
+            },
+            text = {
+                Text(
+                    text = "This removes your personal profile data, cancels active help requests and assignments, turns off volunteer availability, and disables login. This cannot be undone."
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = ::deleteAccount,
+                    enabled = !deletingAccount
+                ) {
+                    Text(if (deletingAccount) "Deleting..." else "Delete Account")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { showDeleteDialog = false },
+                    enabled = !deletingAccount
+                ) {
+                    Text("Keep Account")
+                }
+            }
+        )
+    }
 
     AppDrawerScaffold(
         title = "Settings",
@@ -63,6 +130,34 @@ fun SettingsScreen(
                 onClick = onLogout,
                 modifier = Modifier.fillMaxWidth()
             )
+
+            SectionCard {
+                SectionHeader(
+                    title = "Delete Account",
+                    subtitle = "Remove your account and personal data from NEPH."
+                )
+
+                Text(
+                    text = "Active assignments and volunteer availability will be cancelled before your account is disabled.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                deleteError?.let { message ->
+                    Text(
+                        text = message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+
+                PrimaryButton(
+                    text = "Delete Account",
+                    onClick = { showDeleteDialog = true },
+                    loading = deletingAccount,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
     }
 }
@@ -76,7 +171,8 @@ private fun SettingsScreenPreview() {
             onProfileClick = {},
             profileBadgeText = "PP",
             onNavigateToPrivacySecurity = {},
-            onLogout = {}
+            onLogout = {},
+            onAccountDeleted = {}
         )
     }
 }

--- a/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
@@ -397,6 +397,12 @@ fun AppNavGraph(
                         popUpTo(navController.graph.id) { inclusive = true }
                         launchSingleTop = true
                     }
+                },
+                onAccountDeleted = {
+                    navController.navigate(Routes.Welcome.route) {
+                        popUpTo(navController.graph.id) { inclusive = true }
+                        launchSingleTop = true
+                    }
                 }
             )
         }

--- a/backend/migrations/20260506_100000__support_account_soft_deletion.sql
+++ b/backend/migrations/20260506_100000__support_account_soft_deletion.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE user_profiles
+  ALTER COLUMN first_name DROP NOT NULL,
+  ALTER COLUMN last_name DROP NOT NULL;
+
+ALTER TABLE help_requests
+  ALTER COLUMN contact_phone DROP NOT NULL;
+
+ALTER TABLE request_locations
+  ALTER COLUMN country DROP NOT NULL,
+  ALTER COLUMN city DROP NOT NULL,
+  ALTER COLUMN district DROP NOT NULL;
+
+COMMIT;

--- a/backend/src/modules/auth/controller.js
+++ b/backend/src/modules/auth/controller.js
@@ -7,6 +7,7 @@ const {
   requestPasswordReset,
   resetPassword,
   logoutUser,
+  deleteCurrentUser,
 } = require('./service');
 const {
   validateSignupInput,
@@ -244,6 +245,26 @@ async function logout(req, res) {
   }
 }
 
+async function deleteMe(req, res) {
+  try {
+    const result = await deleteCurrentUser(req.user.userId);
+
+    return res.status(200).json(result);
+  } catch (error) {
+    if (error.code === 'USER_NOT_FOUND') {
+      return res.status(404).json({
+        code: error.code,
+        message: error.message,
+      });
+    }
+
+    return res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      message: 'Something went wrong',
+    });
+  }
+}
+
 module.exports = {
   getAuthInfo,
   signup,
@@ -254,4 +275,5 @@ module.exports = {
   forgotPassword,
   resetPasswordHandler,
   logout,
+  deleteMe,
 };

--- a/backend/src/modules/auth/repository.js
+++ b/backend/src/modules/auth/repository.js
@@ -1,4 +1,4 @@
-const { query } = require('../../db/pool');
+const { pool, query } = require('../../db/pool');
 
 async function findUserByEmail(email) {
   const result = await query(
@@ -128,6 +128,343 @@ async function findUserAuthStateById(userId) {
   return result.rows[0] || null;
 }
 
+async function softDeleteUserAccount(userId) {
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    const userResult = await client.query(
+      `
+        SELECT user_id, is_deleted
+        FROM users
+        WHERE user_id = $1
+        FOR UPDATE
+      `,
+      [userId],
+    );
+    const user = userResult.rows[0] || null;
+
+    if (!user || user.is_deleted) {
+      await client.query('ROLLBACK');
+      return null;
+    }
+
+    const ownedOpenRequestsResult = await client.query(
+      `
+        SELECT request_id
+        FROM help_requests
+        WHERE user_id = $1
+          AND status IN ('PENDING', 'ASSIGNED', 'IN_PROGRESS')
+      `,
+      [userId],
+    );
+    const ownedOpenRequestIds = ownedOpenRequestsResult.rows.map((row) => row.request_id);
+
+    const assignedActiveRequestsResult = await client.query(
+      `
+        SELECT DISTINCT a.request_id, hr.status
+        FROM assignments a
+        JOIN volunteers v ON v.volunteer_id = a.volunteer_id
+        JOIN help_requests hr ON hr.request_id = a.request_id
+        WHERE v.user_id = $1
+          AND a.is_cancelled = FALSE
+      `,
+      [userId],
+    );
+    const assignedActiveRequestIds = assignedActiveRequestsResult.rows.map((row) => row.request_id);
+    const assignedOpenRequestIds = assignedActiveRequestsResult.rows
+      .filter((row) => ['PENDING', 'ASSIGNED', 'IN_PROGRESS'].includes(row.status))
+      .map((row) => row.request_id);
+    const affectedRequestIds = [...new Set([...ownedOpenRequestIds, ...assignedActiveRequestIds])];
+
+    if (affectedRequestIds.length > 0) {
+      await client.query(
+        `
+          DELETE FROM assignments
+          WHERE is_cancelled = FALSE
+            AND (
+              request_id = ANY($1::varchar[])
+              OR volunteer_id IN (
+                SELECT volunteer_id
+                FROM volunteers
+                WHERE user_id = $2
+              )
+            )
+        `,
+        [affectedRequestIds, userId],
+      );
+    }
+
+    if (ownedOpenRequestIds.length > 0) {
+      await client.query(
+        `
+          UPDATE help_requests
+          SET status = 'CANCELLED',
+              cancelled_at = COALESCE(cancelled_at, CURRENT_TIMESTAMP)
+          WHERE request_id = ANY($1::varchar[])
+        `,
+        [ownedOpenRequestIds],
+      );
+    }
+
+    const requestsToResync = assignedOpenRequestIds.filter(
+      (requestId) => !ownedOpenRequestIds.includes(requestId),
+    );
+
+    for (const requestId of requestsToResync) {
+      await client.query(
+        `
+          UPDATE help_requests hr
+          SET status = CASE
+            WHEN hr.status = 'IN_PROGRESS' THEN 'IN_PROGRESS'::request_status
+            WHEN EXISTS (
+              SELECT 1
+              FROM assignments a
+              WHERE a.request_id = hr.request_id
+                AND a.is_cancelled = FALSE
+            ) THEN 'ASSIGNED'::request_status
+            ELSE 'PENDING'::request_status
+          END
+          WHERE hr.request_id = $1
+        `,
+        [requestId],
+      );
+    }
+
+    const volunteerResult = await client.query(
+      `
+        UPDATE volunteers
+        SET is_available = FALSE,
+            last_known_latitude = NULL,
+            last_known_longitude = NULL,
+            location_updated_at = NULL,
+            available_until = NULL,
+            availability_confirmed_at = NULL,
+            last_location_accuracy_meters = NULL,
+            last_location_source = NULL
+        WHERE user_id = $1
+        RETURNING volunteer_id
+      `,
+      [userId],
+    );
+
+    for (const volunteer of volunteerResult.rows) {
+      await client.query(
+        `
+          INSERT INTO availability_records (
+            availability_id,
+            volunteer_id,
+            is_available,
+            stored_locally,
+            synced_at
+          )
+          VALUES ($1, $2, FALSE, FALSE, CURRENT_TIMESTAMP)
+        `,
+        [`avr_delete_${volunteer.volunteer_id}`, volunteer.volunteer_id],
+      );
+    }
+
+    await client.query(
+      `
+        UPDATE request_locations rl
+        SET country = NULL,
+            city = NULL,
+            district = NULL,
+            neighborhood = NULL,
+            extra_address = NULL,
+            latitude = NULL,
+            longitude = NULL,
+            is_gps_location = FALSE,
+            is_last_known = FALSE
+        FROM help_requests hr
+        WHERE hr.request_id = rl.request_id
+          AND hr.user_id = $1
+      `,
+      [userId],
+    );
+
+    await client.query(
+      `
+        UPDATE help_requests
+        SET user_id = NULL,
+            other_help_text = '',
+            risk_flags = ARRAY[]::TEXT[],
+            vulnerable_groups = ARRAY[]::TEXT[],
+            description = NULL,
+            blood_type = NULL,
+            contact_full_name = NULL,
+            contact_phone = NULL,
+            contact_alternative_phone = NULL,
+            consent_given = FALSE
+        WHERE user_id = $1
+      `,
+      [userId],
+    );
+
+    await client.query(
+      `
+        UPDATE user_profiles
+        SET first_name = NULL,
+            last_name = NULL,
+            phone_number = NULL
+        WHERE user_id = $1
+      `,
+      [userId],
+    );
+
+    await client.query(
+      `
+        UPDATE physical_info pi
+        SET age = NULL,
+            date_of_birth = NULL,
+            gender = NULL,
+            height = NULL,
+            weight = NULL
+        FROM user_profiles up
+        WHERE up.profile_id = pi.profile_id
+          AND up.user_id = $1
+      `,
+      [userId],
+    );
+
+    await client.query(
+      `
+        UPDATE health_info hi
+        SET medical_conditions = ARRAY[]::TEXT[],
+            chronic_diseases = ARRAY[]::TEXT[],
+            allergies = ARRAY[]::TEXT[],
+            medications = ARRAY[]::TEXT[],
+            blood_type = NULL
+        FROM user_profiles up
+        WHERE up.profile_id = hi.profile_id
+          AND up.user_id = $1
+      `,
+      [userId],
+    );
+
+    await client.query(
+      `
+        UPDATE location_profiles lp
+        SET address = NULL,
+            city = NULL,
+            country = NULL,
+            latitude = NULL,
+            longitude = NULL,
+            district = NULL,
+            neighborhood = NULL,
+            display_address = NULL,
+            extra_address = NULL,
+            country_code = NULL,
+            postal_code = NULL,
+            place_id = NULL,
+            coordinate_source = NULL,
+            coordinate_captured_at = NULL,
+            coordinate_accuracy_meters = NULL,
+            last_updated = CURRENT_TIMESTAMP
+        FROM user_profiles up
+        WHERE up.profile_id = lp.profile_id
+          AND up.user_id = $1
+      `,
+      [userId],
+    );
+
+    await client.query(
+      `
+        UPDATE privacy_settings ps
+        SET profile_visibility = 'PRIVATE',
+            health_info_visibility = 'PRIVATE',
+            location_visibility = 'PRIVATE',
+            location_sharing_enabled = FALSE
+        FROM user_profiles up
+        WHERE up.profile_id = ps.profile_id
+          AND up.user_id = $1
+      `,
+      [userId],
+    );
+
+    await client.query(
+      `
+        UPDATE expertise e
+        SET profession = NULL,
+            expertise_area = NULL,
+            is_verified = FALSE
+        FROM user_profiles up
+        WHERE up.profile_id = e.profile_id
+          AND up.user_id = $1
+      `,
+      [userId],
+    );
+
+    await client.query(
+      `
+        UPDATE user_safety_statuses
+        SET status = 'unknown',
+            status_note = NULL,
+            share_location_consent = FALSE,
+            latitude = NULL,
+            longitude = NULL,
+            location_accuracy_meters = NULL,
+            location_source = NULL,
+            location_captured_at = NULL,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE user_id = $1
+      `,
+      [userId],
+    );
+
+    await client.query('DELETE FROM user_operational_locations WHERE user_id = $1', [userId]);
+    await client.query('DELETE FROM notification_devices WHERE user_id = $1', [userId]);
+    await client.query('DELETE FROM notification_preferences WHERE user_id = $1', [userId]);
+    await client.query('DELETE FROM notification_type_preferences WHERE user_id = $1', [userId]);
+    await client.query(
+      `
+        UPDATE notification_deliveries
+        SET device_token = NULL,
+            error_message = NULL
+        WHERE user_id = $1
+      `,
+      [userId],
+    );
+    await client.query('DELETE FROM notifications WHERE recipient_user_id = $1', [userId]);
+    await client.query('UPDATE notifications SET actor_user_id = NULL WHERE actor_user_id = $1', [userId]);
+    await client.query('DELETE FROM safety_circle_invites WHERE inviter_user_id = $1 OR invitee_user_id = $1', [userId]);
+    await client.query('DELETE FROM safety_circle_members WHERE user_id = $1', [userId]);
+    await client.query('DELETE FROM safety_circles WHERE owner_user_id = $1', [userId]);
+
+    const deletedResult = await client.query(
+      `
+        UPDATE users
+        SET is_deleted = TRUE,
+            email = CONCAT('deleted+', md5(user_id || ':' || clock_timestamp()::text), '@deleted.invalid'),
+            password_hash = 'deleted-account-disabled',
+            is_email_verified = FALSE,
+            accepted_terms = FALSE,
+            is_banned = FALSE,
+            ban_reason = NULL,
+            banned_at = NULL
+        WHERE user_id = $1
+        RETURNING user_id, is_deleted
+      `,
+      [userId],
+    );
+
+    await client.query('COMMIT');
+
+    return {
+      userId: deletedResult.rows[0].user_id,
+      cancelledRequestCount: ownedOpenRequestIds.length,
+      cancelledAssignmentRequestCount: assignedActiveRequestIds.length,
+      availabilityCancelled: volunteerResult.rowCount > 0,
+    };
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
 module.exports = {
   findUserByEmail,
   findUserById,
@@ -136,4 +473,5 @@ module.exports = {
   markEmailVerified,
   updateUserPassword,
   findAdminByUserId,
+  softDeleteUserAccount,
 };

--- a/backend/src/modules/auth/repository.js
+++ b/backend/src/modules/auth/repository.js
@@ -163,7 +163,7 @@ async function softDeleteUserAccount(userId) {
 
     const assignedActiveRequestsResult = await client.query(
       `
-        SELECT DISTINCT a.request_id, hr.status
+        SELECT DISTINCT a.assignment_id, a.request_id, hr.status
         FROM assignments a
         JOIN volunteers v ON v.volunteer_id = a.volunteer_id
         JOIN help_requests hr ON hr.request_id = a.request_id
@@ -172,27 +172,26 @@ async function softDeleteUserAccount(userId) {
       `,
       [userId],
     );
-    const assignedActiveRequestIds = assignedActiveRequestsResult.rows.map((row) => row.request_id);
+    const assignedActiveRequestIds = [
+      ...new Set(assignedActiveRequestsResult.rows.map((row) => row.request_id)),
+    ];
+    const volunteerAssignmentIds = assignedActiveRequestsResult.rows.map((row) => row.assignment_id);
     const assignedOpenRequestIds = assignedActiveRequestsResult.rows
       .filter((row) => ['PENDING', 'ASSIGNED', 'IN_PROGRESS'].includes(row.status))
       .map((row) => row.request_id);
-    const affectedRequestIds = [...new Set([...ownedOpenRequestIds, ...assignedActiveRequestIds])];
 
-    if (affectedRequestIds.length > 0) {
+    if (ownedOpenRequestIds.length > 0 || volunteerAssignmentIds.length > 0) {
       await client.query(
         `
-          DELETE FROM assignments
+          UPDATE assignments
+          SET is_cancelled = TRUE
           WHERE is_cancelled = FALSE
             AND (
               request_id = ANY($1::varchar[])
-              OR volunteer_id IN (
-                SELECT volunteer_id
-                FROM volunteers
-                WHERE user_id = $2
-              )
+              OR assignment_id = ANY($2::varchar[])
             )
         `,
-        [affectedRequestIds, userId],
+        [ownedOpenRequestIds, volunteerAssignmentIds],
       );
     }
 

--- a/backend/src/modules/auth/repository.js
+++ b/backend/src/modules/auth/repository.js
@@ -216,13 +216,15 @@ async function softDeleteUserAccount(userId) {
         `
           UPDATE help_requests hr
           SET status = CASE
-            WHEN hr.status = 'IN_PROGRESS' THEN 'IN_PROGRESS'::request_status
             WHEN EXISTS (
               SELECT 1
               FROM assignments a
               WHERE a.request_id = hr.request_id
                 AND a.is_cancelled = FALSE
-            ) THEN 'ASSIGNED'::request_status
+            ) THEN CASE
+              WHEN hr.status = 'IN_PROGRESS' THEN 'IN_PROGRESS'::request_status
+              ELSE 'ASSIGNED'::request_status
+            END
             ELSE 'PENDING'::request_status
           END
           WHERE hr.request_id = $1

--- a/backend/src/modules/auth/routes.js
+++ b/backend/src/modules/auth/routes.js
@@ -51,6 +51,7 @@ const {
   forgotPassword,
   resetPasswordHandler,
   logout,
+  deleteMe,
 } = require('./controller');
 const { requireAuth } = require('./middleware');
 
@@ -65,6 +66,7 @@ authRouter.post('/forgot-password', authLimiter, forgotPassword);
 authRouter.post('/reset-password', authLimiter, resetPasswordHandler);
 authRouter.post('/logout', requireAuth, logout);
 authRouter.get('/me', requireAuth, getMe);
+authRouter.delete('/me', requireAuth, deleteMe);
 
 // Backward-compatibility alias for legacy admin paths under /api/auth/admin/*
 authRouter.use('/admin', adminRouter);

--- a/backend/src/modules/auth/service.js
+++ b/backend/src/modules/auth/service.js
@@ -8,6 +8,7 @@ const {
   findUserById,
   findAdminByUserId,
   updateUserPassword,
+  softDeleteUserAccount,
 } = require('./repository');
 const { sendVerificationEmail, sendPasswordResetEmail } = require('../../config/mailer');
 
@@ -293,6 +294,24 @@ async function logoutUser() {
   };
 }
 
+async function deleteCurrentUser(userId) {
+  const result = await softDeleteUserAccount(userId);
+
+  if (!result) {
+    const error = new Error('User not found');
+    error.code = 'USER_NOT_FOUND';
+    throw error;
+  }
+
+  return {
+    message: 'Account deleted successfully.',
+    deleted: true,
+    cancelledRequestCount: result.cancelledRequestCount,
+    cancelledAssignmentRequestCount: result.cancelledAssignmentRequestCount,
+    availabilityCancelled: result.availabilityCancelled,
+  };
+}
+
 module.exports = {
   signupUser,
   loginUser,
@@ -302,4 +321,5 @@ module.exports = {
   requestPasswordReset,
   resetPassword,
   logoutUser,
+  deleteCurrentUser,
 };

--- a/backend/src/modules/availability/repository.js
+++ b/backend/src/modules/availability/repository.js
@@ -739,13 +739,15 @@ async function syncRequestStatusPreservingInProgress(requestId, executor = null)
   const sql = `
     UPDATE help_requests hr
     SET status = CASE
-      WHEN hr.status = 'IN_PROGRESS' THEN 'IN_PROGRESS'::request_status
       WHEN EXISTS (
         SELECT 1
         FROM assignments a
         WHERE a.request_id = hr.request_id
           AND a.is_cancelled = FALSE
-      ) THEN 'ASSIGNED'::request_status
+      ) THEN CASE
+        WHEN hr.status = 'IN_PROGRESS' THEN 'IN_PROGRESS'::request_status
+        ELSE 'ASSIGNED'::request_status
+      END
       ELSE 'PENDING'::request_status
     END
     WHERE hr.request_id = $1

--- a/backend/tests/integration/modules/auth/auth.integration.test.js
+++ b/backend/tests/integration/modules/auth/auth.integration.test.js
@@ -41,6 +41,11 @@ const validUser = {
 beforeEach(async () => {
   await query(`
     TRUNCATE TABLE
+      safety_circle_invites,
+      safety_circle_members,
+      safety_circles,
+      user_operational_locations,
+      user_safety_statuses,
       notification_deliveries,
       notification_devices,
       notification_type_preferences,
@@ -272,6 +277,264 @@ describe('GET /api/auth/me', () => {
 
     expect(meRes.status).toBe(403);
     expect(meRes.body.code).toBe('USER_BANNED');
+  });
+});
+
+// ─── DELETE /api/auth/me ─────────────────────────────────────────────────────
+
+describe('DELETE /api/auth/me', () => {
+  test('401 - no token', async () => {
+    const app = createTestApp();
+    const res = await request(app).delete('/api/auth/me');
+    expect(res.status).toBe(401);
+  });
+
+  test('200 - soft-deletes account data and cancels active work', async () => {
+    const app = createTestApp();
+    await request(app).post('/api/auth/signup').send(validUser);
+    await query(`UPDATE users SET is_email_verified = TRUE WHERE email = $1`, [validUser.email]);
+
+    const loginRes = await request(app).post('/api/auth/login').send({
+      email: validUser.email,
+      password: validUser.password,
+    });
+    const token = loginRes.body.accessToken;
+
+    const userRow = await query(`SELECT user_id FROM users WHERE email = $1`, [validUser.email]);
+    const userId = userRow.rows[0].user_id;
+    const otherUserId = 'other-delete-test-user';
+    const profileId = 'profile-delete-test';
+    const volunteerId = 'volunteer-delete-test';
+    const ownedRequestId = 'owned-delete-test-request';
+    const assignedRequestId = 'assigned-delete-test-request';
+
+    await query(
+      `INSERT INTO users (user_id, email, password_hash, is_email_verified, accepted_terms)
+       VALUES ($1, $2, $3, TRUE, TRUE)`,
+      [otherUserId, 'other-delete-test@example.com', 'hashed-password'],
+    );
+
+    await query(
+      `INSERT INTO user_profiles (profile_id, user_id, first_name, last_name, phone_number)
+       VALUES ($1, $2, 'Jane', 'Requester', '5550000000')`,
+      [profileId, userId],
+    );
+    await query(
+      `INSERT INTO physical_info (physical_id, profile_id, age, date_of_birth, gender, height, weight)
+       VALUES ('physical-delete-test', $1, 30, '1996-01-01', 'female', 170, 60)`,
+      [profileId],
+    );
+    await query(
+      `INSERT INTO health_info (health_id, profile_id, medical_conditions, chronic_diseases, allergies, medications, blood_type)
+       VALUES ('health-delete-test', $1, ARRAY['asthma'], ARRAY['diabetes'], ARRAY['pollen'], ARRAY['med'], 'A+')`,
+      [profileId],
+    );
+    await query(
+      `INSERT INTO location_profiles (
+         location_profile_id, profile_id, address, city, country, latitude, longitude,
+         display_address, country_code, district, neighborhood, extra_address, postal_code,
+         place_id, coordinate_accuracy_meters, coordinate_source, coordinate_captured_at
+       )
+       VALUES (
+         'location-profile-delete-test', $1, 'Home address', 'Istanbul', 'Turkey', 41.01, 29.01,
+         'Home display', 'TR', 'Kadikoy', 'Moda', 'Street 1', '34000',
+         'place-delete-test', 12, 'profile_form', CURRENT_TIMESTAMP
+       )`,
+      [profileId],
+    );
+    await query(
+      `INSERT INTO privacy_settings (settings_id, profile_id, profile_visibility, health_info_visibility, location_visibility, location_sharing_enabled)
+       VALUES ('privacy-delete-test', $1, 'PUBLIC', 'PUBLIC', 'PUBLIC', TRUE)`,
+      [profileId],
+    );
+    await query(
+      `INSERT INTO expertise (expertise_id, profile_id, profession, expertise_area, is_verified)
+       VALUES ('expertise-delete-test', $1, 'Doctor', 'First Aid', TRUE)`,
+      [profileId],
+    );
+    await query(
+      `INSERT INTO volunteers (
+         volunteer_id, user_id, is_available, skills, need_types, last_known_latitude,
+         last_known_longitude, location_updated_at, available_until, availability_confirmed_at,
+         last_location_accuracy_meters, last_location_source
+       )
+       VALUES ($1, $2, TRUE, ARRAY['first_aid'], ARRAY['medical'], 41.02, 29.02,
+         CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '1 hour', CURRENT_TIMESTAMP, 8, 'device')`,
+      [volunteerId, userId],
+    );
+    await query(
+      `INSERT INTO help_requests (
+         request_id, user_id, help_types, other_help_text, affected_people_count, risk_flags,
+         vulnerable_groups, need_type, description, blood_type, contact_full_name,
+         contact_phone, contact_alternative_phone, consent_given, status
+       )
+       VALUES ($1, $2, ARRAY['medical'], 'needs oxygen', 1, ARRAY['injury'],
+         ARRAY['elderly'], 'medical', 'personal details', 'A+', 'Jane Requester',
+         5000000000, 5000000001, TRUE, 'ASSIGNED')`,
+      [ownedRequestId, userId],
+    );
+    await query(
+      `INSERT INTO request_locations (
+         location_id, request_id, country, city, district, neighborhood, extra_address,
+         latitude, longitude, is_gps_location, is_last_known
+       )
+       VALUES ('owned-location-delete-test', $1, 'Turkey', 'Istanbul', 'Kadikoy', 'Moda',
+         'Street 1', 41.01, 29.01, TRUE, TRUE)`,
+      [ownedRequestId],
+    );
+    await query(
+      `INSERT INTO help_requests (
+         request_id, user_id, help_types, affected_people_count, need_type,
+         contact_full_name, contact_phone, consent_given, status
+       )
+       VALUES ($1, $2, ARRAY['shelter'], 1, 'shelter', 'Other User', 5000000002, TRUE, 'ASSIGNED')`,
+      [assignedRequestId, otherUserId],
+    );
+    await query(
+      `INSERT INTO request_locations (location_id, request_id, country, city, district)
+       VALUES ('assigned-location-delete-test', $1, 'Turkey', 'Istanbul', 'Besiktas')`,
+      [assignedRequestId],
+    );
+    await query(
+      `INSERT INTO assignments (assignment_id, volunteer_id, request_id)
+       VALUES ('assignment-delete-test', $1, $2)`,
+      [volunteerId, assignedRequestId],
+    );
+    await query(
+      `INSERT INTO user_safety_statuses (
+         user_id, status, status_note, share_location_consent, latitude, longitude,
+         location_accuracy_meters, location_source, location_captured_at
+       )
+       VALUES ($1, 'safe', 'At home', TRUE, 41.03, 29.03, 10, 'device', CURRENT_TIMESTAMP)`,
+      [userId],
+    );
+    await query(
+      `INSERT INTO user_operational_locations (user_id, latitude, longitude, accuracy_meters, source, captured_at)
+       VALUES ($1, 41.04, 29.04, 10, 'device', CURRENT_TIMESTAMP)`,
+      [userId],
+    );
+
+    const res = await request(app)
+      .delete('/api/auth/me')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({
+      deleted: true,
+      cancelledRequestCount: 1,
+      cancelledAssignmentRequestCount: 1,
+      availabilityCancelled: true,
+    }));
+
+    const deletedUser = await query(
+      `SELECT is_deleted, email, password_hash, is_email_verified, accepted_terms
+       FROM users WHERE user_id = $1`,
+      [userId],
+    );
+    expect(deletedUser.rows[0]).toEqual(expect.objectContaining({
+      is_deleted: true,
+      password_hash: 'deleted-account-disabled',
+      is_email_verified: false,
+      accepted_terms: false,
+    }));
+    expect(deletedUser.rows[0].email).not.toBe(validUser.email);
+    expect(deletedUser.rows[0].email).toMatch(/^deleted\+[a-f0-9]{32}@deleted\.invalid$/);
+
+    const deletedProfile = await query(
+      `SELECT first_name, last_name, phone_number FROM user_profiles WHERE user_id = $1`,
+      [userId],
+    );
+    expect(deletedProfile.rows[0]).toEqual({
+      first_name: null,
+      last_name: null,
+      phone_number: null,
+    });
+
+    const deletedLocationProfile = await query(
+      `SELECT address, city, country, latitude, longitude, display_address, place_id
+       FROM location_profiles WHERE profile_id = $1`,
+      [profileId],
+    );
+    expect(deletedLocationProfile.rows[0]).toEqual(expect.objectContaining({
+      address: null,
+      city: null,
+      country: null,
+      latitude: null,
+      longitude: null,
+      display_address: null,
+      place_id: null,
+    }));
+
+    const deletedOwnedRequest = await query(
+      `SELECT user_id, status, contact_full_name, contact_phone, consent_given, description
+       FROM help_requests WHERE request_id = $1`,
+      [ownedRequestId],
+    );
+    expect(deletedOwnedRequest.rows[0]).toEqual(expect.objectContaining({
+      user_id: null,
+      status: 'CANCELLED',
+      contact_full_name: null,
+      contact_phone: null,
+      consent_given: false,
+      description: null,
+    }));
+
+    const deletedRequestLocation = await query(
+      `SELECT country, city, district, latitude, longitude, is_gps_location, is_last_known
+       FROM request_locations WHERE request_id = $1`,
+      [ownedRequestId],
+    );
+    expect(deletedRequestLocation.rows[0]).toEqual(expect.objectContaining({
+      country: null,
+      city: null,
+      district: null,
+      latitude: null,
+      longitude: null,
+      is_gps_location: false,
+      is_last_known: false,
+    }));
+
+    const volunteer = await query(
+      `SELECT is_available, last_known_latitude, last_known_longitude, available_until
+       FROM volunteers WHERE volunteer_id = $1`,
+      [volunteerId],
+    );
+    expect(volunteer.rows[0]).toEqual(expect.objectContaining({
+      is_available: false,
+      last_known_latitude: null,
+      last_known_longitude: null,
+      available_until: null,
+    }));
+
+    const activeAssignments = await query(
+      `SELECT COUNT(*)::int AS count FROM assignments WHERE volunteer_id = $1 AND is_cancelled = FALSE`,
+      [volunteerId],
+    );
+    expect(activeAssignments.rows[0].count).toBe(0);
+
+    const assignedRequest = await query(
+      `SELECT status FROM help_requests WHERE request_id = $1`,
+      [assignedRequestId],
+    );
+    expect(assignedRequest.rows[0].status).toBe('PENDING');
+
+    const availabilityRecord = await query(
+      `SELECT COUNT(*)::int AS count FROM availability_records
+       WHERE volunteer_id = $1 AND is_available = FALSE`,
+      [volunteerId],
+    );
+    expect(availabilityRecord.rows[0].count).toBeGreaterThan(0);
+
+    const operationalLocations = await query(
+      `SELECT COUNT(*)::int AS count FROM user_operational_locations WHERE user_id = $1`,
+      [userId],
+    );
+    expect(operationalLocations.rows[0].count).toBe(0);
+
+    const oldTokenRes = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${token}`);
+    expect(oldTokenRes.status).toBe(401);
   });
 });
 

--- a/backend/tests/integration/modules/auth/auth.integration.test.js
+++ b/backend/tests/integration/modules/auth/auth.integration.test.js
@@ -303,8 +303,10 @@ describe('DELETE /api/auth/me', () => {
     const userRow = await query(`SELECT user_id FROM users WHERE email = $1`, [validUser.email]);
     const userId = userRow.rows[0].user_id;
     const otherUserId = 'other-delete-test-user';
+    const otherVolunteerUserId = 'other-delete-test-volunteer-user';
     const profileId = 'profile-delete-test';
     const volunteerId = 'volunteer-delete-test';
+    const otherVolunteerId = 'other-volunteer-delete-test';
     const ownedRequestId = 'owned-delete-test-request';
     const assignedRequestId = 'assigned-delete-test-request';
 
@@ -312,6 +314,11 @@ describe('DELETE /api/auth/me', () => {
       `INSERT INTO users (user_id, email, password_hash, is_email_verified, accepted_terms)
        VALUES ($1, $2, $3, TRUE, TRUE)`,
       [otherUserId, 'other-delete-test@example.com', 'hashed-password'],
+    );
+    await query(
+      `INSERT INTO users (user_id, email, password_hash, is_email_verified, accepted_terms)
+       VALUES ($1, $2, $3, TRUE, TRUE)`,
+      [otherVolunteerUserId, 'other-volunteer-delete-test@example.com', 'hashed-password'],
     );
 
     await query(
@@ -363,6 +370,16 @@ describe('DELETE /api/auth/me', () => {
       [volunteerId, userId],
     );
     await query(
+      `INSERT INTO volunteers (
+         volunteer_id, user_id, is_available, skills, need_types, last_known_latitude,
+         last_known_longitude, location_updated_at, available_until, availability_confirmed_at,
+         last_location_accuracy_meters, last_location_source
+       )
+       VALUES ($1, $2, TRUE, ARRAY['shelter'], ARRAY['shelter'], 41.025, 29.025,
+         CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '1 hour', CURRENT_TIMESTAMP, 8, 'device')`,
+      [otherVolunteerId, otherVolunteerUserId],
+    );
+    await query(
       `INSERT INTO help_requests (
          request_id, user_id, help_types, other_help_text, affected_people_count, risk_flags,
          vulnerable_groups, need_type, description, blood_type, contact_full_name,
@@ -399,6 +416,11 @@ describe('DELETE /api/auth/me', () => {
       `INSERT INTO assignments (assignment_id, volunteer_id, request_id)
        VALUES ('assignment-delete-test', $1, $2)`,
       [volunteerId, assignedRequestId],
+    );
+    await query(
+      `INSERT INTO assignments (assignment_id, volunteer_id, request_id)
+       VALUES ('assignment-other-volunteer-delete-test', $1, $2)`,
+      [otherVolunteerId, assignedRequestId],
     );
     await query(
       `INSERT INTO user_safety_statuses (
@@ -506,17 +528,33 @@ describe('DELETE /api/auth/me', () => {
       available_until: null,
     }));
 
+    const deletedVolunteerAssignment = await query(
+      `SELECT is_cancelled FROM assignments WHERE assignment_id = 'assignment-delete-test'`,
+    );
+    expect(deletedVolunteerAssignment.rows[0].is_cancelled).toBe(true);
+
     const activeAssignments = await query(
       `SELECT COUNT(*)::int AS count FROM assignments WHERE volunteer_id = $1 AND is_cancelled = FALSE`,
       [volunteerId],
     );
     expect(activeAssignments.rows[0].count).toBe(0);
 
+    const remainingVolunteerAssignment = await query(
+      `SELECT is_cancelled FROM assignments WHERE assignment_id = 'assignment-other-volunteer-delete-test'`,
+    );
+    expect(remainingVolunteerAssignment.rows[0].is_cancelled).toBe(false);
+
+    const activeAssignmentsForRequest = await query(
+      `SELECT COUNT(*)::int AS count FROM assignments WHERE request_id = $1 AND is_cancelled = FALSE`,
+      [assignedRequestId],
+    );
+    expect(activeAssignmentsForRequest.rows[0].count).toBe(1);
+
     const assignedRequest = await query(
       `SELECT status FROM help_requests WHERE request_id = $1`,
       [assignedRequestId],
     );
-    expect(assignedRequest.rows[0].status).toBe('PENDING');
+    expect(assignedRequest.rows[0].status).toBe('ASSIGNED');
 
     const availabilityRecord = await query(
       `SELECT COUNT(*)::int AS count FROM availability_records

--- a/backend/tests/integration/modules/auth/auth.integration.test.js
+++ b/backend/tests/integration/modules/auth/auth.integration.test.js
@@ -574,6 +574,82 @@ describe('DELETE /api/auth/me', () => {
       .set('Authorization', `Bearer ${token}`);
     expect(oldTokenRes.status).toBe(401);
   });
+
+  test('200 - reopens an in-progress request when the deleted user was the only active volunteer', async () => {
+    const app = createTestApp();
+    const deleteUser = {
+      email: 'delete-only-in-progress@example.com',
+      password: '12345678',
+      acceptedTerms: true,
+    };
+    await request(app).post('/api/auth/signup').send(deleteUser);
+    await query(`UPDATE users SET is_email_verified = TRUE WHERE email = $1`, [deleteUser.email]);
+
+    const loginRes = await request(app).post('/api/auth/login').send({
+      email: deleteUser.email,
+      password: deleteUser.password,
+    });
+    const token = loginRes.body.accessToken;
+
+    const deletingUserRow = await query(`SELECT user_id FROM users WHERE email = $1`, [deleteUser.email]);
+    const deletingUserId = deletingUserRow.rows[0].user_id;
+    const requesterUserId = 'requester-only-in-progress-delete-test';
+    const volunteerId = 'volunteer-only-in-progress-delete-test';
+    const requestId = 'request-only-in-progress-delete-test';
+    const assignmentId = 'assignment-only-in-progress-delete-test';
+
+    await query(
+      `INSERT INTO users (user_id, email, password_hash, is_email_verified, accepted_terms)
+       VALUES ($1, $2, $3, TRUE, TRUE)`,
+      [requesterUserId, 'requester-only-in-progress-delete-test@example.com', 'hashed-password'],
+    );
+    await query(
+      `INSERT INTO volunteers (
+         volunteer_id, user_id, is_available, skills, need_types, last_known_latitude,
+         last_known_longitude, location_updated_at, available_until, availability_confirmed_at
+       )
+       VALUES ($1, $2, TRUE, ARRAY['shelter'], ARRAY['shelter'], 41.02, 29.02,
+         CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '1 hour', CURRENT_TIMESTAMP)`,
+      [volunteerId, deletingUserId],
+    );
+    await query(
+      `INSERT INTO help_requests (
+         request_id, user_id, help_types, affected_people_count, need_type,
+         contact_full_name, contact_phone, consent_given, status
+       )
+       VALUES ($1, $2, ARRAY['shelter'], 1, 'shelter', 'Requester', 5000000002, TRUE, 'IN_PROGRESS')`,
+      [requestId, requesterUserId],
+    );
+    await query(
+      `INSERT INTO assignments (assignment_id, volunteer_id, request_id)
+       VALUES ($1, $2, $3)`,
+      [assignmentId, volunteerId, requestId],
+    );
+
+    const res = await request(app)
+      .delete('/api/auth/me')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+
+    const cancelledAssignment = await query(
+      `SELECT is_cancelled FROM assignments WHERE assignment_id = $1`,
+      [assignmentId],
+    );
+    expect(cancelledAssignment.rows[0].is_cancelled).toBe(true);
+
+    const activeAssignmentsForRequest = await query(
+      `SELECT COUNT(*)::int AS count FROM assignments WHERE request_id = $1 AND is_cancelled = FALSE`,
+      [requestId],
+    );
+    expect(activeAssignmentsForRequest.rows[0].count).toBe(0);
+
+    const requestStatus = await query(
+      `SELECT status FROM help_requests WHERE request_id = $1`,
+      [requestId],
+    );
+    expect(requestStatus.rows[0].status).toBe('PENDING');
+  });
 });
 
 // ─── GET /api/auth/verify-email ──────────────────────────────────────────────

--- a/backend/tests/integration/modules/availability/availability.integration.test.js
+++ b/backend/tests/integration/modules/availability/availability.integration.test.js
@@ -913,7 +913,7 @@ describe('Availability integration', () => {
     expect(requestStatus.rows[0].status).toBe('IN_PROGRESS');
   });
 
-  test('POST /api/availability/toggle to false preserves IN_PROGRESS while cancelling assignment', async () => {
+  test('POST /api/availability/toggle to false reopens IN_PROGRESS when no active assignments remain', async () => {
     const app = createTestApp();
     const volunteerUserId = 'user_v_in_progress_preserve';
     const requesterUserId = 'user_r_in_progress_preserve';
@@ -949,7 +949,7 @@ describe('Availability integration', () => {
     expect(assignmentRows.rows).toHaveLength(0);
 
     const requestStatus = await query('SELECT status FROM help_requests WHERE request_id = $1', ['req_in_progress_preserve']);
-    expect(requestStatus.rows[0].status).toBe('IN_PROGRESS');
+    expect(requestStatus.rows[0].status).toBe('PENDING');
   });
 
   test('minimum first coverage happens before SAR expansion across simultaneous requests', async () => {

--- a/backend/tests/unit/modules/auth/controller.test.js
+++ b/backend/tests/unit/modules/auth/controller.test.js
@@ -15,6 +15,7 @@ const {
   forgotPassword,
   resetPasswordHandler,
   logout,
+  deleteMe,
 } = require('../../../../src/modules/auth/controller');
 
 const {
@@ -26,6 +27,7 @@ const {
   requestPasswordReset,
   resetPassword,
   logoutUser,
+  deleteCurrentUser,
 } = require('../../../../src/modules/auth/service');
 
 const {
@@ -451,5 +453,56 @@ describe('logout', () => {
     await logout(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+// ─── deleteMe ────────────────────────────────────────────────────────────────
+
+describe('deleteMe', () => {
+  test('200 - soft-deletes current user', async () => {
+    deleteCurrentUser.mockResolvedValue({
+      message: 'Account deleted successfully.',
+      deleted: true,
+    });
+    const req = { user: { userId: 'uuid-1' } };
+    const res = mockRes();
+
+    await deleteMe(req, res);
+
+    expect(deleteCurrentUser).toHaveBeenCalledWith('uuid-1');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ deleted: true }));
+  });
+
+  test('404 - user not found', async () => {
+    const error = new Error('User not found');
+    error.code = 'USER_NOT_FOUND';
+    deleteCurrentUser.mockRejectedValue(error);
+    const req = { user: { userId: 'uuid-1' } };
+    const res = mockRes();
+
+    await deleteMe(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'USER_NOT_FOUND',
+      }),
+    );
+  });
+
+  test('500 - internal error', async () => {
+    deleteCurrentUser.mockRejectedValue(new Error('unexpected'));
+    const req = { user: { userId: 'uuid-1' } };
+    const res = mockRes();
+
+    await deleteMe(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'INTERNAL_ERROR',
+      }),
+    );
   });
 });

--- a/backend/tests/unit/modules/auth/routes.rate-limit.test.js
+++ b/backend/tests/unit/modules/auth/routes.rate-limit.test.js
@@ -16,6 +16,7 @@ function loadAuthRouteExportsWithLimiterEnabled() {
     forgotPassword: (_req, res) => res.status(200).json({ ok: true }),
     resetPasswordHandler: (_req, res) => res.status(200).json({ ok: true }),
     logout: (_req, res) => res.status(200).json({ ok: true }),
+    deleteMe: (_req, res) => res.status(200).json({ ok: true }),
   }));
   jest.doMock('../../../../src/modules/admin/routes', () => {
     const mockExpress = require('express');

--- a/backend/tests/unit/modules/auth/service.test.js
+++ b/backend/tests/unit/modules/auth/service.test.js
@@ -17,6 +17,7 @@ const {
   requestPasswordReset,
   resetPassword,
   logoutUser,
+  deleteCurrentUser,
 } = require('../../../../src/modules/auth/service');
 
 const {
@@ -26,6 +27,7 @@ const {
   findUserById,
   findAdminByUserId,
   updateUserPassword,
+  softDeleteUserAccount,
 } = require('../../../../src/modules/auth/repository');
 
 const {
@@ -380,5 +382,32 @@ describe('logoutUser', () => {
   test('returns success message', async () => {
     const result = await logoutUser();
     expect(result.message).toBeDefined();
+  });
+});
+
+// ─── deleteCurrentUser ───────────────────────────────────────────────────────
+
+describe('deleteCurrentUser', () => {
+  test('soft-deletes the current user', async () => {
+    softDeleteUserAccount.mockResolvedValue({
+      userId: 'uuid-1',
+      cancelledRequestCount: 1,
+      cancelledAssignmentRequestCount: 1,
+      availabilityCancelled: true,
+    });
+
+    const result = await deleteCurrentUser('uuid-1');
+
+    expect(softDeleteUserAccount).toHaveBeenCalledWith('uuid-1');
+    expect(result.deleted).toBe(true);
+    expect(result.availabilityCancelled).toBe(true);
+  });
+
+  test('throws USER_NOT_FOUND when account is already deleted', async () => {
+    softDeleteUserAccount.mockResolvedValue(null);
+
+    await expect(deleteCurrentUser('uuid-1')).rejects.toMatchObject({
+      code: 'USER_NOT_FOUND',
+    });
   });
 });

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -11,6 +11,7 @@ import { TextArea } from "@/components/ui/inputs/TextArea";
 import { ToggleSwitch } from "@/components/ui/selection/ToggleSwitch";
 import { Checkbox } from "@/components/ui/selection/Checkbox";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
 import { HelperText } from "@/components/ui/display/HelperText";
 import {
     LocationPicker,
@@ -20,7 +21,12 @@ import {
 import { bloodTypeOptions } from "@/lib/bloodTypes";
 import { countryCodeOptions } from "@/lib/countryCodes";
 import { expertiseOptions, professionOptions } from "@/lib/profileOptions";
-import { clearAccessToken, fetchCurrentUser, getAccessToken } from "@/lib/auth";
+import {
+    clearAccessToken,
+    deleteCurrentAccount,
+    fetchCurrentUser,
+    getAccessToken,
+} from "@/lib/auth";
 import { ApiError } from "@/lib/api";
 import { fetchLocationTree, searchLocations } from "@/lib/location";
 import {
@@ -126,6 +132,8 @@ export default function ProfileView() {
         React.useState<LocationPickerValue | null>(null);
     const [loading, setLoading] = React.useState(true);
     const [saving, setSaving] = React.useState(false);
+    const [deleteModalOpen, setDeleteModalOpen] = React.useState(false);
+    const [deletingAccount, setDeletingAccount] = React.useState(false);
     const [error, setError] = React.useState("");
     const [info, setInfo] = React.useState("");
     const [initialShareLocation, setInitialShareLocation] =
@@ -647,6 +655,41 @@ export default function ProfileView() {
         }
     };
 
+    const handleDeleteAccount = async () => {
+        const token = getAccessToken();
+
+        if (!token) {
+            clearAccessToken();
+            router.replace("/login");
+            return;
+        }
+
+        try {
+            setDeletingAccount(true);
+            setError("");
+            setInfo("");
+
+            await deleteCurrentAccount(token);
+            clearAccessToken();
+            router.replace("/");
+        } catch (err) {
+            if (err instanceof ApiError && err.status === 401) {
+                clearAccessToken();
+                router.replace("/login");
+                return;
+            }
+
+            setError(
+                err instanceof Error && err.message
+                    ? err.message
+                    : "Could not delete your account. Please try again."
+            );
+            setDeleteModalOpen(false);
+        } finally {
+            setDeletingAccount(false);
+        }
+    };
+
     if (loading) {
         return <p className="text-sm text-gray-500">Loading...</p>;
     }
@@ -724,6 +767,38 @@ export default function ProfileView() {
 
     return (
         <div className="flex gap-10">
+            {deleteModalOpen ? (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+                    <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+                        <h3 className="text-lg font-semibold text-gray-900">
+                            Delete account?
+                        </h3>
+                        <p className="mt-3 text-sm leading-6 text-gray-600">
+                            This will soft-delete your account, remove personal profile
+                            data, cancel your active help requests, and turn off active
+                            volunteer availability. This action cannot be undone.
+                        </p>
+                        <div className="mt-6 flex gap-3">
+                            <SecondaryButton
+                                type="button"
+                                onClick={() => setDeleteModalOpen(false)}
+                                disabled={deletingAccount}
+                                className="border-gray-300 text-gray-700 hover:bg-gray-50"
+                            >
+                                Keep Account
+                            </SecondaryButton>
+                            <PrimaryButton
+                                type="button"
+                                onClick={handleDeleteAccount}
+                                loading={deletingAccount}
+                            >
+                                Delete Account
+                            </PrimaryButton>
+                        </div>
+                    </div>
+                </div>
+            ) : null}
+
             <div className="flex w-64 flex-col items-center gap-4">
                 <Avatar size="lg" />
                 <div className="text-center">
@@ -1156,6 +1231,24 @@ export default function ProfileView() {
                         Save Changes
                     </PrimaryButton>
                 </div>
+
+                <SectionCard>
+                    <SectionHeader title="Delete Account" />
+                    <p className="mb-4 text-sm text-gray-500">
+                        Permanently remove personal account data from your profile and
+                        cancel active emergency participation before disabling login.
+                    </p>
+                    <SecondaryButton
+                        type="button"
+                        onClick={() => {
+                            setError("");
+                            setInfo("");
+                            setDeleteModalOpen(true);
+                        }}
+                    >
+                        Delete Account
+                    </SecondaryButton>
+                </SectionCard>
             </div>
         </div>
     );

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -44,6 +44,14 @@ type ResetPasswordResponse = {
 
 type CurrentUserResponse = AuthUser;
 
+type DeleteAccountResponse = {
+    message: string;
+    deleted: boolean;
+    cancelledRequestCount: number;
+    cancelledAssignmentRequestCount: number;
+    availabilityCancelled: boolean;
+};
+
 type SetAccessTokenOptions = {
     rememberMe?: boolean;
 };
@@ -163,6 +171,13 @@ export async function resetPassword(payload: {
 
 export async function fetchCurrentUser(token: string) {
     return apiRequest<CurrentUserResponse>("/auth/me", {
+        token: token.trim(),
+    });
+}
+
+export async function deleteCurrentAccount(token: string) {
+    return apiRequest<DeleteAccountResponse>("/auth/me", {
+        method: "DELETE",
         token: token.trim(),
     });
 }


### PR DESCRIPTION
- This PR adds account soft-delete via DELETE /api/auth/me, anonymizing personal data and cancelling active help requests, assignments, and volunteer availability. Adds web and Android Delete Account confirmation flows with backend/unit/integration coverage.

Resolves #411