### PR TITLE
fix: make overflowing screens scrollable

### DIFF
--- a/android/app/src/main/java/com/neph/features/assignedrequest/presentation/AssignedRequestScreen.kt
+++ b/android/app/src/main/java/com/neph/features/assignedrequest/presentation/AssignedRequestScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,7 +20,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.foundation.verticalScroll
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.neph.core.sync.OfflineSyncScheduler
@@ -204,9 +202,7 @@ fun AssignedRequestScreen(
                 val request = currentRequest!!
 
                 Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .verticalScroll(rememberScrollState()),
+                    modifier = Modifier.fillMaxWidth(),
                     verticalArrangement = Arrangement.spacedBy(spacing.lg)
                 ) {
                     SectionCard {

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -199,8 +197,7 @@ fun GatheringAreasScreen(
         profileLabel = if (isAuthenticated) "Profile" else "Login / Create Account"
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(spacing.lg),
-            modifier = Modifier.verticalScroll(rememberScrollState())
+            verticalArrangement = Arrangement.spacedBy(spacing.lg)
         ) {
             SectionCard {
                 Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -16,9 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -190,8 +188,7 @@ fun HelpRequestMapScreen(
         profileLabel = if (isAuthenticated) "Profile" else "Login / Create Account"
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(spacing.lg),
-            modifier = Modifier.verticalScroll(rememberScrollState())
+            verticalArrangement = Arrangement.spacedBy(spacing.lg)
         ) {
             SectionCard {
                 Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {

--- a/android/app/src/main/java/com/neph/features/nearbyusers/presentation/NearbyVisibleUsersScreen.kt
+++ b/android/app/src/main/java/com/neph/features/nearbyusers/presentation/NearbyVisibleUsersScreen.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -119,9 +117,7 @@ fun NearbyVisibleUsersScreen(
         contentAlignment = Alignment.TopCenter
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState()),
+            modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(spacing.md)
         ) {
             SectionCard {

--- a/android/app/src/main/java/com/neph/features/news/presentation/NewsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/news/presentation/NewsScreen.kt
@@ -155,7 +155,8 @@ fun NewsScreen(
         onOpenSettings = onOpenSettings,
         onProfileClick = onProfileClick,
         profileBadgeText = profileBadgeText,
-        profileLabel = if (isAuthenticated) "Profile" else "Login / Create Account"
+        profileLabel = if (isAuthenticated) "Profile" else "Login / Create Account",
+        contentFillMaxSize = true
     ) {
         Column(
             modifier = Modifier.fillMaxHeight(),

--- a/android/app/src/main/java/com/neph/features/notifications/presentation/NotificationsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/notifications/presentation/NotificationsScreen.kt
@@ -3,6 +3,7 @@ package com.neph.features.notifications.presentation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -85,10 +86,16 @@ fun NotificationsScreen(
         onProfileClick = onProfileClick,
         profileBadgeText = profileBadgeText,
         profileLabel = if (isAuthenticated) "Profile" else "Login / Create Account",
+        contentFillMaxSize = true,
         contentScrollable = false
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(spacing.lg)) {
-            SectionCard {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(spacing.lg)
+        ) {
+            SectionCard(
+                modifier = Modifier.weight(1f)
+            ) {
                 SectionHeader(
                     title = "Notifications",
                     subtitle = if (isAuthenticated) {
@@ -158,7 +165,12 @@ fun NotificationsScreen(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 } else {
-                    LazyColumn(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(spacing.sm)
+                    ) {
                         items(notifications, key = { it.id }) { notification ->
                             Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
                                 Row(

--- a/android/app/src/main/java/com/neph/features/notifications/presentation/NotificationsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/notifications/presentation/NotificationsScreen.kt
@@ -84,7 +84,8 @@ fun NotificationsScreen(
         onOpenSettings = onOpenSettings,
         onProfileClick = onProfileClick,
         profileBadgeText = profileBadgeText,
-        profileLabel = if (isAuthenticated) "Profile" else "Login / Create Account"
+        profileLabel = if (isAuthenticated) "Profile" else "Login / Create Account",
+        contentScrollable = false
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(spacing.lg)) {
             SectionCard {

--- a/android/app/src/main/java/com/neph/features/profile/presentation/ProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/ProfileScreen.kt
@@ -3,8 +3,6 @@ package com.neph.features.profile.presentation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -85,9 +83,7 @@ fun ProfileScreen(
             HelperText(text = "Loading your profile...")
         } else {
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState()),
+                modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(spacing.lg)
             ) {
                 val countryLabel = profile.country?.let { availableLocationData[it]?.label ?: it }

--- a/android/app/src/main/java/com/neph/features/safetycircles/presentation/SafetyCirclesScreen.kt
+++ b/android/app/src/main/java/com/neph/features/safetycircles/presentation/SafetyCirclesScreen.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.CircularProgressIndicator
@@ -287,9 +285,7 @@ fun SafetyCirclesScreen(
         contentAlignment = Alignment.TopCenter
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState()),
+            modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(spacing.md)
         ) {
             if (loading) {

--- a/android/app/src/main/java/com/neph/ui/layout/AppDrawerScaffold.kt
+++ b/android/app/src/main/java/com/neph/ui/layout/AppDrawerScaffold.kt
@@ -14,7 +14,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Person
@@ -63,6 +65,7 @@ fun AppDrawerScaffold(
     profileLabel: String = "Profile",
     contentMaxWidth: Dp = 960.dp,
     contentFillMaxSize: Boolean = false,
+    contentScrollable: Boolean = !contentFillMaxSize,
     contentAlignment: Alignment = Alignment.TopCenter,
     topBarActions: @Composable RowScope.() -> Unit = {},
     content: @Composable () -> Unit
@@ -260,17 +263,26 @@ fun AppDrawerScaffold(
                     .fillMaxSize()
                     .padding(innerPadding)
             ) {
+                val contentModifier = Modifier
+                    .then(
+                        if (contentFillMaxSize) {
+                            Modifier.fillMaxSize()
+                        } else {
+                            Modifier.fillMaxWidth()
+                        }
+                    )
+                    .widthIn(max = contentMaxWidth)
+                    .align(contentAlignment)
+                    .then(
+                        if (contentScrollable) {
+                            Modifier.verticalScroll(rememberScrollState())
+                        } else {
+                            Modifier
+                        }
+                    )
+
                 Column(
-                    modifier = Modifier
-                        .then(
-                            if (contentFillMaxSize) {
-                                Modifier.fillMaxSize()
-                            } else {
-                                Modifier.fillMaxWidth()
-                            }
-                        )
-                        .widthIn(max = contentMaxWidth)
-                        .align(contentAlignment),
+                    modifier = contentModifier,
                     verticalArrangement = Arrangement.spacedBy(spacing.lg)
                 ) {
                     content()

--- a/android/app/src/main/java/com/neph/ui/layout/ScreenContainer.kt
+++ b/android/app/src/main/java/com/neph/ui/layout/ScreenContainer.kt
@@ -1,9 +1,10 @@
 package com.neph.ui.layout
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -21,6 +22,8 @@ fun ScreenContainer(
     Box(
         modifier = modifier
             .fillMaxSize()
+            .navigationBarsPadding()
+            .imePadding()
             .padding(horizontal = spacing.xl, vertical = spacing.xl),
         contentAlignment = contentAlignment,
         content = content


### PR DESCRIPTION
## Summary

This PR fixes Android screen scrolling behavior for pages where content can exceed the visible screen height.

Changes include:

- Ensures long Android screens can scroll vertically when content overflows
- Prevents bottom content, buttons, helper texts, and form fields from being cut off
- Improves usability on smaller phone screens
- Preserves existing top bars, drawer behavior, spacing, and screen structure
- Keeps the fix Android-only

## Context

Some Android pages behaved as if their content was forced into a single screen. As a result, bottom content could become partially visible or unreachable because the page did not scroll properly.

This PR addresses the shared/layout-level causes where possible and applies screen-specific scroll fixes only where needed.

## Scope

Affected Android areas checked/fixed include:

- Request Help
- Profile / Edit Profile
- Complete Profile
- Gathering Areas
- Settings / Privacy / Security
- My Help Requests
- Assigned Request
- Emergency Info
- Other screens using shared Android layout/scaffold patterns where relevant

## Validation

- Verified that overflowing Android screens can scroll vertically
- Verified bottom buttons/content are reachable
- Verified existing short-content screens still render normally
- Verified top bars/drawer layout behavior is preserved
- Ran relevant Android build/checks where available

## Notes

This PR does not change web code, backend code, navigation structure, or product behavior. It only fixes Android scrolling/layout overflow behavior.

Closes #498 