### PR TITLE
Fix/profile remove profession keep first aid, add web DOB picker

### DIFF
--- a/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
@@ -392,7 +392,6 @@ fun CompleteProfileScreen(
             }
 
             Text("Residential Location", style = MaterialTheme.typography.titleMedium)
-            HelperText(text = "This is your home/neighborhood location. It is not automatically updated by GPS.")
 
             if (locationLoading) {
                 HelperText(text = "Loading location options...")

--- a/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
@@ -33,7 +33,6 @@ import com.neph.features.profile.data.locationData
 import com.neph.features.profile.data.normalizeDateOfBirth
 import com.neph.features.profile.data.normalizePhoneParts
 import com.neph.features.profile.data.parseListField
-import com.neph.features.profile.data.professionOptionsFor
 import com.neph.features.profile.data.sanitizeDecimalInput
 import com.neph.features.profile.data.splitFullName
 import com.neph.features.profile.data.toEditableString
@@ -96,7 +95,6 @@ fun CompleteProfileScreen(
     var district by rememberSaveable { mutableStateOf(existingProfile.district.orEmpty()) }
     var neighborhood by rememberSaveable { mutableStateOf(existingProfile.neighborhood.orEmpty()) }
     var extraAddress by rememberSaveable { mutableStateOf(existingProfile.extraAddress.orEmpty()) }
-    var profession by rememberSaveable { mutableStateOf(existingProfile.profession) }
     var expertise by rememberSaveable { mutableStateOf(existingProfile.expertise) }
     var loading by rememberSaveable { mutableStateOf(false) }
     var error by rememberSaveable { mutableStateOf("") }
@@ -242,7 +240,6 @@ fun CompleteProfileScreen(
                     district = district,
                     neighborhood = neighborhood,
                     extraAddress = extraAddress.takeIf(String::isNotBlank),
-                    profession = profession?.trim()?.takeIf(String::isNotBlank),
                     expertise = parseListField(expertise.joinToString(", "))
                 )
                 ProfileRepository.syncProfile(

--- a/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
@@ -375,23 +375,7 @@ fun CompleteProfileScreen(
                 label = "Allergies (optional - comma-separated)"
             )
 
-            Text("Profession", style = MaterialTheme.typography.titleMedium)
-
-            AppDropdown(
-                value = profession.orEmpty(),
-                onValueChange = { profession = it },
-                label = "Profession",
-                options = professionOptionsFor(profession),
-                placeholder = "Select your profession"
-            )
-
             Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
-                Text(
-                    text = "Expertise (optional)",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
-
                 expertiseOptionsFor(expertise).forEach { option ->
                     AppCheckbox(
                         checked = option in expertise,

--- a/android/app/src/main/java/com/neph/features/profile/data/Expertise.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/Expertise.kt
@@ -1,7 +1,7 @@
 package com.neph.features.profile.data
 
 val expertiseOptions = listOf(
-    "First Aid"
+    "Do you know first aid?"
 )
 
 fun normalizeExpertise(selectedExpertise: List<String>): List<String> {
@@ -9,7 +9,7 @@ fun normalizeExpertise(selectedExpertise: List<String>): List<String> {
 
     return selectedExpertise
         .map { it.trim() }
-        .filter { it.equals(allowed, ignoreCase = true) }
+        .filter { it.equals(allowed, ignoreCase = true) || it.equals("First Aid", ignoreCase = true) }
         .map { allowed }
         .distinct()
 }

--- a/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
+++ b/android/app/src/main/java/com/neph/features/profile/data/ProfileRepository.kt
@@ -259,15 +259,6 @@ object ProfileRepository {
             )
 
             JsonHttpClient.request(
-                path = "/profiles/me/profession",
-                method = "PATCH",
-                token = token,
-                body = JSONObject().apply {
-                    putNullable("profession", normalizedProfile.profession)
-                }
-            )
-
-            JsonHttpClient.request(
                 path = "/profiles/me/expertise-areas",
                 method = "PUT",
                 token = token,

--- a/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
@@ -459,40 +459,22 @@ fun EditProfileScreen(
 
             SectionCard {
                 Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
-                    SectionHeader(title = "Profession")
+                    SectionHeader(title = "First Aid")
 
-                    AppDropdown(
-                        value = profile.profession.orEmpty(),
-                        onValueChange = { value ->
-                            profile = profile.copy(profession = value.takeIf(String::isNotBlank))
-                        },
-                        label = "Profession",
-                        options = professionOptionsFor(profile.profession),
-                        placeholder = "Select your profession"
-                    )
-
-                    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
-                        Text(
-                            text = "Expertise (optional)",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurface
+                    expertiseOptionsFor(profile.expertise).forEach { option ->
+                        AppCheckbox(
+                            checked = option in profile.expertise,
+                            onCheckedChange = { checked ->
+                                profile = profile.copy(
+                                    expertise = if (checked) {
+                                        profile.expertise + option
+                                    } else {
+                                        profile.expertise - option
+                                    }
+                                )
+                            },
+                            label = option
                         )
-
-                        expertiseOptionsFor(profile.expertise).forEach { option ->
-                            AppCheckbox(
-                                checked = option in profile.expertise,
-                                onCheckedChange = { checked ->
-                                    profile = profile.copy(
-                                        expertise = if (checked) {
-                                            profile.expertise + option
-                                        } else {
-                                            profile.expertise - option
-                                        }
-                                    )
-                                },
-                                label = option
-                            )
-                        }
                     }
                 }
             }

--- a/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
@@ -34,7 +34,6 @@ import com.neph.features.profile.data.locationData
 import com.neph.features.profile.data.normalizeDateOfBirth
 import com.neph.features.profile.data.normalizePhoneParts
 import com.neph.features.profile.data.parseListField
-import com.neph.features.profile.data.professionOptionsFor
 import com.neph.features.profile.data.sanitizeDecimalInput
 import com.neph.features.profile.data.toEditableString
 import com.neph.features.requesthelp.data.RequestHelpRepository

--- a/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/EditProfileScreen.kt
@@ -453,7 +453,6 @@ fun EditProfileScreen(
                         label = "Allergies"
                     )
 
-                    HelperText(text = "Document upload is still unavailable because the backend upload flow does not exist yet.")
                 }
             }
 
@@ -481,10 +480,7 @@ fun EditProfileScreen(
 
             SectionCard {
                 Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
-                    SectionHeader(
-                        title = "Residential Location",
-                        subtitle = "This is your home/neighborhood location. It is not automatically updated by GPS."
-                    )
+                    SectionHeader(title = "Residential Location")
 
                     if (locationLoading) {
                         HelperText(text = "Loading location options...")

--- a/android/app/src/main/java/com/neph/features/profile/presentation/ProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/ProfileScreen.kt
@@ -123,10 +123,9 @@ fun ProfileScreen(
 
                 ProfileSection(title = "Contact") {
                     ProfileFieldRow(label = "Phone", value = profile.phone)
-                    ProfileFieldRow(label = "Profession", value = profile.profession)
                     ProfileFieldRow(
-                        label = "Expertise",
-                        value = profile.expertise.takeIf { it.isNotEmpty() }?.joinToString(", ")
+                        label = "First Aid",
+                        value = if (profile.expertise.any { it.equals("Do you know first aid?", ignoreCase = true) || it.equals("First Aid", ignoreCase = true) }) "Yes" else null
                     )
                 }
 

--- a/web/e2e/onboarding.spec.js
+++ b/web/e2e/onboarding.spec.js
@@ -36,11 +36,10 @@ test('new user can sign up, verify email, complete their profile, and see persis
   await page.locator('#height').fill('168');
   await page.locator('#weight').fill('58');
   await page.locator('#gender').selectOption('female');
-  await page.locator('#dateOfBirth').fill('1998-01-15');
+  await page.locator('#dateOfBirth').fill('19980115');
   await page.locator('#bloodType').selectOption('a_pos');
   await page.locator('#medicalHistory').fill('Seasonal asthma');
-  await page.locator('#profession').selectOption('Engineer');
-  await page.getByLabel('First Aid').check();
+  await page.getByLabel('Do you know first aid?').check();
   await page.locator('#country').selectOption('tr');
   await page.locator('#city').selectOption('istanbul');
   await page.locator('#district').selectOption('kadikoy');
@@ -74,6 +73,5 @@ test('new user can sign up, verify email, complete their profile, and see persis
   expect(profile.locationProfile.city?.toLocaleLowerCase('tr')).toBe('istanbul');
   expect(profile.locationProfile.address).toContain('Test Apartment 7');
   expect(profile.privacySettings.locationSharingEnabled).toBe(false);
-  expect(profile.expertise[0].profession).toBe('Engineer');
-  expect(profile.expertise[0].expertiseAreas).toContain('First Aid');
+  expect(profile.expertise[0].expertiseAreas).toContain('Do you know first aid?');
 });

--- a/web/src/components/feature/auth/CompleteProfileForm.tsx
+++ b/web/src/components/feature/auth/CompleteProfileForm.tsx
@@ -17,7 +17,8 @@ import {
 } from "@/components/feature/location";
 import { bloodTypeOptions } from "@/lib/bloodTypes";
 import { countryCodeOptions } from "@/lib/countryCodes";
-import { expertiseOptions, professionOptions } from "@/lib/profileOptions";
+import { DateInput } from "@/components/ui/inputs/DateInput";
+import { expertiseOptions } from "@/lib/profileOptions";
 import { getAccessToken, SIGNUP_DRAFT_KEY } from "@/lib/auth";
 import { fetchLocationTree, searchLocations } from "@/lib/location";
 import {
@@ -31,7 +32,6 @@ import {
     patchMyLocation,
     patchMyPhysical,
     patchMyPrivacy,
-    patchMyProfession,
     patchMyProfile,
     putMyExpertiseAreas,
     validateExpertiseAreas,
@@ -50,7 +50,6 @@ type ProfileForm = {
     medicalHistory: string;
     chronicDiseases: string;
     allergies: string;
-    profession: string;
     expertise: string[];
     country: string;
     city: string;
@@ -73,7 +72,6 @@ const initialForm: ProfileForm = {
     medicalHistory: "",
     chronicDiseases: "",
     allergies: "",
-    profession: "",
     expertise: [],
     country: "",
     city: "",
@@ -515,10 +513,6 @@ export default function CompleteProfileForm() {
                 locationSharingEnabled: form.shareLocation,
             });
 
-            await patchMyProfession(token, {
-                profession: form.profession.trim() || null,
-            });
-
             await putMyExpertiseAreas(token, {
                 expertiseAreas,
             });
@@ -644,14 +638,10 @@ export default function CompleteProfileForm() {
             </ProfileInfoRow>
 
             <ProfileInfoRow label="Date of Birth">
-                <TextInput
+                <DateInput
                     id="dateOfBirth"
-                    type="date"
                     value={form.dateOfBirth}
-                    max={new Date().toISOString().slice(0, 10)}
-                    onChange={(e) =>
-                        setForm({ ...form, dateOfBirth: e.target.value })
-                    }
+                    onChange={(v) => setForm({ ...form, dateOfBirth: v })}
                 />
             </ProfileInfoRow>
 
@@ -699,20 +689,8 @@ export default function CompleteProfileForm() {
                 />
             </ProfileInfoRow>
 
-            <ProfileInfoRow label="Profession">
-                <SelectInput
-                    id="profession"
-                    options={professionOptions}
-                    value={form.profession}
-                    onChange={(e) =>
-                        setForm({ ...form, profession: e.target.value })
-                    }
-                />
-
+            <ProfileInfoRow label="First Aid">
                 <div className="flex flex-col gap-3">
-                    <p className="text-sm font-medium text-[color:var(--text-primary)]">
-                        Expertise (optional)
-                    </p>
                     {expertiseOptions.map((option) => (
                         <Checkbox
                             key={option}

--- a/web/src/components/feature/auth/CompleteProfileForm.tsx
+++ b/web/src/components/feature/auth/CompleteProfileForm.tsx
@@ -386,11 +386,17 @@ export default function CompleteProfileForm() {
         }
 
         const dobPattern = /^\d{4}-\d{2}-\d{2}$/;
-        const dateOfBirth = new Date(form.dateOfBirth);
+        if (!dobPattern.test(form.dateOfBirth)) {
+            setError("Please enter a valid date of birth (YYYY-MM-DD) that is not in the future.");
+            return;
+        }
+        const [dobYear, dobMonth, dobDay] = form.dateOfBirth.split("-").map(Number);
+        const dateOfBirth = new Date(dobYear, dobMonth - 1, dobDay);
         if (
-            !dobPattern.test(form.dateOfBirth) ||
-            Number.isNaN(dateOfBirth.getTime()) ||
-            dateOfBirth > new Date()
+            dateOfBirth.getFullYear() !== dobYear ||
+            dateOfBirth.getMonth() + 1 !== dobMonth ||
+            dateOfBirth.getDate() !== dobDay ||
+            dateOfBirth >= new Date(new Date().toDateString())
         ) {
             setError("Please enter a valid date of birth (YYYY-MM-DD) that is not in the future.");
             return;

--- a/web/src/components/feature/auth/CompleteProfileForm.tsx
+++ b/web/src/components/feature/auth/CompleteProfileForm.tsx
@@ -385,9 +385,14 @@ export default function CompleteProfileForm() {
             return;
         }
 
+        const dobPattern = /^\d{4}-\d{2}-\d{2}$/;
         const dateOfBirth = new Date(form.dateOfBirth);
-        if (Number.isNaN(dateOfBirth.getTime()) || dateOfBirth > new Date()) {
-            setError("Please select a valid date of birth.");
+        if (
+            !dobPattern.test(form.dateOfBirth) ||
+            Number.isNaN(dateOfBirth.getTime()) ||
+            dateOfBirth > new Date()
+        ) {
+            setError("Please enter a valid date of birth (YYYY-MM-DD) that is not in the future.");
             return;
         }
 

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -491,11 +491,17 @@ export default function ProfileView() {
 
         if (profile.dateOfBirth) {
             const dobPattern = /^\d{4}-\d{2}-\d{2}$/;
-            const dateOfBirth = new Date(profile.dateOfBirth);
+            if (!dobPattern.test(profile.dateOfBirth)) {
+                setError("Please enter a valid date of birth (YYYY-MM-DD) that is not in the future.");
+                return;
+            }
+            const [dobYear, dobMonth, dobDay] = profile.dateOfBirth.split("-").map(Number);
+            const dateOfBirth = new Date(dobYear, dobMonth - 1, dobDay);
             if (
-                !dobPattern.test(profile.dateOfBirth) ||
-                Number.isNaN(dateOfBirth.getTime()) ||
-                dateOfBirth > new Date()
+                dateOfBirth.getFullYear() !== dobYear ||
+                dateOfBirth.getMonth() + 1 !== dobMonth ||
+                dateOfBirth.getDate() !== dobDay ||
+                dateOfBirth >= new Date(new Date().toDateString())
             ) {
                 setError("Please enter a valid date of birth (YYYY-MM-DD) that is not in the future.");
                 return;

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -489,6 +489,19 @@ export default function ProfileView() {
             return;
         }
 
+        if (profile.dateOfBirth) {
+            const dobPattern = /^\d{4}-\d{2}-\d{2}$/;
+            const dateOfBirth = new Date(profile.dateOfBirth);
+            if (
+                !dobPattern.test(profile.dateOfBirth) ||
+                Number.isNaN(dateOfBirth.getTime()) ||
+                dateOfBirth > new Date()
+            ) {
+                setError("Please enter a valid date of birth (YYYY-MM-DD) that is not in the future.");
+                return;
+            }
+        }
+
         if (
             !initialShareLocation &&
             profile.shareLocation &&
@@ -574,7 +587,7 @@ export default function ProfileView() {
                 }) || null;
 
             await patchMyPhysical(token, {
-                dateOfBirth: profile.dateOfBirth || null,
+                dateOfBirth: /^\d{4}-\d{2}-\d{2}$/.test(profile.dateOfBirth || "") ? profile.dateOfBirth : null,
                 gender: profile.gender || null,
                 height: profile.height ? Number(profile.height) : undefined,
                 weight: profile.weight ? Number(profile.weight) : undefined,

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -20,7 +20,8 @@ import {
 } from "@/components/feature/location";
 import { bloodTypeOptions } from "@/lib/bloodTypes";
 import { countryCodeOptions } from "@/lib/countryCodes";
-import { expertiseOptions, professionOptions } from "@/lib/profileOptions";
+import { DateInput } from "@/components/ui/inputs/DateInput";
+import { expertiseOptions } from "@/lib/profileOptions";
 import {
     clearAccessToken,
     deleteCurrentAccount,
@@ -50,7 +51,6 @@ import {
     patchMyLocation,
     patchMyPhysical,
     patchMyPrivacy,
-    patchMyProfession,
     validateExpertiseAreas,
     putMyExpertiseAreas,
 } from "@/lib/profile";
@@ -625,10 +625,6 @@ export default function ProfileView() {
                 locationSharingEnabled: profile.shareLocation,
             });
 
-            await patchMyProfession(token, {
-                profession: profile.profession.trim() || null,
-            });
-
             await putMyExpertiseAreas(token, {
                 expertiseAreas,
             });
@@ -933,19 +929,14 @@ export default function ProfileView() {
                             ]}
                         />
                         <div>
-                            <TextInput
+                            <DateInput
                                 id="dateOfBirth"
                                 label="Date of Birth"
-                                type="date"
-                                max={new Date().toISOString().slice(0, 10)}
                                 value={profile.dateOfBirth}
-                                onChange={(e) =>
+                                onChange={(v) =>
                                     setProfile((currentProfile) =>
                                         currentProfile
-                                            ? {
-                                                ...currentProfile,
-                                                dateOfBirth: e.target.value,
-                                            }
+                                            ? { ...currentProfile, dateOfBirth: v }
                                             : currentProfile
                                     )
                                 }
@@ -955,53 +946,31 @@ export default function ProfileView() {
                 </SectionCard>
 
                 <SectionCard>
-                    <SectionHeader title="Profession" />
-                    <p className="mb-3 text-xs text-[color:var(--text-muted)]">
-                        Your profession and expertise help with community coordination.
-                    </p>
+                    <SectionHeader title="First Aid" />
 
-                    <div className="flex flex-col gap-4">
-                        <SelectInput
-                            id="profession"
-                            label="Profession"
-                            value={profile.profession}
-                            onChange={(e) =>
-                                setProfile((currentProfile) =>
-                                    currentProfile
-                                        ? { ...currentProfile, profession: e.target.value }
-                                        : currentProfile
-                                )
-                            }
-                            options={professionOptions}
-                        />
-
-                        <div className="flex flex-col gap-3">
-                            <p className="text-sm font-medium text-[color:var(--text-primary)]">
-                                Expertise (optional)
-                            </p>
-                            {expertiseOptions.map((option) => (
-                                <Checkbox
-                                    key={option}
-                                    id={`profile-expertise-${option}`}
-                                    label={option}
-                                    checked={profile.expertise.includes(option)}
-                                    onCheckedChange={(checked) =>
-                                        setProfile((currentProfile) =>
-                                            currentProfile
-                                                ? {
-                                                    ...currentProfile,
-                                                    expertise: checked
-                                                        ? [...currentProfile.expertise, option]
-                                                        : currentProfile.expertise.filter(
-                                                            (item) => item !== option
-                                                        ),
-                                                }
-                                                : currentProfile
-                                        )
-                                    }
-                                />
-                            ))}
-                        </div>
+                    <div className="flex flex-col gap-3">
+                        {expertiseOptions.map((option) => (
+                            <Checkbox
+                                key={option}
+                                id={`profile-expertise-${option}`}
+                                label={option}
+                                checked={profile.expertise.includes(option)}
+                                onCheckedChange={(checked) =>
+                                    setProfile((currentProfile) =>
+                                        currentProfile
+                                            ? {
+                                                ...currentProfile,
+                                                expertise: checked
+                                                    ? [...currentProfile.expertise, option]
+                                                    : currentProfile.expertise.filter(
+                                                        (item) => item !== option
+                                                    ),
+                                            }
+                                            : currentProfile
+                                    )
+                                }
+                            />
+                        ))}
                     </div>
                 </SectionCard>
 

--- a/web/src/components/ui/inputs/DateInput.tsx
+++ b/web/src/components/ui/inputs/DateInput.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+type DateInputProps = {
+    id?: string;
+    label?: string;
+    value: string;
+    onChange: (value: string) => void;
+    error?: string;
+    className?: string;
+};
+
+function autoFormat(raw: string): string {
+    const digits = raw.replace(/\D/g, "").slice(0, 8);
+    let out = "";
+    for (let i = 0; i < digits.length; i++) {
+        if (i === 4 || i === 6) out += "-";
+        out += digits[i];
+    }
+    return out;
+}
+
+/**
+ * ISO date input (YYYY-MM-DD).
+ *
+ * - Typing: accepts digits only, inserts dashes automatically.
+ * - Calendar icon: opens a hidden <input type="date"> picker; selected date
+ *   syncs back to the text field and vice-versa.
+ */
+export function DateInput({ id, label, value, onChange, error, className }: DateInputProps) {
+    const pickerRef = React.useRef<HTMLInputElement>(null);
+
+    function handleTextChange(e: React.ChangeEvent<HTMLInputElement>) {
+        const formatted = autoFormat(e.target.value);
+        if (formatted.length === 10) {
+            const today = new Date().toISOString().slice(0, 10);
+            if (formatted > today) return; // reject future dates
+        }
+        onChange(formatted);
+    }
+
+    function handlePickerChange(e: React.ChangeEvent<HTMLInputElement>) {
+        onChange(e.target.value); // already YYYY-MM-DD
+    }
+
+    return (
+        <div className="flex w-full flex-col gap-2">
+            {label ? (
+                <label
+                    htmlFor={id}
+                    className="text-sm font-medium text-[color:var(--text-primary)]"
+                >
+                    {label}
+                </label>
+            ) : null}
+
+            <div className="relative flex items-center">
+                <input
+                    id={id}
+                    type="text"
+                    inputMode="numeric"
+                    placeholder="YYYY-MM-DD"
+                    value={value}
+                    onChange={handleTextChange}
+                    maxLength={10}
+                    className={cn(
+                        "h-11 w-full rounded-[10px] border bg-[color:var(--surface-card)] px-3 pr-10 text-sm text-[color:var(--text-primary)]",
+                        "border-[color:var(--border-subtle)] placeholder:text-[color:var(--text-muted)]",
+                        "outline-none transition-colors focus:border-[color:var(--primary-500)]",
+                        error && "border-[color:var(--primary-500)]",
+                        className
+                    )}
+                />
+
+                {/* hidden native date picker — triggered only by calendar icon button */}
+                <input
+                    ref={pickerRef}
+                    type="date"
+                    value={value}
+                    max={new Date().toISOString().slice(0, 10)}
+                    onChange={handlePickerChange}
+                    className="pointer-events-none absolute h-0 w-0 opacity-0"
+                    tabIndex={-1}
+                    aria-hidden="true"
+                />
+
+                <button
+                    type="button"
+                    onClick={() => pickerRef.current?.showPicker?.()}
+                    className="absolute right-3 text-[color:var(--text-muted)] hover:text-[color:var(--text-primary)]"
+                    aria-label="Open calendar"
+                    tabIndex={-1}
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                        <line x1="16" y1="2" x2="16" y2="6" />
+                        <line x1="8" y1="2" x2="8" y2="6" />
+                        <line x1="3" y1="10" x2="21" y2="10" />
+                    </svg>
+                </button>
+            </div>
+
+            {error ? (
+                <p className="text-xs text-[color:var(--primary-500)]">{error}</p>
+            ) : null}
+        </div>
+    );
+}

--- a/web/src/lib/profile.ts
+++ b/web/src/lib/profile.ts
@@ -209,6 +209,7 @@ export function mapBackendProfileToEditableProfile(
             .map((area) => area.trim())
             .filter((area) =>
                 expertiseOptions.some((allowed) => allowed.toLocaleLowerCase() === area.toLocaleLowerCase())
+                || area.toLocaleLowerCase() === "first aid"
             )
             .map(() => expertiseOptions[0]),
         height:

--- a/web/src/lib/profileOptions.ts
+++ b/web/src/lib/profileOptions.ts
@@ -7,5 +7,5 @@ export const professionOptions = [
 ];
 
 export const expertiseOptions = [
-    "First Aid",
+    "Do you know first aid?",
 ];


### PR DESCRIPTION
### Summary

This PR cleans up the profile forms on both Android and Web by removing the unused Profession field and improving the First Aid and Date of Birth UX.

### Changes

**Remove Profession**
- Removed Profession dropdown from Complete Profile and Edit Profile on Android and Web
- Removed `patchMyProfession` API calls from both web forms
- `professionOptions` still exists in `profileOptions.ts` but is no longer used in the UI

**First Aid**
- Renamed expertise label from `"First Aid"` to `"Do you know first aid?"` for clarity
- Legacy values stored as `"First Aid"` are normalized to the new label on load (Android + Web)

**Date of Birth — Web** *(aligned with Android implementation in #527)*
- Replaced `<input type="date">` with a new `DateInput` component
- Supports manual `YYYY-MM-DD` entry with auto-inserted dashes
- Calendar icon opens the native date picker
- Future dates are rejected on manual entry; `max` constraint applied to the native picker

**Cleanup**
- Removed two placeholder helper text messages from Android profile screens (`"Document upload is still unavailable..."` and `"This is your home/neighborhood location..."`)

---

### Testing

- Android: `compileDebugKotlin` BUILD SUCCESSFUL
- Web: `tsc --noEmit` clean