### PR TITLE
feat: Expand gathering area POI categories and expose stable category metadata

### DIFF
--- a/backend/src/modules/gathering-areas/service.js
+++ b/backend/src/modules/gathering-areas/service.js
@@ -6,6 +6,15 @@ const DEFAULT_CACHE_MAX_ENTRIES = 500;
 const DEFAULT_OVERPASS_USER_AGENT = 'NEPH-Backend/1.0 (+https://github.com/bounswe/bounswe2026group6)';
 const CACHE_COORDINATE_DECIMALS = 4;
 const FALLBACK_REASON = 'No verified backend fallback gathering-area data is available';
+const CATEGORY_METADATA = {
+  assembly_point: { key: 'assembly_point', label: 'Assembly Point' },
+  shelter: { key: 'shelter', label: 'Shelter' },
+  hospital: { key: 'hospital', label: 'Hospital' },
+  police: { key: 'police', label: 'Police Station' },
+  fire_station: { key: 'fire_station', label: 'Fire Station' },
+  pharmacy: { key: 'pharmacy', label: 'Pharmacy' },
+  other: { key: 'other', label: 'Other' },
+};
 
 const nearbyCache = new Map();
 
@@ -122,6 +131,21 @@ function buildOverpassQuery({ lat, lon, radius }) {
     `  node(around:${radius},${lat},${lon})["amenity"="shelter"];`,
     `  way(around:${radius},${lat},${lon})["amenity"="shelter"];`,
     `  relation(around:${radius},${lat},${lon})["amenity"="shelter"];`,
+    `  node(around:${radius},${lat},${lon})["amenity"="hospital"];`,
+    `  way(around:${radius},${lat},${lon})["amenity"="hospital"];`,
+    `  relation(around:${radius},${lat},${lon})["amenity"="hospital"];`,
+    `  node(around:${radius},${lat},${lon})["healthcare"="hospital"];`,
+    `  way(around:${radius},${lat},${lon})["healthcare"="hospital"];`,
+    `  relation(around:${radius},${lat},${lon})["healthcare"="hospital"];`,
+    `  node(around:${radius},${lat},${lon})["amenity"="police"];`,
+    `  way(around:${radius},${lat},${lon})["amenity"="police"];`,
+    `  relation(around:${radius},${lat},${lon})["amenity"="police"];`,
+    `  node(around:${radius},${lat},${lon})["amenity"="fire_station"];`,
+    `  way(around:${radius},${lat},${lon})["amenity"="fire_station"];`,
+    `  relation(around:${radius},${lat},${lon})["amenity"="fire_station"];`,
+    `  node(around:${radius},${lat},${lon})["amenity"="pharmacy"];`,
+    `  way(around:${radius},${lat},${lon})["amenity"="pharmacy"];`,
+    `  relation(around:${radius},${lat},${lon})["amenity"="pharmacy"];`,
     ');',
     'out center tags;',
   ].join('\n');
@@ -133,6 +157,11 @@ function buildOverpassLightweightQuery({ lat, lon, radius }) {
     '(',
       `  node(around:${radius},${lat},${lon})["emergency"="assembly_point"];`,
       `  node(around:${radius},${lat},${lon})["amenity"="shelter"];`,
+      `  node(around:${radius},${lat},${lon})["amenity"="hospital"];`,
+      `  node(around:${radius},${lat},${lon})["healthcare"="hospital"];`,
+      `  node(around:${radius},${lat},${lon})["amenity"="police"];`,
+      `  node(around:${radius},${lat},${lon})["amenity"="fire_station"];`,
+      `  node(around:${radius},${lat},${lon})["amenity"="pharmacy"];`,
     ');',
     'out tags;',
   ].join('\n');
@@ -173,6 +202,34 @@ function calculateDistanceMeters(fromLat, fromLon, toLat, toLon) {
   return earthRadiusMeters * c;
 }
 
