### PR TITLE
feat: add current location offline nearby refresh

### DIFF
--- a/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
+++ b/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
@@ -19,7 +19,7 @@ import com.neph.BuildConfig
         SyncOperationEntity::class,
         SyncMetadataEntity::class
     ],
-    version = 9,
+    version = 10,
     exportSchema = false
 )
 abstract class NephDatabase : RoomDatabase() {
@@ -146,6 +146,67 @@ object NephDatabaseProvider {
             database.execSQL("CREATE INDEX IF NOT EXISTS index_nearby_visible_users_fetchedAtEpochMillis ON nearby_visible_users (fetchedAtEpochMillis)")
         }
     }
+    private val Migration9To10 = object : Migration(9, 10) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS nearby_visible_users_new (
+                    cacheOwnerUserId TEXT NOT NULL,
+                    cacheSource TEXT NOT NULL DEFAULT 'RESIDENTIAL_PROFILE',
+                    userId TEXT NOT NULL,
+                    displayName TEXT,
+                    safetyStatus TEXT NOT NULL,
+                    statusUpdatedAt TEXT,
+                    latitude REAL,
+                    longitude REAL,
+                    locationCapturedAt TEXT,
+                    visibilityScope TEXT,
+                    fetchedAtEpochMillis INTEGER NOT NULL,
+                    expiresAtEpochMillis INTEGER NOT NULL,
+                    PRIMARY KEY(cacheOwnerUserId, cacheSource, userId)
+                )
+                """.trimIndent()
+            )
+            database.execSQL(
+                """
+                INSERT INTO nearby_visible_users_new (
+                    cacheOwnerUserId,
+                    cacheSource,
+                    userId,
+                    displayName,
+                    safetyStatus,
+                    statusUpdatedAt,
+                    latitude,
+                    longitude,
+                    locationCapturedAt,
+                    visibilityScope,
+                    fetchedAtEpochMillis,
+                    expiresAtEpochMillis
+                )
+                SELECT
+                    cacheOwnerUserId,
+                    'RESIDENTIAL_PROFILE',
+                    userId,
+                    displayName,
+                    safetyStatus,
+                    statusUpdatedAt,
+                    latitude,
+                    longitude,
+                    locationCapturedAt,
+                    visibilityScope,
+                    fetchedAtEpochMillis,
+                    expiresAtEpochMillis
+                FROM nearby_visible_users
+                """.trimIndent()
+            )
+            database.execSQL("DROP TABLE nearby_visible_users")
+            database.execSQL("ALTER TABLE nearby_visible_users_new RENAME TO nearby_visible_users")
+            database.execSQL("CREATE INDEX IF NOT EXISTS index_nearby_visible_users_cacheOwnerUserId ON nearby_visible_users (cacheOwnerUserId)")
+            database.execSQL("CREATE INDEX IF NOT EXISTS index_nearby_visible_users_cacheOwnerUserId_cacheSource ON nearby_visible_users (cacheOwnerUserId, cacheSource)")
+            database.execSQL("CREATE INDEX IF NOT EXISTS index_nearby_visible_users_safetyStatus ON nearby_visible_users (safetyStatus)")
+            database.execSQL("CREATE INDEX IF NOT EXISTS index_nearby_visible_users_fetchedAtEpochMillis ON nearby_visible_users (fetchedAtEpochMillis)")
+        }
+    }
 
     fun initialize(context: Context) {
         getInstance(context)
@@ -165,7 +226,8 @@ object NephDatabaseProvider {
                 Migration5To6,
                 Migration6To7,
                 Migration7To8,
-                Migration8To9
+                Migration8To9,
+                Migration9To10
             )
                 .build()
                 .also { instance = it }

--- a/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineDaos.kt
@@ -132,19 +132,27 @@ interface NearbyVisibleUserDao {
         """
         SELECT * FROM nearby_visible_users
         WHERE cacheOwnerUserId = :cacheOwnerUserId
+          AND cacheSource = :cacheSource
         ORDER BY fetchedAtEpochMillis DESC, displayName ASC, userId ASC
         """
     )
-    fun observeByCacheOwner(cacheOwnerUserId: String): Flow<List<NearbyVisibleUserEntity>>
+    fun observeByCacheOwnerAndSource(
+        cacheOwnerUserId: String,
+        cacheSource: String
+    ): Flow<List<NearbyVisibleUserEntity>>
 
     @Query(
         """
         SELECT * FROM nearby_visible_users
         WHERE cacheOwnerUserId = :cacheOwnerUserId
+          AND cacheSource = :cacheSource
         ORDER BY fetchedAtEpochMillis DESC, displayName ASC, userId ASC
         """
     )
-    suspend fun getByCacheOwner(cacheOwnerUserId: String): List<NearbyVisibleUserEntity>
+    suspend fun getByCacheOwnerAndSource(
+        cacheOwnerUserId: String,
+        cacheSource: String
+    ): List<NearbyVisibleUserEntity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertAll(users: List<NearbyVisibleUserEntity>)
@@ -153,10 +161,18 @@ interface NearbyVisibleUserDao {
         """
         DELETE FROM nearby_visible_users
         WHERE cacheOwnerUserId = :cacheOwnerUserId
