### PR TITLE
fix: Android location permission bootstrap and privacy defaults

### DIFF
--- a/android/app/src/main/java/com/neph/MainActivity.kt
+++ b/android/app/src/main/java/com/neph/MainActivity.kt
@@ -2,11 +2,13 @@ package com.neph
 
 import android.Manifest
 import android.app.Activity
+import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.AlertDialog
@@ -33,6 +35,7 @@ import com.neph.features.availability.data.AvailabilityRepository
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.operationallocation.data.OperationalLocationRepository
 import com.neph.features.operationallocation.data.OperationalLocationUpdater
+import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.features.profile.data.ProfileRepository
 import com.neph.features.notifications.data.PushTokenSync
 import com.neph.features.requesthelp.data.RequestHelpRepository
@@ -40,9 +43,18 @@ import com.neph.features.safetystatus.data.SafetyStatusRepository
 import com.neph.navigation.AppNavGraph
 import com.neph.navigation.Routes
 import com.neph.ui.theme.NephTheme
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
+    private val initialLocationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { grants ->
+        val granted = DeviceLocationProvider.hasLocationPermission(this) || grants.values.any { it }
+        syncLocationPermissionPrivacy(granted)
+        requestNotificationPermissionIfNeeded()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         NephAppContext.initialize(applicationContext)
@@ -54,7 +66,9 @@ class MainActivity : ComponentActivity() {
         ProfileRepository.initialize(applicationContext)
         RequestHelpRepository.initialize(applicationContext)
         SafetyStatusRepository.initialize(applicationContext)
-        requestNotificationPermissionIfNeeded()
+        if (!requestInitialLocationPermissionIfNeeded()) {
+            requestNotificationPermissionIfNeeded()
+        }
         PushTokenSync.syncCurrentToken()
         OfflineSyncScheduler.schedulePeriodicSync(applicationContext)
         OfflineSyncScheduler.enqueueSync(applicationContext, reason = "app-start")
@@ -72,6 +86,38 @@ class MainActivity : ComponentActivity() {
     private fun refreshOperationalLocationSilently() {
         lifecycleScope.launch {
             OperationalLocationUpdater.refreshIfAllowed(applicationContext)
+        }
+    }
+
+    private fun requestInitialLocationPermissionIfNeeded(): Boolean {
+        val prefs = getSharedPreferences(InitialPermissionPrefsName, Context.MODE_PRIVATE)
+        val alreadyPrompted = prefs.getBoolean(InitialLocationPermissionPromptedKey, false)
+        val alreadyGranted = DeviceLocationProvider.hasLocationPermission(this)
+
+        if (alreadyPrompted) {
+            return false
+        }
+
+        if (alreadyGranted) {
+            prefs.edit().putBoolean(InitialLocationPermissionPromptedKey, true).apply()
+            syncLocationPermissionPrivacy(granted = true)
+            return false
+        }
+
+        prefs.edit().putBoolean(InitialLocationPermissionPromptedKey, true).apply()
+        initialLocationPermissionLauncher.launch(DeviceLocationProvider.RequiredLocationPermissions)
+        return true
+    }
+
+    private fun syncLocationPermissionPrivacy(granted: Boolean) {
+        lifecycleScope.launch {
+            try {
+                ProfileRepository.syncPrivacyDefaultsForLocationPermission(granted)
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                // Permission-derived privacy defaults are opportunistic and should not block app launch.
+            }
         }
     }
 
@@ -95,6 +141,8 @@ class MainActivity : ComponentActivity() {
     }
 
     companion object {
+        private const val InitialPermissionPrefsName = "neph_initial_permissions"
+        private const val InitialLocationPermissionPromptedKey = "initialLocationPermissionPrompted"
         private const val REQUEST_POST_NOTIFICATIONS = 1001
     }
 }

--- a/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
+++ b/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
@@ -107,6 +107,7 @@ object AuthRepository {
         )
 
         return try {
+            ProfileRepository.syncPendingLocationPermissionPrivacyHintIfNeeded()
             ProfileRepository.fetchAndCacheRemoteProfile()
             AuthSessionStore.clearPendingVerificationEmail()
             NephAppContext.getOrNull()?.let { OfflineSyncScheduler.enqueueSync(it, reason = "login") }
@@ -146,6 +147,7 @@ object AuthRepository {
         if (accessToken.isNotBlank()) {
             val userId = response.optJSONObject("user")?.optString("userId")?.trim().orEmpty()
             AuthSessionStore.saveAccessToken(accessToken, rememberMe = true, userId = userId)
+            ProfileRepository.syncPendingLocationPermissionPrivacyHintIfNeeded()
             PushTokenSync.syncCurrentToken()
             NephAppContext.getOrNull()?.let { OfflineSyncScheduler.enqueueSync(it, reason = "email-verified") }
         }

--- a/android/app/src/main/java/com/neph/features/privacysecurity/presentation/PrivacySecurityScreen.kt
+++ b/android/app/src/main/java/com/neph/features/privacysecurity/presentation/PrivacySecurityScreen.kt
@@ -50,9 +50,11 @@ fun PrivacySecurityScreen(
 
     var loading by remember { mutableStateOf(true) }
     var saving by remember { mutableStateOf(false) }
-    var profileVisibility by remember { mutableStateOf(PrivateVisibility) }
-    var healthInfoVisibility by remember { mutableStateOf(PrivateVisibility) }
-    var locationVisibility by remember { mutableStateOf(PrivateVisibility) }
+    var profileVisibility by remember { mutableStateOf(ProfileRepository.DefaultProfileVisibility) }
+    var healthInfoVisibility by remember { mutableStateOf(ProfileRepository.DefaultHealthInfoVisibility) }
+    var locationVisibility by remember {
+        mutableStateOf(ProfileRepository.defaultLocationVisibilityFromStoredPermission())
+    }
     var shareLocation by remember { mutableStateOf(false) }
     var initialShareLocation by remember { mutableStateOf(false) }
     var hasSavedCoordinates by remember { mutableStateOf(false) }
@@ -62,9 +64,9 @@ fun PrivacySecurityScreen(
     LaunchedEffect(Unit) {
         try {
             val profile = ProfileRepository.fetchAndCacheRemoteProfile()
-            profileVisibility = profile.profileVisibility ?: PrivateVisibility
-            healthInfoVisibility = profile.healthInfoVisibility ?: PrivateVisibility
-            locationVisibility = profile.locationVisibility ?: PrivateVisibility
+            profileVisibility = profile.profileVisibility ?: ProfileRepository.DefaultProfileVisibility
+            healthInfoVisibility = profile.healthInfoVisibility ?: ProfileRepository.DefaultHealthInfoVisibility
+            locationVisibility = profile.locationVisibility ?: ProfileRepository.defaultLocationVisibilityFromStoredPermission()
             shareLocation = profile.shareLocation == true
             initialShareLocation = profile.shareLocation == true
             hasSavedCoordinates = profile.sharedLatitude != null && profile.sharedLongitude != null

--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileData.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileData.kt
@@ -30,6 +30,7 @@ data class ProfileData(
     val profileVisibility: String? = null,
     val healthInfoVisibility: String? = null,
     val locationVisibility: String? = null,
+    val locationVisibilityInitialized: Boolean = false,
     val shareLocation: Boolean? = null,
     val sharedLatitude: Double? = null,
     val sharedLongitude: Double? = null

--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
@@ -13,6 +13,7 @@ import java.util.Locale
 object ProfileRepository {
     private const val PrefsName = "neph_profile"
     private const val LocationPermissionPrivacyHintKey = "locationPermissionPrivacyHint"
+    private const val PendingLocationPermissionPrivacyHintSyncKey = "pendingLocationPermissionPrivacyHintSync"
 
     internal const val DefaultProfileVisibility = "EMERGENCY_ONLY"
     internal const val DefaultHealthInfoVisibility = "EMERGENCY_ONLY"
@@ -67,6 +68,11 @@ object ProfileRepository {
         return defaultLocationVisibilityForPermission(
             prefs.getBoolean(LocationPermissionPrivacyHintKey, false)
         )
+    }
+
+    fun hasPendingLocationPermissionPrivacyHintSync(): Boolean {
+        ensureInitialized()
+        return prefs.getBoolean(PendingLocationPermissionPrivacyHintSyncKey, false)
     }
 
     fun resetForTesting() {
@@ -249,6 +255,7 @@ object ProfileRepository {
             )
 
             saveProfile(normalizedProfile)
+            clearPendingLocationPermissionPrivacyHintSync()
 
             val refreshed = fetchAndCacheRemoteProfile()
             saveProfile(refreshed)
@@ -323,6 +330,7 @@ object ProfileRepository {
 
         val token = AuthSessionStore.getAccessToken().orEmpty()
         if (token.isBlank()) {
+            markPendingLocationPermissionPrivacyHintSync()
             return null
         }
 
@@ -334,12 +342,44 @@ object ProfileRepository {
             return null
         }
 
-        return syncPrivacySettings(
+        if (!shouldSyncLocationPermissionBootstrap(profile)) {
+            clearPendingLocationPermissionPrivacyHintSync()
+            return profile
+        }
+
+        val updated = syncPrivacySettings(
             profileVisibility = profile.profileVisibility ?: DefaultProfileVisibility,
             healthInfoVisibility = profile.healthInfoVisibility ?: DefaultHealthInfoVisibility,
-            locationVisibility = defaultLocationVisibilityForPermission(locationPermissionGranted),
+            locationVisibility = resolveLocationVisibilityForPermissionBootstrap(
+                profile = profile,
+                locationPermissionGranted = locationPermissionGranted
+            ),
             locationSharingEnabled = profile.shareLocation == true
         )
+        clearPendingLocationPermissionPrivacyHintSync()
+        return updated
+    }
+
+    suspend fun syncPendingLocationPermissionPrivacyHintIfNeeded(): ProfileData? {
+        ensureInitialized()
+        if (!hasPendingLocationPermissionPrivacyHintSync()) {
+            return null
+        }
+
+        val token = AuthSessionStore.getAccessToken().orEmpty()
+        if (token.isBlank()) {
+            return null
+        }
+
+        return try {
+            syncPrivacyDefaultsForLocationPermission(
+                prefs.getBoolean(LocationPermissionPrivacyHintKey, false)
+            )
+        } catch (cancellationException: CancellationException) {
+            throw cancellationException
+        } catch (_: Exception) {
+            null
+        }
     }
 
     internal fun buildPrivacySettingsPatchPayload(
@@ -358,6 +398,21 @@ object ProfileRepository {
 
     internal fun defaultLocationVisibilityForPermission(granted: Boolean): String {
         return if (granted) LocationPermissionGrantedVisibility else DefaultLocationVisibility
+    }
+
+    internal fun shouldSyncLocationPermissionBootstrap(profile: ProfileData): Boolean {
+        return !profile.locationVisibilityInitialized
+    }
+
+    internal fun resolveLocationVisibilityForPermissionBootstrap(
+        profile: ProfileData,
+        locationPermissionGranted: Boolean
+    ): String {
+        return if (profile.locationVisibilityInitialized) {
+            profile.locationVisibility ?: DefaultLocationVisibility
+        } else {
+            defaultLocationVisibilityForPermission(locationPermissionGranted)
+        }
     }
 
     internal fun mergePrivacySettingsResponse(
@@ -379,6 +434,7 @@ object ProfileRepository {
             locationVisibility = normalizeVisibility(
                 privacySettings.optStringOrNull("locationVisibility") ?: requestedLocationVisibility
             ),
+            locationVisibilityInitialized = true,
             shareLocation = privacySettings.optNullableBoolean("locationSharingEnabled")
                 ?: requestedLocationSharingEnabled
         )
@@ -523,6 +579,7 @@ object ProfileRepository {
             putString("profileVisibility", normalizeVisibility(profile.profileVisibility))
             putString("healthInfoVisibility", normalizeVisibility(profile.healthInfoVisibility))
             putString("locationVisibility", normalizeVisibility(profile.locationVisibility))
+            putBoolean("locationVisibilityInitialized", profile.locationVisibilityInitialized)
             putBoolean("shareLocation", profile.shareLocation ?: false)
             putString("sharedLatitude", profile.sharedLatitude?.toString())
             putString("sharedLongitude", profile.sharedLongitude?.toString())
@@ -571,6 +628,7 @@ object ProfileRepository {
             profileVisibility = normalizeVisibility(prefs.getString("profileVisibility", null)),
             healthInfoVisibility = normalizeVisibility(prefs.getString("healthInfoVisibility", null)),
             locationVisibility = normalizeVisibility(prefs.getString("locationVisibility", null)),
+            locationVisibilityInitialized = prefs.getBoolean("locationVisibilityInitialized", false),
             shareLocation = if (prefs.contains("shareLocation")) prefs.getBoolean("shareLocation", false) else null,
             sharedLatitude = prefs.getString("sharedLatitude", null)?.toDoubleOrNull(),
             sharedLongitude = prefs.getString("sharedLongitude", null)?.toDoubleOrNull()
@@ -667,10 +725,24 @@ object ProfileRepository {
                 privacySettings.optStringOrNull("locationVisibility"),
                 defaultLocationVisibilityFromStoredPermission()
             ),
+            locationVisibilityInitialized = privacySettings.optNullableBoolean("locationVisibilityInitialized")
+                ?: privacySettings.has("locationVisibility"),
             shareLocation = privacySettings.optNullableBoolean("locationSharingEnabled"),
             sharedLatitude = sharedLatitude,
             sharedLongitude = sharedLongitude
         )
+    }
+
+    private fun markPendingLocationPermissionPrivacyHintSync() {
+        prefs.edit()
+            .putBoolean(PendingLocationPermissionPrivacyHintSyncKey, true)
+            .apply()
+    }
+
+    private fun clearPendingLocationPermissionPrivacyHintSync() {
+        prefs.edit()
+            .remove(PendingLocationPermissionPrivacyHintSyncKey)
+            .apply()
     }
 
     private fun parseLocationAddress(

--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
@@ -12,6 +12,12 @@ import java.util.Locale
 
 object ProfileRepository {
     private const val PrefsName = "neph_profile"
+    private const val LocationPermissionPrivacyHintKey = "locationPermissionPrivacyHint"
+
+    internal const val DefaultProfileVisibility = "EMERGENCY_ONLY"
+    internal const val DefaultHealthInfoVisibility = "EMERGENCY_ONLY"
+    internal const val DefaultLocationVisibility = "PRIVATE"
+    internal const val LocationPermissionGrantedVisibility = "EMERGENCY_ONLY"
 
     private lateinit var prefs: SharedPreferences
     private var cachedProfile = ProfileData()
@@ -45,6 +51,22 @@ object ProfileRepository {
     fun getProfile(): ProfileData {
         ensureInitialized()
         return cachedProfile
+    }
+
+    fun rememberLocationPermissionPrivacyHint(granted: Boolean) {
+        ensureInitialized()
+        prefs.edit()
+            .putBoolean(LocationPermissionPrivacyHintKey, granted)
+            .apply()
+    }
+
+    fun defaultLocationVisibilityFromStoredPermission(): String {
+        if (!::prefs.isInitialized) {
+            return DefaultLocationVisibility
+        }
+        return defaultLocationVisibilityForPermission(
+            prefs.getBoolean(LocationPermissionPrivacyHintKey, false)
+        )
     }
 
     fun resetForTesting() {
@@ -201,9 +223,9 @@ object ProfileRepository {
                 method = "PATCH",
                 token = token,
                 body = JSONObject().apply {
-                    put("profileVisibility", normalizedProfile.profileVisibility ?: "PRIVATE")
-                    put("healthInfoVisibility", normalizedProfile.healthInfoVisibility ?: "PRIVATE")
-                    put("locationVisibility", normalizedProfile.locationVisibility ?: "PRIVATE")
+                    put("profileVisibility", normalizedProfile.profileVisibility ?: DefaultProfileVisibility)
+                    put("healthInfoVisibility", normalizedProfile.healthInfoVisibility ?: DefaultHealthInfoVisibility)
+                    put("locationVisibility", normalizedProfile.locationVisibility ?: defaultLocationVisibilityFromStoredPermission())
                     put("locationSharingEnabled", profile.shareLocation ?: false)
                 }
             )
@@ -295,6 +317,31 @@ object ProfileRepository {
         return updated
     }
 
+    suspend fun syncPrivacyDefaultsForLocationPermission(locationPermissionGranted: Boolean): ProfileData? {
+        ensureInitialized()
+        rememberLocationPermissionPrivacyHint(locationPermissionGranted)
+
+        val token = AuthSessionStore.getAccessToken().orEmpty()
+        if (token.isBlank()) {
+            return null
+        }
+
+        val profile = try {
+            fetchAndCacheRemoteProfile()
+        } catch (cancellationException: CancellationException) {
+            throw cancellationException
+        } catch (_: Exception) {
+            return null
+        }
+
+        return syncPrivacySettings(
+            profileVisibility = profile.profileVisibility ?: DefaultProfileVisibility,
+            healthInfoVisibility = profile.healthInfoVisibility ?: DefaultHealthInfoVisibility,
+            locationVisibility = defaultLocationVisibilityForPermission(locationPermissionGranted),
+            locationSharingEnabled = profile.shareLocation == true
+        )
+    }
+
     internal fun buildPrivacySettingsPatchPayload(
         profileVisibility: String,
         healthInfoVisibility: String,
@@ -307,6 +354,10 @@ object ProfileRepository {
             put("locationVisibility", normalizeVisibility(locationVisibility))
             put("locationSharingEnabled", locationSharingEnabled)
         }
+    }
+
+    internal fun defaultLocationVisibilityForPermission(granted: Boolean): String {
+        return if (granted) LocationPermissionGrantedVisibility else DefaultLocationVisibility
     }
 
     internal fun mergePrivacySettingsResponse(
@@ -604,9 +655,18 @@ object ProfileRepository {
                 .takeIf { it.isNotBlank() },
             extraAddress = extraAddressFromBackend
                 ?: cachedProfileSnapshot.extraAddress,
-            profileVisibility = normalizeVisibility(privacySettings.optStringOrNull("profileVisibility")),
-            healthInfoVisibility = normalizeVisibility(privacySettings.optStringOrNull("healthInfoVisibility")),
-            locationVisibility = normalizeVisibility(privacySettings.optStringOrNull("locationVisibility")),
+            profileVisibility = normalizeVisibility(
+                privacySettings.optStringOrNull("profileVisibility"),
+                DefaultProfileVisibility
+            ),
+            healthInfoVisibility = normalizeVisibility(
+                privacySettings.optStringOrNull("healthInfoVisibility"),
+                DefaultHealthInfoVisibility
+            ),
+            locationVisibility = normalizeVisibility(
+                privacySettings.optStringOrNull("locationVisibility"),
+                defaultLocationVisibilityFromStoredPermission()
+            ),
             shareLocation = privacySettings.optNullableBoolean("locationSharingEnabled"),
             sharedLatitude = sharedLatitude,
             sharedLongitude = sharedLongitude
@@ -721,11 +781,12 @@ object ProfileRepository {
         return if (has(key) && !isNull(key)) optDouble(key) else null
     }
 
-    private fun normalizeVisibility(value: String?): String {
+    private fun normalizeVisibility(value: String?, fallback: String = DefaultLocationVisibility): String {
         return when (value?.uppercase(Locale.ROOT)) {
             "PUBLIC" -> "PUBLIC"
             "EMERGENCY_ONLY" -> "EMERGENCY_ONLY"
-            else -> "PRIVATE"
+            "PRIVATE" -> "PRIVATE"
+            else -> fallback
         }
     }
 

--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
@@ -12,6 +12,7 @@ import java.util.Locale
 
 object ProfileRepository {
     private const val PrefsName = "neph_profile"
+    private const val PermissionPrefsName = "neph_profile_permission_privacy"
     private const val LocationPermissionPrivacyHintKey = "locationPermissionPrivacyHint"
     private const val PendingLocationPermissionPrivacyHintSyncKey = "pendingLocationPermissionPrivacyHintSync"
 
@@ -21,6 +22,7 @@ object ProfileRepository {
     internal const val LocationPermissionGrantedVisibility = "EMERGENCY_ONLY"
 
     private lateinit var prefs: SharedPreferences
+    private lateinit var permissionPrefs: SharedPreferences
     private var cachedProfile = ProfileData()
 
     internal const val LocationSharingInitializationMessage =
@@ -33,8 +35,20 @@ object ProfileRepository {
     fun initialize(context: Context) {
         if (!::prefs.isInitialized) {
             prefs = context.applicationContext.getSharedPreferences(PrefsName, Context.MODE_PRIVATE)
+            permissionPrefs = context.applicationContext.getSharedPreferences(PermissionPrefsName, Context.MODE_PRIVATE)
             cachedProfile = readProfileFromPrefs()
         }
+    }
+
+    internal fun initializeForTesting(
+        profilePrefs: SharedPreferences,
+        permissionPrivacyPrefs: SharedPreferences
+    ) {
+        requireDebugBuildForTestingReset()
+
+        prefs = profilePrefs
+        permissionPrefs = permissionPrivacyPrefs
+        cachedProfile = readProfileFromPrefs()
     }
 
     fun saveProfile(new: ProfileData) {
@@ -56,23 +70,28 @@ object ProfileRepository {
 
     fun rememberLocationPermissionPrivacyHint(granted: Boolean) {
         ensureInitialized()
-        prefs.edit()
+        permissionPrefs.edit()
             .putBoolean(LocationPermissionPrivacyHintKey, granted)
             .apply()
     }
 
     fun defaultLocationVisibilityFromStoredPermission(): String {
-        if (!::prefs.isInitialized) {
+        if (!::permissionPrefs.isInitialized) {
             return DefaultLocationVisibility
         }
         return defaultLocationVisibilityForPermission(
-            prefs.getBoolean(LocationPermissionPrivacyHintKey, false)
+            permissionPrefs.getBoolean(LocationPermissionPrivacyHintKey, false)
         )
     }
 
     fun hasPendingLocationPermissionPrivacyHintSync(): Boolean {
         ensureInitialized()
-        return prefs.getBoolean(PendingLocationPermissionPrivacyHintSyncKey, false)
+        return permissionPrefs.getBoolean(PendingLocationPermissionPrivacyHintSyncKey, false)
+    }
+
+    internal fun rememberLocationPermissionPrivacyHintForPendingSync(granted: Boolean) {
+        rememberLocationPermissionPrivacyHint(granted)
+        markPendingLocationPermissionPrivacyHintSync()
     }
 
     fun resetForTesting() {
@@ -81,6 +100,9 @@ object ProfileRepository {
         cachedProfile = ProfileData()
         if (::prefs.isInitialized) {
             prefs.edit().clear().commit()
+        }
+        if (::permissionPrefs.isInitialized) {
+            permissionPrefs.edit().clear().commit()
         }
     }
 
@@ -326,13 +348,13 @@ object ProfileRepository {
 
     suspend fun syncPrivacyDefaultsForLocationPermission(locationPermissionGranted: Boolean): ProfileData? {
         ensureInitialized()
-        rememberLocationPermissionPrivacyHint(locationPermissionGranted)
 
         val token = AuthSessionStore.getAccessToken().orEmpty()
         if (token.isBlank()) {
-            markPendingLocationPermissionPrivacyHintSync()
+            rememberLocationPermissionPrivacyHintForPendingSync(locationPermissionGranted)
             return null
         }
+        rememberLocationPermissionPrivacyHint(locationPermissionGranted)
 
         val profile = try {
             fetchAndCacheRemoteProfile()
@@ -373,7 +395,7 @@ object ProfileRepository {
 
         return try {
             syncPrivacyDefaultsForLocationPermission(
-                prefs.getBoolean(LocationPermissionPrivacyHintKey, false)
+                permissionPrefs.getBoolean(LocationPermissionPrivacyHintKey, false)
             )
         } catch (cancellationException: CancellationException) {
             throw cancellationException
@@ -734,13 +756,13 @@ object ProfileRepository {
     }
 
     private fun markPendingLocationPermissionPrivacyHintSync() {
-        prefs.edit()
+        permissionPrefs.edit()
             .putBoolean(PendingLocationPermissionPrivacyHintSyncKey, true)
             .apply()
     }
 
     private fun clearPendingLocationPermissionPrivacyHintSync() {
-        prefs.edit()
+        permissionPrefs.edit()
             .remove(PendingLocationPermissionPrivacyHintSyncKey)
             .apply()
     }
@@ -863,7 +885,7 @@ object ProfileRepository {
     }
 
     private fun ensureInitialized() {
-        check(::prefs.isInitialized) {
+        check(::prefs.isInitialized && ::permissionPrefs.isInitialized) {
             "ProfileRepository must be initialized before use."
         }
     }

--- a/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
+++ b/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
@@ -1,5 +1,6 @@
 package com.neph.features.profile.data
 
+import android.content.SharedPreferences
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -63,6 +64,27 @@ class ProfileRepositoryLocationPayloadTest {
         )
 
         assertEquals("EMERGENCY_ONLY", result)
+    }
+
+    @Test
+    fun loggedOutPermissionHint_survivesNormalLoginProfileClearUntilPendingSync() {
+        ProfileRepository.initializeForTesting(
+            profilePrefs = FakeSharedPreferences(),
+            permissionPrivacyPrefs = FakeSharedPreferences()
+        )
+
+        try {
+            ProfileRepository.saveProfile(ProfileData(email = "cached@example.com"))
+            ProfileRepository.rememberLocationPermissionPrivacyHintForPendingSync(granted = true)
+
+            ProfileRepository.clearProfile()
+
+            assertEquals(ProfileData(), ProfileRepository.getProfile())
+            assertTrue(ProfileRepository.hasPendingLocationPermissionPrivacyHintSync())
+            assertEquals("EMERGENCY_ONLY", ProfileRepository.defaultLocationVisibilityFromStoredPermission())
+        } finally {
+            ProfileRepository.resetForTesting()
+        }
     }
 
     @Test
@@ -312,5 +334,103 @@ class ProfileRepositoryLocationPayloadTest {
         assertFalse(payload.has("latitude"))
         assertFalse(payload.has("longitude"))
         assertFalse(payload.has("coordinate"))
+    }
+}
+
+private class FakeSharedPreferences : SharedPreferences {
+    private val values = mutableMapOf<String, Any?>()
+
+    override fun getAll(): MutableMap<String, *> = values.toMutableMap()
+
+    override fun getString(key: String?, defValue: String?): String? {
+        return values[key] as? String ?: defValue
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getStringSet(key: String?, defValues: MutableSet<String>?): MutableSet<String>? {
+        return values[key] as? MutableSet<String> ?: defValues
+    }
+
+    override fun getInt(key: String?, defValue: Int): Int {
+        return values[key] as? Int ?: defValue
+    }
+
+    override fun getLong(key: String?, defValue: Long): Long {
+        return values[key] as? Long ?: defValue
+    }
+
+    override fun getFloat(key: String?, defValue: Float): Float {
+        return values[key] as? Float ?: defValue
+    }
+
+    override fun getBoolean(key: String?, defValue: Boolean): Boolean {
+        return values[key] as? Boolean ?: defValue
+    }
+
+    override fun contains(key: String?): Boolean {
+        return values.containsKey(key)
+    }
+
+    override fun edit(): SharedPreferences.Editor {
+        return FakeEditor()
+    }
+
+    override fun registerOnSharedPreferenceChangeListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener?
+    ) = Unit
+
+    override fun unregisterOnSharedPreferenceChangeListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener?
+    ) = Unit
+
+    private inner class FakeEditor : SharedPreferences.Editor {
+        private val pendingValues = mutableMapOf<String, Any?>()
+        private val removals = mutableSetOf<String>()
+        private var clearRequested = false
+
+        override fun putString(key: String?, value: String?): SharedPreferences.Editor = apply {
+            key?.let { pendingValues[it] = value }
+        }
+
+        override fun putStringSet(key: String?, values: MutableSet<String>?): SharedPreferences.Editor = apply {
+            key?.let { pendingValues[it] = values }
+        }
+
+        override fun putInt(key: String?, value: Int): SharedPreferences.Editor = apply {
+            key?.let { pendingValues[it] = value }
+        }
+
+        override fun putLong(key: String?, value: Long): SharedPreferences.Editor = apply {
+            key?.let { pendingValues[it] = value }
+        }
+
+        override fun putFloat(key: String?, value: Float): SharedPreferences.Editor = apply {
+            key?.let { pendingValues[it] = value }
+        }
+
+        override fun putBoolean(key: String?, value: Boolean): SharedPreferences.Editor = apply {
+            key?.let { pendingValues[it] = value }
+        }
+
+        override fun remove(key: String?): SharedPreferences.Editor = apply {
+            key?.let { removals += it }
+        }
+
+        override fun clear(): SharedPreferences.Editor = apply {
+            clearRequested = true
+        }
+
+        override fun commit(): Boolean {
+            apply()
+            return true
+        }
+
+        override fun apply() {
+            if (clearRequested) {
+                values.clear()
+            }
+            removals.forEach(values::remove)
+            values.putAll(pendingValues)
+        }
     }
 }

--- a/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
+++ b/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
@@ -36,6 +36,36 @@ class ProfileRepositoryLocationPayloadTest {
     }
 
     @Test
+    fun resolveLocationVisibilityForPermissionBootstrap_preservesExistingLocationVisibility() {
+        val profile = ProfileData(
+            locationVisibility = "PUBLIC",
+            locationVisibilityInitialized = true
+        )
+
+        val result = ProfileRepository.resolveLocationVisibilityForPermissionBootstrap(
+            profile = profile,
+            locationPermissionGranted = false
+        )
+
+        assertEquals("PUBLIC", result)
+    }
+
+    @Test
+    fun resolveLocationVisibilityForPermissionBootstrap_usesPermissionDefaultWhenUninitialized() {
+        val profile = ProfileData(
+            locationVisibility = "PRIVATE",
+            locationVisibilityInitialized = false
+        )
+
+        val result = ProfileRepository.resolveLocationVisibilityForPermissionBootstrap(
+            profile = profile,
+            locationPermissionGranted = true
+        )
+
+        assertEquals("EMERGENCY_ONLY", result)
+    }
+
+    @Test
     fun mergePrivacySettingsResponse_preservesUnrelatedCachedProfileFields() {
         val cached = ProfileData(
             firstName = "Ada",
@@ -87,6 +117,7 @@ class ProfileRepositoryLocationPayloadTest {
             profileVisibility = "PUBLIC",
             healthInfoVisibility = "EMERGENCY_ONLY",
             locationVisibility = "PUBLIC",
+            locationVisibilityInitialized = true,
             shareLocation = true
         ), updated)
     }

--- a/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
+++ b/android/app/src/test/java/com/neph/features/profile/data/ProfileRepositoryLocationPayloadTest.kt
@@ -30,6 +30,12 @@ class ProfileRepositoryLocationPayloadTest {
     }
 
     @Test
+    fun defaultLocationVisibilityForPermission_tracksPermissionGrant() {
+        assertEquals("EMERGENCY_ONLY", ProfileRepository.defaultLocationVisibilityForPermission(true))
+        assertEquals("PRIVATE", ProfileRepository.defaultLocationVisibilityForPermission(false))
+    }
+
+    @Test
     fun mergePrivacySettingsResponse_preservesUnrelatedCachedProfileFields() {
         val cached = ProfileData(
             firstName = "Ada",

--- a/backend/migrations/20260507_140000__default_profile_health_visibility_emergency_only.sql
+++ b/backend/migrations/20260507_140000__default_profile_health_visibility_emergency_only.sql
@@ -1,0 +1,3 @@
+ALTER TABLE privacy_settings
+  ALTER COLUMN profile_visibility SET DEFAULT 'EMERGENCY_ONLY',
+  ALTER COLUMN health_info_visibility SET DEFAULT 'EMERGENCY_ONLY';

--- a/backend/src/modules/profiles/repository.js
+++ b/backend/src/modules/profiles/repository.js
@@ -621,6 +621,7 @@ async function findProfileBundleByUserId(userId) {
       up.first_name,
       up.last_name,
       up.phone_number,
+      ps.settings_id AS privacy_settings_id,
       ps.profile_visibility,
       ps.health_info_visibility,
       ps.location_visibility,

--- a/backend/src/modules/profiles/repository.js
+++ b/backend/src/modules/profiles/repository.js
@@ -1,6 +1,10 @@
 const { query } = require('../../db/pool');
 const { randomUUID } = require('crypto');
 
+const DEFAULT_PROFILE_VISIBILITY = 'EMERGENCY_ONLY';
+const DEFAULT_HEALTH_INFO_VISIBILITY = 'EMERGENCY_ONLY';
+const DEFAULT_LOCATION_VISIBILITY = 'PRIVATE';
+
 function makeId(prefix) {
   return `${prefix}_${randomUUID().replace(/-/g, '')}`;
 }
@@ -480,9 +484,9 @@ async function upsertPrivacySettings(profileId, data, providedFields = []) {
     VALUES (
       $1,
       $2,
-      CASE WHEN $7 THEN $3::visibility_level ELSE 'PRIVATE'::visibility_level END,
-      CASE WHEN $8 THEN $4::visibility_level ELSE 'PRIVATE'::visibility_level END,
-      CASE WHEN $9 THEN $5::visibility_level ELSE 'PRIVATE'::visibility_level END,
+      CASE WHEN $7 THEN $3::visibility_level ELSE '${DEFAULT_PROFILE_VISIBILITY}'::visibility_level END,
+      CASE WHEN $8 THEN $4::visibility_level ELSE '${DEFAULT_HEALTH_INFO_VISIBILITY}'::visibility_level END,
+      CASE WHEN $9 THEN $5::visibility_level ELSE '${DEFAULT_LOCATION_VISIBILITY}'::visibility_level END,
       CASE WHEN $10 THEN $6 ELSE FALSE END
     )
     ON CONFLICT (profile_id)

--- a/backend/src/modules/profiles/service.js
+++ b/backend/src/modules/profiles/service.js
@@ -60,6 +60,7 @@ function mapProfileRow(row) {
       profileVisibility: row.profile_visibility || DEFAULT_PROFILE_VISIBILITY,
       healthInfoVisibility: row.health_info_visibility || DEFAULT_HEALTH_INFO_VISIBILITY,
       locationVisibility: row.location_visibility || DEFAULT_LOCATION_VISIBILITY,
+      locationVisibilityInitialized: Boolean(row.privacy_settings_id && row.location_visibility),
       locationSharingEnabled: row.location_sharing_enabled || false,
     },
     healthInfo: {

--- a/backend/src/modules/profiles/service.js
+++ b/backend/src/modules/profiles/service.js
@@ -13,6 +13,10 @@ const {
   listExpertiseByProfileId,
 } = require('./repository');
 
+const DEFAULT_PROFILE_VISIBILITY = 'EMERGENCY_ONLY';
+const DEFAULT_HEALTH_INFO_VISIBILITY = 'EMERGENCY_ONLY';
+const DEFAULT_LOCATION_VISIBILITY = 'PRIVATE';
+
 function toIsoDateString(value) {
   if (!value) {
     return null;
@@ -53,9 +57,9 @@ function mapProfileRow(row) {
       phoneNumber: row.phone_number,
     },
     privacySettings: {
-      profileVisibility: row.profile_visibility || 'PRIVATE',
-      healthInfoVisibility: row.health_info_visibility || 'PRIVATE',
-      locationVisibility: row.location_visibility || 'PRIVATE',
+      profileVisibility: row.profile_visibility || DEFAULT_PROFILE_VISIBILITY,
+      healthInfoVisibility: row.health_info_visibility || DEFAULT_HEALTH_INFO_VISIBILITY,
+      locationVisibility: row.location_visibility || DEFAULT_LOCATION_VISIBILITY,
       locationSharingEnabled: row.location_sharing_enabled || false,
     },
     healthInfo: {

--- a/backend/tests/integration/modules/profiles/profiles.integration.test.js
+++ b/backend/tests/integration/modules/profiles/profiles.integration.test.js
@@ -403,6 +403,8 @@ describe('profiles integration', () => {
 
 		expect(response.status).toBe(200);
 		expect(response.body.privacySettings.profileVisibility).toBe('PUBLIC');
+		expect(response.body.privacySettings.healthInfoVisibility).toBe('EMERGENCY_ONLY');
+		expect(response.body.privacySettings.locationVisibility).toBe('PRIVATE');
 	});
 
 	test('PATCH /api/profiles/me/profession returns 401 without token', async () => {

--- a/backend/tests/unit/modules/profiles/service.test.js
+++ b/backend/tests/unit/modules/profiles/service.test.js
@@ -79,6 +79,17 @@ describe('profiles service', () => {
 		expect(result.expertise[0].profession).toBe('Doctor');
 	});
 
+	test('getMyProfile defaults profile and health visibility to emergency only', async () => {
+		repository.findProfileBundleByUserId.mockResolvedValueOnce(makeBundleRow());
+		repository.listExpertiseByProfileId.mockResolvedValueOnce([]);
+
+		const result = await getMyProfile('u1');
+
+		expect(result.privacySettings.profileVisibility).toBe('EMERGENCY_ONLY');
+		expect(result.privacySettings.healthInfoVisibility).toBe('EMERGENCY_ONLY');
+		expect(result.privacySettings.locationVisibility).toBe('PRIVATE');
+	});
+
 	test('getMyProfile maps date_of_birth to physicalInfo.dateOfBirth', async () => {
 		repository.findProfileBundleByUserId.mockResolvedValueOnce(
 			makeBundleRow({ date_of_birth: '1998-06-20' }),

--- a/backend/tests/unit/modules/profiles/service.test.js
+++ b/backend/tests/unit/modules/profiles/service.test.js
@@ -32,6 +32,7 @@ function makeBundleRow(overrides = {}) {
 		first_name: 'Ada',
 		last_name: 'Lovelace',
 		phone_number: null,
+		privacy_settings_id: null,
 		profile_visibility: null,
 		health_info_visibility: null,
 		location_visibility: null,
@@ -88,6 +89,22 @@ describe('profiles service', () => {
 		expect(result.privacySettings.profileVisibility).toBe('EMERGENCY_ONLY');
 		expect(result.privacySettings.healthInfoVisibility).toBe('EMERGENCY_ONLY');
 		expect(result.privacySettings.locationVisibility).toBe('PRIVATE');
+		expect(result.privacySettings.locationVisibilityInitialized).toBe(false);
+	});
+
+	test('getMyProfile reports location visibility initialized when privacy row exists', async () => {
+		repository.findProfileBundleByUserId.mockResolvedValueOnce(
+			makeBundleRow({
+				privacy_settings_id: 'set_1',
+				location_visibility: 'PUBLIC',
+			}),
+		);
+		repository.listExpertiseByProfileId.mockResolvedValueOnce([]);
+
+		const result = await getMyProfile('u1');
+
+		expect(result.privacySettings.locationVisibility).toBe('PUBLIC');
+		expect(result.privacySettings.locationVisibilityInitialized).toBe(true);
 	});
 
 	test('getMyProfile maps date_of_birth to physicalInfo.dateOfBirth', async () => {

--- a/web/src/lib/profile.ts
+++ b/web/src/lib/profile.ts
@@ -14,6 +14,7 @@ export type BackendProfileResponse = {
         profileVisibility: string;
         healthInfoVisibility: string;
         locationVisibility: string;
+        locationVisibilityInitialized?: boolean;
         locationSharingEnabled: boolean;
     };
     healthInfo: {


### PR DESCRIPTION
Related to the issue [#486](https://github.com/bounswe/bounswe2026group6/issues/486).

## Summary
- prompt for foreground location permission on first Android launch
- sync the initial permission result into saved location visibility defaults
- default profile and health visibility to `EMERGENCY_ONLY` instead of `PRIVATE`
- add backend migration/runtime defaults and focused tests