+function mapTagsToCategory(tags) {
+  if (tags.emergency === 'assembly_point') {
+    return CATEGORY_METADATA.assembly_point;
+  }
+
+  if (tags.amenity === 'shelter') {
+    return CATEGORY_METADATA.shelter;
+  }
+
+  if (tags.amenity === 'hospital' || tags.healthcare === 'hospital') {
+    return CATEGORY_METADATA.hospital;
+  }
+
+  if (tags.amenity === 'police') {
+    return CATEGORY_METADATA.police;
+  }
+
+  if (tags.amenity === 'fire_station') {
+    return CATEGORY_METADATA.fire_station;
+  }
+
+  if (tags.amenity === 'pharmacy') {
+    return CATEGORY_METADATA.pharmacy;
+  }
+
+  return CATEGORY_METADATA.other;
+}
+
 function mapElementToFeature(element, center) {
   if (!isObject(element)) {
     return null;
@@ -187,6 +244,7 @@ function mapElementToFeature(element, center) {
   }
 
   const distanceMeters = Math.round(calculateDistanceMeters(center.lat, center.lon, lat, lon));
+  const category = mapTagsToCategory(tags);
 
   return {
     type: 'Feature',
@@ -198,7 +256,8 @@ function mapElementToFeature(element, center) {
       id: String(element.id || ''),
       osmType: element.type || '',
       name: tags.name || tags['name:tr'] || '',
-      category: tags.emergency || tags.amenity || 'unknown',
+      category: category.key,
+      categoryLabel: category.label,
       distanceMeters,
       rawTags: tags,
     },
@@ -254,6 +313,10 @@ function withSource(result, source, extraMeta = {}) {
       ...extraMeta,
     },
   };
+}
+
+function buildCategoryMetadata() {
+  return Object.values(CATEGORY_METADATA);
 }
 
 async function fetchNearbyFromOverpassUrl(queryText, url) {
@@ -360,6 +423,7 @@ async function getNearbyGatheringAreas(params) {
       meta: {
         requestedLimit: params.limit,
         returnedCount: collection.features.length,
+        categories: buildCategoryMetadata(),
       },
       collection,
     };
@@ -392,6 +456,7 @@ async function getNearbyGatheringAreas(params) {
         returnedCount: collection.features.length,
         providerErrorCode: error.code,
         fallbackReason: FALLBACK_REASON,
+        categories: buildCategoryMetadata(),
       },
       collection,
     };

--- a/backend/tests/integration/modules/gathering-areas/gathering-areas.integration.test.js
+++ b/backend/tests/integration/modules/gathering-areas/gathering-areas.integration.test.js
@@ -60,15 +60,25 @@ describe('gathering-areas integration', () => {
     expect(response.status).toBe(200);
     expect(response.body.source).toBe('overpass');
     expect(response.body.radius).toBe(1500);
-    expect(response.body.meta).toEqual({
+    expect(response.body.meta).toMatchObject({
       requestedLimit: 10,
       returnedCount: 1,
     });
+    expect(response.body.meta.categories).toEqual(expect.arrayContaining([
+      { key: 'assembly_point', label: 'Assembly Point' },
+      { key: 'shelter', label: 'Shelter' },
+      { key: 'hospital', label: 'Hospital' },
+      { key: 'police', label: 'Police Station' },
+      { key: 'fire_station', label: 'Fire Station' },
+      { key: 'pharmacy', label: 'Pharmacy' },
+      { key: 'other', label: 'Other' },
+    ]));
     expect(response.body.collection).toBeTruthy();
     expect(response.body.collection.type).toBe('FeatureCollection');
     expect(response.body.collection.features).toHaveLength(1);
     expect(response.body.collection.features[0].geometry.coordinates).toEqual([29.01, 41.01]);
     expect(response.body.collection.features[0].properties.category).toBe('assembly_point');
+    expect(response.body.collection.features[0].properties.categoryLabel).toBe('Assembly Point');
     expect(response.body.collection.features[0].properties.distanceMeters).toBeGreaterThanOrEqual(0);
   });
 
@@ -382,5 +392,81 @@ describe('gathering-areas integration', () => {
 
     const [first, second] = response.body.collection.features;
     expect(first.properties.distanceMeters).toBeLessThanOrEqual(second.properties.distanceMeters);
+  });
+
+  test('GET /api/gathering-areas/nearby maps supported and unknown categories to stable keys', async () => {
+    const app = createApp();
+
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        elements: [
+          {
+            type: 'node',
+            id: 5101,
+            lat: 41.0100,
+            lon: 29.0100,
+            tags: { amenity: 'hospital' },
+          },
+          {
+            type: 'node',
+            id: 5102,
+            lat: 41.0101,
+            lon: 29.0101,
+            tags: { healthcare: 'hospital' },
+          },
+          {
+            type: 'node',
+            id: 5103,
+            lat: 41.0102,
+            lon: 29.0102,
+            tags: { amenity: 'police' },
+          },
+          {
+            type: 'node',
+            id: 5104,
+            lat: 41.0103,
+            lon: 29.0103,
+            tags: { amenity: 'fire_station' },
+          },
+          {
+            type: 'node',
+            id: 5105,
+            lat: 41.0104,
+            lon: 29.0104,
+            tags: { amenity: 'pharmacy' },
+          },
+          {
+            type: 'node',
+            id: 5106,
+            lat: 41.0105,
+            lon: 29.0105,
+            tags: { amenity: 'school' },
+          },
+        ],
+      }),
+    });
+
+    const response = await request(app)
+      .get('/api/gathering-areas/nearby?lat=41.01&lon=29.01&radius=2000&limit=10');
+
+    expect(response.status).toBe(200);
+    const categories = response.body.collection.features.map((feature) => feature.properties.category);
+    expect(categories).toEqual(expect.arrayContaining([
+      'hospital',
+      'police',
+      'fire_station',
+      'pharmacy',
+      'other',
+    ]));
+
+    const labels = response.body.collection.features.map((feature) => feature.properties.categoryLabel);
+    expect(labels).toEqual(expect.arrayContaining([
+      'Hospital',
+      'Police Station',
+      'Fire Station',
+      'Pharmacy',
+      'Other',
+    ]));
   });
 });

