### PR TITLE
Fix Android lifecycle timestamp timezone display

### DIFF
--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestLifecycleFormatting.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestLifecycleFormatting.kt
@@ -3,7 +3,10 @@ package com.neph.features.requesthelp.data
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 internal fun formatOperationalLevel(value: String?): String? {
     return value
@@ -17,12 +20,32 @@ internal fun formatOperationalLevel(value: String?): String? {
 }
 
 internal fun formatLifecycleTimestamp(raw: String?): String? {
-    return raw
+    val value = raw
         ?.trim()
         ?.takeIf { it.isNotBlank() }
-        ?.replace('T', ' ')
-        ?.substringBefore('.')
-        ?.substringBefore('Z')
+        ?: return null
+
+    val instant = parseTimestampToInstant(value)
+        ?: return value
+            .replace('T', ' ')
+            .substringBefore('.')
+            .substringBefore('Z')
+
+    return LifecycleDisplayFormatter
+        .withZone(ZoneId.systemDefault())
+        .format(instant)
+}
+
+private val LifecycleDisplayFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.US)
+
+private fun parseTimestampToInstant(raw: String): Instant? {
+    val value = raw.trim().takeIf { it.isNotBlank() } ?: return null
+
+    return runCatching { Instant.parse(value) }
+        .recoverCatching { OffsetDateTime.parse(value).toInstant() }
+        .recoverCatching { LocalDateTime.parse(value.replace(' ', 'T')).toInstant(ZoneOffset.UTC) }
+        .getOrNull()
 }
 
 internal fun buildDurationLabel(
@@ -59,8 +82,5 @@ private fun formatDurationMinutes(totalMinutes: Long): String {
 private fun parseTimestampToEpochMillis(raw: String?): Long? {
     val value = raw?.trim()?.takeIf { it.isNotBlank() } ?: return null
 
-    return runCatching { Instant.parse(value).toEpochMilli() }
-        .recoverCatching { OffsetDateTime.parse(value).toInstant().toEpochMilli() }
-        .recoverCatching { LocalDateTime.parse(value.replace(' ', 'T')).toInstant(ZoneOffset.UTC).toEpochMilli() }
-        .getOrNull()
+    return parseTimestampToInstant(value)?.toEpochMilli()
 }

--- a/android/app/src/test/java/com/neph/features/assignedrequest/data/AssignedRequestRepositoryMappingTest.kt
+++ b/android/app/src/test/java/com/neph/features/assignedrequest/data/AssignedRequestRepositoryMappingTest.kt
@@ -1,11 +1,27 @@
 package com.neph.features.assignedrequest.data
 
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 import org.json.JSONArray
 import org.json.JSONObject
+import java.util.TimeZone
 
 class AssignedRequestRepositoryMappingTest {
+    private lateinit var previousTimeZone: TimeZone
+
+    @Before
+    fun setUp() {
+        previousTimeZone = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+    }
+
+    @After
+    fun tearDown() {
+        TimeZone.setDefault(previousTimeZone)
+    }
+
     @Test
     fun mapAssignmentIncludesUrgencyPriorityAndAgingLabels() {
         val assignment = JSONObject().apply {

--- a/android/app/src/test/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepositoryMappingTest.kt
+++ b/android/app/src/test/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepositoryMappingTest.kt
@@ -3,13 +3,29 @@ package com.neph.features.myhelprequests.data
 import com.neph.core.database.HelpRequestEntity
 import com.neph.core.sync.LocalOwnerType
 import com.neph.core.sync.SyncStatus
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
+import java.util.TimeZone
 
 class MyHelpRequestsRepositoryMappingTest {
+    private lateinit var previousTimeZone: TimeZone
+
+    @Before
+    fun setUp() {
+        previousTimeZone = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+    }
+
+    @After
+    fun tearDown() {
+        TimeZone.setDefault(previousTimeZone)
+    }
+
     @Test
     fun toUiModelIncludesLifecycleOperationalLabelsForClosedRequests() {
         val model = HelpRequestEntity(

--- a/android/app/src/test/java/com/neph/features/requesthelp/data/RequestLifecycleFormattingTest.kt
+++ b/android/app/src/test/java/com/neph/features/requesthelp/data/RequestLifecycleFormattingTest.kt
@@ -1,0 +1,37 @@
+package com.neph.features.requesthelp.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.TimeZone
+
+class RequestLifecycleFormattingTest {
+    @Test
+    fun formatLifecycleTimestampUsesDeviceTimezoneForUtcInput() {
+        withDefaultTimeZone("Europe/Istanbul") {
+            assertEquals(
+                "2026-04-26 13:00:00",
+                formatLifecycleTimestamp("2026-04-26T10:00:00.000Z")
+            )
+        }
+    }
+
+    @Test
+    fun formatLifecycleTimestampUsesDeviceTimezoneForOffsetInput() {
+        withDefaultTimeZone("Europe/Istanbul") {
+            assertEquals(
+                "2026-04-26 13:00:00",
+                formatLifecycleTimestamp("2026-04-26T12:00:00+02:00")
+            )
+        }
+    }
+
+    private fun withDefaultTimeZone(id: String, block: () -> Unit) {
+        val previous = TimeZone.getDefault()
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone(id))
+            block()
+        } finally {
+            TimeZone.setDefault(previous)
+        }
+    }
+}


### PR DESCRIPTION
**Closes**

- Closes #405

**Summary**

Fixes Android lifecycle timestamp display so backend UTC timestamps are shown in the device's local timezone instead of appearing as GMT+0.

**Changes**

- Parses lifecycle timestamps as instants before formatting.
- Displays request lifecycle times using the phone's local timezone.
- Covers guest online refresh flows where server timestamps replace local offline timestamps.
- Adds timezone-focused unit tests.
- Keeps existing mapping tests deterministic by pinning their timezone.
