### PR TITLE
fix: Android Privacy & Security nested scroll crash

### DIFF
--- a/android/app/src/androidTest/java/com/neph/e2e/AuthenticatedSessionAndroidE2ETest.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/AuthenticatedSessionAndroidE2ETest.kt
@@ -71,7 +71,7 @@ class AuthenticatedSessionAndroidE2ETest {
     }
 
     @Test
-    fun authenticatedUser_can_openPrivacySecurity_and_logout() {
+    fun authenticatedUser_can_openPrivacySecurityFromSettings_and_logout() {
         waitForText("I need help")
         composeRule.onNodeWithText("I need help").assertIsDisplayed()
 
@@ -79,8 +79,9 @@ class AuthenticatedSessionAndroidE2ETest {
         waitForClickable("Privacy & Security")
         clickableNode("Privacy & Security").performClick()
 
-        waitForText("Configure privacy safely from your profile flow.")
-        composeRule.onNodeWithText("Configure privacy safely from your profile flow.").assertIsDisplayed()
+        waitForText("Profile visibility")
+        composeRule.onNodeWithText("Profile visibility").assertIsDisplayed()
+        composeRule.onNodeWithText("Save Privacy Settings").assertIsDisplayed()
 
         composeRule.activity.runOnUiThread {
             composeRule.activity.onBackPressedDispatcher.onBackPressed()

--- a/android/app/src/main/java/com/neph/features/privacysecurity/presentation/PrivacySecurityScreen.kt
+++ b/android/app/src/main/java/com/neph/features/privacysecurity/presentation/PrivacySecurityScreen.kt
@@ -3,8 +3,6 @@ package com.neph.features.privacysecurity.presentation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -133,9 +131,7 @@ fun PrivacySecurityScreen(
             HelperText(text = "Loading privacy settings...")
         } else {
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState()),
+                modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(spacing.lg)
             ) {
                 SectionCard {


### PR DESCRIPTION
### Description

Fixes [#448](https://github.com/bounswe/bounswe2026group6/issues/448).

### Changes

- Removed the inner verticalScroll from PrivacySecurityScreen.
- Kept AppScaffold as the single vertical scroll owner for the screen.
- Updated the Android E2E regression path to verify Settings → Privacy & Security opens and renders real screen content.

### Verification

- ./gradlew :app:compileE2eKotlin
- ./gradlew :app:compileE2eAndroidTestKotlin