--- a/backend/tests/unit/modules/gathering-areas/service.test.js
+++ b/backend/tests/unit/modules/gathering-areas/service.test.js
@@ -14,6 +14,57 @@ afterAll(() => {
 });
 
 describe('gathering-areas service', () => {
+  test('getNearbyGatheringAreas includes expanded category filters in Overpass query', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ elements: [] }),
+    });
+
+    await gatheringAreasService.getNearbyGatheringAreas({
+      lat: 41.01,
+      lon: 29.01,
+      radius: 1500,
+      limit: 10,
+    });
+
+    const requestInit = global.fetch.mock.calls[0][1];
+    const queryText = decodeURIComponent(requestInit.body.toString());
+
+    expect(queryText).toContain('["emergency"="assembly_point"]');
+    expect(queryText).toContain('["amenity"="shelter"]');
+    expect(queryText).toContain('["amenity"="hospital"]');
+    expect(queryText).toContain('["healthcare"="hospital"]');
+    expect(queryText).toContain('["amenity"="police"]');
+    expect(queryText).toContain('["amenity"="fire_station"]');
+    expect(queryText).toContain('["amenity"="pharmacy"]');
+  });
+
+  test('getNearbyGatheringAreas returns stable category metadata in fallback response', async () => {
+    global.fetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    });
+
+    const result = await gatheringAreasService.getNearbyGatheringAreas({
+      lat: 41.01,
+      lon: 29.01,
+      radius: 1500,
+      limit: 10,
+    });
+
+    expect(result.source).toBe('fallback');
+    expect(result.meta.categories).toEqual(expect.arrayContaining([
+      { key: 'assembly_point', label: 'Assembly Point' },
+      { key: 'shelter', label: 'Shelter' },
+      { key: 'hospital', label: 'Hospital' },
+      { key: 'police', label: 'Police Station' },
+      { key: 'fire_station', label: 'Fire Station' },
+      { key: 'pharmacy', label: 'Pharmacy' },
+      { key: 'other', label: 'Other' },
+    ]));
+  });
+
   test('getNearbyGatheringAreas rethrows unexpected internal errors instead of returning fallback', async () => {
     const unexpectedError = new Error('unexpected transform failure');
     const element = {


### PR DESCRIPTION
This PR implements issue #474 by expanding emergency-relevant POI category support in the Gathering Areas backend and exposing a stable category contract for frontend clients.

## What Changed

### 1. Expanded Overpass category coverage
Updated Overpass queries to include:
- `assembly_point` (`emergency=assembly_point`)
- `shelter` (`amenity=shelter`)
- `hospital` (`amenity=hospital` or `healthcare=hospital`)
- `police` (`amenity=police`)
- `fire_station` (`amenity=fire_station`)
- `pharmacy` (`amenity=pharmacy`)

Applied to both:
- primary query (`out center tags`)
- lightweight retry query (`out tags`)

### 2. Stable backend category mapping
Added stable category mapping from raw OSM tags to internal keys:
- `assembly_point`
- `shelter`
- `hospital`
- `police`
- `fire_station`
- `pharmacy`
- `other` (safe fallback for unknown/unsupported tags)

### 3. Stable category metadata for clients
Response metadata now includes category filter metadata:
- `meta.categories: [{ key, label }, ...]`

This enables frontend clients to build filter UIs without hardcoding category definitions.

### 4. Feature properties contract improvement
Each feature now returns:
- `properties.category` (stable key)
- `properties.categoryLabel` (display label)

This preserves category display capability and improves consistency across clients.

## Files Updated
- `backend/src/modules/gathering-areas/service.js`
- `backend/tests/unit/modules/gathering-areas/service.test.js`
- `backend/tests/integration/modules/gathering-areas/gathering-areas.integration.test.js`

## Tests
Added/updated tests for:
- expanded Overpass query coverage
- stable fallback metadata (`meta.categories`)
- stable category-key/label mapping for supported and unknown categories

Executed test command:
- `npm.cmd test -- tests/unit/modules/gathering-areas/service.test.js tests/integration/modules/gathering-areas/gathering-areas.integration.test.js tests/integration/modules/gathering-areas/gathering-areas.provider-failures.integration.test.js`

Result:
- 3/3 test suites passed
- 21/21 tests passed

## Acceptance Criteria Coverage
- Stable category keys are returned
- Existing assembly_point and shelter behavior is preserved
- Additional emergency POI categories are supported
- Unknown categories are safely mapped to `other`
- Category mapping and contract behavior are covered by tests
- Provider failure/stale/fallback behavior remains intact



Closes #474 