### PR TITLE
fix: restore mobile map loading and gathering areas map

### DIFF
--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.neph.core.network.ApiException
 import com.neph.features.gatheringareas.data.GatheringAreaItem
 import com.neph.features.gatheringareas.data.GatheringAreasRepository
@@ -35,6 +36,8 @@ import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
 import com.neph.ui.layout.AppDrawerScaffold
 import com.neph.ui.location.rememberForegroundLocationPermissionRequester
+import com.neph.ui.map.LeafletMapMarker
+import com.neph.ui.map.LeafletMarkerMap
 import com.neph.ui.map.NephMapIntegration
 import com.neph.ui.map.formatMapCoordinate
 import com.neph.ui.theme.LocalNephSpacing
@@ -68,6 +71,7 @@ fun GatheringAreasScreen(
     var lastCenterLongitude by remember { mutableStateOf<Double?>(null) }
     var lastSearchOrigin by remember { mutableStateOf<GatheringAreasSearchOrigin?>(null) }
     var nearbyResult by remember { mutableStateOf<NearbyGatheringAreasResult?>(null) }
+    var selectedAreaId by remember { mutableStateOf<String?>(null) }
     val hasSearchCenter = lastCenterLatitude != null && lastCenterLongitude != null
 
     fun fetchGatheringAreas(
@@ -96,6 +100,7 @@ fun GatheringAreasScreen(
                 sourceLabel = normalizedLabel
                 lastCenterLatitude = result.centerLatitude
                 lastCenterLongitude = result.centerLongitude
+                selectedAreaId = result.areas.firstOrNull()?.id
 
                 if (result.areas.isEmpty()) {
                     infoMessage = "No gathering areas were found in this area."
@@ -279,6 +284,15 @@ fun GatheringAreasScreen(
                 }
 
                 nearbyResult?.areas?.isEmpty() == true -> {
+                    val result = nearbyResult ?: return@AppDrawerScaffold
+
+                    GatheringAreasMapCard(
+                        result = result,
+                        selectedAreaId = null,
+                        onAreaSelected = { selectedAreaId = it },
+                        onOpenAreaInMap = ::openAreaInMap
+                    )
+
                     SectionCard {
                         Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
                             SectionHeader(
@@ -304,6 +318,8 @@ fun GatheringAreasScreen(
 
                 else -> {
                     val result = nearbyResult ?: return@AppDrawerScaffold
+                    val selectedArea = result.areas.firstOrNull { it.id == selectedAreaId }
+                        ?: result.areas.firstOrNull()
 
                     SectionCard {
                         Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
@@ -325,6 +341,13 @@ fun GatheringAreasScreen(
                             }
                         }
                     }
+
+                    GatheringAreasMapCard(
+                        result = result,
+                        selectedAreaId = selectedArea?.id,
+                        onAreaSelected = { selectedAreaId = it },
+                        onOpenAreaInMap = ::openAreaInMap
+                    )
 
                     result.areas.forEachIndexed { index, area ->
                         SectionCard {
@@ -361,6 +384,10 @@ fun GatheringAreasScreen(
                                     )
                                 }
 
+                                if (area.id == selectedArea?.id) {
+                                    HelperText(text = "Selected on map.")
+                                }
+
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
                                     horizontalArrangement = Arrangement.End
@@ -386,6 +413,125 @@ fun GatheringAreasScreen(
                     HelperText(text = infoMessage)
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun GatheringAreasMapCard(
+    result: NearbyGatheringAreasResult,
+    selectedAreaId: String?,
+    onAreaSelected: (String) -> Unit,
+    onOpenAreaInMap: (GatheringAreaItem) -> Unit
+) {
+    val spacing = LocalNephSpacing.current
+    var mapReady by remember(result.centerLatitude, result.centerLongitude, result.areas, selectedAreaId) {
+        mutableStateOf(false)
+    }
+    var mapError by remember(result.centerLatitude, result.centerLongitude, result.areas, selectedAreaId) {
+        mutableStateOf("")
+    }
+    val selectedArea = result.areas.firstOrNull { it.id == selectedAreaId }
+    val markers = result.areas.map { area ->
+        LeafletMapMarker(
+            id = area.id,
+            latitude = area.latitude,
+            longitude = area.longitude,
+            title = area.name.ifBlank { "Unnamed Gathering Area" },
+            subtitle = "${formatCategory(area.category)} • ${formatDistance(area.distanceMeters)}"
+        )
+    }
+
+    SectionCard {
+        Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+            SectionHeader(
+                title = "Gathering Areas Map",
+                subtitle = if (markers.isEmpty()) {
+                    "Showing the searched area. No gathering area markers were returned."
+                } else {
+                    "Tap a marker to preview that gathering area."
+                }
+            )
+
+            LeafletMarkerMap(
+                centerLatitude = result.centerLatitude,
+                centerLongitude = result.centerLongitude,
+                markers = markers,
+                selectedMarkerId = selectedAreaId,
+                onMarkerSelected = onAreaSelected,
+                onMapReady = { mapReady = true },
+                onMapError = { message ->
+                    mapError = message.ifBlank { "Map failed to load. Check your connection and try again." }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(280.dp)
+            )
+
+            if (!mapReady && mapError.isBlank()) {
+                HelperText(text = "Loading map...")
+            }
+
+            if (mapError.isNotBlank()) {
+                HelperText(text = mapError)
+            }
+
+            if (markers.isEmpty()) {
+                HelperText(
+                    text = "No gathering area markers are available for this search center."
+                )
+            }
+
+            selectedArea?.let { area ->
+                GatheringAreaMapSelectionPreview(
+                    area = area,
+                    onOpenAreaInMap = onOpenAreaInMap
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GatheringAreaMapSelectionPreview(
+    area: GatheringAreaItem,
+    onOpenAreaInMap: (GatheringAreaItem) -> Unit
+) {
+    val spacing = LocalNephSpacing.current
+
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        Text(
+            text = area.name.ifBlank { "Unnamed Gathering Area" },
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.SemiBold
+        )
+        Text(
+            text = "Category: ${formatCategory(area.category)}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = "Distance: ${formatDistance(area.distanceMeters)}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        val address = area.addressLine?.takeIf { it.isNotBlank() }
+        Text(
+            text = address ?: "Coordinates: ${formatMapCoordinate(area.latitude)}, ${formatMapCoordinate(area.longitude)}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+        ) {
+            TextActionButton(
+                text = "Open in Map",
+                onClick = { onOpenAreaInMap(area) }
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
+++ b/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
@@ -1,0 +1,332 @@
+package com.neph.ui.map
+
+import android.annotation.SuppressLint
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.webkit.JavascriptInterface
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.ByteArrayInputStream
+import java.util.Locale
+
+data class LeafletMapMarker(
+    val id: String,
+    val latitude: Double,
+    val longitude: Double,
+    val title: String,
+    val subtitle: String = ""
+)
+
+private const val LeafletMarkerMapBridgeName = "AndroidLeafletMarkerMap"
+private const val LeafletMapBaseUrl = "https://neph.app/android-map/"
+internal const val LeafletCssUrl = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+internal const val LeafletJsUrl = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+private const val LeafletAssetOrigin = "https://unpkg.com"
+private val AllowedOpenStreetMapTileHosts = setOf(
+    "tile.openstreetmap.org",
+    "a.tile.openstreetmap.org",
+    "b.tile.openstreetmap.org",
+    "c.tile.openstreetmap.org"
+)
+private val OpenStreetMapTilePathPattern = Regex("""^/\d+/\d+/\d+\.png$""")
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+internal fun LeafletMapWebView(
+    html: String,
+    bridgeName: String,
+    bridge: Any,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+
+    key(html) {
+        AndroidView(
+            factory = {
+                WebView(context).apply {
+                    settings.javaScriptEnabled = true
+                    settings.domStorageEnabled = false
+                    settings.useWideViewPort = true
+                    settings.loadWithOverviewMode = true
+                    settings.allowFileAccess = false
+                    settings.allowContentAccess = false
+                    settings.javaScriptCanOpenWindowsAutomatically = false
+                    settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+                    webViewClient = LeafletMapWebViewClient()
+                    addJavascriptInterface(bridge, bridgeName)
+                    loadDataWithBaseURL(LeafletMapBaseUrl, html, "text/html", "utf-8", null)
+                }
+            },
+            modifier = modifier
+        )
+    }
+}
+
+@Composable
+fun LeafletMarkerMap(
+    centerLatitude: Double,
+    centerLongitude: Double,
+    markers: List<LeafletMapMarker>,
+    selectedMarkerId: String?,
+    onMarkerSelected: (String) -> Unit,
+    onMapReady: () -> Unit,
+    onMapError: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val latestOnMarkerSelected by rememberUpdatedState(onMarkerSelected)
+    val latestOnMapReady by rememberUpdatedState(onMapReady)
+    val latestOnMapError by rememberUpdatedState(onMapError)
+    val html = remember(centerLatitude, centerLongitude, markers, selectedMarkerId) {
+        buildLeafletMarkerMapHtml(
+            centerLatitude = centerLatitude,
+            centerLongitude = centerLongitude,
+            markers = markers,
+            selectedMarkerId = selectedMarkerId,
+            bridgeName = LeafletMarkerMapBridgeName
+        )
+    }
+    val bridge = remember {
+        LeafletMarkerMapBridge(
+            onMarkerSelected = { latestOnMarkerSelected(it) },
+            onMapReady = { latestOnMapReady() },
+            onMapError = { latestOnMapError(it) }
+        )
+    }
+
+    LeafletMapWebView(
+        html = html,
+        bridgeName = LeafletMarkerMapBridgeName,
+        bridge = bridge,
+        modifier = modifier
+    )
+}
+
+internal fun buildLeafletDocumentHead(): String {
+    return """
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <!-- Keep embedded maps limited to Leaflet assets, OSM tiles, and inline map scripts. -->
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; form-action 'none'; frame-src 'none'; object-src 'none'; style-src 'self' $LeafletAssetOrigin 'unsafe-inline'; script-src $LeafletAssetOrigin 'unsafe-inline'; img-src https://tile.openstreetmap.org https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'none'; font-src 'none'; media-src 'none'; navigate-to 'none'" />
+        <link rel="stylesheet" href="$LeafletCssUrl" />
+        <script src="$LeafletJsUrl"></script>
+        <style>
+            html, body, #map { height: 100%; margin: 0; padding: 0; }
+        </style>
+    """.trimIndent()
+}
+
+internal fun buildLeafletErrorScript(bridgeName: String): String {
+    return """
+        function notifyMapError(message) {
+            if (window.$bridgeName && window.$bridgeName.onMapError) {
+                window.$bridgeName.onMapError(String(message || 'Map failed to load.'));
+            }
+        }
+
+        window.onerror = function(message) {
+            notifyMapError(message);
+        };
+
+        if (!window.L) {
+            notifyMapError('Map library could not be loaded.');
+            throw new Error('Leaflet failed to load.');
+        }
+    """.trimIndent()
+}
+
+internal fun buildLeafletMarkerMapHtml(
+    centerLatitude: Double,
+    centerLongitude: Double,
+    markers: List<LeafletMapMarker>,
+    selectedMarkerId: String?,
+    bridgeName: String,
+    zoom: Int = 13
+): String {
+    val formattedLat = String.format(Locale.US, "%.6f", centerLatitude)
+    val formattedLon = String.format(Locale.US, "%.6f", centerLongitude)
+    val markersJson = JSONArray(
+        markers.map { marker ->
+            JSONObject()
+                .put("id", marker.id)
+                .put("latitude", marker.latitude)
+                .put("longitude", marker.longitude)
+                .put("title", marker.title)
+                .put("subtitle", marker.subtitle)
+        }
+    ).toString()
+    val selectedMarkerJson = selectedMarkerId?.let(JSONObject::quote) ?: "null"
+
+    return """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            ${buildLeafletDocumentHead()}
+        </head>
+        <body>
+            <div id="map"></div>
+            <script>
+                ${buildLeafletErrorScript(bridgeName)}
+
+                var center = [$formattedLat, $formattedLon];
+                var markerData = $markersJson;
+                var selectedMarkerId = $selectedMarkerJson;
+                var map = L.map('map').setView(center, $zoom);
+                var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                    maxZoom: 19,
+                    attribution: '(c) OpenStreetMap'
+                }).addTo(map);
+
+                tiles.on('tileerror', function() {
+                    notifyMapError('Map tiles could not be loaded.');
+                });
+
+                L.circleMarker(center, {
+                    radius: 7,
+                    color: '#2563EB',
+                    weight: 2,
+                    fillColor: '#3B82F6',
+                    fillOpacity: 0.50
+                }).addTo(map).bindTooltip('Search center', { direction: 'top' });
+
+                function escapeHtml(value) {
+                    return String(value || '').replace(/[&<>"']/g, function(character) {
+                        return {
+                            '&': '&amp;',
+                            '<': '&lt;',
+                            '>': '&gt;',
+                            '"': '&quot;',
+                            "'": '&#39;'
+                        }[character];
+                    });
+                }
+
+                var bounds = [center];
+                markerData.forEach(function(marker) {
+                    var selected = marker.id === selectedMarkerId;
+                    var areaMarker = L.circleMarker([marker.latitude, marker.longitude], {
+                        radius: selected ? 11 : 8,
+                        color: selected ? '#7F1D1D' : '#B91C1C',
+                        weight: selected ? 3 : 2,
+                        fillColor: selected ? '#B91C1C' : '#DC2626',
+                        fillOpacity: selected ? 0.95 : 0.82
+                    }).addTo(map);
+                    var label = marker.subtitle
+                        ? escapeHtml(marker.title) + '<br />' + escapeHtml(marker.subtitle)
+                        : escapeHtml(marker.title);
+                    areaMarker.bindTooltip(label, { direction: 'top' });
+                    areaMarker.on('click', function() {
+                        if (window.$bridgeName && window.$bridgeName.onMarkerSelected) {
+                            window.$bridgeName.onMarkerSelected(marker.id);
+                        }
+                    });
+                    bounds.push([marker.latitude, marker.longitude]);
+                });
+
+                if (bounds.length > 1) {
+                    map.fitBounds(bounds, { padding: [24, 24], maxZoom: 15 });
+                }
+
+                if (window.$bridgeName && window.$bridgeName.onMapReady) {
+                    map.whenReady(function() {
+                        window.$bridgeName.onMapReady();
+                    });
+                }
+            </script>
+        </body>
+        </html>
+    """.trimIndent()
+}
+
+private class LeafletMarkerMapBridge(
+    private val onMarkerSelected: (String) -> Unit,
+    private val onMapReady: () -> Unit,
+    private val onMapError: (String) -> Unit
+) {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    @JavascriptInterface
+    fun onMarkerSelected(id: String?) {
+        val trimmed = id?.trim().orEmpty()
+        if (trimmed.isBlank()) return
+        mainHandler.post {
+            onMarkerSelected(trimmed)
+        }
+    }
+
+    @JavascriptInterface
+    fun onMapReady() {
+        mainHandler.post { onMapReady() }
+    }
+
+    @JavascriptInterface
+    fun onMapError(message: String?) {
+        val trimmed = message?.trim().orEmpty()
+        mainHandler.post {
+            onMapError(trimmed)
+        }
+    }
+}
+
+private class LeafletMapWebViewClient : WebViewClient() {
+    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        val uri = request?.url ?: return true
+        return !request.isForMainFrame || !isAllowedLeafletMapNavigation(uri)
+    }
+
+    @Suppress("DEPRECATION")
+    override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+        val uri = url?.let(Uri::parse) ?: return true
+        return !isAllowedLeafletMapNavigation(uri)
+    }
+
+    override fun shouldInterceptRequest(view: WebView?, request: WebResourceRequest?): WebResourceResponse? {
+        val uri = request?.url ?: return emptyBlockedResponse()
+        return if (isAllowedLeafletMapResource(uri)) {
+            null
+        } else {
+            emptyBlockedResponse()
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    override fun shouldInterceptRequest(view: WebView?, url: String?): WebResourceResponse? {
+        val uri = url?.let(Uri::parse) ?: return emptyBlockedResponse()
+        return if (isAllowedLeafletMapResource(uri)) {
+            null
+        } else {
+            emptyBlockedResponse()
+        }
+    }
+
+    private fun emptyBlockedResponse(): WebResourceResponse {
+        return WebResourceResponse("text/plain", "utf-8", ByteArrayInputStream(ByteArray(0)))
+    }
+}
+
+private fun isAllowedLeafletMapNavigation(uri: Uri): Boolean {
+    return uri.toString() == LeafletMapBaseUrl
+}
+
+private fun isAllowedLeafletMapResource(uri: Uri): Boolean {
+    val url = uri.toString()
+    if (url == LeafletMapBaseUrl || url == LeafletCssUrl || url == LeafletJsUrl) {
+        return true
+    }
+
+    return uri.scheme == "https" &&
+        uri.host in AllowedOpenStreetMapTileHosts &&
+        OpenStreetMapTilePathPattern.matches(uri.path.orEmpty())
+}

--- a/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
+++ b/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
@@ -1,15 +1,9 @@
 package com.neph.ui.map
 
 import android.annotation.SuppressLint
-import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.webkit.JavascriptInterface
-import android.webkit.WebResourceRequest
-import android.webkit.WebResourceResponse
-import android.webkit.WebSettings
-import android.webkit.WebView
-import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,20 +15,17 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.viewinterop.AndroidView
 import com.neph.ui.components.buttons.PrimaryButton
 import com.neph.ui.components.buttons.SecondaryButton
 import com.neph.ui.components.display.HelperText
 import com.neph.ui.theme.LocalNephSpacing
-import java.io.ByteArrayInputStream
 import java.util.Locale
 
 data class MapPickerSelection(
@@ -149,18 +140,8 @@ fun MapPickerDialog(
 }
 
 private const val MapPickerBridgeName = "AndroidMapPicker"
-private const val MapPickerBaseUrl = "https://neph.app/map-picker/"
-private const val LeafletCssUrl = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-private const val LeafletJsUrl = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
 private const val DefaultCenterLatitude = 39.9334
 private const val DefaultCenterLongitude = 32.8597
-private val AllowedOpenStreetMapTileHosts = setOf(
-    "tile.openstreetmap.org",
-    "a.tile.openstreetmap.org",
-    "b.tile.openstreetmap.org",
-    "c.tile.openstreetmap.org"
-)
-private val OpenStreetMapTilePathPattern = Regex("""^/\d+/\d+/\d+\.png$""")
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -171,36 +152,28 @@ private fun MapPickerMap(
     onMapReady: () -> Unit,
     onMapError: (String) -> Unit
 ) {
-    val context = LocalContext.current
+    val latestOnLocationSelected by rememberUpdatedState(onLocationSelected)
+    val latestOnMapReady by rememberUpdatedState(onMapReady)
+    val latestOnMapError by rememberUpdatedState(onMapError)
     val html = remember(initialLatitude, initialLongitude) {
         buildMapHtml(initialLatitude, initialLongitude)
     }
     val bridge = remember {
-        MapPickerBridge(onLocationSelected, onMapReady, onMapError)
-    }
-
-    key(html) {
-        AndroidView(
-            factory = {
-                WebView(context).apply {
-                    settings.javaScriptEnabled = true
-                    settings.domStorageEnabled = false
-                    settings.useWideViewPort = true
-                    settings.loadWithOverviewMode = true
-                    settings.allowFileAccess = false
-                    settings.allowContentAccess = false
-                    settings.javaScriptCanOpenWindowsAutomatically = false
-                    settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
-                    webViewClient = MapPickerWebViewClient()
-                    addJavascriptInterface(bridge, MapPickerBridgeName)
-                    loadDataWithBaseURL(MapPickerBaseUrl, html, "text/html", "utf-8", null)
-                }
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(260.dp)
+        MapPickerBridge(
+            onLocationSelected = { lat, lon -> latestOnLocationSelected(lat, lon) },
+            onMapReady = { latestOnMapReady() },
+            onMapError = { latestOnMapError(it) }
         )
     }
+
+    LeafletMapWebView(
+        html = html,
+        bridgeName = MapPickerBridgeName,
+        bridge = bridge,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(260.dp)
+    )
 }
 
 private class MapPickerBridge(
@@ -231,57 +204,6 @@ private class MapPickerBridge(
     }
 }
 
-private class MapPickerWebViewClient : WebViewClient() {
-    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
-        val uri = request?.url ?: return true
-        return !request.isForMainFrame || !isAllowedMapPickerNavigation(uri)
-    }
-
-    @Suppress("DEPRECATION")
-    override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
-        val uri = url?.let(Uri::parse) ?: return true
-        return !isAllowedMapPickerNavigation(uri)
-    }
-
-    override fun shouldInterceptRequest(view: WebView?, request: WebResourceRequest?): WebResourceResponse? {
-        val uri = request?.url ?: return emptyBlockedResponse()
-        return if (isAllowedMapPickerResource(uri)) {
-            null
-        } else {
-            emptyBlockedResponse()
-        }
-    }
-
-    @Suppress("DEPRECATION")
-    override fun shouldInterceptRequest(view: WebView?, url: String?): WebResourceResponse? {
-        val uri = url?.let(Uri::parse) ?: return emptyBlockedResponse()
-        return if (isAllowedMapPickerResource(uri)) {
-            null
-        } else {
-            emptyBlockedResponse()
-        }
-    }
-
-    private fun emptyBlockedResponse(): WebResourceResponse {
-        return WebResourceResponse("text/plain", "utf-8", ByteArrayInputStream(ByteArray(0)))
-    }
-}
-
-private fun isAllowedMapPickerNavigation(uri: Uri): Boolean {
-    return uri.toString() == MapPickerBaseUrl
-}
-
-private fun isAllowedMapPickerResource(uri: Uri): Boolean {
-    val url = uri.toString()
-    if (url == MapPickerBaseUrl || url == LeafletCssUrl || url == LeafletJsUrl) {
-        return true
-    }
-
-    return uri.scheme == "https" &&
-        uri.host in AllowedOpenStreetMapTileHosts &&
-        OpenStreetMapTilePathPattern.matches(uri.path.orEmpty())
-}
-
 private fun buildMapHtml(initialLatitude: Double?, initialLongitude: Double?): String {
     val hasInitial = initialLatitude != null && initialLongitude != null
     val centerLat = initialLatitude ?: DefaultCenterLatitude
@@ -294,18 +216,13 @@ private fun buildMapHtml(initialLatitude: Double?, initialLongitude: Double?): S
         <!DOCTYPE html>
         <html>
         <head>
-            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            <!-- Keep the embedded picker limited to Leaflet assets, OSM tiles, and its inline script. -->
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; form-action 'none'; frame-src 'none'; object-src 'none'; style-src 'self' '$LeafletCssUrl' 'unsafe-inline'; script-src '$LeafletJsUrl' 'unsafe-inline'; img-src https://tile.openstreetmap.org https://a.tile.openstreetmap.org https://b.tile.openstreetmap.org https://c.tile.openstreetmap.org; connect-src 'none'; font-src 'none'; media-src 'none'; navigate-to 'none'" />
-            <link rel="stylesheet" href="$LeafletCssUrl" />
-            <script src="$LeafletJsUrl"></script>
-            <style>
-                html, body, #map { height: 100%; margin: 0; padding: 0; }
-            </style>
+            ${buildLeafletDocumentHead()}
         </head>
         <body>
             <div id="map"></div>
             <script>
+                ${buildLeafletErrorScript(MapPickerBridgeName)}
+
                 var map = L.map('map').setView([$formattedLat, $formattedLon], $zoom);
                 var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                     maxZoom: 19,
@@ -322,11 +239,8 @@ private fun buildMapHtml(initialLatitude: Double?, initialLongitude: Double?): S
 
                 if (window.$MapPickerBridgeName && window.$MapPickerBridgeName.onMapError) {
                     tiles.on('tileerror', function() {
-                        window.$MapPickerBridgeName.onMapError('Map tiles could not be loaded.');
+                        notifyMapError('Map tiles could not be loaded.');
                     });
-                    window.onerror = function(message) {
-                        window.$MapPickerBridgeName.onMapError(String(message || 'Map failed to load.'));
-                    };
                 }
 
                 function setMarker(lat, lon) {

--- a/android/app/src/test/java/com/neph/ui/map/LeafletMapWebViewTest.kt
+++ b/android/app/src/test/java/com/neph/ui/map/LeafletMapWebViewTest.kt
@@ -1,0 +1,41 @@
+package com.neph.ui.map
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LeafletMapWebViewTest {
+    @Test
+    fun buildLeafletDocumentHead_allowsLeafletOriginWithoutQuotedUrlSources() {
+        val head = buildLeafletDocumentHead()
+
+        assertTrue(head.contains("script-src https://unpkg.com 'unsafe-inline'"))
+        assertTrue(head.contains("style-src 'self' https://unpkg.com 'unsafe-inline'"))
+        assertFalse(head.contains("script-src 'https://unpkg.com"))
+        assertFalse(head.contains("style-src 'self' 'https://unpkg.com"))
+    }
+
+    @Test
+    fun buildLeafletMarkerMapHtml_serializesMarkersAndSelection() {
+        val html = buildLeafletMarkerMapHtml(
+            centerLatitude = 41.0,
+            centerLongitude = 29.0,
+            markers = listOf(
+                LeafletMapMarker(
+                    id = "area-1",
+                    latitude = 41.01,
+                    longitude = 29.02,
+                    title = "Assembly Area",
+                    subtitle = "Assembly Point"
+                )
+            ),
+            selectedMarkerId = "area-1",
+            bridgeName = "AndroidLeafletMarkerMap"
+        )
+
+        assertTrue(html.contains("\"id\":\"area-1\""))
+        assertTrue(html.contains("var selectedMarkerId = \"area-1\";"))
+        assertTrue(html.contains("window.AndroidLeafletMarkerMap.onMarkerSelected(marker.id);"))
+        assertTrue(html.contains("map.fitBounds(bounds"))
+    }
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

This PR fixes Android/mobile map behavior across the affected map surfaces.

Changes include:

- Fixes mobile map loading for shared map picker flows
- Keeps Profile/Edit Profile map picker working for residential/profile location selection
- Keeps Request Help map picker working for operational/request location selection
- Adds/fixes the Android Gathering Areas in-app map surface
- Shows gathering area markers on the Android Gathering Areas map
- Preserves existing external `Open in Map` behavior
- Ensures map rendering itself does not require location permission

## Context

Mobile maps were not working correctly on Android, while web maps were working.

The issue was broader than `MapPickerDialog`: Gathering Areas did not have a working in-app Android map surface and was only using external map intents through `NephMapIntegration`.

## Location Semantics Preserved

NEPH has two separate location concepts:

- Profile/Edit Profile map picker updates residential/profile location
- Request Help map picker updates operational/request location

This PR preserves that distinction.

## Validation

- Ran Android compile/checks
- Verified relevant Android map/gathering area tests where available
- Manually reasoned through:
  - Profile/Edit Profile map picker
  - Request Help map picker
  - Gathering Areas map/results flow
  - location permission denial behavior

## Notes

Map rendering does not request location permission by itself. Permission is only needed for current-location actions such as `Use Current Location` or `Center on My Location`.

Closes #494 