### PR TITLE
feat: add multi-select request type filters to Help Request Map to mobile

### DIFF
--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -61,6 +63,36 @@ import com.neph.ui.theme.NephTheme
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
+private val RequestTypeFilterOrder = listOf(
+    CrisisRequestType.FIRST_AID,
+    CrisisRequestType.SHELTER,
+    CrisisRequestType.FOOD_WATER,
+    CrisisRequestType.SEARCH_AND_RESCUE,
+    CrisisRequestType.OTHER
+)
+
+internal fun filterVisibleRequests(
+    requests: List<ActiveHelpRequestMapItem>,
+    selectedTypes: Set<CrisisRequestType>
+): List<ActiveHelpRequestMapItem> {
+    if (selectedTypes.isEmpty()) {
+        return requests
+    }
+    return requests.filter { it.type in selectedTypes }
+}
+
+internal fun reconcileSelectedRequestId(
+    selectedRequestId: String?,
+    visibleRequests: List<ActiveHelpRequestMapItem>
+): String? {
+    if (selectedRequestId == null) {
+        return null
+    }
+    return selectedRequestId.takeIf { selected ->
+        visibleRequests.any { it.requestId == selected }
+    }
+}
+
 @Composable
 fun HelpRequestMapScreen(
     onNavigateToRoute: (String) -> Unit,
@@ -78,6 +110,7 @@ fun HelpRequestMapScreen(
     var infoMessage by remember { mutableStateOf("") }
     var requests by remember { mutableStateOf(emptyList<ActiveHelpRequestMapItem>()) }
     var selectedRequestId by remember { mutableStateOf<String?>(null) }
+    var selectedTypes by remember { mutableStateOf(setOf<CrisisRequestType>()) }
 
     fun loadWaitingRequests() {
         scope.launch {
@@ -133,7 +166,14 @@ fun HelpRequestMapScreen(
         loadWaitingRequests()
     }
 
-    val selectedRequest = requests.firstOrNull { it.requestId == selectedRequestId } ?: requests.firstOrNull()
+    val visibleRequests = filterVisibleRequests(requests, selectedTypes)
+
+    LaunchedEffect(visibleRequests, selectedRequestId) {
+        selectedRequestId = reconcileSelectedRequestId(selectedRequestId, visibleRequests)
+    }
+
+    val selectedRequest = visibleRequests.firstOrNull { it.requestId == selectedRequestId } ?: visibleRequests.firstOrNull()
+    val isFilterEmpty = !loading && requests.isNotEmpty() && visibleRequests.isEmpty()
 
     AppDrawerScaffold(
         title = "Help Request Map",
@@ -204,8 +244,22 @@ fun HelpRequestMapScreen(
 
                 else -> {
                     SectionCard {
+                        RequestTypeFiltersCard(
+                            selectedTypes = selectedTypes,
+                            onToggleType = { type ->
+                                selectedTypes = if (type in selectedTypes) {
+                                    selectedTypes - type
+                                } else {
+                                    selectedTypes + type
+                                }
+                            },
+                            onClear = { selectedTypes = emptySet() }
+                        )
+                    }
+
+                    SectionCard {
                         CrisisRequestMapPanel(
-                            requests = requests,
+                            requests = visibleRequests,
                             selectedRequestId = selectedRequest?.requestId,
                             onSelectRequest = { selectedRequestId = it }
                         )
@@ -238,7 +292,11 @@ fun HelpRequestMapScreen(
                                 fontWeight = FontWeight.SemiBold
                             )
 
-                            requests.forEachIndexed { index, item ->
+                            if (visibleRequests.isEmpty()) {
+                                HelperText(text = "No waiting requests in view.")
+                            }
+
+                            visibleRequests.forEachIndexed { index, item ->
                                 RequestListItem(
                                     item = item,
                                     selected = item.requestId == selectedRequest?.requestId,
@@ -246,7 +304,7 @@ fun HelpRequestMapScreen(
                                     onOpenMap = { openRequestInMap(item) }
                                 )
 
-                                if (index < requests.lastIndex) {
+                                if (index < visibleRequests.lastIndex) {
                                     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                                 }
                             }
@@ -255,9 +313,109 @@ fun HelpRequestMapScreen(
                 }
             }
 
+            if (isFilterEmpty) {
+                SectionCard {
+                    HelperText(text = "No help requests match the selected request type filters.")
+                }
+            }
+
             if (infoMessage.isNotBlank()) {
                 SectionCard {
                     HelperText(text = infoMessage)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RequestTypeFiltersCard(
+    selectedTypes: Set<CrisisRequestType>,
+    onToggleType: (CrisisRequestType) -> Unit,
+    onClear: () -> Unit
+) {
+    val spacing = LocalNephSpacing.current
+
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Filter by Request Type",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold
+            )
+            TextActionButton(
+                text = "Clear",
+                enabled = selectedTypes.isNotEmpty(),
+                onClick = onClear
+            )
+        }
+
+        androidx.compose.foundation.layout.FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm)
+        ) {
+            RequestTypeFilterOrder.forEach { type ->
+                val style = markerStyle(type)
+                val selected = type in selectedTypes
+                FilterChip(
+                    selected = selected,
+                    onClick = { onToggleType(type) },
+                    label = {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(10.dp)
+                                    .clip(RoundedCornerShape(999.dp))
+                                    .background(style.color)
+                            )
+                            Text(text = ActiveHelpRequestsRepository.labelForType(type))
+                        }
+                    },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                )
+            }
+        }
+
+        Text(
+            text = "Legend",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.SemiBold
+        )
+        androidx.compose.foundation.layout.FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(spacing.md),
+            verticalArrangement = Arrangement.spacedBy(spacing.sm)
+        ) {
+            RequestTypeFilterOrder.forEach { type ->
+                val style = markerStyle(type)
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(10.dp)
+                            .clip(RoundedCornerShape(999.dp))
+                            .background(style.color)
+                    )
+                    Text(
+                        text = ActiveHelpRequestsRepository.labelForType(type),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
             }
         }

--- a/android/app/src/test/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreenFilterLogicTest.kt
+++ b/android/app/src/test/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreenFilterLogicTest.kt
@@ -1,0 +1,83 @@
+package com.neph.features.helprequestmap.presentation
+
+import com.neph.features.helprequestmap.data.ActiveHelpRequestMapItem
+import com.neph.features.helprequestmap.data.CrisisRequestType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HelpRequestMapScreenFilterLogicTest {
+    private val firstAid = request(
+        requestId = "req-first-aid",
+        type = CrisisRequestType.FIRST_AID,
+        typeLabel = "First Aid"
+    )
+    private val shelter = request(
+        requestId = "req-shelter",
+        type = CrisisRequestType.SHELTER,
+        typeLabel = "Shelter"
+    )
+    private val foodWater = request(
+        requestId = "req-food",
+        type = CrisisRequestType.FOOD_WATER,
+        typeLabel = "Food / Water Supplies"
+    )
+
+    @Test
+    fun filterVisibleRequests_whenNoTypeSelected_returnsAllRequests() {
+        val requests = listOf(firstAid, shelter, foodWater)
+
+        val visible = filterVisibleRequests(requests, emptySet())
+
+        assertEquals(requests.map { it.requestId }, visible.map { it.requestId })
+    }
+
+    @Test
+    fun filterVisibleRequests_whenMultipleTypesSelected_returnsMatchingUnion() {
+        val requests = listOf(firstAid, shelter, foodWater)
+
+        val visible = filterVisibleRequests(
+            requests = requests,
+            selectedTypes = setOf(CrisisRequestType.SHELTER, CrisisRequestType.FOOD_WATER)
+        )
+
+        assertEquals(listOf("req-shelter", "req-food"), visible.map { it.requestId })
+    }
+
+    @Test
+    fun reconcileSelectedRequestId_whenSelectedItemFilteredOut_returnsNull() {
+        val visible = listOf(shelter, foodWater)
+
+        val selected = reconcileSelectedRequestId("req-first-aid", visible)
+
+        assertNull(selected)
+    }
+
+    @Test
+    fun reconcileSelectedRequestId_whenSelectedItemStillVisible_keepsSelection() {
+        val visible = listOf(shelter, foodWater)
+
+        val selected = reconcileSelectedRequestId("req-shelter", visible)
+
+        assertEquals("req-shelter", selected)
+    }
+
+    private fun request(
+        requestId: String,
+        type: CrisisRequestType,
+        typeLabel: String
+    ): ActiveHelpRequestMapItem {
+        return ActiveHelpRequestMapItem(
+            requestId = requestId,
+            rawType = type.name.lowercase(),
+            type = type,
+            typeLabel = typeLabel,
+            priorityLevel = "MEDIUM",
+            createdAt = "2026-05-01T10:00:00.000Z",
+            latitude = 41.0,
+            longitude = 29.0,
+            city = "istanbul",
+            district = "sisli"
+        )
+    }
+}


### PR DESCRIPTION
This PR implements the Android scope of issue #476 for the active Help Request Map by adding request-type-based multi-select filtering while preserving existing marker/list/detail behavior.

### What’s Included
- Added multi-select request type filters on Android Help Request Map
- Added clear/reset action to restore default “show all” visibility
- Added request-type legend aligned with marker colors
- Applied filtering to visible map markers and waiting request list only
- Preserved existing marker styling and selected marker visibility
- Kept request type text visible in selected detail/list (not color-only UX)
- Added filter-empty state message when no request matches selected filters
- Cleared selected request when filter changes hide that selected request

### Canonical Request Types Used
- `FIRST_AID`
- `SHELTER`
- `FOOD_WATER`
- `SEARCH_AND_RESCUE`
- `OTHER`

### Scope and Safety
- No backend assignment/matching/ownership/status logic changed
- No API redesign introduced
- Existing loading/error/refresh behavior preserved

### Tests Added
- Added unit tests for filter/selection behavior:
  - `filterVisibleRequests` returns all when no filter is selected
  - multi-select returns union of selected request types
  - selected request is cleared when filtered out
  - selected request is preserved when still visible

### Files Changed
- `android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt`
- `android/app/src/test/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreenFilterLogicTest.kt`

Closes #476 