### PR TITLE
feat: add viewport-based discovery for resource maps

### DIFF
--- a/android/app/src/main/java/com/neph/features/gatheringareas/data/GatheringAreasRepository.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/data/GatheringAreasRepository.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.Locale
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.roundToInt
@@ -79,6 +81,37 @@ object GatheringAreasRepository {
             fallbackLatitude = latitude,
             fallbackLongitude = longitude,
             fallbackRadius = normalizedRadius,
+            fallbackLimit = normalizedLimit
+        )
+    }
+
+    suspend fun fetchViewportGatheringAreas(
+        bbox: String,
+        centerLatitude: Double,
+        centerLongitude: Double,
+        widestVisibleDimensionKm: Double,
+        limit: Int = DefaultLimit
+    ): NearbyGatheringAreasResult {
+        val normalizedLimit = limit.coerceIn(1, MaxLimit)
+        val normalizedRadiusMeters = (widestVisibleDimensionKm * 1000.0)
+            .roundToInt()
+            .coerceAtLeast(1)
+
+        val response = withTimeoutOrNull(NearbyRequestTimeoutMillis) {
+            JsonHttpClient.request(
+                path = "/gathering-areas/viewport?bbox=${urlEncode(bbox)}&limit=$normalizedLimit"
+            )
+        } ?: throw ApiException(
+            message = "Gathering areas request timed out.",
+            status = 504,
+            code = "OVERPASS_TIMEOUT"
+        )
+
+        return parseNearbyGatheringAreasResponse(
+            response = response,
+            fallbackLatitude = centerLatitude,
+            fallbackLongitude = centerLongitude,
+            fallbackRadius = normalizedRadiusMeters,
             fallbackLimit = normalizedLimit
         )
     }
@@ -246,6 +279,10 @@ object GatheringAreasRepository {
         val c = 2 * atan2(sqrt(a), sqrt(1 - a))
         return (earthRadiusMeters * c).roundToInt()
     }
+}
+
+private fun urlEncode(value: String): String {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8.toString())
 }
 
 private fun formatCategoryLabel(category: String): String {

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -93,6 +93,25 @@ internal fun gatheringAreasMapInstanceKey(
     )
 }
 
