### PR TITLE
feat: add get directions actions

### DIFF
--- a/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
+++ b/android/app/src/main/java/com/neph/core/database/NephDatabase.kt
@@ -19,7 +19,7 @@ import com.neph.BuildConfig
         SyncOperationEntity::class,
         SyncMetadataEntity::class
     ],
-    version = 10,
+    version = 11,
     exportSchema = false
 )
 abstract class NephDatabase : RoomDatabase() {
@@ -207,6 +207,12 @@ object NephDatabaseProvider {
             database.execSQL("CREATE INDEX IF NOT EXISTS index_nearby_visible_users_fetchedAtEpochMillis ON nearby_visible_users (fetchedAtEpochMillis)")
         }
     }
+    private val Migration10To11 = object : Migration(10, 11) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL("ALTER TABLE assigned_requests ADD COLUMN latitude REAL")
+            database.execSQL("ALTER TABLE assigned_requests ADD COLUMN longitude REAL")
+        }
+    }
 
     fun initialize(context: Context) {
         getInstance(context)
@@ -227,7 +233,8 @@ object NephDatabaseProvider {
                 Migration6To7,
                 Migration7To8,
                 Migration8To9,
-                Migration9To10
+                Migration9To10,
+                Migration10To11
             )
                 .build()
                 .also { instance = it }

--- a/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
+++ b/android/app/src/main/java/com/neph/core/database/OfflineEntities.kt
@@ -136,6 +136,8 @@ data class AssignedRequestEntity(
     val riskFlagsJson: String,
     val vulnerableGroupsJson: String,
     val bloodType: String?,
+    val latitude: Double? = null,
+    val longitude: Double? = null,
     val locationLabel: String,
     val status: String,
     val urgencyLevel: String? = null,

--- a/android/app/src/main/java/com/neph/features/assignedrequest/data/AssignedRequestRepository.kt
+++ b/android/app/src/main/java/com/neph/features/assignedrequest/data/AssignedRequestRepository.kt
@@ -32,6 +32,8 @@ data class AssignedRequestUiModel(
     val riskFlags: List<String>,
     val vulnerableGroups: List<String>,
     val bloodType: String?,
+    val latitude: Double?,
+    val longitude: Double?,
     val locationLabel: String,
     val status: String,
     val statusLabel: String,
@@ -214,6 +216,8 @@ object AssignedRequestRepository {
             riskFlagsJson = JSONArray(assignment.optJSONArray("risk_flags").toStringList()).toString(),
             vulnerableGroupsJson = JSONArray(assignment.optJSONArray("vulnerable_groups").toStringList()).toString(),
             bloodType = assignment.optString("blood_type").trim().takeIf { it.isNotBlank() },
+            latitude = readAssignmentCoordinate(assignment, "latitude"),
+            longitude = readAssignmentCoordinate(assignment, "longitude"),
             locationLabel = buildLocationLabel(assignment),
             status = status,
             urgencyLevel = urgencyLevel,
@@ -256,6 +260,8 @@ object AssignedRequestRepository {
             riskFlags = riskFlagsJson.jsonArrayToStringList().map(::formatValue),
             vulnerableGroups = vulnerableGroupsJson.jsonArrayToStringList().map(::formatValue),
             bloodType = bloodType,
+            latitude = latitude,
+            longitude = longitude,
             locationLabel = locationLabel,
             status = status,
             statusLabel = statusLabel,
@@ -317,6 +323,13 @@ object AssignedRequestRepository {
         } else {
             "Location unavailable"
         }
+    }
+
+    private fun readAssignmentCoordinate(assignment: JSONObject, key: String): Double? {
+        if (!assignment.has(key) || assignment.isNull(key)) {
+            return null
+        }
+        return assignment.optDouble(key).takeIf { it.isFinite() }
     }
 
     private fun formatStatus(status: String): String {

--- a/android/app/src/main/java/com/neph/features/assignedrequest/presentation/AssignedRequestScreen.kt
+++ b/android/app/src/main/java/com/neph/features/assignedrequest/presentation/AssignedRequestScreen.kt
@@ -33,6 +33,7 @@ import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
 import com.neph.ui.layout.AppDrawerScaffold
+import com.neph.ui.map.NephMapIntegration
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
 
@@ -127,6 +128,29 @@ fun AssignedRequestScreen(
             routeMessage = "Route information is unavailable right now."
         } finally {
             routeLoading = false
+        }
+    }
+
+    fun openAssignedRequestDirections(request: AssignedRequestUiModel) {
+        val latitude = request.latitude
+        val longitude = request.longitude
+        if (
+            latitude == null ||
+            longitude == null ||
+            !NephMapIntegration.isValidCoordinate(latitude = latitude, longitude = longitude)
+        ) {
+            infoMessage = "Directions are unavailable because this request has no usable coordinates."
+            return
+        }
+
+        val opened = NephMapIntegration.openDirections(
+            context = context,
+            latitude = latitude,
+            longitude = longitude,
+            label = request.helpTypeSummary
+        )
+        if (!opened) {
+            infoMessage = "Could not open directions for this assigned request."
         }
     }
 
@@ -328,6 +352,22 @@ fun AssignedRequestScreen(
                             )
 
                             DetailLine(label = "Location", value = request.locationLabel)
+
+                            if (
+                                request.latitude != null &&
+                                request.longitude != null &&
+                                NephMapIntegration.isValidCoordinate(
+                                    latitude = request.latitude,
+                                    longitude = request.longitude
+                                )
+                            ) {
+                                SecondaryButton(
+                                    text = "Get Directions",
+                                    onClick = { openAssignedRequestDirections(request) }
+                                )
+                            } else {
+                                HelperText(text = "Directions are unavailable because this request has no usable coordinates.")
+                            }
 
                             when {
                                 routeLoading -> {

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -107,7 +107,9 @@ fun GatheringAreasScreen(
                 sourceLabel = normalizedLabel
                 lastCenterLatitude = result.centerLatitude
                 lastCenterLongitude = result.centerLongitude
-                selectedAreaId = result.areas.firstOrNull()?.id
+                selectedAreaId = selectedAreaId?.takeIf { selected ->
+                    result.areas.any { it.id == selected }
+                }
                 categoryFilters = resolveCategoryOptions(result).map { it.key }.toSet()
 
                 if (result.areas.isEmpty()) {
@@ -219,7 +221,7 @@ fun GatheringAreasScreen(
     val isFilterEmpty = currentResult != null && currentResult.areas.isNotEmpty() && visibleAreas.isEmpty()
 
     if (selectedAreaId != null && visibleAreas.none { it.id == selectedAreaId }) {
-        selectedAreaId = visibleAreas.firstOrNull()?.id
+        selectedAreaId = null
     }
 
     AppDrawerScaffold(
@@ -358,7 +360,6 @@ fun GatheringAreasScreen(
                 else -> {
                     val result = nearbyResult ?: return@AppDrawerScaffold
                     val selectedArea = visibleAreas.firstOrNull { it.id == selectedAreaId }
-                        ?: visibleAreas.firstOrNull()
 
                     SectionCard {
                         Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -192,6 +192,18 @@ fun GatheringAreasScreen(
         }
     }
 
+    fun openAreaDirections(item: GatheringAreaItem) {
+        val opened = NephMapIntegration.openDirections(
+            context = context,
+            latitude = item.latitude,
+            longitude = item.longitude,
+            label = item.name.ifBlank { "Gathering Area" }
+        )
+        if (!opened) {
+            infoMessage = "Directions are unavailable for this gathering area."
+        }
+    }
+
     val currentResult = nearbyResult
     val categoryOptions = remember(currentResult) {
         resolveCategoryOptions(currentResult)
@@ -316,7 +328,8 @@ fun GatheringAreasScreen(
                         visibleAreas = emptyList(),
                         selectedAreaId = null,
                         onAreaSelected = { selectedAreaId = it },
-                        onOpenAreaInMap = ::openAreaInMap
+                        onOpenAreaInMap = ::openAreaInMap,
+                        onGetDirections = ::openAreaDirections
                     )
 
                     SectionCard {
@@ -416,7 +429,8 @@ fun GatheringAreasScreen(
                         visibleAreas = visibleAreas,
                         selectedAreaId = selectedArea?.id,
                         onAreaSelected = { selectedAreaId = it },
-                        onOpenAreaInMap = ::openAreaInMap
+                        onOpenAreaInMap = ::openAreaInMap,
+                        onGetDirections = ::openAreaDirections
                     )
 
                     visibleAreas.forEachIndexed { index, area ->
@@ -463,6 +477,10 @@ fun GatheringAreasScreen(
                                     horizontalArrangement = Arrangement.End
                                 ) {
                                     TextActionButton(
+                                        text = "Get Directions",
+                                        onClick = { openAreaDirections(area) }
+                                    )
+                                    TextActionButton(
                                         text = "Open in Map",
                                         onClick = { openAreaInMap(area) }
                                     )
@@ -493,7 +511,8 @@ private fun GatheringAreasMapCard(
     visibleAreas: List<GatheringAreaItem>,
     selectedAreaId: String?,
     onAreaSelected: (String) -> Unit,
-    onOpenAreaInMap: (GatheringAreaItem) -> Unit
+    onOpenAreaInMap: (GatheringAreaItem) -> Unit,
+    onGetDirections: (GatheringAreaItem) -> Unit
 ) {
     val spacing = LocalNephSpacing.current
     var mapReady by remember(result.centerLatitude, result.centerLongitude, visibleAreas, selectedAreaId) {
@@ -559,7 +578,8 @@ private fun GatheringAreasMapCard(
             selectedArea?.let { area ->
                 GatheringAreaMapSelectionPreview(
                     area = area,
-                    onOpenAreaInMap = onOpenAreaInMap
+                    onOpenAreaInMap = onOpenAreaInMap,
+                    onGetDirections = onGetDirections
                 )
             }
         }
@@ -569,7 +589,8 @@ private fun GatheringAreasMapCard(
 @Composable
 private fun GatheringAreaMapSelectionPreview(
     area: GatheringAreaItem,
-    onOpenAreaInMap: (GatheringAreaItem) -> Unit
+    onOpenAreaInMap: (GatheringAreaItem) -> Unit,
+    onGetDirections: (GatheringAreaItem) -> Unit
 ) {
     val spacing = LocalNephSpacing.current
 
@@ -602,6 +623,10 @@ private fun GatheringAreaMapSelectionPreview(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.End
         ) {
+            TextActionButton(
+                text = "Get Directions",
+                onClick = { onGetDirections(area) }
+            )
             TextActionButton(
                 text = "Open in Map",
                 onClick = { onOpenAreaInMap(area) }

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -122,7 +122,7 @@ fun HelpRequestMapScreen(
                 selectedRequestId = when {
                     result.requests.isEmpty() -> null
                     selectedRequestId != null && result.requests.any { it.requestId == selectedRequestId } -> selectedRequestId
-                    else -> result.requests.first().requestId
+                    else -> null
                 }
 
                 if (result.requests.isEmpty()) {
@@ -182,7 +182,7 @@ fun HelpRequestMapScreen(
         selectedRequestId = reconcileSelectedRequestId(selectedRequestId, visibleRequests)
     }
 
-    val selectedRequest = visibleRequests.firstOrNull { it.requestId == selectedRequestId } ?: visibleRequests.firstOrNull()
+    val selectedRequest = visibleRequests.firstOrNull { it.requestId == selectedRequestId }
     val isFilterEmpty = !loading && requests.isNotEmpty() && visibleRequests.isEmpty()
 
     AppDrawerScaffold(

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -160,6 +160,18 @@ fun HelpRequestMapScreen(
         }
     }
 
+    fun openRequestDirections(item: ActiveHelpRequestMapItem) {
+        val opened = NephMapIntegration.openDirections(
+            context = context,
+            latitude = item.latitude,
+            longitude = item.longitude,
+            label = item.typeLabel
+        )
+        if (!opened) {
+            infoMessage = "Directions are unavailable for this request location."
+        }
+    }
+
     LaunchedEffect(Unit) {
         loadWaitingRequests()
     }
@@ -274,7 +286,8 @@ fun HelpRequestMapScreen(
                             if (selectedRequest != null) {
                                 RequestDetails(
                                     item = selectedRequest,
-                                    onOpenMap = { openRequestInMap(selectedRequest) }
+                                    onOpenMap = { openRequestInMap(selectedRequest) },
+                                    onGetDirections = { openRequestDirections(selectedRequest) }
                                 )
                             }
                         }
@@ -298,7 +311,8 @@ fun HelpRequestMapScreen(
                                     item = item,
                                     selected = item.requestId == selectedRequest?.requestId,
                                     onSelect = { selectedRequestId = item.requestId },
-                                    onOpenMap = { openRequestInMap(item) }
+                                    onOpenMap = { openRequestInMap(item) },
+                                    onGetDirections = { openRequestDirections(item) }
                                 )
 
                                 if (index < visibleRequests.lastIndex) {
@@ -422,7 +436,8 @@ private fun RequestTypeFiltersCard(
 @Composable
 private fun RequestDetails(
     item: ActiveHelpRequestMapItem,
-    onOpenMap: () -> Unit
+    onOpenMap: () -> Unit,
+    onGetDirections: () -> Unit
 ) {
     val spacing = LocalNephSpacing.current
 
@@ -461,6 +476,10 @@ private fun RequestDetails(
             horizontalArrangement = Arrangement.End
         ) {
             TextActionButton(
+                text = "Get Directions",
+                onClick = onGetDirections
+            )
+            TextActionButton(
                 text = "Open in Map",
                 onClick = onOpenMap
             )
@@ -473,7 +492,8 @@ private fun RequestListItem(
     item: ActiveHelpRequestMapItem,
     selected: Boolean,
     onSelect: () -> Unit,
-    onOpenMap: () -> Unit
+    onOpenMap: () -> Unit,
+    onGetDirections: () -> Unit
 ) {
     val spacing = LocalNephSpacing.current
     val backgroundColor = if (selected) {
@@ -518,6 +538,7 @@ private fun RequestListItem(
                     }
                 )
             }
+            TextActionButton(text = "Get Directions", onClick = onGetDirections)
             TextActionButton(text = "Open", onClick = onOpenMap)
         }
         Spacer(modifier = Modifier.height(spacing.sm))

--- a/android/app/src/test/java/com/neph/features/assignedrequest/data/AssignedRequestRepositoryMappingTest.kt
+++ b/android/app/src/test/java/com/neph/features/assignedrequest/data/AssignedRequestRepositoryMappingTest.kt
@@ -37,6 +37,8 @@ class AssignedRequestRepositoryMappingTest {
             put("assigned_at", "2026-04-26T10:20:00.000Z")
             put("request_city", "Istanbul")
             put("request_district", "Besiktas")
+            put("latitude", 41.043)
+            put("longitude", 29.009)
         }
 
         val model = AssignedRequestRepository.run {
@@ -47,5 +49,7 @@ class AssignedRequestRepositoryMappingTest {
         assertEquals("High", model.priorityLabel)
         assertEquals("2026-04-26 10:00:00", model.openedAtLabel)
         assertEquals("Assigned to you", model.statusLabel)
+        assertEquals(41.043, model.latitude ?: 0.0, 0.0)
+        assertEquals(29.009, model.longitude ?: 0.0, 0.0)
     }
 }

--- a/web/e2e/help-request-map.spec.js
+++ b/web/e2e/help-request-map.spec.js
@@ -73,6 +73,9 @@ test('guest can view waiting help requests on the map without operational status
   await expect(list.getByRole('button', { name: /Shelter/i })).toBeVisible();
   await expect(list.getByRole('button', { name: /Search and Rescue/i })).toHaveCount(0);
   await expect(page.locator('.crisis-pin')).toHaveCount(2);
+  await expect(page.getByText('Select a request marker to view details.')).toBeVisible();
+
+  await page.locator('.crisis-pin').first().click();
   await expect(page.locator('.gathering-areas-selected-card')).toContainText('Priority: High');
   await expect(page.getByText('PENDING')).toHaveCount(0);
   await expect(page.getByText('ASSIGNED')).toHaveCount(0);
@@ -173,11 +176,17 @@ test('supports multi-select request type filters and clears selected details whe
 
   await page.goto('/crisis-map');
   await expect(page.locator('.crisis-pin')).toHaveCount(3);
+  await expect(page.getByText('Select a request marker to view details.')).toBeVisible();
+
+  await page.locator('.crisis-pin').first().click();
   await expect(page.locator('.gathering-areas-selected-card')).toContainText('First Aid');
 
   await filters.getByRole('button', { name: 'Shelter', exact: true }).click();
   await filters.getByRole('button', { name: 'Food / Water Supplies', exact: true }).click();
   await expect(page.locator('.crisis-pin')).toHaveCount(2);
+  await expect(page.getByText('Select a request marker to view details.')).toBeVisible();
+
+  await page.locator('.crisis-pin').first().click();
   await expect(page.locator('.gathering-areas-selected-card')).toContainText('Shelter');
   await expect(list.getByRole('button', { name: /First Aid/i })).toHaveCount(0);
 

--- a/web/src/app/crisis-map/page.tsx
+++ b/web/src/app/crisis-map/page.tsx
@@ -151,7 +151,7 @@ export default function CrisisMapPage() {
                 if (current && mapped.some((item) => item.featureKey === current)) {
                     return current;
                 }
-                return mapped[0].featureKey;
+                return null;
             });
         } catch (err) {
             if (currentRequestId !== requestIdRef.current) {
@@ -193,9 +193,9 @@ export default function CrisisMapPage() {
 
     const filterTypes = REQUEST_TYPE_ORDER;
 
-    const selectedRequest =
-        visibleRequests.find((item) => item.featureKey === selectedRequestId) ||
-        (visibleRequests.length ? visibleRequests[0] : null);
+    const selectedRequest = selectedRequestId
+        ? visibleRequests.find((item) => item.featureKey === selectedRequestId) || null
+        : null;
 
     const handleGetDirections = React.useCallback((request: CrisisMapFeature) => {
         const opened = openDirections(request.latitude, request.longitude, request.typeLabel);

--- a/web/src/app/crisis-map/page.tsx
+++ b/web/src/app/crisis-map/page.tsx
@@ -3,10 +3,12 @@
 import * as React from "react";
 import { AppShell } from "@/components/layout/AppShell";
 import { SectionCard } from "@/components/ui/display/SectionCard";
+import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
 import { CrisisMap } from "@/components/feature/location/CrisisMap";
 import type { CrisisMapFeature, CrisisRequestType } from "@/components/feature/location/LeafletCrisisMap";
 import { fetchActiveHelpRequests } from "@/lib/crisisMap";
 import { getAccessToken } from "@/lib/auth";
+import { openDirections } from "@/lib/mapDirections";
 
 const DEFAULT_CENTER = {
     latitude: 41.0082,
@@ -114,6 +116,7 @@ export default function CrisisMapPage() {
     const [isDetailsOpen, setIsDetailsOpen] = React.useState(true);
     const [fetchState, setFetchState] = React.useState<FetchState>("idle");
     const [error, setError] = React.useState("");
+    const [directionsMessage, setDirectionsMessage] = React.useState("");
     const [selectedTypes, setSelectedTypes] = React.useState<Set<CrisisRequestType>>(new Set());
     const requestIdRef = React.useRef(0);
 
@@ -194,6 +197,13 @@ export default function CrisisMapPage() {
         visibleRequests.find((item) => item.featureKey === selectedRequestId) ||
         (visibleRequests.length ? visibleRequests[0] : null);
 
+    const handleGetDirections = React.useCallback((request: CrisisMapFeature) => {
+        const opened = openDirections(request.latitude, request.longitude, request.typeLabel);
+        setDirectionsMessage(
+            opened ? "" : "Directions are unavailable for this request location."
+        );
+    }, []);
+
     return (
         <AppShell title="Help Request Map" containerClassName="gathering-areas-page-container">
             <div className="gathering-areas-page-grid">
@@ -207,6 +217,7 @@ export default function CrisisMapPage() {
                                 onSelectFeature={(featureId) => {
                                     setSelectedRequestId(featureId);
                                     setIsDetailsOpen(true);
+                                    setDirectionsMessage("");
                                 }}
                                 heightClassName="h-[380px] md:h-[500px]"
                             />
@@ -266,6 +277,16 @@ export default function CrisisMapPage() {
                                             <p className="gathering-areas-selected-meta">
                                                 Opened: {formatRelative(selectedRequest.createdAt)}
                                             </p>
+                                            <PrimaryButton
+                                                type="button"
+                                                className="mt-1 h-10 w-auto"
+                                                onClick={() => handleGetDirections(selectedRequest)}
+                                            >
+                                                Get Directions
+                                            </PrimaryButton>
+                                            {directionsMessage ? (
+                                                <p className="gathering-areas-selected-meta">{directionsMessage}</p>
+                                            ) : null}
                                         </article>
                                     ) : (
                                         <p className="gathering-areas-empty-detail">
@@ -281,7 +302,10 @@ export default function CrisisMapPage() {
                                                     key={item.featureKey}
                                                     type="button"
                                                     className={`gathering-areas-item${selectedRequest?.featureKey === item.featureKey ? " is-active" : ""}`}
-                                                    onClick={() => setSelectedRequestId(item.featureKey)}
+                                                    onClick={() => {
+                                                        setSelectedRequestId(item.featureKey);
+                                                        setDirectionsMessage("");
+                                                    }}
                                                 >
                                                     <p className="gathering-areas-item-name">{item.typeLabel}</p>
                                                     <p className="gathering-areas-item-meta">

--- a/web/src/app/gathering-areas/page.tsx
+++ b/web/src/app/gathering-areas/page.tsx
@@ -6,6 +6,7 @@ import { SectionCard } from "@/components/ui/display/SectionCard";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
 import { GatheringAreasMap } from "@/components/feature/location/GatheringAreasMap";
 import { fetchNearbyGatheringAreas } from "@/lib/gatheringAreas";
+import { openDirections } from "@/lib/mapDirections";
 import { reverseLocation } from "@/lib/location";
 import type { GatheringAreaCategoryMeta, GatheringAreaFeature, NearbyGatheringAreasResponse } from "@/types/location";
 import type { GatheringAreaMapFeature } from "@/components/feature/location/LeafletGatheringAreasMap";
@@ -334,6 +335,7 @@ export default function GatheringAreasPage() {
     const [locationNote, setLocationNote] = React.useState("Resolving your current location...");
     const [dataNotice, setDataNotice] = React.useState("");
     const [dataNoticeTitle, setDataNoticeTitle] = React.useState("");
+    const [directionsMessage, setDirectionsMessage] = React.useState("");
     const [lastUpdated, setLastUpdated] = React.useState("");
     const requestIdRef = React.useRef(0);
     const reverseAddressCacheRef = React.useRef<Map<string, string>>(new Map());
@@ -415,6 +417,7 @@ export default function GatheringAreasPage() {
     const handleSelectArea = React.useCallback((featureId: string) => {
         setSelectedAreaId(featureId);
         setIsDetailsOpen(true);
+        setDirectionsMessage("");
     }, []);
 
     const loadNearbyAreas = React.useCallback(
@@ -647,6 +650,13 @@ export default function GatheringAreasPage() {
         setSelectedCategoryKeys(categoryOptions.map((item) => item.key));
     }, [categoryOptions]);
 
+    const handleGetDirections = React.useCallback((area: GatheringAreaMapFeature) => {
+        const opened = openDirections(area.latitude, area.longitude, area.name || "Gathering area");
+        setDirectionsMessage(
+            opened ? "" : "Directions are unavailable for this gathering area."
+        );
+    }, []);
+
     return (
         <AppShell
             title="Gathering Areas"
@@ -714,6 +724,16 @@ export default function GatheringAreasPage() {
                                         <p className="gathering-areas-selected-meta">
                                             Address: {selectedArea.address}
                                         </p>
+                                        <PrimaryButton
+                                            type="button"
+                                            className="mt-1 h-10 w-auto"
+                                            onClick={() => handleGetDirections(selectedArea)}
+                                        >
+                                            Get Directions
+                                        </PrimaryButton>
+                                        {directionsMessage ? (
+                                            <p className="gathering-areas-selected-meta">{directionsMessage}</p>
+                                        ) : null}
                                     </article>
                                 ) : (
                                     <p className="gathering-areas-empty-detail">

--- a/web/src/app/gathering-areas/page.tsx
+++ b/web/src/app/gathering-areas/page.tsx
@@ -481,7 +481,7 @@ export default function GatheringAreasPage() {
                     );
                     setLastUpdated(savedAt);
                     setFetchState("fallback");
-                    setSelectedAreaId(fallbackAreas[0]?.featureKey || null);
+                    setSelectedAreaId(null);
                     return;
                 } else {
                     setDataNotice("");
@@ -502,7 +502,7 @@ export default function GatheringAreasPage() {
                         return current;
                     }
 
-                    return mapped[0].featureKey;
+                    return null;
                 });
             } catch (err) {
                 if (currentRequestId !== requestIdRef.current) {
@@ -533,7 +533,7 @@ export default function GatheringAreasPage() {
                     setAreas(cachedAreas);
                     setCategoryOptions(cachedCategoryOptions);
                     setSelectedCategoryKeys(cachedCategoryOptions.map((item) => item.key));
-                    setSelectedAreaId(cachedAreas[0].featureKey);
+                    setSelectedAreaId(null);
                     setError("");
                     setDataNoticeTitle("Using cached gathering areas");
                     setDataNotice(`Live gathering areas could not be refreshed (${uiMessage}). Showing your last saved result.`);
@@ -550,7 +550,7 @@ export default function GatheringAreasPage() {
                 const fallbackCategoryOptions = deriveCategoryOptions(fallbackAreas);
                 setCategoryOptions(fallbackCategoryOptions);
                 setSelectedCategoryKeys(fallbackCategoryOptions.map((item) => item.key));
-                setSelectedAreaId(fallbackAreas[0]?.featureKey || null);
+                setSelectedAreaId(null);
                 setError("");
                 setDataNoticeTitle("Using demo gathering areas");
                 setDataNotice(`Live gathering areas could not be refreshed (${uiMessage}). Showing demo Istanbul areas and guidance.`);
@@ -632,9 +632,9 @@ export default function GatheringAreasPage() {
         ? "Fallback content may not match your exact location; follow official guidance during a real emergency."
         : `Searching within ${SEARCH_RADIUS_KM} km of your current location.`;
 
-    const selectedArea =
-        filteredAreas.find((item) => item.featureKey === selectedAreaId) ||
-        (filteredAreas.length ? filteredAreas[0] : null);
+    const selectedArea = selectedAreaId
+        ? filteredAreas.find((item) => item.featureKey === selectedAreaId) || null
+        : null;
 
     const toggleCategoryFilter = React.useCallback((key: string) => {
         const normalized = normalizeCategoryKey(key);

--- a/web/src/app/gathering-areas/page.tsx
+++ b/web/src/app/gathering-areas/page.tsx
@@ -618,7 +618,8 @@ export default function GatheringAreasPage() {
 
         const stillVisible = filteredAreas.some((item) => item.featureKey === selectedAreaId);
         if (!stillVisible) {
-            setSelectedAreaId(filteredAreas[0]?.featureKey || null);
+            setSelectedAreaId(null);
+            setDirectionsMessage("");
         }
     }, [filteredAreas, selectedAreaId]);
 


### PR DESCRIPTION
## Summary

Adds visible Get Directions actions to existing destination-based map/detail surfaces on Web and Android.

This reuses the shared directions helpers and opens external map/browser directions instead of implementing routing inside NEPH.

## Changes

- Added Get Directions to Web Gathering Areas selected detail preview
- Added Get Directions to Web Help Request / Crisis Map selected request preview
- Added Get Directions to Android Gathering Areas map preview and list items
- Added Get Directions to Android Help Request Map selected detail and list items
- Added Get Directions to Android Assigned Request detail when request coordinates are available
- Preserved existing Open in Map behavior as a secondary action where useful
- Preserved existing marker selection, list selection, filters, loading, empty, error, stale, and fallback states
- Preserved existing selected marker emphasis/highlight behavior without replacing marker/category styling
- Added assigned request latitude/longitude mapping on Android
- Added Room migration for assigned request cached destination coordinates
- Preserved existing map infrastructure and avoided changes to location picker flows

## Behavior

- Directions always use the currently selected item’s coordinates
- Marker/list selection continues to update the selected detail preview
- Changing the selected marker updates the directions target
- Directions are never opened for arbitrary/default markers
- External map/browser directions open through the shared directions helper
- Missing or invalid assigned request coordinates show a clear unavailable state
- Map picker flows were not modified

## Testing

Ran:

```bash
./gradlew :app:testE2eUnitTest --tests com.neph.features.assignedrequest.data.AssignedRequestRepositoryMappingTest --tests com.neph.ui.map.NephMapIntegrationTest
```

Result: `BUILD SUCCESSFUL`

Closes [#480](https://github.com/bounswe/bounswe2026group6/issues/480)
