### PR TITLE
fix: Android account deletion flow

### DIFF
--- a/android/app/src/androidTest/java/com/neph/e2e/AuthenticatedSessionAndroidE2ETest.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/AuthenticatedSessionAndroidE2ETest.kt
@@ -93,6 +93,23 @@ class AuthenticatedSessionAndroidE2ETest {
         composeRule.onNodeWithText("Continue as Guest").assertIsDisplayed()
     }
 
+    @Test
+    fun authenticatedUser_can_deleteAccountFromSettings() {
+        waitForText("I need help")
+        composeRule.onNodeWithText("I need help").assertIsDisplayed()
+
+        composeRule.onAllNodesWithContentDescription("Open settings")[0].performClick()
+        waitForClickable("Delete Account")
+        composeRule.onAllNodes(hasText("Delete Account") and hasClickAction())[0].performClick()
+
+        waitForText("Delete account?")
+        composeRule.onNodeWithText("Delete account?").assertIsDisplayed()
+        composeRule.onAllNodes(hasText("Delete Account") and hasClickAction())[1].performClick()
+
+        waitForText("Continue as Guest")
+        composeRule.onNodeWithText("Continue as Guest").assertIsDisplayed()
+    }
+
     private fun clickableNode(text: String) = composeRule.onNode(hasText(text) and hasClickAction())
 
     private fun waitForClickable(text: String, timeoutMillis: Long = 15_000) {

--- a/android/app/src/androidTest/java/com/neph/e2e/FakeNephBackend.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/FakeNephBackend.kt
@@ -73,7 +73,8 @@ private data class FakeUserState(
     var verified: Boolean,
     var accessToken: String = "access-token-1",
     var profile: FakeProfileState? = null,
-    var safetyStatus: FakeSafetyStatusState = FakeSafetyStatusState()
+    var safetyStatus: FakeSafetyStatusState = FakeSafetyStatusState(),
+    var deleted: Boolean = false
 )
 
 private object MissingJsonField
@@ -193,6 +194,7 @@ class FakeNephBackend {
             route == "/auth/forgot-password" && method == "POST" -> handleForgotPassword(body)
             route == "/auth/reset-password" && method == "POST" -> handleResetPassword(body)
             route == "/auth/me" && method == "GET" -> handleCurrentUser(token)
+            route == "/auth/me" && method == "DELETE" -> handleDeleteCurrentUser(token)
             route == "/profiles/me" && method == "GET" -> handleGetProfile(token)
             route == "/profiles/me" && method == "PATCH" -> handlePatchProfile(token, body)
             route == "/profiles/me/physical" && method == "PATCH" -> handlePatchPhysical(token, body)
@@ -554,6 +556,23 @@ class FakeNephBackend {
         return currentUserJson(requireAuthorizedUser(token))
     }
 
+    private fun handleDeleteCurrentUser(token: String?): JSONObject {
+        val user = requireAuthorizedUser(token)
+        user.deleted = true
+        user.email = "deleted+fake@deleted.invalid"
+        user.password = "deleted-account-disabled"
+        user.verified = false
+        user.profile = null
+        user.safetyStatus = FakeSafetyStatusState()
+
+        return JSONObject()
+            .put("message", "Account deleted successfully.")
+            .put("deleted", true)
+            .put("cancelledRequestCount", 0)
+            .put("cancelledAssignmentRequestCount", 0)
+            .put("availabilityCancelled", false)
+    }
+
     private fun handleGetProfile(token: String?): JSONObject {
         val user = requireAuthorizedUser(token)
         val profile = user.profile ?: throw ApiException("Profile not found", 404, "PROFILE_NOT_FOUND")
@@ -861,7 +880,7 @@ class FakeNephBackend {
 
     private fun requireAuthorizedUser(token: String?): FakeUserState {
         val user = requireUser()
-        if (token.isNullOrBlank() || token != user.accessToken) {
+        if (user.deleted || token.isNullOrBlank() || token != user.accessToken) {
             throw ApiException("Unauthorized", 401, "UNAUTHORIZED")
         }
         return user

--- a/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
+++ b/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
@@ -231,8 +231,8 @@ object AuthRepository {
             token = accessToken
         )
 
-        clearLocalAuthState()
         clearDeletedAccountOfflineState()
+        clearLocalAuthState()
         return response.optString("message").ifBlank { "Account deleted successfully." }
     }
 


### PR DESCRIPTION
Related to the issue [#488](https://github.com/bounswe/bounswe2026group6/issues/488).

### Summary
The issue was that AuthRepository.deleteAccount() cleared the auth token before finishing suspendable local cleanup. That auth-state change could remove the Settings screen from composition and cancel the coroutine before deletion navigation completed. The fix finishes deleted-account offline cleanup first, then clears auth state.

Also added Android e2e coverage by teaching FakeNephBackend to handle DELETE /auth/me and adding a Settings delete-account flow test.