+internal fun reconcileGatheringAreaCategoryFilters(
+    previousOptionKeys: Set<String>,
+    previousSelectedKeys: Set<String>,
+    nextOptionKeys: Set<String>
+): Set<String> {
+    if (nextOptionKeys.isEmpty()) return emptySet()
+
+    val wasShowingAll = previousOptionKeys.isEmpty() ||
+        previousSelectedKeys.isEmpty() ||
+        previousOptionKeys.all { it in previousSelectedKeys }
+
+    if (wasShowingAll) {
+        return nextOptionKeys
+    }
+
+    val newlyAvailableKeys = nextOptionKeys - previousOptionKeys
+    return (previousSelectedKeys intersect nextOptionKeys) + newlyAvailableKeys
+}
+
 @Composable
 @OptIn(ExperimentalLayoutApi::class)
 fun GatheringAreasScreen(
@@ -115,6 +134,7 @@ fun GatheringAreasScreen(
     var mapCenterLatitude by remember { mutableStateOf(TurkeyOverviewLatitude) }
     var mapCenterLongitude by remember { mutableStateOf(TurkeyOverviewLongitude) }
     var mapZoom by remember { mutableStateOf(TurkeyOverviewZoom) }
+    var mapResetNonce by remember { mutableStateOf(0) }
     var currentViewport by remember { mutableStateOf<LeafletMapViewport?>(null) }
     var pendingViewport by remember { mutableStateOf<LeafletMapViewport?>(null) }
     var lastFetchedViewportKey by remember { mutableStateOf<String?>(null) }
@@ -126,22 +146,26 @@ fun GatheringAreasScreen(
     val hasSearchCenter = lastCenterLatitude != null && lastCenterLongitude != null
 
     fun applyViewportResult(result: NearbyGatheringAreasResult) {
+        val previousOptions = resolveCategoryOptions(nearbyResult).map { it.key }.toSet()
+        val nextOptions = resolveCategoryOptions(result).map { it.key }.toSet()
         nearbyResult = result
+        errorMessage = ""
         sourceLabel = "visible area"
         lastCenterLatitude = result.centerLatitude
         lastCenterLongitude = result.centerLongitude
         selectedAreaId = selectedAreaId
             ?.takeIf { selected -> result.areas.any { it.id == selected } }
             ?: result.areas.firstOrNull()?.id
-        val nextOptions = resolveCategoryOptions(result).map { it.key }.toSet()
-        if (categoryFilters.isEmpty()) {
-            categoryFilters = nextOptions
-        }
+        categoryFilters = reconcileGatheringAreaCategoryFilters(
+            previousOptionKeys = previousOptions,
+            previousSelectedKeys = categoryFilters,
+            nextOptionKeys = nextOptions
+        )
 
-        if (result.areas.isEmpty()) {
-            infoMessage = ResourceEmptyMessage
-        } else if (result.skippedCount > 0) {
-            infoMessage = "${result.skippedCount} malformed provider entries were skipped."
+        infoMessage = when {
+            result.areas.isEmpty() -> ResourceEmptyMessage
+            result.skippedCount > 0 -> "${result.skippedCount} malformed provider entries were skipped."
+            else -> ""
         }
     }
 
@@ -162,6 +186,7 @@ fun GatheringAreasScreen(
                     mapCenterLatitude = location.latitude
                     mapCenterLongitude = location.longitude
                     mapZoom = 13
+                    mapResetNonce += 1
                     sourceLabel = "your current location"
                     nearbyResult = null
                     selectedAreaId = null
@@ -266,6 +291,27 @@ fun GatheringAreasScreen(
         }
     }
 
+    fun handleViewportChanged(viewport: LeafletMapViewport) {
+        currentViewport = viewport
+        mapCenterLatitude = viewport.centerLatitude
+        mapCenterLongitude = viewport.centerLongitude
+        if (isLeafletViewportDiscoverable(viewport)) {
+            errorMessage = ""
+            if (infoMessage == ResourceZoomedOutMessage) {
+                infoMessage = ""
+            }
+            pendingViewport = viewport
+        } else {
+            viewportRequestSerial += 1
+            nearbyResult = null
+            selectedAreaId = null
+            lastFetchedViewportKey = null
+            errorMessage = ""
+            loading = false
+            infoMessage = ResourceZoomedOutMessage
+        }
+    }
+
     val currentResult = nearbyResult
     val categoryOptions = remember(currentResult) {
         resolveCategoryOptions(currentResult)
@@ -282,6 +328,17 @@ fun GatheringAreasScreen(
 
     if (selectedAreaId != null && visibleAreas.none { it.id == selectedAreaId }) {
         selectedAreaId = null
+    }
+    val selectedArea = visibleAreas.firstOrNull { it.id == selectedAreaId }
+    val mapResult = currentResult ?: turkeyOverviewGatheringAreasResult()
+    val mapEmptyMarkersMessage = when {
+        loading -> ResourceLoadingMessage
+        errorMessage.isNotBlank() -> ResourceErrorMessage
+        currentViewport == null -> ResourceInitialMessage
+        !isLeafletViewportDiscoverable(currentViewport) -> ResourceZoomedOutMessage
+        isFilterEmpty -> "No results match the selected categories."
+        currentResult?.areas?.isEmpty() == true -> ResourceEmptyMessage
+        else -> ResourceEmptyMessage
     }
 
     AppDrawerScaffold(
@@ -343,9 +400,12 @@ fun GatheringAreasScreen(
                         onClick = {
                             val viewport = currentViewport
                             if (!isLeafletViewportDiscoverable(viewport)) {
+                                errorMessage = ""
+                                loading = false
                                 infoMessage = ResourceZoomedOutMessage
                                 return@SecondaryButton
                             }
+                            errorMessage = ""
                             pendingViewport = viewport
                             viewportRefreshNonce += 1
                         },
@@ -354,73 +414,30 @@ fun GatheringAreasScreen(
                 }
             }
 
+            GatheringAreasMapCard(
+                result = mapResult,
+                visibleAreas = if (currentResult == null) emptyList() else visibleAreas,
+                selectedAreaId = selectedArea?.id,
+                onAreaSelected = { selectedAreaId = it },
+                onOpenAreaInMap = ::openAreaInMap,
+                onGetDirections = ::openAreaDirections,
+                emptyMarkersMessage = mapEmptyMarkersMessage,
+                emptyMapSubtitle = mapEmptyMarkersMessage,
+                mapCenterLatitude = mapCenterLatitude,
+                mapCenterLongitude = mapCenterLongitude,
+                mapZoom = mapZoom,
+                mapResetToken = mapResetNonce,
+                showCenterMarker = false,
+                loadingResources = loading,
+                onViewportChanged = ::handleViewportChanged
+            )
+
             when {
                 nearbyResult == null -> {
-                    GatheringAreasMapCard(
-                        result = turkeyOverviewGatheringAreasResult(),
-                        visibleAreas = emptyList(),
-                        selectedAreaId = null,
-                        onAreaSelected = { selectedAreaId = it },
-                        onOpenAreaInMap = ::openAreaInMap,
-                        onGetDirections = ::openAreaDirections,
-                        emptyMarkersMessage = when {
-                            loading -> ResourceLoadingMessage
-                            errorMessage.isNotBlank() -> ResourceErrorMessage
-                            currentViewport == null -> ResourceInitialMessage
-                            !isLeafletViewportDiscoverable(currentViewport) -> ResourceZoomedOutMessage
-                            else -> ResourceEmptyMessage
-                        },
-                        emptyMapSubtitle = ResourceInitialMessage,
-                        mapCenterLatitude = mapCenterLatitude,
-                        mapCenterLongitude = mapCenterLongitude,
-                        mapZoom = mapZoom,
-                        showCenterMarker = false,
-                        loadingResources = loading,
-                        onViewportChanged = { viewport ->
-                            currentViewport = viewport
-                            if (isLeafletViewportDiscoverable(viewport)) {
-                                pendingViewport = viewport
-                            } else {
-                                viewportRequestSerial += 1
-                                nearbyResult = null
-                                selectedAreaId = null
-                                lastFetchedViewportKey = null
-                                infoMessage = ResourceZoomedOutMessage
-                            }
-                        }
-                    )
+                    Unit
                 }
 
                 nearbyResult?.areas?.isEmpty() == true -> {
-                    val result = nearbyResult ?: return@AppDrawerScaffold
-
-                    GatheringAreasMapCard(
-                        result = result,
-                        visibleAreas = emptyList(),
-                        selectedAreaId = null,
-                        onAreaSelected = { selectedAreaId = it },
-                        onOpenAreaInMap = ::openAreaInMap,
-                        onGetDirections = ::openAreaDirections,
-                        emptyMarkersMessage = ResourceEmptyMessage,
-                        emptyMapSubtitle = ResourceEmptyMessage,
-                        mapCenterLatitude = mapCenterLatitude,
-                        mapCenterLongitude = mapCenterLongitude,
-                        mapZoom = mapZoom,
-                        loadingResources = loading,
-                        onViewportChanged = { viewport ->
-                            currentViewport = viewport
-                            if (isLeafletViewportDiscoverable(viewport)) {
-                                pendingViewport = viewport
-                            } else {
-                                viewportRequestSerial += 1
-                                nearbyResult = null
-                                selectedAreaId = null
-                                lastFetchedViewportKey = null
-                                infoMessage = ResourceZoomedOutMessage
-                            }
-                        }
-                    )
-
                     SectionCard {
                         Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
                             SectionHeader(
@@ -442,7 +459,6 @@ fun GatheringAreasScreen(
 
                 else -> {
                     val result = nearbyResult ?: return@AppDrawerScaffold
-                    val selectedArea = visibleAreas.firstOrNull { it.id == selectedAreaId }
 
                     SectionCard {
                         Column(verticalArrangement = Arrangement.spacedBy(spacing.sm)) {
@@ -510,31 +526,6 @@ fun GatheringAreasScreen(
                             GatheringAreasLegend(categoryOptions = categoryOptions)
                         }
                     }
-
-                    GatheringAreasMapCard(
-                        result = result,
-                        visibleAreas = visibleAreas,
-                        selectedAreaId = selectedArea?.id,
-                        onAreaSelected = { selectedAreaId = it },
-                        onOpenAreaInMap = ::openAreaInMap,
-                        onGetDirections = ::openAreaDirections,
-                        mapCenterLatitude = mapCenterLatitude,
-                        mapCenterLongitude = mapCenterLongitude,
-                        mapZoom = mapZoom,
-                        loadingResources = loading,
-                        onViewportChanged = { viewport ->
-                            currentViewport = viewport
-                            if (isLeafletViewportDiscoverable(viewport)) {
-                                pendingViewport = viewport
-                            } else {
-                                viewportRequestSerial += 1
-                                nearbyResult = null
-                                selectedAreaId = null
-                                lastFetchedViewportKey = null
-                                infoMessage = ResourceZoomedOutMessage
-                            }
-                        }
-                    )
 
                     visibleAreas.forEachIndexed { index, area ->
                         SectionCard {
@@ -633,6 +624,7 @@ private fun GatheringAreasMapCard(
     mapCenterLatitude: Double = result.centerLatitude,
     mapCenterLongitude: Double = result.centerLongitude,
     mapZoom: Int = 13,
+    mapResetToken: Int = 0,
     showCenterMarker: Boolean = true,
     loadingResources: Boolean = false
 ) {
@@ -643,8 +635,7 @@ private fun GatheringAreasMapCard(
     var mapError by remember {
         mutableStateOf("")
     }
-    val mapInstanceKey = GatheringAreasMapInstanceKey(mapCenterLatitude, mapCenterLongitude)
-    val mapInstanceId = remember(mapInstanceKey) {
+    val mapInstanceId = remember(mapResetToken) {
         newLeafletMapInstanceId()
     }
     val currentMapInstanceIdState = remember { mutableStateOf(mapInstanceId) }

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -44,9 +44,13 @@ import com.neph.ui.map.LeafletMapMarker
 import com.neph.ui.map.LeafletMarkerMap
 import com.neph.ui.map.LeafletMapInitializationTimeoutMessage
 import com.neph.ui.map.LeafletMapInitializationTimeoutMillis
+import com.neph.ui.map.LeafletMapViewport
 import com.neph.ui.map.NephMapIntegration
+import com.neph.ui.map.effectiveLeafletViewportKey
 import com.neph.ui.map.isLeafletMapInitializedForInstance
 import com.neph.ui.map.isLeafletTileLoadedSignal
+import com.neph.ui.map.isLeafletViewportDiscoverable
+import com.neph.ui.map.leafletViewportBboxString
 import com.neph.ui.map.leafletMapErrorForInstance
 import com.neph.ui.map.logMapDebug
 import com.neph.ui.map.newLeafletMapInstanceId
@@ -60,30 +64,23 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.Locale
 
-private enum class GatheringAreasSearchOrigin {
-    CURRENT_LOCATION,
-    OTHER
-}
-
 private const val GatheringAreasMapHeightCssPx = 280
 private const val TurkeyOverviewLatitude = 39.0
 private const val TurkeyOverviewLongitude = 35.0
 private const val TurkeyOverviewZoom = 5
+private const val ResourceInitialMessage = "Zoom in or use your device location to see resources in this area."
+private const val ResourceZoomedOutMessage = "Zoom in to see resources in this area."
+private const val ResourceLoadingMessage = "Loading resources in this area..."
+private const val ResourceEmptyMessage = "No resources were found in this visible area."
+private const val ResourceErrorMessage = "Resources could not be loaded for this area. Please try again."
 internal const val GatheringAreasVisibleCategoriesTitle = "Visible Categories"
 internal const val GatheringAreasVisibleCategoriesSubtitle =
     "Selected categories are shown on the map and in the list."
 internal const val GatheringAreasShowAllCategoriesText = "Show All Categories"
 
-internal data class GatheringAreaMapMarkerKey(
-    val id: String,
-    val latitude: Double,
-    val longitude: Double
-)
-
 internal data class GatheringAreasMapInstanceKey(
     val centerLatitude: Double,
-    val centerLongitude: Double,
-    val markers: List<GatheringAreaMapMarkerKey>
+    val centerLongitude: Double
 )
 
 internal fun gatheringAreasMapInstanceKey(
@@ -92,14 +89,7 @@ internal fun gatheringAreasMapInstanceKey(
 ): GatheringAreasMapInstanceKey {
     return GatheringAreasMapInstanceKey(
         centerLatitude = result.centerLatitude,
-        centerLongitude = result.centerLongitude,
-        markers = visibleAreas.map { area ->
-            GatheringAreaMapMarkerKey(
-                id = area.id,
-                latitude = area.latitude,
-                longitude = area.longitude
-            )
-        }
+        centerLongitude = result.centerLongitude
     )
 }
 
@@ -122,60 +112,36 @@ fun GatheringAreasScreen(
     var sourceLabel by remember { mutableStateOf("") }
     var lastCenterLatitude by remember { mutableStateOf<Double?>(null) }
     var lastCenterLongitude by remember { mutableStateOf<Double?>(null) }
-    var lastSearchOrigin by remember { mutableStateOf<GatheringAreasSearchOrigin?>(null) }
+    var mapCenterLatitude by remember { mutableStateOf(TurkeyOverviewLatitude) }
+    var mapCenterLongitude by remember { mutableStateOf(TurkeyOverviewLongitude) }
+    var mapZoom by remember { mutableStateOf(TurkeyOverviewZoom) }
+    var currentViewport by remember { mutableStateOf<LeafletMapViewport?>(null) }
+    var pendingViewport by remember { mutableStateOf<LeafletMapViewport?>(null) }
+    var lastFetchedViewportKey by remember { mutableStateOf<String?>(null) }
+    var viewportRefreshNonce by remember { mutableStateOf(0) }
+    var viewportRequestSerial by remember { mutableStateOf(0) }
     var nearbyResult by remember { mutableStateOf<NearbyGatheringAreasResult?>(null) }
     var selectedAreaId by remember { mutableStateOf<String?>(null) }
     var categoryFilters by remember { mutableStateOf<Set<String>>(emptySet()) }
     val hasSearchCenter = lastCenterLatitude != null && lastCenterLongitude != null
 
-    fun fetchGatheringAreas(
-        lat: Double,
-        lon: Double,
-        label: String,
-        origin: GatheringAreasSearchOrigin
-    ) {
-        val normalizedLabel = label.ifBlank { "selected location" }
-        sourceLabel = normalizedLabel
-        lastCenterLatitude = lat
-        lastCenterLongitude = lon
-        lastSearchOrigin = origin
+    fun applyViewportResult(result: NearbyGatheringAreasResult) {
+        nearbyResult = result
+        sourceLabel = "visible area"
+        lastCenterLatitude = result.centerLatitude
+        lastCenterLongitude = result.centerLongitude
+        selectedAreaId = selectedAreaId
+            ?.takeIf { selected -> result.areas.any { it.id == selected } }
+            ?: result.areas.firstOrNull()?.id
+        val nextOptions = resolveCategoryOptions(result).map { it.key }.toSet()
+        if (categoryFilters.isEmpty()) {
+            categoryFilters = nextOptions
+        }
 
-        scope.launch {
-            loading = true
-            errorMessage = ""
-            infoMessage = ""
-
-            try {
-                val result = GatheringAreasRepository.fetchNearbyGatheringAreas(
-                    latitude = lat,
-                    longitude = lon
-                )
-                nearbyResult = result
-                sourceLabel = normalizedLabel
-                lastCenterLatitude = result.centerLatitude
-                lastCenterLongitude = result.centerLongitude
-                selectedAreaId = selectedAreaId
-                    ?.takeIf { selected -> result.areas.any { it.id == selected } }
-                    ?: result.areas.firstOrNull()?.id
-                categoryFilters = resolveCategoryOptions(result).map { it.key }.toSet()
-
-                if (result.areas.isEmpty()) {
-                    infoMessage = "No gathering areas were found in this area."
-                } else if (result.skippedCount > 0) {
-                    infoMessage = "${result.skippedCount} malformed area entries were skipped safely."
-                }
-            } catch (cancellationException: CancellationException) {
-                throw cancellationException
-            } catch (error: ApiException) {
-                errorMessage = mapGatheringAreasErrorMessage(error)
-                if (origin == GatheringAreasSearchOrigin.CURRENT_LOCATION && isProviderError(error)) {
-                    infoMessage = "Current location detected. Nearby gathering areas could not be loaded right now."
-                }
-            } catch (_: Exception) {
-                errorMessage = "Could not load gathering areas right now."
-            } finally {
-                loading = false
-            }
+        if (result.areas.isEmpty()) {
+            infoMessage = ResourceEmptyMessage
+        } else if (result.skippedCount > 0) {
+            infoMessage = "${result.skippedCount} malformed provider entries were skipped."
         }
     }
 
@@ -193,12 +159,14 @@ fun GatheringAreasScreen(
 
                 val location = attempt.location
                 if (location != null) {
-                    fetchGatheringAreas(
-                        lat = location.latitude,
-                        lon = location.longitude,
-                        label = "your current location",
-                        origin = GatheringAreasSearchOrigin.CURRENT_LOCATION
-                    )
+                    mapCenterLatitude = location.latitude
+                    mapCenterLongitude = location.longitude
+                    mapZoom = 13
+                    sourceLabel = "your current location"
+                    nearbyResult = null
+                    selectedAreaId = null
+                    lastFetchedViewportKey = null
+                    loading = false
                     return@launch
                 }
 
@@ -215,6 +183,51 @@ fun GatheringAreasScreen(
             } catch (_: Exception) {
                 loading = false
                 infoMessage = "Current location is unavailable. Nearby results were not updated."
+            }
+        }
+    }
+
+    LaunchedEffect(effectiveLeafletViewportKey(pendingViewport), viewportRefreshNonce) {
+        val viewport = pendingViewport ?: return@LaunchedEffect
+        if (!isLeafletViewportDiscoverable(viewport)) return@LaunchedEffect
+        val viewportKey = effectiveLeafletViewportKey(viewport) ?: return@LaunchedEffect
+        if (viewportKey == lastFetchedViewportKey && viewportRefreshNonce == 0) {
+            return@LaunchedEffect
+        }
+        delay(450)
+        val requestSerial = viewportRequestSerial + 1
+        viewportRequestSerial = requestSerial
+        loading = true
+        errorMessage = ""
+        infoMessage = ResourceLoadingMessage
+
+        try {
+            val result = GatheringAreasRepository.fetchViewportGatheringAreas(
+                bbox = leafletViewportBboxString(viewport),
+                centerLatitude = viewport.centerLatitude,
+                centerLongitude = viewport.centerLongitude,
+                widestVisibleDimensionKm = viewport.widestVisibleDimensionKm
+            )
+            if (requestSerial == viewportRequestSerial) {
+                lastFetchedViewportKey = viewportKey
+                viewportRefreshNonce = 0
+                applyViewportResult(result)
+            }
+        } catch (cancellationException: CancellationException) {
+            throw cancellationException
+        } catch (error: ApiException) {
+            if (requestSerial == viewportRequestSerial) {
+                errorMessage = mapGatheringAreasErrorMessage(error).ifBlank { ResourceErrorMessage }
+                infoMessage = ""
+            }
+        } catch (_: Exception) {
+            if (requestSerial == viewportRequestSerial) {
+                errorMessage = ResourceErrorMessage
+                infoMessage = ""
+            }
+        } finally {
+            if (requestSerial == viewportRequestSerial) {
+                loading = false
             }
         }
     }
@@ -301,12 +314,16 @@ fun GatheringAreasScreen(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
 
-                    if (hasSearchCenter && lastCenterLatitude != null && lastCenterLongitude != null) {
-                        HelperText(
-                            text = "Showing results around $sourceLabel."
-                        )
+                    if (loading) {
+                        HelperText(text = ResourceLoadingMessage)
+                    } else if (currentViewport == null) {
+                        HelperText(text = ResourceInitialMessage)
+                    } else if (!isLeafletViewportDiscoverable(currentViewport)) {
+                        HelperText(text = ResourceZoomedOutMessage)
+                    } else if (hasSearchCenter && lastCenterLatitude != null && lastCenterLongitude != null) {
+                        HelperText(text = "Showing resources in the visible area.")
                     } else {
-                        HelperText(text = "Use your current location to find nearby gathering areas.")
+                        HelperText(text = ResourceInitialMessage)
                     }
 
                     SecondaryButton(
@@ -322,51 +339,23 @@ fun GatheringAreasScreen(
                     )
 
                     SecondaryButton(
-                        text = "Refresh Nearby Areas",
+                        text = "Refresh Visible Area",
                         onClick = {
-                            val lat = lastCenterLatitude ?: return@SecondaryButton
-                            val lon = lastCenterLongitude ?: return@SecondaryButton
-                            fetchGatheringAreas(
-                                lat = lat,
-                                lon = lon,
-                                label = sourceLabel,
-                                origin = lastSearchOrigin ?: GatheringAreasSearchOrigin.OTHER
-                            )
+                            val viewport = currentViewport
+                            if (!isLeafletViewportDiscoverable(viewport)) {
+                                infoMessage = ResourceZoomedOutMessage
+                                return@SecondaryButton
+                            }
+                            pendingViewport = viewport
+                            viewportRefreshNonce += 1
                         },
-                        enabled = !loading && hasSearchCenter
+                        enabled = !loading
                     )
                 }
             }
 
             when {
-                loading -> {
-                    SectionCard {
-                        HelperText(text = "Loading nearby gathering areas...")
-                    }
-                }
-
-                errorMessage.isNotBlank() -> {
-                    SectionCard {
-                        Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
-                            HelperText(text = errorMessage)
-                            if (hasSearchCenter && lastCenterLatitude != null && lastCenterLongitude != null) {
-                                SecondaryButton(
-                                    text = "Retry",
-                                    onClick = {
-                                        fetchGatheringAreas(
-                                            lat = lastCenterLatitude!!,
-                                            lon = lastCenterLongitude!!,
-                                            label = sourceLabel,
-                                            origin = lastSearchOrigin ?: GatheringAreasSearchOrigin.OTHER
-                                        )
-                                    }
-                                )
-                            }
-                        }
-                    }
-                }
-
-                !hasSearchCenter -> {
+                nearbyResult == null -> {
                     GatheringAreasMapCard(
                         result = turkeyOverviewGatheringAreasResult(),
                         visibleAreas = emptyList(),
@@ -374,10 +363,31 @@ fun GatheringAreasScreen(
                         onAreaSelected = { selectedAreaId = it },
                         onOpenAreaInMap = ::openAreaInMap,
                         onGetDirections = ::openAreaDirections,
-                        emptyMarkersMessage = "Use your device location to find nearby gathering areas.",
-                        emptyMapSubtitle = "Turkey overview. Nearby markers will appear after using your device location.",
-                        mapZoom = TurkeyOverviewZoom,
-                        showCenterMarker = false
+                        emptyMarkersMessage = when {
+                            loading -> ResourceLoadingMessage
+                            errorMessage.isNotBlank() -> ResourceErrorMessage
+                            currentViewport == null -> ResourceInitialMessage
+                            !isLeafletViewportDiscoverable(currentViewport) -> ResourceZoomedOutMessage
+                            else -> ResourceEmptyMessage
+                        },
+                        emptyMapSubtitle = ResourceInitialMessage,
+                        mapCenterLatitude = mapCenterLatitude,
+                        mapCenterLongitude = mapCenterLongitude,
+                        mapZoom = mapZoom,
+                        showCenterMarker = false,
+                        loadingResources = loading,
+                        onViewportChanged = { viewport ->
+                            currentViewport = viewport
+                            if (isLeafletViewportDiscoverable(viewport)) {
+                                pendingViewport = viewport
+                            } else {
+                                viewportRequestSerial += 1
+                                nearbyResult = null
+                                selectedAreaId = null
+                                lastFetchedViewportKey = null
+                                infoMessage = ResourceZoomedOutMessage
+                            }
+                        }
                     )
                 }
 
@@ -390,7 +400,25 @@ fun GatheringAreasScreen(
                         selectedAreaId = null,
                         onAreaSelected = { selectedAreaId = it },
                         onOpenAreaInMap = ::openAreaInMap,
-                        onGetDirections = ::openAreaDirections
+                        onGetDirections = ::openAreaDirections,
+                        emptyMarkersMessage = ResourceEmptyMessage,
+                        emptyMapSubtitle = ResourceEmptyMessage,
+                        mapCenterLatitude = mapCenterLatitude,
+                        mapCenterLongitude = mapCenterLongitude,
+                        mapZoom = mapZoom,
+                        loadingResources = loading,
+                        onViewportChanged = { viewport ->
+                            currentViewport = viewport
+                            if (isLeafletViewportDiscoverable(viewport)) {
+                                pendingViewport = viewport
+                            } else {
+                                viewportRequestSerial += 1
+                                nearbyResult = null
+                                selectedAreaId = null
+                                lastFetchedViewportKey = null
+                                infoMessage = ResourceZoomedOutMessage
+                            }
+                        }
                     )
 
                     SectionCard {
@@ -399,16 +427,12 @@ fun GatheringAreasScreen(
                                 title = "No Gathering Areas Found",
                                 subtitle = "Try refreshing or using your current location for a different area."
                             )
-                            if (hasSearchCenter && lastCenterLatitude != null && lastCenterLongitude != null) {
+                            if (isLeafletViewportDiscoverable(currentViewport)) {
                                 SecondaryButton(
                                     text = "Retry",
                                     onClick = {
-                                        fetchGatheringAreas(
-                                            lat = lastCenterLatitude!!,
-                                            lon = lastCenterLongitude!!,
-                                            label = sourceLabel,
-                                            origin = lastSearchOrigin ?: GatheringAreasSearchOrigin.OTHER
-                                        )
+                                        pendingViewport = currentViewport
+                                        viewportRefreshNonce += 1
                                     }
                                 )
                             }
@@ -493,7 +517,23 @@ fun GatheringAreasScreen(
                         selectedAreaId = selectedArea?.id,
                         onAreaSelected = { selectedAreaId = it },
                         onOpenAreaInMap = ::openAreaInMap,
-                        onGetDirections = ::openAreaDirections
+                        onGetDirections = ::openAreaDirections,
+                        mapCenterLatitude = mapCenterLatitude,
+                        mapCenterLongitude = mapCenterLongitude,
+                        mapZoom = mapZoom,
+                        loadingResources = loading,
+                        onViewportChanged = { viewport ->
+                            currentViewport = viewport
+                            if (isLeafletViewportDiscoverable(viewport)) {
+                                pendingViewport = viewport
+                            } else {
+                                viewportRequestSerial += 1
+                                nearbyResult = null
+                                selectedAreaId = null
+                                lastFetchedViewportKey = null
+                                infoMessage = ResourceZoomedOutMessage
+                            }
+                        }
                     )
 
                     visibleAreas.forEachIndexed { index, area ->
@@ -553,6 +593,23 @@ fun GatheringAreasScreen(
                 }
             }
 
+            if (errorMessage.isNotBlank()) {
+                SectionCard {
+                    Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                        HelperText(text = errorMessage)
+                        if (isLeafletViewportDiscoverable(currentViewport)) {
+                            SecondaryButton(
+                                text = "Retry",
+                                onClick = {
+                                    pendingViewport = currentViewport
+                                    viewportRefreshNonce += 1
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+
             if (infoMessage.isNotBlank()) {
                 SectionCard {
                     HelperText(text = infoMessage)
@@ -570,10 +627,14 @@ private fun GatheringAreasMapCard(
     onAreaSelected: (String) -> Unit,
     onOpenAreaInMap: (GatheringAreaItem) -> Unit,
     onGetDirections: (GatheringAreaItem) -> Unit,
+    onViewportChanged: (LeafletMapViewport) -> Unit,
     emptyMarkersMessage: String = "No gathering area markers are available for this search center.",
     emptyMapSubtitle: String = "Showing the searched area. No gathering area markers were returned.",
+    mapCenterLatitude: Double = result.centerLatitude,
+    mapCenterLongitude: Double = result.centerLongitude,
     mapZoom: Int = 13,
-    showCenterMarker: Boolean = true
+    showCenterMarker: Boolean = true,
+    loadingResources: Boolean = false
 ) {
     val spacing = LocalNephSpacing.current
     val initializedInstanceIdState = remember { mutableStateOf<String?>(null) }
@@ -582,7 +643,7 @@ private fun GatheringAreasMapCard(
     var mapError by remember {
         mutableStateOf("")
     }
-    val mapInstanceKey = gatheringAreasMapInstanceKey(result, visibleAreas)
+    val mapInstanceKey = GatheringAreasMapInstanceKey(mapCenterLatitude, mapCenterLongitude)
     val mapInstanceId = remember(mapInstanceKey) {
         newLeafletMapInstanceId()
     }
@@ -666,13 +727,14 @@ private fun GatheringAreasMapCard(
             LeafletMarkerMap(
                 mapInstanceId = mapInstanceId,
                 currentMapInstanceId = { currentMapInstanceIdState.value },
-                centerLatitude = result.centerLatitude,
-                centerLongitude = result.centerLongitude,
+                centerLatitude = mapCenterLatitude,
+                centerLongitude = mapCenterLongitude,
                 markers = markers,
                 selectedMarkerId = selectedAreaId,
                 mapHeightCssPx = GatheringAreasMapHeightCssPx,
                 zoom = mapZoom,
                 showCenterMarker = showCenterMarker,
+                fitBoundsToMarkers = false,
                 onMarkerSelected = { markerInstanceId, markerId ->
                     if (markerInstanceId == currentMapInstanceIdState.value) {
                         onAreaSelected(markerId)
@@ -694,6 +756,11 @@ private fun GatheringAreasMapCard(
                         mapError = message.ifBlank { "Map failed to load. Check your connection and try again." }
                     }
                 },
+                onViewportChanged = { viewportInstanceId, viewport ->
+                    if (viewportInstanceId == currentMapInstanceIdState.value) {
+                        onViewportChanged(viewport)
+                    }
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(GatheringAreasMapHeightCssPx.dp)
@@ -705,6 +772,10 @@ private fun GatheringAreasMapCard(
 
             if (activeMapError.isNotBlank()) {
                 HelperText(text = activeMapError)
+            }
+
+            if (loadingResources) {
+                HelperText(text = ResourceLoadingMessage)
             }
 
             if (markers.isEmpty()) {

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -49,10 +48,14 @@ import com.neph.ui.layout.AppDrawerScaffold
 import com.neph.ui.map.LeafletMapInitializationTimeoutMessage
 import com.neph.ui.map.LeafletMapInitializationTimeoutMillis
 import com.neph.ui.map.LeafletMapMarker
+import com.neph.ui.map.LeafletMapViewport
 import com.neph.ui.map.LeafletMarkerMap
 import com.neph.ui.map.NephMapIntegration
+import com.neph.ui.map.effectiveLeafletViewportKey
 import com.neph.ui.map.isLeafletMapInitializedForInstance
 import com.neph.ui.map.isLeafletTileLoadedSignal
+import com.neph.ui.map.isLeafletViewportDiscoverable
+import com.neph.ui.map.leafletViewportBboxString
 import com.neph.ui.map.leafletMapErrorForInstance
 import com.neph.ui.map.logMapDebug
 import com.neph.ui.map.newLeafletMapInstanceId
@@ -63,12 +66,16 @@ import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 private const val HelpRequestMapHeightCssPx = 280
 private const val TurkeyOverviewLatitude = 39.0
 private const val TurkeyOverviewLongitude = 35.0
 private const val TurkeyOverviewZoom = 5
+private const val ResourceInitialMessage = "Zoom in or use your device location to see resources in this area."
+private const val ResourceZoomedOutMessage = "Zoom in to see resources in this area."
+private const val ResourceLoadingMessage = "Loading resources in this area..."
+private const val ResourceEmptyMessage = "No resources were found in this visible area."
+private const val ResourceErrorMessage = "Resources could not be loaded for this area. Please try again."
 
 private val RequestTypeFilterOrder = listOf(
     CrisisRequestType.FIRST_AID,
@@ -107,14 +114,14 @@ internal data class HelpRequestMapCenter(
 
 internal data class HelpRequestMapInstanceKey(
     val centerLatitude: Double,
-    val centerLongitude: Double,
-    val markers: List<LeafletMapMarker>
+    val centerLongitude: Double
 )
 
 internal fun helpRequestMapCenter(
     requests: List<ActiveHelpRequestMapItem>
 ): HelpRequestMapCenter {
-    if (requests.isEmpty()) {
+    val validRequests = requests.filter { it.hasValidMapCoordinates() }
+    if (validRequests.isEmpty()) {
         return HelpRequestMapCenter(
             latitude = TurkeyOverviewLatitude,
             longitude = TurkeyOverviewLongitude
@@ -122,15 +129,15 @@ internal fun helpRequestMapCenter(
     }
 
     return HelpRequestMapCenter(
-        latitude = requests.sumOf { it.latitude } / requests.size,
-        longitude = requests.sumOf { it.longitude } / requests.size
+        latitude = validRequests.sumOf { it.latitude } / validRequests.size,
+        longitude = validRequests.sumOf { it.longitude } / validRequests.size
     )
 }
 
 internal fun helpRequestLeafletMarkers(
     requests: List<ActiveHelpRequestMapItem>
 ): List<LeafletMapMarker> {
-    return requests.map { request ->
+    return requests.filter { it.hasValidMapCoordinates() }.map { request ->
         val style = requestMarkerStyle(request.type)
         val subtitle = "Priority: ${ActiveHelpRequestsRepository.formatPriority(request.priorityLevel)} - " +
             "${request.district}, ${request.city}"
@@ -152,9 +159,15 @@ internal fun helpRequestMapInstanceKey(
     val center = helpRequestMapCenter(requests)
     return HelpRequestMapInstanceKey(
         centerLatitude = center.latitude,
-        centerLongitude = center.longitude,
-        markers = helpRequestLeafletMarkers(requests)
+        centerLongitude = center.longitude
     )
+}
+
+private fun ActiveHelpRequestMapItem.hasValidMapCoordinates(): Boolean {
+    return latitude.isFinite() &&
+        longitude.isFinite() &&
+        latitude in -90.0..90.0 &&
+        longitude in -180.0..180.0
 }
 
 @Composable
@@ -166,52 +179,30 @@ fun HelpRequestMapScreen(
     isAuthenticated: Boolean
 ) {
     val spacing = LocalNephSpacing.current
-    val scope = rememberCoroutineScope()
     val context = LocalContext.current
 
-    var loading by remember { mutableStateOf(true) }
+    var loading by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf("") }
     var infoMessage by remember { mutableStateOf("") }
     var requests by remember { mutableStateOf(emptyList<ActiveHelpRequestMapItem>()) }
     var selectedRequestId by remember { mutableStateOf<String?>(null) }
     var selectedTypes by remember { mutableStateOf(setOf<CrisisRequestType>()) }
+    var currentViewport by remember { mutableStateOf<LeafletMapViewport?>(null) }
+    var pendingViewport by remember { mutableStateOf<LeafletMapViewport?>(null) }
+    var lastFetchedViewportKey by remember { mutableStateOf<String?>(null) }
+    var viewportRefreshNonce by remember { mutableStateOf(0) }
+    var viewportRequestSerial by remember { mutableStateOf(0) }
 
-    fun loadWaitingRequests() {
-        scope.launch {
-            loading = true
-            errorMessage = ""
-            infoMessage = ""
-
-            try {
-                val result = ActiveHelpRequestsRepository.fetchWaitingHelpRequests()
-                requests = result.requests
-                selectedRequestId = when {
-                    result.requests.isEmpty() -> null
-                    selectedRequestId != null && result.requests.any { it.requestId == selectedRequestId } -> selectedRequestId
-                    else -> null
-                }
-
-                if (result.requests.isEmpty()) {
-                    infoMessage = "No waiting help requests are available right now."
-                } else if (result.skippedCount > 0) {
-                    infoMessage = "${result.skippedCount} inactive or malformed request entries were hidden."
-                }
-            } catch (cancellationException: CancellationException) {
-                throw cancellationException
-            } catch (error: ApiException) {
-                errorMessage = error.message.ifBlank {
-                    "Could not load waiting help requests."
-                }
-                requests = emptyList()
-                selectedRequestId = null
-            } catch (_: Exception) {
-                errorMessage = "Could not load waiting help requests."
-                requests = emptyList()
-                selectedRequestId = null
-            } finally {
-                loading = false
-            }
+    fun queueViewportRefresh() {
+        val viewport = currentViewport
+        if (!isLeafletViewportDiscoverable(viewport)) {
+            requests = emptyList()
+            selectedRequestId = null
+            infoMessage = ResourceZoomedOutMessage
+            return
         }
+        pendingViewport = viewport
+        viewportRefreshNonce += 1
     }
 
     fun openRequestInMap(item: ActiveHelpRequestMapItem) {
@@ -238,8 +229,58 @@ fun HelpRequestMapScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
-        loadWaitingRequests()
+    LaunchedEffect(effectiveLeafletViewportKey(pendingViewport), viewportRefreshNonce) {
+        val viewport = pendingViewport ?: return@LaunchedEffect
+        if (!isLeafletViewportDiscoverable(viewport)) return@LaunchedEffect
+        val viewportKey = effectiveLeafletViewportKey(viewport) ?: return@LaunchedEffect
+        if (viewportKey == lastFetchedViewportKey && viewportRefreshNonce == 0) {
+            return@LaunchedEffect
+        }
+        delay(450)
+        val requestSerial = viewportRequestSerial + 1
+        viewportRequestSerial = requestSerial
+        loading = true
+        errorMessage = ""
+        infoMessage = ResourceLoadingMessage
+
+        try {
+            val result = ActiveHelpRequestsRepository.fetchWaitingHelpRequests(
+                bbox = leafletViewportBboxString(viewport)
+            )
+            if (requestSerial == viewportRequestSerial) {
+                requests = result.requests
+                lastFetchedViewportKey = viewportKey
+                viewportRefreshNonce = 0
+                selectedRequestId = selectedRequestId
+                    ?.takeIf { selected -> result.requests.any { it.requestId == selected } }
+                infoMessage = when {
+                    result.requests.isEmpty() -> ResourceEmptyMessage
+                    result.skippedCount > 0 ->
+                        "${result.skippedCount} inactive or malformed request entries were hidden."
+                    else -> ""
+                }
+            }
+        } catch (cancellationException: CancellationException) {
+            throw cancellationException
+        } catch (error: ApiException) {
+            if (requestSerial == viewportRequestSerial) {
+                errorMessage = error.message.ifBlank { ResourceErrorMessage }
+                requests = emptyList()
+                selectedRequestId = null
+                infoMessage = ""
+            }
+        } catch (_: Exception) {
+            if (requestSerial == viewportRequestSerial) {
+                errorMessage = ResourceErrorMessage
+                requests = emptyList()
+                selectedRequestId = null
+                infoMessage = ""
+            }
+        } finally {
+            if (requestSerial == viewportRequestSerial) {
+                loading = false
+            }
+        }
     }
 
     val visibleRequests = filterVisibleRequests(requests, selectedTypes)
@@ -283,42 +324,59 @@ fun HelpRequestMapScreen(
 
                     SecondaryButton(
                         text = "Refresh Help Request Map",
-                        onClick = { loadWaitingRequests() },
+                        onClick = { queueViewportRefresh() },
                         enabled = !loading
                     )
                 }
             }
 
             when {
-                loading -> {
-                    SectionCard {
-                        HelperText(text = "Loading waiting help requests...")
-                    }
-                }
-
-                errorMessage.isNotBlank() -> {
-                    SectionCard {
-                        Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
-                            HelperText(text = errorMessage)
-                            SecondaryButton(
-                                text = "Retry",
-                                onClick = { loadWaitingRequests() }
-                            )
-                        }
-                    }
-                }
-
                 requests.isEmpty() -> {
                     SectionCard {
-                        Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
-                            SectionHeader(
-                                title = "No Waiting Requests",
-                                subtitle = "There are no waiting help requests to show on the map right now."
-                            )
-                            SecondaryButton(
-                                text = "Retry",
-                                onClick = { loadWaitingRequests() }
-                            )
+                        CrisisRequestMapPanel(
+                            requests = emptyList(),
+                            selectedRequestId = null,
+                            emptyMarkersMessage = when {
+                                loading -> ResourceLoadingMessage
+                                errorMessage.isNotBlank() -> ResourceErrorMessage
+                                currentViewport == null -> ResourceInitialMessage
+                                !isLeafletViewportDiscoverable(currentViewport) -> ResourceZoomedOutMessage
+                                else -> ResourceEmptyMessage
+                            },
+                            loadingResources = loading,
+                            onViewportChanged = { viewport ->
+                                currentViewport = viewport
+                                if (isLeafletViewportDiscoverable(viewport)) {
+                                    pendingViewport = viewport
+                                } else {
+                                    viewportRequestSerial += 1
+                                    requests = emptyList()
+                                    selectedRequestId = null
+                                    lastFetchedViewportKey = null
+                                    infoMessage = ResourceZoomedOutMessage
+                                }
+                            },
+                            onSelectRequest = { selectedRequestId = it }
+                        )
+                    }
+
+                    if (
+                        lastFetchedViewportKey != null &&
+                        !loading &&
+                        errorMessage.isBlank() &&
+                        isLeafletViewportDiscoverable(currentViewport)
+                    ) {
+                        SectionCard {
+                            Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                                SectionHeader(
+                                    title = "No Waiting Requests",
+                                    subtitle = ResourceEmptyMessage
+                                )
+                                SecondaryButton(
+                                    text = "Retry",
+                                    onClick = { queueViewportRefresh() }
+                                )
+                            }
                         }
                     }
                 }
@@ -342,6 +400,19 @@ fun HelpRequestMapScreen(
                         CrisisRequestMapPanel(
                             requests = visibleRequests,
                             selectedRequestId = selectedRequest?.requestId,
+                            loadingResources = loading,
+                            onViewportChanged = { viewport ->
+                                currentViewport = viewport
+                                if (isLeafletViewportDiscoverable(viewport)) {
+                                    pendingViewport = viewport
+                                } else {
+                                    viewportRequestSerial += 1
+                                    requests = emptyList()
+                                    selectedRequestId = null
+                                    lastFetchedViewportKey = null
+                                    infoMessage = ResourceZoomedOutMessage
+                                }
+                            },
                             onSelectRequest = { selectedRequestId = it }
                         )
                     }
@@ -401,6 +472,18 @@ fun HelpRequestMapScreen(
             if (isFilterEmpty) {
                 SectionCard {
                     HelperText(text = "No help requests match the selected request type filters.")
+                }
+            }
+
+            if (errorMessage.isNotBlank()) {
+                SectionCard {
+                    Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                        HelperText(text = errorMessage)
+                        SecondaryButton(
+                            text = "Retry",
+                            onClick = { queueViewportRefresh() }
+                        )
+                    }
                 }
             }
 
@@ -614,7 +697,7 @@ private fun RequestListItem(
                 )
             }
             TextActionButton(text = "Get Directions", onClick = onGetDirections)
-            TextActionButton(text = "Open", onClick = onOpenMap)
+            TextActionButton(text = "Open in Map", onClick = onOpenMap)
         }
         Spacer(modifier = Modifier.height(spacing.sm))
     }
@@ -624,6 +707,9 @@ private fun RequestListItem(
 private fun CrisisRequestMapPanel(
     requests: List<ActiveHelpRequestMapItem>,
     selectedRequestId: String?,
+    emptyMarkersMessage: String = ResourceEmptyMessage,
+    loadingResources: Boolean = false,
+    onViewportChanged: (LeafletMapViewport) -> Unit,
     onSelectRequest: (String) -> Unit
 ) {
     val spacing = LocalNephSpacing.current
@@ -631,7 +717,7 @@ private fun CrisisRequestMapPanel(
     val tileLoadedInstanceIdState = remember { mutableStateOf<String?>(null) }
     val errorInstanceIdState = remember { mutableStateOf<String?>(null) }
     var mapError by remember { mutableStateOf("") }
-    val mapInstanceKey = helpRequestMapInstanceKey(requests)
+    val mapInstanceKey = HelpRequestMapInstanceKey(TurkeyOverviewLatitude, TurkeyOverviewLongitude)
     val mapInstanceId = remember(mapInstanceKey) {
         newLeafletMapInstanceId()
     }
@@ -648,7 +734,7 @@ private fun CrisisRequestMapPanel(
         errorMessage = mapError
     )
     val selectedRequest = requests.firstOrNull { it.requestId == selectedRequestId }
-    val markers = mapInstanceKey.markers
+    val markers = helpRequestLeafletMarkers(requests)
 
     fun markMapAlive(instanceId: String, source: String) {
         if (instanceId == currentMapInstanceIdState.value) {
@@ -709,6 +795,7 @@ private fun CrisisRequestMapPanel(
             mapHeightCssPx = HelpRequestMapHeightCssPx,
             zoom = if (markers.isEmpty()) TurkeyOverviewZoom else 13,
             showCenterMarker = false,
+            fitBoundsToMarkers = false,
             onMarkerSelected = { markerInstanceId, markerId ->
                 if (markerInstanceId == currentMapInstanceIdState.value) {
                     onSelectRequest(markerId)
@@ -730,6 +817,11 @@ private fun CrisisRequestMapPanel(
                     mapError = message.ifBlank { "Map failed to load. Check your connection and try again." }
                 }
             },
+            onViewportChanged = { viewportInstanceId, viewport ->
+                if (viewportInstanceId == currentMapInstanceIdState.value) {
+                    onViewportChanged(viewport)
+                }
+            },
             modifier = Modifier
                 .fillMaxWidth()
                 .height(HelpRequestMapHeightCssPx.dp)
@@ -743,8 +835,12 @@ private fun CrisisRequestMapPanel(
             HelperText(text = activeMapError)
         }
 
+        if (loadingResources) {
+            HelperText(text = ResourceLoadingMessage)
+        }
+
         if (markers.isEmpty()) {
-            HelperText(text = "No help request markers are available for the selected filters.")
+            HelperText(text = emptyMarkersMessage)
         }
 
         selectedRequest?.let { request ->

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -198,9 +198,12 @@ fun HelpRequestMapScreen(
         if (!isLeafletViewportDiscoverable(viewport)) {
             requests = emptyList()
             selectedRequestId = null
+            errorMessage = ""
+            loading = false
             infoMessage = ResourceZoomedOutMessage
             return
         }
+        errorMessage = ""
         pendingViewport = viewport
         viewportRefreshNonce += 1
     }
@@ -289,8 +292,36 @@ fun HelpRequestMapScreen(
         selectedRequestId = reconcileSelectedRequestId(selectedRequestId, visibleRequests)
     }
 
+    fun handleViewportChanged(viewport: LeafletMapViewport) {
+        currentViewport = viewport
+        if (isLeafletViewportDiscoverable(viewport)) {
+            errorMessage = ""
+            if (infoMessage == ResourceZoomedOutMessage) {
+                infoMessage = ""
+            }
+            pendingViewport = viewport
+        } else {
+            viewportRequestSerial += 1
+            requests = emptyList()
+            selectedRequestId = null
+            lastFetchedViewportKey = null
+            errorMessage = ""
+            loading = false
+            infoMessage = ResourceZoomedOutMessage
+        }
+    }
+
     val selectedRequest = visibleRequests.firstOrNull { it.requestId == selectedRequestId }
     val isFilterEmpty = !loading && requests.isNotEmpty() && visibleRequests.isEmpty()
+    val mapEmptyMarkersMessage = when {
+        loading -> ResourceLoadingMessage
+        errorMessage.isNotBlank() -> ResourceErrorMessage
+        currentViewport == null -> ResourceInitialMessage
+        !isLeafletViewportDiscoverable(currentViewport) -> ResourceZoomedOutMessage
+        isFilterEmpty -> "No help requests match the selected request type filters."
+        lastFetchedViewportKey != null -> ResourceEmptyMessage
+        else -> ResourceInitialMessage
+    }
 
     AppDrawerScaffold(
         title = "Help Request Map",
@@ -330,36 +361,19 @@ fun HelpRequestMapScreen(
                 }
             }
 
+            SectionCard {
+                CrisisRequestMapPanel(
+                    requests = visibleRequests,
+                    selectedRequestId = selectedRequest?.requestId,
+                    emptyMarkersMessage = mapEmptyMarkersMessage,
+                    loadingResources = loading,
+                    onViewportChanged = ::handleViewportChanged,
+                    onSelectRequest = { selectedRequestId = it }
+                )
+            }
+
             when {
                 requests.isEmpty() -> {
-                    SectionCard {
-                        CrisisRequestMapPanel(
-                            requests = emptyList(),
-                            selectedRequestId = null,
-                            emptyMarkersMessage = when {
-                                loading -> ResourceLoadingMessage
-                                errorMessage.isNotBlank() -> ResourceErrorMessage
-                                currentViewport == null -> ResourceInitialMessage
-                                !isLeafletViewportDiscoverable(currentViewport) -> ResourceZoomedOutMessage
-                                else -> ResourceEmptyMessage
-                            },
-                            loadingResources = loading,
-                            onViewportChanged = { viewport ->
-                                currentViewport = viewport
-                                if (isLeafletViewportDiscoverable(viewport)) {
-                                    pendingViewport = viewport
-                                } else {
-                                    viewportRequestSerial += 1
-                                    requests = emptyList()
-                                    selectedRequestId = null
-                                    lastFetchedViewportKey = null
-                                    infoMessage = ResourceZoomedOutMessage
-                                }
-                            },
-                            onSelectRequest = { selectedRequestId = it }
-                        )
-                    }
-
                     if (
                         lastFetchedViewportKey != null &&
                         !loading &&
@@ -393,27 +407,6 @@ fun HelpRequestMapScreen(
                                 }
                             },
                             onClear = { selectedTypes = emptySet() }
-                        )
-                    }
-
-                    SectionCard {
-                        CrisisRequestMapPanel(
-                            requests = visibleRequests,
-                            selectedRequestId = selectedRequest?.requestId,
-                            loadingResources = loading,
-                            onViewportChanged = { viewport ->
-                                currentViewport = viewport
-                                if (isLeafletViewportDiscoverable(viewport)) {
-                                    pendingViewport = viewport
-                                } else {
-                                    viewportRequestSerial += 1
-                                    requests = emptyList()
-                                    selectedRequestId = null
-                                    lastFetchedViewportKey = null
-                                    infoMessage = ResourceZoomedOutMessage
-                                }
-                            },
-                            onSelectRequest = { selectedRequestId = it }
                         )
                     }
 

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -3,17 +3,15 @@ package com.neph.features.helprequestmap.presentation
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -32,17 +30,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.neph.core.network.ApiException
 import com.neph.features.helprequestmap.data.ActiveHelpRequestMapItem
@@ -55,11 +46,29 @@ import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
 import com.neph.ui.layout.AppDrawerScaffold
+import com.neph.ui.map.LeafletMapInitializationTimeoutMessage
+import com.neph.ui.map.LeafletMapInitializationTimeoutMillis
+import com.neph.ui.map.LeafletMapMarker
+import com.neph.ui.map.LeafletMarkerMap
 import com.neph.ui.map.NephMapIntegration
+import com.neph.ui.map.isLeafletMapInitializedForInstance
+import com.neph.ui.map.isLeafletTileLoadedSignal
+import com.neph.ui.map.leafletMapErrorForInstance
+import com.neph.ui.map.logMapDebug
+import com.neph.ui.map.newLeafletMapInstanceId
+import com.neph.ui.map.shouldApplyLeafletMapError
+import com.neph.ui.map.shouldApplyLeafletMapTimeout
+import com.neph.ui.map.shouldClearLeafletMapErrorForSignal
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+
+private const val HelpRequestMapHeightCssPx = 280
+private const val TurkeyOverviewLatitude = 39.0
+private const val TurkeyOverviewLongitude = 35.0
+private const val TurkeyOverviewZoom = 5
 
 private val RequestTypeFilterOrder = listOf(
     CrisisRequestType.FIRST_AID,
@@ -89,6 +98,63 @@ internal fun reconcileSelectedRequestId(
     return selectedRequestId.takeIf { selected ->
         visibleRequests.any { it.requestId == selected }
     }
+}
+
+internal data class HelpRequestMapCenter(
+    val latitude: Double,
+    val longitude: Double
+)
+
+internal data class HelpRequestMapInstanceKey(
+    val centerLatitude: Double,
+    val centerLongitude: Double,
+    val markers: List<LeafletMapMarker>
+)
+
+internal fun helpRequestMapCenter(
+    requests: List<ActiveHelpRequestMapItem>
+): HelpRequestMapCenter {
+    if (requests.isEmpty()) {
+        return HelpRequestMapCenter(
+            latitude = TurkeyOverviewLatitude,
+            longitude = TurkeyOverviewLongitude
+        )
+    }
+
+    return HelpRequestMapCenter(
+        latitude = requests.sumOf { it.latitude } / requests.size,
+        longitude = requests.sumOf { it.longitude } / requests.size
+    )
+}
+
+internal fun helpRequestLeafletMarkers(
+    requests: List<ActiveHelpRequestMapItem>
+): List<LeafletMapMarker> {
+    return requests.map { request ->
+        val style = requestMarkerStyle(request.type)
+        val subtitle = "Priority: ${ActiveHelpRequestsRepository.formatPriority(request.priorityLevel)} - " +
+            "${request.district}, ${request.city}"
+        LeafletMapMarker(
+            id = request.requestId,
+            latitude = request.latitude,
+            longitude = request.longitude,
+            title = request.typeLabel,
+            subtitle = subtitle,
+            strokeColorHex = style.strokeHex,
+            fillColorHex = style.fillHex
+        )
+    }
+}
+
+internal fun helpRequestMapInstanceKey(
+    requests: List<ActiveHelpRequestMapItem>
+): HelpRequestMapInstanceKey {
+    val center = helpRequestMapCenter(requests)
+    return HelpRequestMapInstanceKey(
+        centerLatitude = center.latitude,
+        centerLongitude = center.longitude,
+        markers = helpRequestLeafletMarkers(requests)
+    )
 }
 
 @Composable
@@ -295,6 +361,8 @@ fun HelpRequestMapScreen(
                                     onOpenMap = { openRequestInMap(selectedRequest) },
                                     onGetDirections = { openRequestDirections(selectedRequest) }
                                 )
+                            } else {
+                                HelperText(text = "Tap a request marker or list item to see details.")
                             }
                         }
                     }
@@ -346,6 +414,7 @@ fun HelpRequestMapScreen(
 }
 
 @Composable
+@OptIn(ExperimentalLayoutApi::class)
 private fun RequestTypeFiltersCard(
     selectedTypes: Set<CrisisRequestType>,
     onToggleType: (CrisisRequestType) -> Unit,
@@ -372,13 +441,13 @@ private fun RequestTypeFiltersCard(
             )
         }
 
-        androidx.compose.foundation.layout.FlowRow(
+        FlowRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(spacing.sm),
             verticalArrangement = Arrangement.spacedBy(spacing.sm)
         ) {
             RequestTypeFilterOrder.forEach { type ->
-                val style = markerStyle(type)
+                val style = requestMarkerStyle(type)
                 val selected = type in selectedTypes
                 FilterChip(
                     selected = selected,
@@ -392,7 +461,7 @@ private fun RequestTypeFiltersCard(
                                 modifier = Modifier
                                     .size(10.dp)
                                     .clip(RoundedCornerShape(999.dp))
-                                    .background(style.color)
+                                    .background(style.dotColor)
                             )
                             Text(text = ActiveHelpRequestsRepository.labelForType(type))
                         }
@@ -411,13 +480,13 @@ private fun RequestTypeFiltersCard(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             fontWeight = FontWeight.SemiBold
         )
-        androidx.compose.foundation.layout.FlowRow(
+        FlowRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(spacing.md),
             verticalArrangement = Arrangement.spacedBy(spacing.sm)
         ) {
             RequestTypeFilterOrder.forEach { type ->
-                val style = markerStyle(type)
+                val style = requestMarkerStyle(type)
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(spacing.xs),
                     verticalAlignment = Alignment.CenterVertically
@@ -426,7 +495,7 @@ private fun RequestTypeFiltersCard(
                         modifier = Modifier
                             .size(10.dp)
                             .clip(RoundedCornerShape(999.dp))
-                            .background(style.color)
+                            .background(style.dotColor)
                     )
                     Text(
                         text = ActiveHelpRequestsRepository.labelForType(type),
@@ -558,244 +627,148 @@ private fun CrisisRequestMapPanel(
     onSelectRequest: (String) -> Unit
 ) {
     val spacing = LocalNephSpacing.current
-    var zoom by remember { mutableStateOf(1f) }
-    var panX by remember { mutableStateOf(0f) }
-    var panY by remember { mutableStateOf(0f) }
-    val minLatitude = requests.minOfOrNull { it.latitude } ?: 0.0
-    val maxLatitude = requests.maxOfOrNull { it.latitude } ?: minLatitude
-    val minLongitude = requests.minOfOrNull { it.longitude } ?: 0.0
-    val maxLongitude = requests.maxOfOrNull { it.longitude } ?: minLongitude
-    val latSpan = (maxLatitude - minLatitude).takeIf { it > 0.000001 } ?: 0.01
-    val lonSpan = (maxLongitude - minLongitude).takeIf { it > 0.000001 } ?: 0.01
+    val initializedInstanceIdState = remember { mutableStateOf<String?>(null) }
+    val tileLoadedInstanceIdState = remember { mutableStateOf<String?>(null) }
+    val errorInstanceIdState = remember { mutableStateOf<String?>(null) }
+    var mapError by remember { mutableStateOf("") }
+    val mapInstanceKey = helpRequestMapInstanceKey(requests)
+    val mapInstanceId = remember(mapInstanceKey) {
+        newLeafletMapInstanceId()
+    }
+    val currentMapInstanceIdState = remember { mutableStateOf(mapInstanceId) }
+    currentMapInstanceIdState.value = mapInstanceId
+    val activeMapInitialized = isLeafletMapInitializedForInstance(
+        activeInstanceId = mapInstanceId,
+        initializedInstanceId = initializedInstanceIdState.value
+    )
+    val activeMapError = leafletMapErrorForInstance(
+        activeInstanceId = mapInstanceId,
+        tileLoadedInstanceId = tileLoadedInstanceIdState.value,
+        errorInstanceId = errorInstanceIdState.value,
+        errorMessage = mapError
+    )
     val selectedRequest = requests.firstOrNull { it.requestId == selectedRequestId }
-    val density = LocalDensity.current
+    val markers = mapInstanceKey.markers
+
+    fun markMapAlive(instanceId: String, source: String) {
+        if (instanceId == currentMapInstanceIdState.value) {
+            logMapDebug("native HelpRequestMap initialized source=$source instance=$instanceId")
+            initializedInstanceIdState.value = instanceId
+            if (isLeafletTileLoadedSignal(source)) {
+                tileLoadedInstanceIdState.value = instanceId
+            }
+            if (shouldClearLeafletMapErrorForSignal(source, mapError)) {
+                errorInstanceIdState.value = null
+                mapError = ""
+            }
+        } else {
+            logMapDebug(
+                "native HelpRequestMap initialized ignored stale source=$source instance=$instanceId current=${currentMapInstanceIdState.value}"
+            )
+        }
+    }
+
+    LaunchedEffect(mapInstanceId) {
+        errorInstanceIdState.value = null
+        mapError = ""
+        delay(LeafletMapInitializationTimeoutMillis)
+        if (shouldApplyLeafletMapTimeout(
+                activeInstanceId = mapInstanceId,
+                currentInstanceId = currentMapInstanceIdState.value,
+                initializedInstanceId = initializedInstanceIdState.value,
+                errorInstanceId = errorInstanceIdState.value
+            )
+        ) {
+            logMapDebug("native HelpRequestMap timeout applied instance=$mapInstanceId")
+            errorInstanceIdState.value = mapInstanceId
+            mapError = LeafletMapInitializationTimeoutMessage
+        } else {
+            logMapDebug(
+                "native HelpRequestMap timeout ignored instance=$mapInstanceId current=${currentMapInstanceIdState.value} initialized=${initializedInstanceIdState.value} error=${errorInstanceIdState.value}"
+            )
+        }
+    }
 
     Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
         SectionHeader(
-            title = "Live Crisis Map",
-            subtitle = "Pinch or drag the map, then tap a marker to see request details."
+            title = "Live Help Request Map",
+            subtitle = if (markers.isEmpty()) {
+                "No request markers match the selected filters."
+            } else {
+                "Tap a marker to preview that help request."
+            }
         )
 
-        BoxWithConstraints(
+        LeafletMarkerMap(
+            mapInstanceId = mapInstanceId,
+            currentMapInstanceId = { currentMapInstanceIdState.value },
+            centerLatitude = mapInstanceKey.centerLatitude,
+            centerLongitude = mapInstanceKey.centerLongitude,
+            markers = markers,
+            selectedMarkerId = selectedRequestId,
+            mapHeightCssPx = HelpRequestMapHeightCssPx,
+            zoom = if (markers.isEmpty()) TurkeyOverviewZoom else 13,
+            showCenterMarker = false,
+            onMarkerSelected = { markerInstanceId, markerId ->
+                if (markerInstanceId == currentMapInstanceIdState.value) {
+                    onSelectRequest(markerId)
+                }
+            },
+            onMapReady = { initializedInstanceId, source ->
+                markMapAlive(initializedInstanceId, source)
+            },
+            onMapError = { errorInstanceId, message ->
+                if (
+                    shouldApplyLeafletMapError(
+                        activeInstanceId = errorInstanceId,
+                        currentInstanceId = currentMapInstanceIdState.value,
+                        tileLoadedInstanceId = tileLoadedInstanceIdState.value,
+                        errorMessage = message
+                    )
+                ) {
+                    errorInstanceIdState.value = errorInstanceId
+                    mapError = message.ifBlank { "Map failed to load. Check your connection and try again." }
+                }
+            },
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(1.18f)
-                .clip(RoundedCornerShape(20.dp))
-                .background(
-                    Brush.linearGradient(
-                        listOf(
-                            MaterialTheme.colorScheme.surfaceVariant,
-                            MaterialTheme.colorScheme.background,
-                            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.55f)
-                        )
-                    )
-                )
-                .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(20.dp))
-                .pointerInput(Unit) {
-                    detectTransformGestures { _, pan, gestureZoom, _ ->
-                        val nextZoom = (zoom * gestureZoom).coerceIn(1f, 2.6f)
-                        zoom = nextZoom
-                        panX = (panX + pan.x).coerceIn(-220f * nextZoom, 220f * nextZoom)
-                        panY = (panY + pan.y).coerceIn(-220f * nextZoom, 220f * nextZoom)
-                    }
-                }
-        ) {
-            val availableHeight = maxHeight
-            val availableWidth = maxWidth
+                .height(HelpRequestMapHeightCssPx.dp)
+        )
 
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(availableHeight)
-                    .graphicsLayer {
-                        scaleX = zoom
-                        scaleY = zoom
-                        translationX = panX
-                        translationY = panY
-                    }
-            ) {
-                MapRoad(
-                    modifier = Modifier
-                        .offset {
-                            IntOffset(
-                                0,
-                                with(density) { (availableHeight * 0.22f).roundToPx() }
-                            )
-                        }
-                        .fillMaxWidth()
-                        .height(12.dp)
-                )
-                MapRoad(
-                    modifier = Modifier
-                        .offset {
-                            IntOffset(
-                                0,
-                                with(density) { (availableHeight * 0.58f).roundToPx() }
-                            )
-                        }
-                        .fillMaxWidth()
-                        .height(9.dp)
-                )
-                MapRoad(
-                    modifier = Modifier
-                        .offset {
-                            IntOffset(
-                                with(density) { (availableWidth * 0.30f).roundToPx() },
-                                0
-                            )
-                        }
-                        .size(11.dp, availableHeight)
-                )
-                MapRoad(
-                    modifier = Modifier
-                        .offset {
-                            IntOffset(
-                                with(density) { (availableWidth * 0.70f).roundToPx() },
-                                0
-                            )
-                        }
-                        .size(8.dp, availableHeight)
-                )
-                MapNeighborhoodPatch(
-                    modifier = Modifier
-                        .offset {
-                            IntOffset(
-                                with(density) { (availableWidth * 0.08f).roundToPx() },
-                                with(density) { (availableHeight * 0.10f).roundToPx() }
-                            )
-                        }
-                        .size(width = availableWidth * 0.24f, height = availableHeight * 0.18f)
-                )
-                MapNeighborhoodPatch(
-                    modifier = Modifier
-                        .offset {
-                            IntOffset(
-                                with(density) { (availableWidth * 0.58f).roundToPx() },
-                                with(density) { (availableHeight * 0.68f).roundToPx() }
-                            )
-                        }
-                        .size(width = availableWidth * 0.28f, height = availableHeight * 0.16f)
-                )
+        if (!activeMapInitialized && activeMapError.isBlank()) {
+            HelperText(text = "Loading map...")
+        }
 
-                requests.forEach { item ->
-                    val xFraction = ((item.longitude - minLongitude) / lonSpan).coerceIn(0.08, 0.92)
-                    val yFraction = (1.0 - ((item.latitude - minLatitude) / latSpan)).coerceIn(0.10, 0.88)
-                    val x = with(density) {
-                        (availableWidth * xFraction.toFloat()).roundToPx()
-                    } - 21
-                    val y = with(density) {
-                        (availableHeight * yFraction.toFloat()).roundToPx()
-                    } - 42
+        if (activeMapError.isNotBlank()) {
+            HelperText(text = activeMapError)
+        }
 
-                    MapMarker(
-                        item = item,
-                        selected = item.requestId == selectedRequestId,
-                        modifier = Modifier.offset {
-                            IntOffset(x, y)
-                        },
-                        onClick = { onSelectRequest(item.requestId) }
-                    )
-                }
-            }
+        if (markers.isEmpty()) {
+            HelperText(text = "No help request markers are available for the selected filters.")
+        }
 
-            if (selectedRequest != null) {
-                MapTooltip(
-                    item = selectedRequest,
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .padding(spacing.md)
-                )
-            }
+        selectedRequest?.let { request ->
+            HelpRequestMapSelectionPreview(item = request)
         }
     }
 }
 
 @Composable
-private fun MapRoad(modifier: Modifier) {
-    Box(
-        modifier = modifier
-            .clip(RoundedCornerShape(999.dp))
-            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.72f))
-            .border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.70f), RoundedCornerShape(999.dp))
-    )
-}
-
-@Composable
-private fun MapNeighborhoodPatch(modifier: Modifier) {
-    Box(
-        modifier = modifier
-            .clip(RoundedCornerShape(18.dp))
-            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.32f))
-            .border(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f), RoundedCornerShape(18.dp))
-    )
-}
-
-@Composable
-private fun MapTooltip(
-    item: ActiveHelpRequestMapItem,
-    modifier: Modifier
-) {
-    Column(
-        modifier = modifier
-            .clip(RoundedCornerShape(14.dp))
-            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.94f))
-            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(14.dp))
-            .padding(horizontal = 12.dp, vertical = 10.dp),
-        verticalArrangement = Arrangement.spacedBy(3.dp)
-    ) {
-        Text(
-            text = item.typeLabel,
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurface,
-            fontWeight = FontWeight.SemiBold
-        )
-        Text(
-            text = "Priority: ${ActiveHelpRequestsRepository.formatPriority(item.priorityLevel)}",
-            style = MaterialTheme.typography.labelMedium,
-            color = priorityColor(item.priorityLevel)
-        )
-        Text(
-            text = "${item.district}, ${item.city}",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
-}
-
-@Composable
-private fun MapMarker(
-    item: ActiveHelpRequestMapItem,
-    selected: Boolean,
-    modifier: Modifier,
-    onClick: () -> Unit
-) {
-    Column(
-        modifier = modifier
-            .semantics {
-                contentDescription = "Crisis marker ${item.typeLabel}"
-            }
-            .clickable(onClick = onClick),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        PinGlyph(type = item.type, selected = selected)
-        Box(
-            modifier = Modifier
-                .padding(top = 3.dp)
-                .size(width = 16.dp, height = 5.dp)
-                .clip(RoundedCornerShape(999.dp))
-                .background(Color.Black.copy(alpha = if (selected) 0.30f else 0.18f))
-        )
-    }
-}
-
-@Composable
 private fun PinGlyph(type: CrisisRequestType, selected: Boolean = false) {
-    val style = markerStyle(type)
+    val style = requestMarkerStyle(type)
 
     Box(
         modifier = Modifier
             .size(if (selected) 40.dp else 34.dp)
-            .background(style.color, RoundedCornerShape(topStart = 14.dp, topEnd = 14.dp, bottomEnd = 14.dp, bottomStart = 5.dp))
+            .background(
+                color = style.dotColor,
+                shape = RoundedCornerShape(
+                    topStart = 14.dp,
+                    topEnd = 14.dp,
+                    bottomEnd = 14.dp,
+                    bottomStart = 5.dp
+                )
+            )
             .border(
                 width = if (selected) 3.dp else 2.dp,
                 color = if (selected) MaterialTheme.colorScheme.onSurface else Color.White,
@@ -812,18 +785,46 @@ private fun PinGlyph(type: CrisisRequestType, selected: Boolean = false) {
     }
 }
 
-private data class MarkerStyle(
-    val color: Color,
+@Composable
+private fun HelpRequestMapSelectionPreview(
+    item: ActiveHelpRequestMapItem
+) {
+    val spacing = LocalNephSpacing.current
+
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.xs)) {
+        Text(
+            text = item.typeLabel,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.SemiBold
+        )
+        Text(
+            text = "Priority: ${ActiveHelpRequestsRepository.formatPriority(item.priorityLevel)}",
+            style = MaterialTheme.typography.bodySmall,
+            color = priorityColor(item.priorityLevel)
+        )
+        Text(
+            text = "${item.district}, ${item.city}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+internal data class RequestMarkerStyle(
+    val strokeHex: String,
+    val fillHex: String,
+    val dotColor: Color,
     val glyph: String
 )
 
-private fun markerStyle(type: CrisisRequestType): MarkerStyle {
+internal fun requestMarkerStyle(type: CrisisRequestType): RequestMarkerStyle {
     return when (type) {
-        CrisisRequestType.SHELTER -> MarkerStyle(Color(0xFF3B66D8), "SH")
-        CrisisRequestType.FIRST_AID -> MarkerStyle(Color(0xFFD94141), "+")
-        CrisisRequestType.SEARCH_AND_RESCUE -> MarkerStyle(Color(0xFFF08C00), "SR")
-        CrisisRequestType.FOOD_WATER -> MarkerStyle(Color(0xFF2F9E67), "FW")
-        CrisisRequestType.OTHER -> MarkerStyle(Color(0xFF687280), "?")
+        CrisisRequestType.SHELTER -> RequestMarkerStyle("#1D4ED8", "#3B66D8", Color(0xFF3B66D8), "SH")
+        CrisisRequestType.FIRST_AID -> RequestMarkerStyle("#B42318", "#D94141", Color(0xFFD94141), "+")
+        CrisisRequestType.SEARCH_AND_RESCUE -> RequestMarkerStyle("#C2410C", "#F08C00", Color(0xFFF08C00), "SR")
+        CrisisRequestType.FOOD_WATER -> RequestMarkerStyle("#15803D", "#2F9E67", Color(0xFF2F9E67), "FW")
+        CrisisRequestType.OTHER -> RequestMarkerStyle("#4B5563", "#687280", Color(0xFF687280), "?")
     }
 }
 

--- a/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
+++ b/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
@@ -40,8 +40,22 @@ data class LeafletMapMarker(
     val fillColorHex: String = "#DC2626"
 )
 
+data class LeafletMapViewport(
+    val centerLatitude: Double,
+    val centerLongitude: Double,
+    val north: Double,
+    val south: Double,
+    val east: Double,
+    val west: Double,
+    val zoom: Int,
+    val widthKm: Double,
+    val heightKm: Double,
+    val widestVisibleDimensionKm: Double
+)
+
 private const val LeafletMarkerMapBridgeName = "AndroidLeafletMarkerMap"
 private const val LeafletMapBaseUrl = "https://neph.app/android-map/"
+const val DISCOVERY_VIEWPORT_MAX_KM = 50.0
 internal const val LeafletMapWebViewLogTag = "NephMapWebView"
 internal const val LeafletMapInitializationTimeoutMillis = 15_000L
 internal const val LeafletMapInitializationTimeoutMessage =
@@ -143,6 +157,54 @@ internal fun logMapWarning(message: String) {
     }
 }
 
+fun isLeafletViewportDiscoverable(viewport: LeafletMapViewport?): Boolean {
+    val current = viewport ?: return false
+    return current.centerLatitude.isFinite() &&
+        current.centerLongitude.isFinite() &&
+        current.north.isFinite() &&
+        current.south.isFinite() &&
+        current.east.isFinite() &&
+        current.west.isFinite() &&
+        current.widthKm.isFinite() &&
+        current.heightKm.isFinite() &&
+        current.widestVisibleDimensionKm.isFinite() &&
+        current.centerLatitude in -90.0..90.0 &&
+        current.centerLongitude in -180.0..180.0 &&
+        current.south in -90.0..90.0 &&
+        current.north in -90.0..90.0 &&
+        current.west in -180.0..180.0 &&
+        current.east in -180.0..180.0 &&
+        current.south <= current.north &&
+        current.west <= current.east &&
+        current.widthKm >= 0.0 &&
+        current.heightKm >= 0.0 &&
+        current.widestVisibleDimensionKm <= DISCOVERY_VIEWPORT_MAX_KM
+}
+
+fun effectiveLeafletViewportKey(viewport: LeafletMapViewport?): String? {
+    if (!isLeafletViewportDiscoverable(viewport)) return null
+    val current = viewport ?: return null
+    return String.format(
+        Locale.US,
+        "%.3f,%.3f,%.3f,%.3f",
+        current.west,
+        current.south,
+        current.east,
+        current.north
+    )
+}
+
+fun leafletViewportBboxString(viewport: LeafletMapViewport): String {
+    return String.format(
+        Locale.US,
+        "%.6f,%.6f,%.6f,%.6f",
+        viewport.west,
+        viewport.south,
+        viewport.east,
+        viewport.north
+    )
+}
+
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
 internal fun LeafletMapWebView(
@@ -203,22 +265,25 @@ fun LeafletMarkerMap(
     mapHeightCssPx: Int = LeafletMapFallbackHeightCssPx,
     zoom: Int = 13,
     showCenterMarker: Boolean = true,
+    fitBoundsToMarkers: Boolean = true,
     onMarkerSelected: (String, String) -> Unit,
     onMapReady: (String, String) -> Unit,
     onMapError: (String, String) -> Unit,
+    onViewportChanged: ((String, LeafletMapViewport) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     val latestOnMarkerSelected by rememberUpdatedState(onMarkerSelected)
     val latestOnMapReady by rememberUpdatedState(onMapReady)
     val latestOnMapError by rememberUpdatedState(onMapError)
+    val latestOnViewportChanged by rememberUpdatedState(onViewportChanged)
     val latestCurrentMapInstanceId by rememberUpdatedState(currentMapInstanceId)
     val html = remember(
         mapInstanceId,
         centerLatitude,
         centerLongitude,
-        markers,
         zoom,
-        showCenterMarker
+        showCenterMarker,
+        fitBoundsToMarkers
     ) {
         buildLeafletMarkerMapHtml(
             mapInstanceId = mapInstanceId,
@@ -229,6 +294,7 @@ fun LeafletMarkerMap(
             bridgeName = LeafletMarkerMapBridgeName,
             zoom = zoom,
             showCenterMarker = showCenterMarker,
+            fitBoundsToMarkers = fitBoundsToMarkers,
             mapHeightCssPx = mapHeightCssPx
         )
     }
@@ -237,7 +303,10 @@ fun LeafletMarkerMap(
             currentMapInstanceId = { latestCurrentMapInstanceId() },
             onMarkerSelected = { instanceId, markerId -> latestOnMarkerSelected(instanceId, markerId) },
             onMapReady = { instanceId, source -> latestOnMapReady(instanceId, source) },
-            onMapError = { instanceId, message -> latestOnMapError(instanceId, message) }
+            onMapError = { instanceId, message -> latestOnMapError(instanceId, message) },
+            onViewportChanged = { instanceId, viewport ->
+                latestOnViewportChanged?.invoke(instanceId, viewport)
+            }
         )
     }
 
@@ -246,14 +315,36 @@ fun LeafletMarkerMap(
         html = html,
         bridgeName = LeafletMarkerMapBridgeName,
         bridge = bridge,
-        javaScriptUpdate = buildSelectedMarkerUpdateScript(selectedMarkerId),
+        javaScriptUpdate = buildMarkerMapUpdateScript(markers, selectedMarkerId),
         modifier = modifier
     )
 }
 
-private fun buildSelectedMarkerUpdateScript(selectedMarkerId: String?): String {
+private fun buildMarkerMapUpdateScript(markers: List<LeafletMapMarker>, selectedMarkerId: String?): String {
+    val markersJson = leafletMarkersJson(markers)
     val selectedMarkerJson = selectedMarkerId?.let(JSONObject::quote) ?: "null"
-    return "if (window.nephSelectMarker) { window.nephSelectMarker($selectedMarkerJson); }"
+    return """
+        if (window.nephSetMarkers) {
+            window.nephSetMarkers($markersJson, $selectedMarkerJson);
+        } else if (window.nephSelectMarker) {
+            window.nephSelectMarker($selectedMarkerJson);
+        }
+    """.trimIndent()
+}
+
+private fun leafletMarkersJson(markers: List<LeafletMapMarker>): String {
+    return JSONArray(
+        markers.map { marker ->
+            JSONObject()
+                .put("id", marker.id)
+                .put("latitude", marker.latitude)
+                .put("longitude", marker.longitude)
+                .put("title", marker.title)
+                .put("subtitle", marker.subtitle)
+                .put("strokeColorHex", marker.strokeColorHex)
+                .put("fillColorHex", marker.fillColorHex)
+        }
+    ).toString()
 }
 
 internal fun buildLeafletDocumentHead(mapHeightCssPx: Int = LeafletMapFallbackHeightCssPx): String {
@@ -410,23 +501,14 @@ internal fun buildLeafletMarkerMapHtml(
     bridgeName: String,
     zoom: Int = 13,
     showCenterMarker: Boolean = true,
+    fitBoundsToMarkers: Boolean = true,
     mapHeightCssPx: Int = LeafletMapFallbackHeightCssPx
 ): String {
     val formattedLat = String.format(Locale.US, "%.6f", centerLatitude)
     val formattedLon = String.format(Locale.US, "%.6f", centerLongitude)
-    val markersJson = JSONArray(
-        markers.map { marker ->
-            JSONObject()
-                .put("id", marker.id)
-                .put("latitude", marker.latitude)
-                .put("longitude", marker.longitude)
-                .put("title", marker.title)
-                .put("subtitle", marker.subtitle)
-                .put("strokeColorHex", marker.strokeColorHex)
-                .put("fillColorHex", marker.fillColorHex)
-        }
-    ).toString()
+    val markersJson = leafletMarkersJson(markers)
     val selectedMarkerJson = selectedMarkerId?.let(JSONObject::quote) ?: "null"
+    val fitBoundsToMarkersJson = if (fitBoundsToMarkers) "true" else "false"
     val centerMarkerScript = if (showCenterMarker) {
         """
                 L.circleMarker(center, {
@@ -455,6 +537,7 @@ internal fun buildLeafletMarkerMapHtml(
                 var center = [$formattedLat, $formattedLon];
                 var markerData = $markersJson;
                 var selectedMarkerId = $selectedMarkerJson;
+                var fitBoundsToMarkers = $fitBoundsToMarkersJson;
                 var mapElement = document.getElementById('map');
                 if (!mapElement) {
                     failMap('Map failed to load.');
@@ -523,38 +606,97 @@ internal fun buildLeafletMarkerMapHtml(
                     });
                 };
 
-                markerData.forEach(function(marker) {
-                    var selected = marker.id === selectedMarkerId;
-                    var areaMarker = L.circleMarker(
-                        [marker.latitude, marker.longitude],
-                        markerOptions(marker, selected)
-                    ).addTo(map);
-                    var label = marker.subtitle
-                        ? escapeHtml(marker.title) + '<br />' + escapeHtml(marker.subtitle)
-                        : escapeHtml(marker.title);
-                    areaMarker.bindTooltip(label, { direction: 'top' });
-                    areaMarker.on('click', function() {
-                        window.nephSelectMarker(marker.id);
-                        if (window.$bridgeName && window.$bridgeName.onMarkerSelected) {
-                            window.$bridgeName.onMarkerSelected(nephMapInstanceId, marker.id);
-                        }
+                window.nephSetMarkers = function(nextMarkers, nextSelectedMarkerId) {
+                    markerData = Array.isArray(nextMarkers) ? nextMarkers : [];
+                    selectedMarkerId = nextSelectedMarkerId || null;
+                    Object.keys(areaMarkersById).forEach(function(id) {
+                        map.removeLayer(areaMarkersById[id].marker);
                     });
-                    areaMarkersById[marker.id] = {
-                        marker: areaMarker,
-                        data: marker
-                    };
-                    bounds.push([marker.latitude, marker.longitude]);
-                });
+                    areaMarkersById = {};
+                    bounds = [center];
 
-                if (bounds.length > 1) {
+                    markerData.forEach(function(marker) {
+                        var selected = marker.id === selectedMarkerId;
+                        var areaMarker = L.circleMarker(
+                            [marker.latitude, marker.longitude],
+                            markerOptions(marker, selected)
+                        ).addTo(map);
+                        var label = marker.subtitle
+                            ? escapeHtml(marker.title) + '<br />' + escapeHtml(marker.subtitle)
+                            : escapeHtml(marker.title);
+                        areaMarker.bindTooltip(label, { direction: 'top' });
+                        areaMarker.on('click', function() {
+                            window.nephSelectMarker(marker.id);
+                            if (window.$bridgeName && window.$bridgeName.onMarkerSelected) {
+                                window.$bridgeName.onMarkerSelected(nephMapInstanceId, marker.id);
+                            }
+                        });
+                        areaMarkersById[marker.id] = {
+                            marker: areaMarker,
+                            data: marker
+                        };
+                        bounds.push([marker.latitude, marker.longitude]);
+                    });
+                };
+
+                window.nephSetMarkers(markerData, selectedMarkerId);
+
+                if (fitBoundsToMarkers && bounds.length > 1) {
                     map.fitBounds(bounds, { padding: [24, 24], maxZoom: 15 });
                 }
+
+                function distanceKm(lat1, lon1, lat2, lon2) {
+                    var earthRadiusKm = 6371;
+                    var dLat = (lat2 - lat1) * Math.PI / 180;
+                    var dLon = (lon2 - lon1) * Math.PI / 180;
+                    var a =
+                        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                        Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+                        Math.sin(dLon / 2) * Math.sin(dLon / 2);
+                    return earthRadiusKm * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+                }
+
+                function notifyViewportChanged() {
+                    if (!window.$bridgeName || !window.$bridgeName.onViewportChanged) {
+                        return;
+                    }
+                    var currentCenter = map.getCenter();
+                    var currentBounds = map.getBounds();
+                    var north = currentBounds.getNorth();
+                    var south = currentBounds.getSouth();
+                    var east = currentBounds.getEast();
+                    var west = currentBounds.getWest();
+                    var centerLat = currentCenter.lat;
+                    var centerLon = currentCenter.lng;
+                    var midLat = (north + south) / 2;
+                    var midLon = (east + west) / 2;
+                    var widthKm = distanceKm(midLat, west, midLat, east);
+                    var heightKm = distanceKm(south, midLon, north, midLon);
+                    var widestKm = Math.max(widthKm, heightKm);
+                    window.$bridgeName.onViewportChanged(
+                        nephMapInstanceId,
+                        centerLat,
+                        centerLon,
+                        north,
+                        south,
+                        east,
+                        west,
+                        map.getZoom(),
+                        widthKm,
+                        heightKm,
+                        widestKm
+                    );
+                }
+
+                map.on('moveend zoomend', notifyViewportChanged);
 
                 map.whenReady(function() {
                     logNephMapBreadcrumb('NEPH_MAP: whenReady fired');
                     notifyMapReadyOnce();
+                    notifyViewportChanged();
                 });
                 setTimeout(notifyMapReadyOnce, 1000);
+                setTimeout(notifyViewportChanged, 1000);
             </script>
         </body>
         </html>
@@ -565,7 +707,8 @@ private class LeafletMarkerMapBridge(
     private val currentMapInstanceId: () -> String,
     private val onMarkerSelected: (String, String) -> Unit,
     private val onMapReady: (String, String) -> Unit,
-    private val onMapError: (String, String) -> Unit
+    private val onMapError: (String, String) -> Unit,
+    private val onViewportChanged: (String, LeafletMapViewport) -> Unit
 ) {
     private val mainHandler = Handler(Looper.getMainLooper())
     private var readyDeliveredInstanceId: String? = null
@@ -675,6 +818,51 @@ private class LeafletMarkerMapBridge(
                 return@post
             }
             onMapError(incomingInstanceId, trimmed)
+        }
+    }
+
+    @JavascriptInterface
+    fun onViewportChanged(
+        instanceId: String?,
+        centerLatitude: Double,
+        centerLongitude: Double,
+        north: Double,
+        south: Double,
+        east: Double,
+        west: Double,
+        zoom: Int,
+        widthKm: Double,
+        heightKm: Double,
+        widestVisibleDimensionKm: Double
+    ) {
+        val incomingInstanceId = instanceId.orEmpty()
+        val currentInstanceId = currentMapInstanceId()
+        if (incomingInstanceId != currentInstanceId) {
+            logMapDebug(
+                "native onViewportChanged ignored stale instance=$incomingInstanceId current=$currentInstanceId"
+            )
+            return
+        }
+        val viewport = LeafletMapViewport(
+            centerLatitude = centerLatitude,
+            centerLongitude = centerLongitude,
+            north = north,
+            south = south,
+            east = east,
+            west = west,
+            zoom = zoom,
+            widthKm = widthKm,
+            heightKm = heightKm,
+            widestVisibleDimensionKm = widestVisibleDimensionKm
+        )
+        mainHandler.post {
+            if (incomingInstanceId != currentMapInstanceId()) {
+                logMapDebug(
+                    "native onViewportChanged ignored stale instance=$incomingInstanceId current=${currentMapInstanceId()}"
+                )
+                return@post
+            }
+            onViewportChanged(incomingInstanceId, viewport)
         }
     }
 

--- a/android/app/src/test/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreenTest.kt
+++ b/android/app/src/test/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreenTest.kt
@@ -74,9 +74,31 @@ class GatheringAreasScreenTest {
         val visibleAreas = result.areas
 
         val firstKey = gatheringAreasMapInstanceKey(result, visibleAreas)
-        val afterSelectionOnlyKey = gatheringAreasMapInstanceKey(result, visibleAreas)
+        val afterMarkerChangeKey = gatheringAreasMapInstanceKey(result, emptyList())
 
-        assertEquals(firstKey, afterSelectionOnlyKey)
+        assertEquals(firstKey, afterMarkerChangeKey)
+    }
+
+    @Test
+    fun reconcileGatheringAreaCategoryFilters_whenPreviouslyShowingAll_selectsAllNewCategories() {
+        val reconciled = reconcileGatheringAreaCategoryFilters(
+            previousOptionKeys = setOf("assembly_point", "shelter"),
+            previousSelectedKeys = setOf("assembly_point", "shelter"),
+            nextOptionKeys = setOf("hospital", "pharmacy")
+        )
+
+        assertEquals(setOf("hospital", "pharmacy"), reconciled)
+    }
+
+    @Test
+    fun reconcileGatheringAreaCategoryFilters_preservesHiddenCategoriesButShowsNewOnes() {
+        val reconciled = reconcileGatheringAreaCategoryFilters(
+            previousOptionKeys = setOf("assembly_point", "shelter"),
+            previousSelectedKeys = setOf("assembly_point"),
+            nextOptionKeys = setOf("assembly_point", "shelter", "hospital")
+        )
+
+        assertEquals(setOf("assembly_point", "hospital"), reconciled)
     }
 
     private fun sampleNearbyResult(): NearbyGatheringAreasResult {

--- a/android/app/src/test/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreenFilterLogicTest.kt
+++ b/android/app/src/test/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreenFilterLogicTest.kt
@@ -77,6 +77,26 @@ class HelpRequestMapScreenFilterLogicTest {
     }
 
     @Test
+    fun helpRequestLeafletMarkers_whenNoRequests_returnsEmptyList() {
+        val markers = helpRequestLeafletMarkers(emptyList())
+
+        assertEquals(emptyList<String>(), markers.map { it.id })
+    }
+
+    @Test
+    fun helpRequestLeafletMarkers_ignoresMalformedCoordinatesDefensively() {
+        val markers = helpRequestLeafletMarkers(
+            listOf(
+                firstAid,
+                shelter.copy(requestId = "req-invalid", latitude = Double.NaN, longitude = 29.0),
+                foodWater.copy(requestId = "req-out-of-range", latitude = 91.0, longitude = 29.0)
+            )
+        )
+
+        assertEquals(listOf("req-first-aid"), markers.map { it.id })
+    }
+
+    @Test
     fun helpRequestMapInstanceKey_staysStableForSameVisibleMarkers() {
         val visible = listOf(firstAid, shelter)
 
@@ -97,6 +117,41 @@ class HelpRequestMapScreenFilterLogicTest {
 
         assertEquals(41.0, center.latitude, 0.0)
         assertEquals(29.0, center.longitude, 0.0)
+    }
+
+    @Test
+    fun helpRequestMapCenter_whenNoRequests_usesTurkeyOverviewCenter() {
+        val center = helpRequestMapCenter(emptyList())
+
+        assertEquals(39.0, center.latitude, 0.0)
+        assertEquals(35.0, center.longitude, 0.0)
+    }
+
+    @Test
+    fun helpRequestMapCenter_ignoresMalformedCoordinatesDefensively() {
+        val visible = listOf(
+            firstAid.copy(latitude = 40.0, longitude = 28.0),
+            shelter.copy(latitude = Double.POSITIVE_INFINITY, longitude = 30.0),
+            foodWater.copy(latitude = 41.0, longitude = 181.0)
+        )
+
+        val center = helpRequestMapCenter(visible)
+
+        assertEquals(40.0, center.latitude, 0.0)
+        assertEquals(28.0, center.longitude, 0.0)
+    }
+
+    @Test
+    fun helpRequestMapCenter_whenOnlyMalformedCoordinates_usesTurkeyOverviewCenter() {
+        val visible = listOf(
+            firstAid.copy(latitude = Double.NaN, longitude = 28.0),
+            shelter.copy(latitude = 41.0, longitude = Double.NEGATIVE_INFINITY)
+        )
+
+        val center = helpRequestMapCenter(visible)
+
+        assertEquals(39.0, center.latitude, 0.0)
+        assertEquals(35.0, center.longitude, 0.0)
     }
 
     @Test

--- a/android/app/src/test/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreenFilterLogicTest.kt
+++ b/android/app/src/test/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreenFilterLogicTest.kt
@@ -62,6 +62,52 @@ class HelpRequestMapScreenFilterLogicTest {
         assertEquals("req-shelter", selected)
     }
 
+    @Test
+    fun helpRequestLeafletMarkers_usesRequestCoordinatesAndStableTypeColors() {
+        val markers = helpRequestLeafletMarkers(listOf(firstAid, shelter))
+
+        assertEquals(listOf("req-first-aid", "req-shelter"), markers.map { it.id })
+        assertEquals(41.0, markers.first().latitude, 0.0)
+        assertEquals(29.0, markers.first().longitude, 0.0)
+        assertEquals("First Aid", markers.first().title)
+        assertEquals("#B42318", markers.first().strokeColorHex)
+        assertEquals("#D94141", markers.first().fillColorHex)
+        assertEquals("#1D4ED8", markers.last().strokeColorHex)
+        assertEquals("#3B66D8", markers.last().fillColorHex)
+    }
+
+    @Test
+    fun helpRequestMapInstanceKey_staysStableForSameVisibleMarkers() {
+        val visible = listOf(firstAid, shelter)
+
+        val firstKey = helpRequestMapInstanceKey(visible)
+        val afterSelectionOnlyKey = helpRequestMapInstanceKey(visible)
+
+        assertEquals(firstKey, afterSelectionOnlyKey)
+    }
+
+    @Test
+    fun helpRequestMapCenter_usesAverageRequestCoordinates() {
+        val visible = listOf(
+            firstAid.copy(latitude = 40.0, longitude = 28.0),
+            shelter.copy(latitude = 42.0, longitude = 30.0)
+        )
+
+        val center = helpRequestMapCenter(visible)
+
+        assertEquals(41.0, center.latitude, 0.0)
+        assertEquals(29.0, center.longitude, 0.0)
+    }
+
+    @Test
+    fun requestMarkerStyle_keepsRequestTypeVisualMappingStable() {
+        assertEquals("+", requestMarkerStyle(CrisisRequestType.FIRST_AID).glyph)
+        assertEquals("SH", requestMarkerStyle(CrisisRequestType.SHELTER).glyph)
+        assertEquals("FW", requestMarkerStyle(CrisisRequestType.FOOD_WATER).glyph)
+        assertEquals("SR", requestMarkerStyle(CrisisRequestType.SEARCH_AND_RESCUE).glyph)
+        assertEquals("?", requestMarkerStyle(CrisisRequestType.OTHER).glyph)
+    }
+
     private fun request(
         requestId: String,
         type: CrisisRequestType,

--- a/android/app/src/test/java/com/neph/ui/map/LeafletMapWebViewTest.kt
+++ b/android/app/src/test/java/com/neph/ui/map/LeafletMapWebViewTest.kt
@@ -132,6 +132,31 @@ class LeafletMapWebViewTest {
     }
 
     @Test
+    fun leafletViewportDiscovery_usesWidestVisibleDimension() {
+        val discoverable = viewport(widthKm = 20.0, heightKm = 50.0)
+        val tooWide = viewport(widthKm = 20.0, heightKm = 50.1)
+
+        assertTrue(isLeafletViewportDiscoverable(discoverable))
+        assertFalse(isLeafletViewportDiscoverable(tooWide))
+    }
+
+    @Test
+    fun leafletViewportDiscovery_rejectsInvalidBounds() {
+        assertFalse(isLeafletViewportDiscoverable(viewport(widthKm = 10.0, heightKm = 10.0, north = 91.0)))
+        assertFalse(isLeafletViewportDiscoverable(viewport(widthKm = Double.NaN, heightKm = 10.0)))
+        assertFalse(isLeafletViewportDiscoverable(viewport(widthKm = 10.0, heightKm = 10.0, west = 30.0, east = 29.0)))
+    }
+
+    @Test
+    fun effectiveLeafletViewportKey_roundsBoundsForDuplicateSuppression() {
+        val first = viewport(widthKm = 20.0, heightKm = 20.0, west = 29.0004, east = 29.1004)
+        val sameEffectiveViewport = viewport(widthKm = 20.0, heightKm = 20.0, west = 29.00049, east = 29.10049)
+
+        assertEquals(effectiveLeafletViewportKey(first), effectiveLeafletViewportKey(sameEffectiveViewport))
+        assertEquals("29.000,40.900,29.100,41.100", effectiveLeafletViewportKey(first))
+    }
+
+    @Test
     fun buildLeafletDocumentHead_allowsLeafletOriginWithoutQuotedUrlSources() {
         val head = buildLeafletDocumentHead()
 
@@ -269,5 +294,46 @@ class LeafletMapWebViewTest {
         assertTrue(html.contains("notifyMapAlive('tileload');"))
         assertTrue(html.contains("function notifyMapReadyOnce()"))
         assertTrue(html.contains("setTimeout(notifyMapReadyOnce, 1000);"))
+        assertTrue(html.contains("function notifyViewportChanged()"))
+        assertTrue(html.contains("window.AndroidLeafletMarkerMap.onViewportChanged("))
+        assertTrue(html.contains("map.on('moveend zoomend', notifyViewportChanged);"))
+    }
+
+    @Test
+    fun buildLeafletMarkerMapHtml_canDisableMarkerFitBoundsForViewportDiscovery() {
+        val html = buildLeafletMarkerMapHtml(
+            mapInstanceId = "test-map-discovery",
+            centerLatitude = 39.0,
+            centerLongitude = 35.0,
+            markers = emptyList(),
+            selectedMarkerId = null,
+            bridgeName = "AndroidLeafletMarkerMap",
+            fitBoundsToMarkers = false
+        )
+
+        assertTrue(html.contains("var fitBoundsToMarkers = false;"))
+        assertTrue(html.contains("if (fitBoundsToMarkers && bounds.length > 1)"))
+    }
+
+    private fun viewport(
+        widthKm: Double,
+        heightKm: Double,
+        north: Double = 41.1,
+        south: Double = 40.9,
+        east: Double = 29.1,
+        west: Double = 29.0
+    ): LeafletMapViewport {
+        return LeafletMapViewport(
+            centerLatitude = (north + south) / 2,
+            centerLongitude = (east + west) / 2,
+            north = north,
+            south = south,
+            east = east,
+            west = west,
+            zoom = 12,
+            widthKm = widthKm,
+            heightKm = heightKm,
+            widestVisibleDimensionKm = maxOf(widthKm, heightKm)
+        )
     }
 }

--- a/backend/src/modules/gathering-areas/controller.js
+++ b/backend/src/modules/gathering-areas/controller.js
@@ -1,5 +1,5 @@
-const { getNearbyGatheringAreas } = require('./service');
-const { validateNearbyQuery } = require('./validators');
+const { getNearbyGatheringAreas, getViewportGatheringAreas } = require('./service');
+const { validateNearbyQuery, validateViewportQuery } = require('./validators');
 
 function sendError(response, status, code, message) {
   return response.status(status).json({ code, message });
@@ -36,6 +36,21 @@ async function handleNearbyGatheringAreas(request, response) {
   }
 }
 
+async function handleViewportGatheringAreas(request, response) {
+  const validation = validateViewportQuery(request.query || {});
+  if (!validation.ok) {
+    return sendError(response, 400, validation.code, validation.message);
+  }
+
+  try {
+    const result = await getViewportGatheringAreas(validation.value);
+    return response.status(200).json(result);
+  } catch (error) {
+    return mapServiceError(response, error);
+  }
+}
+
 module.exports = {
   handleNearbyGatheringAreas,
+  handleViewportGatheringAreas,
 };

--- a/backend/src/modules/gathering-areas/routes.js
+++ b/backend/src/modules/gathering-areas/routes.js
@@ -1,10 +1,11 @@
 const express = require('express');
 
-const { handleNearbyGatheringAreas } = require('./controller');
+const { handleNearbyGatheringAreas, handleViewportGatheringAreas } = require('./controller');
 
 const gatheringAreasRouter = express.Router();
 
 gatheringAreasRouter.get('/nearby', handleNearbyGatheringAreas);
+gatheringAreasRouter.get('/viewport', handleViewportGatheringAreas);
 
 module.exports = {
   gatheringAreasRouter,

--- a/backend/src/modules/gathering-areas/service.js
+++ b/backend/src/modules/gathering-areas/service.js
@@ -63,6 +63,16 @@ function buildCacheKey({ lat, lon, radius, limit }) {
   return `${lat.toFixed(CACHE_COORDINATE_DECIMALS)}:${lon.toFixed(CACHE_COORDINATE_DECIMALS)}:${radius}:${limit}`;
 }
 
+function buildViewportCacheKey({ bbox, limit }) {
+  return [
+    bbox.minLon.toFixed(CACHE_COORDINATE_DECIMALS),
+    bbox.minLat.toFixed(CACHE_COORDINATE_DECIMALS),
+    bbox.maxLon.toFixed(CACHE_COORDINATE_DECIMALS),
+    bbox.maxLat.toFixed(CACHE_COORDINATE_DECIMALS),
+    limit,
+  ].join(':');
+}
+
 function readFreshCache(cacheKey) {
   const entry = nearbyCache.get(cacheKey);
   if (!entry) {
@@ -162,6 +172,62 @@ function buildOverpassLightweightQuery({ lat, lon, radius }) {
       `  node(around:${radius},${lat},${lon})["amenity"="police"];`,
       `  node(around:${radius},${lat},${lon})["amenity"="fire_station"];`,
       `  node(around:${radius},${lat},${lon})["amenity"="pharmacy"];`,
+    ');',
+    'out tags;',
+  ].join('\n');
+}
+
+function buildOverpassBboxQuery({ bbox }) {
+  const south = bbox.minLat;
+  const west = bbox.minLon;
+  const north = bbox.maxLat;
+  const east = bbox.maxLon;
+
+  return [
+    '[out:json][timeout:25];',
+    '(',
+    `  node(${south},${west},${north},${east})["emergency"="assembly_point"];`,
+    `  way(${south},${west},${north},${east})["emergency"="assembly_point"];`,
+    `  relation(${south},${west},${north},${east})["emergency"="assembly_point"];`,
+    `  node(${south},${west},${north},${east})["amenity"="shelter"];`,
+    `  way(${south},${west},${north},${east})["amenity"="shelter"];`,
+    `  relation(${south},${west},${north},${east})["amenity"="shelter"];`,
+    `  node(${south},${west},${north},${east})["amenity"="hospital"];`,
+    `  way(${south},${west},${north},${east})["amenity"="hospital"];`,
+    `  relation(${south},${west},${north},${east})["amenity"="hospital"];`,
+    `  node(${south},${west},${north},${east})["healthcare"="hospital"];`,
+    `  way(${south},${west},${north},${east})["healthcare"="hospital"];`,
+    `  relation(${south},${west},${north},${east})["healthcare"="hospital"];`,
+    `  node(${south},${west},${north},${east})["amenity"="police"];`,
+    `  way(${south},${west},${north},${east})["amenity"="police"];`,
+    `  relation(${south},${west},${north},${east})["amenity"="police"];`,
+    `  node(${south},${west},${north},${east})["amenity"="fire_station"];`,
+    `  way(${south},${west},${north},${east})["amenity"="fire_station"];`,
+    `  relation(${south},${west},${north},${east})["amenity"="fire_station"];`,
+    `  node(${south},${west},${north},${east})["amenity"="pharmacy"];`,
+    `  way(${south},${west},${north},${east})["amenity"="pharmacy"];`,
+    `  relation(${south},${west},${north},${east})["amenity"="pharmacy"];`,
+    ');',
+    'out center tags;',
+  ].join('\n');
+}
+
+function buildOverpassBboxLightweightQuery({ bbox }) {
+  const south = bbox.minLat;
+  const west = bbox.minLon;
+  const north = bbox.maxLat;
+  const east = bbox.maxLon;
+
+  return [
+    '[out:json][timeout:25];',
+    '(',
+      `  node(${south},${west},${north},${east})["emergency"="assembly_point"];`,
+      `  node(${south},${west},${north},${east})["amenity"="shelter"];`,
+      `  node(${south},${west},${north},${east})["amenity"="hospital"];`,
+      `  node(${south},${west},${north},${east})["healthcare"="hospital"];`,
+      `  node(${south},${west},${north},${east})["amenity"="police"];`,
+      `  node(${south},${west},${north},${east})["amenity"="fire_station"];`,
+      `  node(${south},${west},${north},${east})["amenity"="pharmacy"];`,
     ');',
     'out tags;',
   ].join('\n');
@@ -467,6 +533,22 @@ async function fetchNearbyFromOverpass(params) {
   }
 }
 
+async function fetchViewportFromOverpass(params) {
+  try {
+    return await fetchNearbyFromOverpassWithQuery(buildOverpassBboxQuery(params));
+  } catch (error) {
+    const shouldRetryWithLightweightQuery =
+      error &&
+      (error.code === 'OVERPASS_UNAVAILABLE' || error.code === 'OVERPASS_TIMEOUT');
+
+    if (!shouldRetryWithLightweightQuery) {
+      throw error;
+    }
+
+    return fetchNearbyFromOverpassWithQuery(buildOverpassBboxLightweightQuery(params));
+  }
+}
+
 async function getNearbyGatheringAreas(params) {
   const cacheKey = buildCacheKey(params);
   const cached = readFreshCache(cacheKey);
@@ -531,11 +613,69 @@ async function getNearbyGatheringAreas(params) {
   }
 }
 
+async function getViewportGatheringAreas(params) {
+  const cacheKey = buildViewportCacheKey(params);
+  const cached = readFreshCache(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const payload = await fetchViewportFromOverpass(params);
+    const collection = toFeatureCollection(payload.elements, params.limit, params.center);
+
+    const result = {
+      center: params.center,
+      radius: params.radius,
+      source: 'overpass',
+      meta: {
+        requestedLimit: params.limit,
+        returnedCount: collection.features.length,
+        categories: buildCategoryMetadata(),
+        viewport: params.viewport,
+      },
+      collection,
+    };
+
+    writeToCache(cacheKey, result);
+    return result;
+  } catch (error) {
+    if (!isProviderFailure(error)) {
+      throw error;
+    }
+
+    const staleCached = readStaleCache(cacheKey);
+    if (staleCached) {
+      return withSource(staleCached, 'stale_cache', {
+        stale: true,
+        providerErrorCode: error.code,
+      });
+    }
+
+    const collection = toFallbackFeatureCollection();
+    return {
+      center: params.center,
+      radius: params.radius,
+      source: 'fallback',
+      meta: {
+        requestedLimit: params.limit,
+        returnedCount: collection.features.length,
+        providerErrorCode: error.code,
+        fallbackReason: FALLBACK_REASON,
+        categories: buildCategoryMetadata(),
+        viewport: params.viewport,
+      },
+      collection,
+    };
+  }
+}
+
 function __resetNearbyCache() {
   nearbyCache.clear();
 }
 
 module.exports = {
   getNearbyGatheringAreas,
+  getViewportGatheringAreas,
   __resetNearbyCache,
 };

--- a/backend/src/modules/gathering-areas/validators.js
+++ b/backend/src/modules/gathering-areas/validators.js
@@ -2,6 +2,7 @@ const DEFAULT_RADIUS_METERS = 2000;
 const MAX_RADIUS_METERS = 10000;
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 50;
+const MAX_VIEWPORT_DIMENSION_KM = 50;
 
 function parsePositiveInteger(value, fallback, max) {
   if (value === undefined) {
@@ -65,6 +66,109 @@ function validateNearbyQuery(query) {
   };
 }
 
+function toRadians(value) {
+  return (value * Math.PI) / 180;
+}
+
+function calculateDistanceKm(fromLat, fromLon, toLat, toLon) {
+  const earthRadiusKm = 6371;
+  const dLat = toRadians(toLat - fromLat);
+  const dLon = toRadians(toLon - fromLon);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRadians(fromLat)) * Math.cos(toRadians(toLat)) *
+    Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+  return earthRadiusKm * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function parseBbox(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return null;
+  }
+
+  const parts = value.split(',').map((part) => Number(part.trim()));
+  if (parts.length !== 4) {
+    return null;
+  }
+
+  if (parts.some((part) => !Number.isFinite(part))) {
+    return null;
+  }
+
+  const [minLon, minLat, maxLon, maxLat] = parts;
+  return { minLon, minLat, maxLon, maxLat };
+}
+
+function validateViewportQuery(query) {
+  const bbox = parseBbox(query.bbox);
+  if (!bbox) {
+    return {
+      ok: false,
+      code: 'VALIDATION_ERROR',
+      message: 'bbox must have 4 comma-separated values: minLng,minLat,maxLng,maxLat',
+    };
+  }
+
+  if (bbox.minLon < -180 || bbox.maxLon > 180 || bbox.minLon > bbox.maxLon) {
+    return {
+      ok: false,
+      code: 'VALIDATION_ERROR',
+      message: 'bbox longitude values are invalid',
+    };
+  }
+
+  if (bbox.minLat < -90 || bbox.maxLat > 90 || bbox.minLat > bbox.maxLat) {
+    return {
+      ok: false,
+      code: 'VALIDATION_ERROR',
+      message: 'bbox latitude values are invalid',
+    };
+  }
+
+  const centerLat = (bbox.minLat + bbox.maxLat) / 2;
+  const centerLon = (bbox.minLon + bbox.maxLon) / 2;
+  const widthKm = calculateDistanceKm(centerLat, bbox.minLon, centerLat, bbox.maxLon);
+  const heightKm = calculateDistanceKm(bbox.minLat, centerLon, bbox.maxLat, centerLon);
+  const widestVisibleDimensionKm = Math.max(widthKm, heightKm);
+
+  if (widestVisibleDimensionKm > MAX_VIEWPORT_DIMENSION_KM) {
+    return {
+      ok: false,
+      code: 'VIEWPORT_TOO_LARGE',
+      message: 'bbox viewport must be 50 km wide or smaller',
+    };
+  }
+
+  const limit = parsePositiveInteger(query.limit, DEFAULT_LIMIT, MAX_LIMIT);
+  if (limit === null) {
+    return {
+      ok: false,
+      code: 'VALIDATION_ERROR',
+      message: 'limit must be a positive integer',
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      bbox,
+      center: {
+        lat: centerLat,
+        lon: centerLon,
+      },
+      radius: Math.ceil(widestVisibleDimensionKm * 1000),
+      limit,
+      viewport: {
+        widthKm,
+        heightKm,
+        widestVisibleDimensionKm,
+      },
+    },
+  };
+}
+
 module.exports = {
   validateNearbyQuery,
+  validateViewportQuery,
 };

--- a/backend/tests/unit/modules/gathering-areas/service.test.js
+++ b/backend/tests/unit/modules/gathering-areas/service.test.js
@@ -142,4 +142,54 @@ describe('gathering-areas service', () => {
       limit: 10,
     })).rejects.toThrow('unexpected transform failure');
   });
+
+  test('getViewportGatheringAreas uses bbox Overpass query and response metadata', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        elements: [
+          {
+            type: 'node',
+            id: 9201,
+            lat: 41.01,
+            lon: 29.02,
+            tags: { amenity: 'shelter', name: 'Viewport Shelter' },
+          },
+        ],
+      }),
+    });
+
+    const result = await gatheringAreasService.getViewportGatheringAreas({
+      bbox: {
+        minLon: 28.9,
+        minLat: 40.9,
+        maxLon: 29.2,
+        maxLat: 41.1,
+      },
+      center: {
+        lat: 41.0,
+        lon: 29.05,
+      },
+      radius: 40000,
+      limit: 10,
+      viewport: {
+        widthKm: 25,
+        heightKm: 22,
+        widestVisibleDimensionKm: 25,
+      },
+    });
+
+    const requestInit = global.fetch.mock.calls[0][1];
+    const queryText = decodeURIComponent(requestInit.body.toString());
+
+    expect(queryText).toContain('node(40.9,28.9,41.1,29.2)["amenity"="shelter"]');
+    expect(result.center).toEqual({ lat: 41.0, lon: 29.05 });
+    expect(result.radius).toBe(40000);
+    expect(result.meta.viewport).toEqual({
+      widthKm: 25,
+      heightKm: 22,
+      widestVisibleDimensionKm: 25,
+    });
+    expect(result.collection.features[0].properties.name).toBe('Viewport Shelter');
+  });
 });

--- a/backend/tests/unit/modules/gathering-areas/validators.test.js
+++ b/backend/tests/unit/modules/gathering-areas/validators.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { validateNearbyQuery, validateViewportQuery } = require('../../../../src/modules/gathering-areas/validators');
+
+describe('gathering-areas validators', () => {
+  test('validateViewportQuery accepts discoverable bbox', () => {
+    const result = validateViewportQuery({
+      bbox: '28.9,40.9,29.2,41.1',
+      limit: '10',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.value.bbox).toEqual({
+      minLon: 28.9,
+      minLat: 40.9,
+      maxLon: 29.2,
+      maxLat: 41.1,
+    });
+    expect(result.value.viewport.widestVisibleDimensionKm).toBeLessThanOrEqual(50);
+  });
+
+  test('validateViewportQuery rejects invalid and too-large bbox', () => {
+    expect(validateViewportQuery({ bbox: '28.9,40.9,29.2' }).ok).toBe(false);
+    expect(validateViewportQuery({ bbox: '29.2,40.9,28.9,41.1' }).ok).toBe(false);
+
+    const tooLarge = validateViewportQuery({
+      bbox: '28.0,40.0,30.0,42.0',
+    });
+
+    expect(tooLarge.ok).toBe(false);
+    expect(tooLarge.code).toBe('VIEWPORT_TOO_LARGE');
+  });
+
+  test('validateNearbyQuery keeps existing nearby behavior', () => {
+    const result = validateNearbyQuery({
+      lat: '41.01',
+      lon: '29.01',
+      radius: '999999',
+      limit: '999',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.value.radius).toBe(10000);
+    expect(result.value.limit).toBe(50);
+  });
+});


### PR DESCRIPTION
## Summary

This PR improves NEPH's Android/backend resource map experience across marker-based maps.

It focuses on two related improvements:

1. Improving the Android Active Help Request Map screen so it uses the same reliable map behavior and UX quality as the improved Gathering Areas map.
2. Adding Android viewport-based marker discovery so users can browse map resources by zooming and panning, instead of only seeing markers around a fixed/current location.

This applies only to Android maps that display multiple markers, such as Gathering Areas and Active Help Requests / Crisis Map. Single-point map picker dialogs are intentionally left unchanged. Web viewport discovery is not included in this PR.

## Changes

### Active Help Request Map

- Audited and improved the Android Active Help Request Map screen.
- Aligned the map display behavior with the shared marker-map experience used by Gathering Areas where appropriate.
- Ensured active/waiting help requests with valid coordinates are displayed as geographic markers.
- Preserved request type filters, selected request details, `Get Directions`, and `Open in Map`.
- Kept malformed or missing-coordinate requests from breaking the map.
- Preserved existing Request Help form and submission behavior.

### Viewport-Based Marker Discovery

- Added viewport-based marker loading/display behavior for Android resource maps.
- Markers are hidden while the map is zoomed out too far.
- Markers load/show only when the visible map area is local enough, approximately 50 km or smaller.
- Panning the map while zoomed in updates markers for the newly visible area.
- `Use Current Location` remains available as a shortcut to recenter and load nearby resources.
- Added stale-request protection so older map fetches do not overwrite newer viewport results.
- Preserved existing filters and selected marker behavior when map results change.

### Backend

- Added Gathering Areas viewport endpoint support for safe bounded map discovery.
- Kept the existing nearby Gathering Areas endpoint behavior intact.
- Added validation to prevent unsafe or overly large viewport queries.

## Affected Areas

- Android Active Help Request Map
- Android Gathering Areas map
- Android shared Leaflet marker-map behavior
- Backend Gathering Areas viewport endpoint support

## Not Included

- Web Gathering Areas viewport discovery
- Web Crisis / Active Help Request viewport discovery
- Profile / Complete Profile map pickers
- Request Help single-location map picker
- Request Help form behavior

## Expected Behavior

- Android resource maps open without requiring current location permission.
- Users can manually zoom/pan to any area of Turkey.
- Markers are not shown or fetched while the map is too zoomed out.
- Once the visible area is local enough, markers for that area are shown.
- Moving the map to another city updates the visible markers.
- Existing category/type filters continue to work.
- Selected marker details remain safe when results change.
- No full-country marker fetch is performed.
- Map picker flows continue working as before.

## Testing

- Android CI passed.
- Backend CI passed.
- E2E tests passed.
- Added/updated tests for shared Leaflet viewport behavior.
- Added/updated tests for Help Request Map marker/filter behavior.
- Added/updated tests for Gathering Areas viewport validation and service behavior.
- Manual smoke testing should cover zooming, panning, filters, selected markers, `Use Current Location`, and map picker non-regression.

Partially addresses #531 by implementing the Android/backend scope.