+          AND cacheSource = :cacheSource
           AND userId NOT IN (:visibleUserIds)
         """
     )
-    suspend fun deleteUsersNotIn(cacheOwnerUserId: String, visibleUserIds: List<String>)
+    suspend fun deleteUsersNotIn(
+        cacheOwnerUserId: String,
+        cacheSource: String,
+        visibleUserIds: List<String>
+    )
+
+    @Query("DELETE FROM nearby_visible_users WHERE cacheOwnerUserId = :cacheOwnerUserId AND cacheSource = :cacheSource")
+    suspend fun clearByCacheOwnerAndSource(cacheOwnerUserId: String, cacheSource: String)
 
     @Query("DELETE FROM nearby_visible_users WHERE cacheOwnerUserId = :cacheOwnerUserId")
     suspend fun clearByCacheOwner(cacheOwnerUserId: String)

--- a/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
@@ -156,15 +156,17 @@ data class AssignedRequestEntity(
 
 @Entity(
     tableName = "nearby_visible_users",
-    primaryKeys = ["cacheOwnerUserId", "userId"],
+    primaryKeys = ["cacheOwnerUserId", "cacheSource", "userId"],
     indices = [
         Index(value = ["cacheOwnerUserId"]),
+        Index(value = ["cacheOwnerUserId", "cacheSource"]),
         Index(value = ["safetyStatus"]),
         Index(value = ["fetchedAtEpochMillis"])
     ]
 )
 data class NearbyVisibleUserEntity(
     val cacheOwnerUserId: String,
+    val cacheSource: String,
     val userId: String,
     val displayName: String?,
     val safetyStatus: String,

--- a/android/app/src/main/java/com/neph/features/nearbyusers/data/NearbyVisibleUsersRepository.kt
+++ b/android/app/src/main/java/com/neph/features/nearbyusers/data/NearbyVisibleUsersRepository.kt
@@ -4,13 +4,16 @@ import com.neph.core.database.NearbyVisibleUserEntity
 import com.neph.core.database.NephDatabaseProvider
 import com.neph.core.network.ApiException
 import com.neph.core.network.JsonHttpClient
+import com.neph.features.profile.data.CurrentDeviceLocation
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.CancellationException
 import org.json.JSONObject
+import java.util.Locale
 import kotlin.math.round
 
 data class NearbyVisibleUserUiModel(
+    val cacheSource: NearbyVisibleUsersCacheSource,
     val userId: String,
     val displayName: String?,
     val safetyStatus: String,
@@ -27,6 +30,17 @@ data class NearbyVisibleUserUiModel(
         get() = latitude != null && longitude != null
 }
 
+enum class NearbyVisibleUsersCacheSource(val storageValue: String) {
+    RESIDENTIAL_PROFILE("RESIDENTIAL_PROFILE"),
+    CURRENT_OPERATIONAL_LOCATION("CURRENT_OPERATIONAL_LOCATION");
+
+    companion object {
+        fun fromStorageValue(value: String): NearbyVisibleUsersCacheSource {
+            return values().firstOrNull { it.storageValue == value } ?: RESIDENTIAL_PROFILE
+        }
+    }
+}
+
 data class NearbyVisibleUsersResult(
     val users: List<NearbyVisibleUserUiModel>,
     val fromCache: Boolean,
@@ -40,23 +54,90 @@ object NearbyVisibleUsersRepository {
 
     private val database get() = NephDatabaseProvider.requireInstance()
 
-    fun observeCachedUsers(cacheOwnerUserId: String): Flow<List<NearbyVisibleUserUiModel>> {
+    fun observeCachedUsers(
+        cacheOwnerUserId: String,
+        cacheSource: NearbyVisibleUsersCacheSource = NearbyVisibleUsersCacheSource.RESIDENTIAL_PROFILE
+    ): Flow<List<NearbyVisibleUserUiModel>> {
         return database.nearbyVisibleUserDao()
-            .observeByCacheOwner(cacheOwnerUserId)
+            .observeByCacheOwnerAndSource(cacheOwnerUserId, cacheSource.storageValue)
             .map { entities -> entities.map { it.toUiModel(System.currentTimeMillis()) } }
     }
 
     suspend fun refreshNearbyVisibleUsers(token: String, cacheOwnerUserId: String): NearbyVisibleUsersResult {
+        return refreshNearbyVisibleUsersForSource(
+            token = token,
+            cacheOwnerUserId = cacheOwnerUserId,
+            cacheSource = NearbyVisibleUsersCacheSource.RESIDENTIAL_PROFILE,
+            path = "/safety-status/visible?nearby=true"
+        )
+    }
+
+    suspend fun refreshNearbyVisibleUsersForCurrentLocation(
+        token: String,
+        cacheOwnerUserId: String,
+        currentLocation: CurrentDeviceLocation
+    ): NearbyVisibleUsersResult {
+        val latitude = "%.6f".format(Locale.US, currentLocation.latitude)
+        val longitude = "%.6f".format(Locale.US, currentLocation.longitude)
+        return refreshNearbyVisibleUsersForSource(
+            token = token,
+            cacheOwnerUserId = cacheOwnerUserId,
+            cacheSource = NearbyVisibleUsersCacheSource.CURRENT_OPERATIONAL_LOCATION,
+            path = "/safety-status/visible?nearby=true&context=current-location&latitude=$latitude&longitude=$longitude",
+            fallbackToCacheOnApiError = false
+        )
+    }
+
+    internal fun parseVisibleSafetyStatuses(
+        response: JSONObject,
+        now: Long,
+        cacheOwnerUserId: String,
+        cacheSource: NearbyVisibleUsersCacheSource = NearbyVisibleUsersCacheSource.RESIDENTIAL_PROFILE
+    ): List<NearbyVisibleUserEntity> {
+        val items = response.optJSONArray("safetyStatuses") ?: return emptyList()
+        return buildList {
+            for (index in 0 until items.length()) {
+                items.optJSONObject(index)?.toNearbyVisibleUserEntity(
+                    now = now,
+                    cacheOwnerUserId = cacheOwnerUserId,
+                    cacheSource = cacheSource
+                )?.let(::add)
+            }
+        }.distinctBy { it.userId }
+    }
+
+    internal fun isEntityStale(entity: NearbyVisibleUserEntity, now: Long): Boolean {
+        return entity.expiresAtEpochMillis <= now || entity.fetchedAtEpochMillis + StaleAfterMillis <= now
+    }
+
+    suspend fun clearLocalCache(cacheOwnerUserId: String? = null) {
+        if (cacheOwnerUserId.isNullOrBlank()) {
+            database.nearbyVisibleUserDao().clearAll()
+        } else {
+            database.nearbyVisibleUserDao().clearByCacheOwner(cacheOwnerUserId)
+        }
+    }
+
+    private suspend fun refreshNearbyVisibleUsersForSource(
+        token: String,
+        cacheOwnerUserId: String,
+        cacheSource: NearbyVisibleUsersCacheSource,
+        path: String,
+        fallbackToCacheOnApiError: Boolean = true
+    ): NearbyVisibleUsersResult {
         val now = System.currentTimeMillis()
         database.nearbyVisibleUserDao().deleteExpired(now)
 
         return try {
             val response = JsonHttpClient.request(
-                path = "/safety-status/visible?nearby=true",
+                path = path,
                 token = token
             )
-            val entities = parseVisibleSafetyStatuses(response, now, cacheOwnerUserId)
-            database.nearbyVisibleUserDao().clearByCacheOwner(cacheOwnerUserId)
+            val entities = parseVisibleSafetyStatuses(response, now, cacheOwnerUserId, cacheSource)
+            database.nearbyVisibleUserDao().clearByCacheOwnerAndSource(
+                cacheOwnerUserId = cacheOwnerUserId,
+                cacheSource = cacheSource.storageValue
+            )
             if (entities.isNotEmpty()) {
                 database.nearbyVisibleUserDao().upsertAll(entities)
             }
@@ -69,38 +150,22 @@ object NearbyVisibleUsersRepository {
         } catch (cancellationException: CancellationException) {
             throw cancellationException
         } catch (error: ApiException) {
-            if (error.status == 401) {
+            if (error.status == 401 || !fallbackToCacheOnApiError) {
                 throw error
             }
-            returnCachedUsers(cacheOwnerUserId, now)
+            returnCachedUsers(cacheOwnerUserId, cacheSource, now)
         } catch (error: Exception) {
-            returnCachedUsers(cacheOwnerUserId, now)
+            returnCachedUsers(cacheOwnerUserId, cacheSource, now)
         }
-    }
-
-    internal fun parseVisibleSafetyStatuses(
-        response: JSONObject,
-        now: Long,
-        cacheOwnerUserId: String
-    ): List<NearbyVisibleUserEntity> {
-        val items = response.optJSONArray("safetyStatuses") ?: return emptyList()
-        return buildList {
-            for (index in 0 until items.length()) {
-                items.optJSONObject(index)?.toNearbyVisibleUserEntity(now, cacheOwnerUserId)?.let(::add)
-            }
-        }.distinctBy { it.userId }
-    }
-
-    internal fun isEntityStale(entity: NearbyVisibleUserEntity, now: Long): Boolean {
-        return entity.expiresAtEpochMillis <= now || entity.fetchedAtEpochMillis + StaleAfterMillis <= now
     }
 
     private suspend fun returnCachedUsers(
         cacheOwnerUserId: String,
+        cacheSource: NearbyVisibleUsersCacheSource,
         now: Long
     ): NearbyVisibleUsersResult {
         val cached = database.nearbyVisibleUserDao()
-            .getByCacheOwner(cacheOwnerUserId)
+            .getByCacheOwnerAndSource(cacheOwnerUserId, cacheSource.storageValue)
             .map { it.toUiModel(now, forceStale = true) }
         return NearbyVisibleUsersResult(
             users = cached,
@@ -114,15 +179,11 @@ object NearbyVisibleUsersRepository {
         )
     }
 
-    suspend fun clearLocalCache(cacheOwnerUserId: String? = null) {
-        if (cacheOwnerUserId.isNullOrBlank()) {
-            database.nearbyVisibleUserDao().clearAll()
-        } else {
-            database.nearbyVisibleUserDao().clearByCacheOwner(cacheOwnerUserId)
-        }
-    }
-
-    private fun JSONObject.toNearbyVisibleUserEntity(now: Long, cacheOwnerUserId: String): NearbyVisibleUserEntity? {
+    private fun JSONObject.toNearbyVisibleUserEntity(
+        now: Long,
+        cacheOwnerUserId: String,
+        cacheSource: NearbyVisibleUsersCacheSource
+    ): NearbyVisibleUserEntity? {
         val userId = optString("userId").trim()
         if (userId.isBlank()) {
             return null
@@ -134,6 +195,7 @@ object NearbyVisibleUsersRepository {
 
         return NearbyVisibleUserEntity(
             cacheOwnerUserId = cacheOwnerUserId,
+            cacheSource = cacheSource.storageValue,
             userId = userId,
             displayName = optString("displayName").takeIf { it.isNotBlank() && it != "null" },
             safetyStatus = optString("status").ifBlank { "unknown" },
@@ -156,6 +218,7 @@ object NearbyVisibleUsersRepository {
         forceStale: Boolean = false
     ): NearbyVisibleUserUiModel {
         return NearbyVisibleUserUiModel(
+            cacheSource = NearbyVisibleUsersCacheSource.fromStorageValue(cacheSource),
             userId = userId,
             displayName = displayName,
             safetyStatus = safetyStatus,

--- a/android/app/src/main/java/com/neph/features/nearbyusers/presentation/NearbyVisibleUsersScreen.kt
+++ b/android/app/src/main/java/com/neph/features/nearbyusers/presentation/NearbyVisibleUsersScreen.kt
@@ -20,19 +20,26 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.neph.core.network.ApiException
 import com.neph.features.auth.data.AuthRepository
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.nearbyusers.data.NearbyVisibleUserUiModel
+import com.neph.features.nearbyusers.data.NearbyVisibleUsersCacheSource
 import com.neph.features.nearbyusers.data.NearbyVisibleUsersRepository
+import com.neph.features.operationallocation.data.OperationalLocationRepository
+import com.neph.features.profile.data.CurrentLocationShareWarning
+import com.neph.features.profile.data.DeviceLocationProvider
+import com.neph.features.profile.data.ProfileRepository
 import com.neph.navigation.Routes
 import com.neph.ui.components.buttons.SecondaryButton
 import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
 import com.neph.ui.layout.AppDrawerScaffold
+import com.neph.ui.location.rememberForegroundLocationPermissionRequester
 import com.neph.ui.theme.LocalNephSpacing
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
@@ -51,12 +58,16 @@ fun NearbyVisibleUsersScreen(
 ) {
     val spacing = LocalNephSpacing.current
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
     val token = AuthSessionStore.getAccessToken()
     var users by remember { mutableStateOf<List<NearbyVisibleUserUiModel>>(emptyList()) }
     var loading by remember { mutableStateOf(false) }
     var message by remember { mutableStateOf("") }
     var errorMessage by remember { mutableStateOf("") }
     var showingCachedData by remember { mutableStateOf(false) }
+    var activeCacheSource by remember {
+        mutableStateOf(NearbyVisibleUsersCacheSource.RESIDENTIAL_PROFILE)
+    }
 
     fun loadNearbyUsers() {
         val safeToken = token
@@ -76,6 +87,7 @@ fun NearbyVisibleUsersScreen(
                     cacheOwnerUserId = cacheOwnerUserId
                 )
                 users = result.users
+                activeCacheSource = NearbyVisibleUsersCacheSource.RESIDENTIAL_PROFILE
                 showingCachedData = result.fromCache || result.isStale
                 message = when {
                     result.message != null -> result.message
@@ -98,6 +110,102 @@ fun NearbyVisibleUsersScreen(
             } finally {
                 loading = false
             }
+        }
+    }
+
+    fun updateOfflineDataForCurrentLocation() {
+        val safeToken = token
+        val cacheOwnerUserId = AuthSessionStore.getCurrentUserId()
+        if (safeToken.isNullOrBlank() || cacheOwnerUserId.isNullOrBlank()) {
+            onNavigateToLogin()
+            return
+        }
+
+        loading = true
+        message = ""
+        errorMessage = ""
+        scope.launch {
+            try {
+                val profile = try {
+                    ProfileRepository.fetchAndCacheRemoteProfile()
+                } catch (apiError: ApiException) {
+                    if (apiError.status == 401) {
+                        throw apiError
+                    }
+                    showingCachedData = false
+                    message = "Could not verify current-location privacy settings. Offline data was not updated."
+                    return@launch
+                } catch (_: Exception) {
+                    showingCachedData = false
+                    message = "Could not verify current-location privacy settings. Offline data was not updated."
+                    return@launch
+                }
+
+                if (profile.shareLocation != true) {
+                    showingCachedData = false
+                    message = "Share Current Location is disabled in privacy settings. Offline data was not updated."
+                    return@launch
+                }
+
+                val attempt = DeviceLocationProvider.captureCurrentLocationForSharing(
+                    context = context,
+                    sharingEnabled = true
+                )
+                val location = attempt.location
+                if (location == null) {
+                    showingCachedData = false
+                    message = when (attempt.warning) {
+                        CurrentLocationShareWarning.PERMISSION_DENIED ->
+                            "Location permission was denied. Offline data was not updated."
+
+                        CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
+                        null -> "Current location is unavailable. Offline data was not updated."
+                    }
+                    return@launch
+                }
+
+                OperationalLocationRepository.saveAndSyncIfAuthenticated(location)
+                val result = NearbyVisibleUsersRepository.refreshNearbyVisibleUsersForCurrentLocation(
+                    token = safeToken,
+                    cacheOwnerUserId = cacheOwnerUserId,
+                    currentLocation = location
+                )
+                users = result.users
+                activeCacheSource = NearbyVisibleUsersCacheSource.CURRENT_OPERATIONAL_LOCATION
+                showingCachedData = result.fromCache || result.isStale
+                message = when {
+                    result.message != null -> result.message
+                    result.users.isEmpty() -> "No visible users were found around your current location."
+                    result.fromCache -> "Showing cached current-location offline data. This information may be stale."
+                    else -> "Offline data for your current location was updated."
+                }
+            } catch (error: ApiException) {
+                if (error.status == 401) {
+                    AuthRepository.logout()
+                    errorMessage = "Session expired. Please log in again."
+                    onNavigateToLogin()
+                } else if (error.status == 403 || error.code == "CURRENT_LOCATION_NEARBY_NOT_ALLOWED") {
+                    errorMessage = "Current-location offline refresh is blocked by privacy or location safety rules."
+                } else {
+                    errorMessage = error.message.ifBlank { "Could not update offline data for current location." }
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                errorMessage = "Could not update offline data for current location."
+            } finally {
+                loading = false
+            }
+        }
+    }
+
+    val locationPermissionRequester = rememberForegroundLocationPermissionRequester { result ->
+        if (result.granted) {
+            updateOfflineDataForCurrentLocation()
+        } else {
+            loading = false
+            errorMessage = ""
+            message = "Location permission was denied. Offline data was not updated."
         }
     }
 
@@ -135,6 +243,17 @@ fun NearbyVisibleUsersScreen(
                         onClick = { loadNearbyUsers() },
                         enabled = !loading
                     )
+                    SecondaryButton(
+                        text = "Update Offline Data for Current Location",
+                        onClick = {
+                            if (locationPermissionRequester.refreshPermissionState()) {
+                                updateOfflineDataForCurrentLocation()
+                            } else {
+                                locationPermissionRequester.requestPermission()
+                            }
+                        },
+                        enabled = !loading
+                    )
                 }
             }
 
@@ -146,6 +265,18 @@ fun NearbyVisibleUsersScreen(
                 SectionCard {
                     HelperText(text = "Cached data may be stale. Refresh when connectivity is available.")
                 }
+            }
+
+            SectionCard {
+                HelperText(
+                    text = when (activeCacheSource) {
+                        NearbyVisibleUsersCacheSource.RESIDENTIAL_PROFILE ->
+                            "Showing offline cache from your residential/profile area."
+
+                        NearbyVisibleUsersCacheSource.CURRENT_OPERATIONAL_LOCATION ->
+                            "Showing offline cache from your last manual current-location update."
+                    }
+                )
             }
 
             if (message.isNotBlank()) {

--- a/android/app/src/test/java/com/neph/features/nearbyusers/data/NearbyVisibleUsersRepositoryTest.kt
+++ b/android/app/src/test/java/com/neph/features/nearbyusers/data/NearbyVisibleUsersRepositoryTest.kt
@@ -41,6 +41,7 @@ class NearbyVisibleUsersRepositoryTest {
 
         assertEquals(1, users.size)
         assertEquals("viewer-1", users[0].cacheOwnerUserId)
+        assertEquals(NearbyVisibleUsersCacheSource.RESIDENTIAL_PROFILE.storageValue, users[0].cacheSource)
         assertEquals("user-visible", users[0].userId)
         assertEquals("Visible User", users[0].displayName)
         assertEquals("safe", users[0].safetyStatus)
@@ -48,6 +49,33 @@ class NearbyVisibleUsersRepositoryTest {
         assertEquals(41.043, users[0].latitude ?: 0.0, 0.0)
         assertEquals(29.010, users[0].longitude ?: 0.0, 0.0)
         assertEquals(now, users[0].fetchedAtEpochMillis)
+    }
+
+    @Test
+    fun parserStoresCurrentLocationCacheSourceSeparately() {
+        val response = JSONObject()
+            .put(
+                "safetyStatuses",
+                JSONArray()
+                    .put(
+                        JSONObject()
+                            .put("userId", "user-current-location")
+                            .put("displayName", "Current Nearby")
+                            .put("status", "safe")
+                    )
+            )
+
+        val user = NearbyVisibleUsersRepository.parseVisibleSafetyStatuses(
+            response,
+            now = 2_000L,
+            cacheOwnerUserId = "viewer-1",
+            cacheSource = NearbyVisibleUsersCacheSource.CURRENT_OPERATIONAL_LOCATION
+        ).single()
+
+        assertEquals(
+            NearbyVisibleUsersCacheSource.CURRENT_OPERATIONAL_LOCATION.storageValue,
+            user.cacheSource
+        )
     }
 
     @Test
@@ -80,6 +108,7 @@ class NearbyVisibleUsersRepositoryTest {
     fun stalePolicyMarksCacheStaleAfterRefreshWindowOrExpiry() {
         val entity = NearbyVisibleUserEntity(
             cacheOwnerUserId = "viewer-1",
+            cacheSource = NearbyVisibleUsersCacheSource.RESIDENTIAL_PROFILE.storageValue,
             userId = "user-stale",
             displayName = "Stale User",
             safetyStatus = "unknown",

--- a/backend/src/modules/safety-status/controller.js
+++ b/backend/src/modules/safety-status/controller.js
@@ -15,9 +15,27 @@ function sendError(response, status, code, message, details) {
 
 function parseVisibleStatusesQuery(query) {
   const nearbyOnly = String(query.nearby || '').toLowerCase() === 'true';
+  const context = String(query.context || '').trim().toLowerCase();
+  const usesCurrentLocation = context === 'current-location';
+  const latitude = query.latitude === undefined ? null : Number(query.latitude);
+  const longitude = query.longitude === undefined ? null : Number(query.longitude);
+
+  if (usesCurrentLocation) {
+    if (!nearbyOnly) {
+      return { error: 'current-location context requires nearby=true.' };
+    }
+    if (!Number.isFinite(latitude) || latitude < -90 || latitude > 90) {
+      return { error: 'latitude must be a number between -90 and 90.' };
+    }
+    if (!Number.isFinite(longitude) || longitude < -180 || longitude > 180) {
+      return { error: 'longitude must be a number between -180 and 180.' };
+    }
+  }
 
   return {
     nearbyOnly,
+    context,
+    currentLocation: usesCurrentLocation ? { latitude, longitude } : null,
   };
 }
 
@@ -49,12 +67,20 @@ async function handlePatchMySafetyStatus(request, response) {
 async function handleGetVisibleSafetyStatuses(request, response) {
   try {
     const query = parseVisibleStatusesQuery(request.query || {});
+    if (query.error) {
+      return sendError(response, 400, 'VALIDATION_FAILED', query.error);
+    }
     const safetyStatuses = await getVisibleSafetyStatuses(request.user.userId, {
       isAdmin: Boolean(request.user.isAdmin),
       nearbyOnly: query.nearbyOnly,
+      nearbyContext: query.context,
+      currentLocation: query.currentLocation,
     });
     return response.status(200).json({ safetyStatuses });
   } catch (error) {
+    if (error.status && error.code) {
+      return sendError(response, error.status, error.code, error.message);
+    }
     console.error('safetyStatus.handleGetVisibleSafetyStatuses failed', error);
     return sendError(response, 500, 'INTERNAL_ERROR', 'Unexpected server error');
   }

--- a/backend/src/modules/safety-status/repository.js
+++ b/backend/src/modules/safety-status/repository.js
@@ -58,6 +58,69 @@ function mapVisibleSafetyStatus(row, { isAdmin = false } = {}) {
   };
 }
 
+function createCurrentLocationGuardError(message) {
+  const error = new Error(message);
+  error.status = 403;
+  error.code = 'CURRENT_LOCATION_NEARBY_NOT_ALLOWED';
+  return error;
+}
+
+async function requireAllowedCurrentLocationContext(viewerUserId, requestedLocation) {
+  const result = await query(
+    `
+      SELECT
+        COALESCE(ps.location_sharing_enabled, FALSE) AS location_sharing_enabled,
+        uol.latitude,
+        uol.longitude,
+        uol.updated_at,
+        CASE
+          WHEN uol.latitude IS NULL OR uol.longitude IS NULL THEN NULL
+          ELSE (
+            6371 * ACOS(
+              LEAST(
+                1,
+                GREATEST(
+                  -1,
+                  SIN(RADIANS($2::double precision)) * SIN(RADIANS(uol.latitude::double precision))
+                    + COS(RADIANS($2::double precision)) * COS(RADIANS(uol.latitude::double precision))
+                    * COS(RADIANS(uol.longitude::double precision - $3::double precision))
+                )
+              )
+            )
+          )
+        END AS requested_distance_km
+      FROM users u
+      LEFT JOIN user_profiles up ON up.user_id = u.user_id
+      LEFT JOIN privacy_settings ps ON ps.profile_id = up.profile_id
+      LEFT JOIN user_operational_locations uol ON uol.user_id = u.user_id
+      WHERE u.user_id = $1;
+    `,
+    [viewerUserId, requestedLocation.latitude, requestedLocation.longitude],
+  );
+
+  const row = result.rows[0];
+  if (!row || !row.location_sharing_enabled) {
+    throw createCurrentLocationGuardError('Current-location nearby refresh is disabled by privacy settings.');
+  }
+
+  if (row.latitude == null || row.longitude == null) {
+    throw createCurrentLocationGuardError('Current operational location is not available.');
+  }
+
+  if (row.updated_at == null || new Date(row.updated_at).getTime() < Date.now() - 2 * 60 * 60 * 1000) {
+    throw createCurrentLocationGuardError('Current operational location is stale.');
+  }
+
+  if (Number(row.requested_distance_km) > 1) {
+    throw createCurrentLocationGuardError('Requested coordinates do not match the latest operational location.');
+  }
+
+  return {
+    latitude: Number(row.latitude),
+    longitude: Number(row.longitude),
+  };
+}
+
 async function findSafetyStatusByUserId(userId) {
   const result = await query(
     `
@@ -163,7 +226,20 @@ async function upsertSafetyStatus(userId, input) {
   return mapSafetyStatus(result.rows[0]);
 }
 
-async function listVisibleSafetyStatuses(viewerUserId, { isAdmin = false, nearbyOnly = false } = {}) {
+async function listVisibleSafetyStatuses(
+  viewerUserId,
+  {
+    isAdmin = false,
+    nearbyOnly = false,
+    nearbyContext = '',
+    currentLocation = null,
+  } = {},
+) {
+  const usesCurrentLocation = nearbyContext === 'current-location' && currentLocation;
+  const effectiveCurrentLocation = usesCurrentLocation
+    ? await requireAllowedCurrentLocationContext(viewerUserId, currentLocation)
+    : null;
+  const nearbyRadiusKm = 10;
   const result = await query(
     `
       WITH visible_statuses AS (
@@ -187,6 +263,8 @@ async function listVisibleSafetyStatuses(viewerUserId, { isAdmin = false, nearby
         target_lp.city,
         target_lp.district,
         target_lp.neighborhood,
+        target_lp.latitude AS profile_latitude,
+        target_lp.longitude AS profile_longitude,
         viewer_lp.country AS viewer_country,
         viewer_lp.city AS viewer_city,
         viewer_lp.district AS viewer_district,
@@ -222,7 +300,27 @@ async function listVisibleSafetyStatuses(viewerUserId, { isAdmin = false, nearby
       FROM visible_statuses
       WHERE $3 = FALSE
         OR (
-          user_id <> $1
+          $7 = TRUE
+          AND user_id <> $1
+          AND profile_latitude IS NOT NULL
+          AND profile_longitude IS NOT NULL
+          AND (
+            6371 * ACOS(
+              LEAST(
+                1,
+                GREATEST(
+                  -1,
+                  SIN(RADIANS($4::double precision)) * SIN(RADIANS(profile_latitude::double precision))
+                    + COS(RADIANS($4::double precision)) * COS(RADIANS(profile_latitude::double precision))
+                    * COS(RADIANS(profile_longitude::double precision - $5::double precision))
+                )
+              )
+            )
+          ) <= $6
+        )
+        OR (
+          $7 = FALSE
+          AND user_id <> $1
           AND NULLIF(TRIM(COALESCE(viewer_neighborhood, '')), '') IS NOT NULL
           AND NULLIF(TRIM(COALESCE(neighborhood, '')), '') IS NOT NULL
           AND LOWER(TRIM(COALESCE(viewer_country, ''))) = LOWER(TRIM(COALESCE(country, '')))
@@ -232,7 +330,15 @@ async function listVisibleSafetyStatuses(viewerUserId, { isAdmin = false, nearby
         )
       ORDER BY updated_at DESC, user_id ASC;
     `,
-    [viewerUserId, isAdmin, Boolean(nearbyOnly)],
+    [
+      viewerUserId,
+      isAdmin,
+      Boolean(nearbyOnly),
+      effectiveCurrentLocation ? effectiveCurrentLocation.latitude : 0,
+      effectiveCurrentLocation ? effectiveCurrentLocation.longitude : 0,
+      nearbyRadiusKm,
+      Boolean(usesCurrentLocation),
+    ],
   );
 
   return result.rows.map((row) => mapVisibleSafetyStatus(row, { isAdmin }));

--- a/backend/tests/integration/modules/safety-status/safety-status.integration.test.js
+++ b/backend/tests/integration/modules/safety-status/safety-status.integration.test.js
@@ -106,6 +106,7 @@ async function seedProfile(userId, options = {}) {
 beforeEach(async () => {
   await query(`
     TRUNCATE TABLE
+      user_operational_locations,
       user_safety_statuses,
       messages,
       assignments,
@@ -475,5 +476,136 @@ describe('safety-status integration', () => {
       latitude: 41.044,
       longitude: 29.01,
     });
+  });
+
+  test('GET /api/safety-status/visible nearby supports explicit current-location context', async () => {
+    const app = createTestApp();
+    const viewerId = 'user_current_location_viewer';
+    const nearId = 'user_current_location_near';
+    const farId = 'user_current_location_far';
+    await seedActiveUser(viewerId);
+    await seedActiveUser(nearId);
+    await seedActiveUser(farId);
+    await seedProfile(viewerId, {
+      profileVisibility: 'PRIVATE',
+      locationVisibility: 'PRIVATE',
+      locationSharingEnabled: true,
+      neighborhood: 'Moda',
+      latitude: 40.988,
+      longitude: 29.024,
+    });
+    await query(
+      `
+        INSERT INTO user_operational_locations (user_id, latitude, longitude, accuracy_meters, source, captured_at)
+        VALUES ($1, 41.043, 29.009, 20, 'DEVICE_GPS', CURRENT_TIMESTAMP);
+      `,
+      [viewerId],
+    );
+    await seedProfile(nearId, {
+      firstName: 'Current',
+      lastName: 'Nearby',
+      profileVisibility: 'PUBLIC',
+      locationVisibility: 'PUBLIC',
+      locationSharingEnabled: true,
+      neighborhood: 'Levazim',
+      latitude: 41.044,
+      longitude: 29.01,
+    });
+    await seedProfile(farId, {
+      firstName: 'Current',
+      lastName: 'Far',
+      profileVisibility: 'PUBLIC',
+      locationVisibility: 'PUBLIC',
+      locationSharingEnabled: true,
+      neighborhood: 'Bursa',
+      latitude: 40.182,
+      longitude: 29.066,
+    });
+
+    for (const userId of [viewerId, nearId, farId]) {
+      await request(app)
+        .patch('/api/safety-status/me')
+        .set('Authorization', `Bearer ${buildAuthToken(userId)}`)
+        .send({
+          status: userId === farId ? 'safe' : 'not_safe',
+          shareLocationConsent: true,
+          location: { latitude: 41.044, longitude: 29.01 },
+        })
+        .expect(200);
+    }
+
+    const response = await request(app)
+      .get('/api/safety-status/visible?nearby=true&context=current-location&latitude=41.043&longitude=29.009')
+      .set('Authorization', `Bearer ${buildAuthToken(viewerId)}`);
+
+    expect(response.status).toBe(200);
+    const byUserId = Object.fromEntries(
+      response.body.safetyStatuses.map((item) => [item.userId, item]),
+    );
+    expect(byUserId[nearId]).toMatchObject({
+      displayName: 'Current Nearby',
+      status: 'not_safe',
+    });
+    expect(byUserId[viewerId]).toBeUndefined();
+    expect(byUserId[farId]).toBeUndefined();
+  });
+
+  test('GET /api/safety-status/visible current-location context requires allowed synced operational location', async () => {
+    const app = createTestApp();
+    const viewerId = 'user_current_location_guard';
+    await seedActiveUser(viewerId);
+    await seedProfile(viewerId, {
+      profileVisibility: 'PRIVATE',
+      locationVisibility: 'PRIVATE',
+      locationSharingEnabled: false,
+      neighborhood: 'Moda',
+      latitude: 40.988,
+      longitude: 29.024,
+    });
+    await query(
+      `
+        INSERT INTO user_operational_locations (user_id, latitude, longitude, accuracy_meters, source, captured_at)
+        VALUES ($1, 41.043, 29.009, 20, 'DEVICE_GPS', CURRENT_TIMESTAMP);
+      `,
+      [viewerId],
+    );
+
+    const disabledResponse = await request(app)
+      .get('/api/safety-status/visible?nearby=true&context=current-location&latitude=41.043&longitude=29.009')
+      .set('Authorization', `Bearer ${buildAuthToken(viewerId)}`);
+
+    expect(disabledResponse.status).toBe(403);
+    expect(disabledResponse.body.code).toBe('CURRENT_LOCATION_NEARBY_NOT_ALLOWED');
+
+    await query(
+      `
+        UPDATE privacy_settings ps
+        SET location_sharing_enabled = TRUE
+        FROM user_profiles up
+        WHERE ps.profile_id = up.profile_id
+          AND up.user_id = $1;
+      `,
+      [viewerId],
+    );
+
+    const mismatchResponse = await request(app)
+      .get('/api/safety-status/visible?nearby=true&context=current-location&latitude=40.182&longitude=29.066')
+      .set('Authorization', `Bearer ${buildAuthToken(viewerId)}`);
+
+    expect(mismatchResponse.status).toBe(403);
+    expect(mismatchResponse.body.code).toBe('CURRENT_LOCATION_NEARBY_NOT_ALLOWED');
+  });
+
+  test('GET /api/safety-status/visible current-location context validates coordinates', async () => {
+    const app = createTestApp();
+    const viewerId = 'user_current_location_invalid';
+    await seedActiveUser(viewerId);
+
+    const response = await request(app)
+      .get('/api/safety-status/visible?nearby=true&context=current-location&latitude=bad&longitude=29.009')
+      .set('Authorization', `Bearer ${buildAuthToken(viewerId)}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('VALIDATION_FAILED');
   });
 });


### PR DESCRIPTION
**Closes #471**

**Summary**
- Adds privacy-aware manual offline cache refresh for nearby visible users around the user's current operational location.

**Changes**
- Adds a manual **Update Offline Data for Current Location** action to the Nearby Users screen.
- Keeps default nearby offline cache behavior based on residential/profile area.
- Separates residential/profile cache from current operational location cache with cache source metadata.
- Requests foreground location permission only when the user triggers the current-location refresh.
- Blocks current-location refresh when **Share Current Location** is disabled or privacy settings cannot be freshly verified.
- Captures current operational location without overwriting residential/profile location.
- Requires backend current-location lookup to match the user's latest synced operational location.
- Prevents arbitrary coordinate lookup by rejecting mismatched or stale operational-location requests.
- Stores refreshed current-location nearby data in local cache.
- Repeated current-location refreshes replace only the previous current-location cache.
- Shows clear success, denied, unavailable, cached/stale, empty, blocked, and failed states.
- Adds backend support for current-location nearby lookup with explicit coordinates.
- Preserves existing privacy and trusted-circle visibility rules for returned users and cached locations.
- Adds Android cache source tests.
- Adds backend integration coverage for current-location nearby lookup, coordinate validation, privacy blocking, and coordinate mismatch blocking.

**Migration Note**
- Android Room DB is bumped from 9 to 10 to add `cacheSource` metadata for nearby visible user cache.
- This is a local Android cache migration only; no backend PostgreSQL schema migration is needed.
- Existing cached nearby users are migrated as `RESIDENTIAL_PROFILE`.


