### PR TITLE
feat: add first-signup step-by-step onboarding modal and remove static help tab

### DIFF
--- a/web/e2e/onboarding.spec.js
+++ b/web/e2e/onboarding.spec.js
@@ -55,18 +55,19 @@ test('new user can sign up, verify email, complete their profile, and see persis
   await page.getByRole('button', { name: 'Save' }).click();
 
   await expect(page).toHaveURL(/\/profile$/);
-  await expect(page.getByRole('heading', { name: 'Home Overview' })).toBeVisible();
-  await page.getByRole('button', { name: 'Next' }).click();
+  const tutorialDialog = page.getByRole('dialog', { name: 'Home Overview' });
+  await expect(tutorialDialog.getByRole('heading', { name: 'Home Overview' })).toBeVisible();
+  await tutorialDialog.getByRole('button', { name: 'Next', exact: true }).click();
   await expect(page.getByRole('heading', { name: 'News and Announcements' })).toBeVisible();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('dialog', { name: 'News and Announcements' }).getByRole('button', { name: 'Next', exact: true }).click();
   await expect(page.getByRole('heading', { name: 'Emergency Tools' })).toBeVisible();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('dialog', { name: 'Emergency Tools' }).getByRole('button', { name: 'Next', exact: true }).click();
   await expect(page.getByRole('heading', { name: 'Help Request Map' })).toBeVisible();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('dialog', { name: 'Help Request Map' }).getByRole('button', { name: 'Next', exact: true }).click();
   await expect(page.getByRole('heading', { name: 'Gathering Areas' })).toBeVisible();
-  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('dialog', { name: 'Gathering Areas' }).getByRole('button', { name: 'Next', exact: true }).click();
   await expect(page.getByRole('heading', { name: 'Your Profile and Privacy' })).toBeVisible();
-  await page.getByRole('button', { name: 'Finish' }).click();
+  await page.getByRole('dialog', { name: 'Your Profile and Privacy' }).getByRole('button', { name: 'Finish' }).click();
   await expect(page.getByRole('heading', { name: 'Home Overview' })).toHaveCount(0);
   await expect(page.getByText('Jane Onboard')).toBeVisible();
   await expect(page.locator('p, span').filter({ hasText: email }).first()).toBeVisible();

--- a/web/e2e/onboarding.spec.js
+++ b/web/e2e/onboarding.spec.js
@@ -55,7 +55,19 @@ test('new user can sign up, verify email, complete their profile, and see persis
   await page.getByRole('button', { name: 'Save' }).click();
 
   await expect(page).toHaveURL(/\/profile$/);
-  await expect(page.getByRole('heading', { name: 'Profile' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Home Overview' })).toBeVisible();
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByRole('heading', { name: 'News and Announcements' })).toBeVisible();
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByRole('heading', { name: 'Emergency Tools' })).toBeVisible();
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByRole('heading', { name: 'Help Request Map' })).toBeVisible();
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByRole('heading', { name: 'Gathering Areas' })).toBeVisible();
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByRole('heading', { name: 'Your Profile and Privacy' })).toBeVisible();
+  await page.getByRole('button', { name: 'Finish' }).click();
+  await expect(page.getByRole('heading', { name: 'Home Overview' })).toHaveCount(0);
   await expect(page.getByText('Jane Onboard')).toBeVisible();
   await expect(page.locator('p, span').filter({ hasText: email }).first()).toBeVisible();
 

--- a/web/src/components/feature/auth/CompleteProfileForm.tsx
+++ b/web/src/components/feature/auth/CompleteProfileForm.tsx
@@ -19,7 +19,11 @@ import { bloodTypeOptions } from "@/lib/bloodTypes";
 import { countryCodeOptions } from "@/lib/countryCodes";
 import { DateInput } from "@/components/ui/inputs/DateInput";
 import { expertiseOptions } from "@/lib/profileOptions";
-import { getAccessToken, SIGNUP_DRAFT_KEY } from "@/lib/auth";
+import {
+    getAccessToken,
+    SIGNUP_DRAFT_KEY,
+    WEB_TUTORIAL_PENDING_KEY,
+} from "@/lib/auth";
 import { fetchLocationTree, searchLocations } from "@/lib/location";
 import {
     LocationTreeByCountry,
@@ -529,6 +533,7 @@ export default function CompleteProfileForm() {
             });
 
             sessionStorage.removeItem(SIGNUP_DRAFT_KEY);
+            window.localStorage.setItem(WEB_TUTORIAL_PENDING_KEY, "1");
             router.push("/profile");
         } catch (err) {
             const baseMessage =

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -1,6 +1,10 @@
+"use client";
+
 import * as React from "react";
 import { TopNavbar } from "@/components/layout/TopNavbar";
 import { PageContainer } from "@/components/layout/PageContainer";
+import { useAuthSession } from "@/lib/authSession";
+import { WEB_TUTORIAL_PENDING_KEY } from "@/lib/auth";
 
 type AppShellProps = {
     title?: string;
@@ -9,12 +13,90 @@ type AppShellProps = {
     children: React.ReactNode;
 };
 
+const tutorialSteps = [
+    {
+        title: "Home Overview",
+        subtitle: "Start here for the fastest snapshot.",
+        description:
+            "Use Home to see key updates quickly and jump to emergency tools without searching the full app.",
+    },
+    {
+        title: "News and Announcements",
+        subtitle: "Follow verified updates.",
+        description:
+            "Open News to track emergency announcements, preparedness notes, and community communication in one feed.",
+    },
+    {
+        title: "Emergency Tools",
+        subtitle: "Map and contacts in one flow.",
+        description:
+            "Emergency Numbers gives direct hotline access for urgent contact scenarios.",
+    },
+    {
+        title: "Help Request Map",
+        subtitle: "See active help context on the map.",
+        description:
+            "Use Help Request Map to view location-based emergency request activity and understand where support may be needed.",
+    },
+    {
+        title: "Gathering Areas",
+        subtitle: "Find nearby safe assembly points.",
+        description:
+            "Use Gathering Areas to locate assembly and support points around your area and review available map context quickly.",
+    },
+    {
+        title: "Your Profile and Privacy",
+        subtitle: "Keep coordination data accurate.",
+        description:
+            "Update Profile with contact and location details, then review Privacy & Security settings to control what is shared.",
+    },
+] as const;
+
 export function AppShell({
     title,
     titleClassName,
     containerClassName,
     children,
 }: AppShellProps) {
+    const { state } = useAuthSession();
+    const [showTutorial, setShowTutorial] = React.useState(false);
+    const [stepIndex, setStepIndex] = React.useState(0);
+
+    React.useEffect(() => {
+        if (state.phase !== "authenticated" || !state.user?.userId) {
+            return;
+        }
+
+        const pending = window.localStorage.getItem(WEB_TUTORIAL_PENDING_KEY) === "1";
+        if (!pending) {
+            return;
+        }
+
+        const seenKey = `neph_web_tutorial_seen_${state.user.userId}`;
+        const hasSeen = window.localStorage.getItem(seenKey) === "1";
+
+        if (hasSeen) {
+            window.localStorage.removeItem(WEB_TUTORIAL_PENDING_KEY);
+            return;
+        }
+
+        setShowTutorial(true);
+        setStepIndex(0);
+    }, [state.phase, state.user?.userId]);
+
+    const isLastStep = stepIndex === tutorialSteps.length - 1;
+    const progress = ((stepIndex + 1) / tutorialSteps.length) * 100;
+    const currentStep = tutorialSteps[stepIndex];
+
+    const closeTutorial = React.useCallback(() => {
+        if (state.user?.userId) {
+            const seenKey = `neph_web_tutorial_seen_${state.user.userId}`;
+            window.localStorage.setItem(seenKey, "1");
+        }
+        window.localStorage.removeItem(WEB_TUTORIAL_PENDING_KEY);
+        setShowTutorial(false);
+    }, [state.user?.userId]);
+
     return (
         <div className="app-shell">
             <TopNavbar />
@@ -30,6 +112,74 @@ export function AppShell({
                     {children}
                 </PageContainer>
             </main>
+            {showTutorial ? (
+                <div className="web-tutorial-overlay" role="dialog" aria-modal="true" aria-labelledby="web-tutorial-title">
+                    <div className="web-tutorial-modal">
+                        <div className="web-tutorial-head">
+                            <p className="web-tutorial-kicker">Welcome to NEPH</p>
+                            <button
+                                type="button"
+                                className="web-tutorial-skip"
+                                onClick={closeTutorial}
+                            >
+                                Skip
+                            </button>
+                        </div>
+
+                        <h2 id="web-tutorial-title" className="web-tutorial-title">
+                            {currentStep.title}
+                        </h2>
+                        <p className="web-tutorial-copy">{currentStep.subtitle}</p>
+
+                        <div className="web-tutorial-progress-track" aria-hidden="true">
+                            <span className="web-tutorial-progress-fill" style={{ width: `${progress}%` }} />
+                        </div>
+
+                        <div className="web-tutorial-dots" aria-hidden="true">
+                            {tutorialSteps.map((step, index) => (
+                                <span
+                                    key={step.title}
+                                    className={`web-tutorial-dot${index === stepIndex ? " is-active" : ""}`}
+                                />
+                            ))}
+                        </div>
+
+                        <div className="web-tutorial-list">
+                            <p>{currentStep.description}</p>
+                        </div>
+
+                        <div className="web-tutorial-actions">
+                            <button
+                                type="button"
+                                className="web-tutorial-ghost"
+                                onClick={() => setStepIndex((prev) => Math.max(prev - 1, 0))}
+                                disabled={stepIndex === 0}
+                            >
+                                Back
+                            </button>
+                            {isLastStep ? (
+                                <button
+                                    type="button"
+                                    className="web-tutorial-close"
+                                    onClick={closeTutorial}
+                                >
+                                    Finish
+                                </button>
+                            ) : (
+                                <button
+                                    type="button"
+                                    className="web-tutorial-close"
+                                    onClick={() =>
+                                        setStepIndex((prev) => Math.min(prev + 1, tutorialSteps.length - 1))
+                                    }
+                                >
+                                    Next
+                                </button>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            ) : null}
         </div>
     );
 }

--- a/web/src/components/layout/TopNavbar.tsx
+++ b/web/src/components/layout/TopNavbar.tsx
@@ -20,7 +20,13 @@ const navItemsOrdered = [
     { label: "Privacy & Security", href: "/privacy-security" },
 ];
 
-const guestAllowedPaths = new Set(["/home", "/news", "/emergency-numbers", "/crisis-map", "/gathering-areas"]);
+const guestAllowedPaths = new Set([
+    "/home",
+    "/news",
+    "/emergency-numbers",
+    "/crisis-map",
+    "/gathering-areas",
+]);
 
 function resolveUserInitials(email: string | null | undefined) {
     const localPart = (email || "").trim().split("@")[0] || "";

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -2,6 +2,7 @@ import { apiRequest } from "@/lib/api";
 
 export const ACCESS_TOKEN_KEY = "neph_access_token";
 export const SIGNUP_DRAFT_KEY = "neph_signup_draft";
+export const WEB_TUTORIAL_PENDING_KEY = "neph_web_tutorial_pending";
 
 export type AuthUser = {
     userId: string;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -2266,6 +2266,168 @@ textarea::placeholder {
     color: var(--text-primary);
 }
 
+.web-tutorial-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 120;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(17, 24, 39, 0.55);
+    backdrop-filter: blur(3px);
+}
+
+.web-tutorial-modal {
+    width: min(680px, 100%);
+    max-height: min(90vh, 760px);
+    overflow-y: auto;
+    border-radius: 20px;
+    border: 1px solid var(--border-subtle);
+    background: var(--surface-card);
+    box-shadow: var(--shadow-overlay);
+    padding: 22px;
+}
+
+.web-tutorial-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.web-tutorial-kicker {
+    margin: 0;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--primary-500);
+}
+
+.web-tutorial-skip {
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-pill);
+    background: var(--surface-card);
+    color: var(--text-secondary);
+    padding: 6px 12px;
+    font-size: 0.82rem;
+    font-weight: 600;
+}
+
+.web-tutorial-skip:hover {
+    border-color: var(--primary-soft-200);
+    color: var(--primary-600);
+}
+
+.web-tutorial-title {
+    margin: 14px 0 0;
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--text-primary);
+}
+
+.web-tutorial-copy {
+    margin: 8px 0 0;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.web-tutorial-progress-track {
+    margin-top: 16px;
+    height: 7px;
+    border-radius: 999px;
+    background: var(--surface-soft);
+    overflow: hidden;
+}
+
+.web-tutorial-progress-fill {
+    display: block;
+    height: 100%;
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--hero-from), var(--hero-via), var(--hero-to));
+    transition: width 220ms ease;
+}
+
+.web-tutorial-dots {
+    margin-top: 12px;
+    display: flex;
+    gap: 8px;
+}
+
+.web-tutorial-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--border-subtle);
+}
+
+.web-tutorial-dot.is-active {
+    width: 18px;
+    background: var(--primary-500);
+}
+
+.web-tutorial-list {
+    margin-top: 14px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--primary-soft-100) 55%, var(--surface-card)),
+        var(--surface-card)
+    );
+    padding: 14px;
+}
+
+.web-tutorial-list p {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.55;
+    color: var(--text-primary);
+}
+
+.web-tutorial-actions {
+    margin-top: 16px;
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.web-tutorial-ghost {
+    flex: 1;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-card);
+    color: var(--text-secondary);
+    padding: 11px 14px;
+    font-size: 0.9rem;
+    font-weight: 700;
+}
+
+.web-tutorial-ghost:hover:not(:disabled) {
+    border-color: var(--primary-soft-200);
+    color: var(--primary-600);
+}
+
+.web-tutorial-ghost:disabled {
+    opacity: 0.45;
+}
+
+.web-tutorial-close {
+    flex: 1;
+    border: 1px solid transparent;
+    border-radius: var(--radius-md);
+    background: linear-gradient(135deg, var(--hero-from), var(--hero-via), var(--hero-to));
+    color: var(--text-on-primary);
+    padding: 11px 14px;
+    font-size: 0.9rem;
+    font-weight: 700;
+}
+
+.web-tutorial-close:hover {
+    filter: brightness(1.04);
+}
+
 .site-footer {
     margin-top: 48px;
     border-top: 1px solid var(--border-subtle);


### PR DESCRIPTION

This PR replaces the separate “How NEPH Works” web tab with a first-signup, step-by-step onboarding modal shown after completing profile setup.

What Changed
Added a multi-step tutorial modal in AppShell with:
Back, Next, Skip, Finish
progress bar + step indicators
dedicated steps for:
Home Overview
News and Announcements
Emergency Tools
Help Request Map
Gathering Areas
Profile and Privacy
Triggered tutorial only after successful first profile completion:
sets WEB_TUTORIAL_PENDING_KEY on complete-profile success
redirects user to /profile
Updated tutorial state handling:
pending is cleared only on Skip/Finish
seen is marked on Skip/Finish (not on modal open)
Removed static help-page navigation entry approach:
removed “How NEPH Works” links from navbar/footer
Updated onboarding e2e test flow to validate tutorial steps and completion.
Why
Product requirement changed from a standalone web help page to an onboarding-style first-use walkthrough that introduces key pages and actions in context.

Files Touched
web/src/components/layout/AppShell.tsx
web/src/styles/globals.css
web/src/components/feature/auth/CompleteProfileForm.tsx
web/src/lib/auth.ts
web/src/components/layout/TopNavbar.tsx
web/src/components/layout/SiteFooter.tsx
web/e2e/onboarding.spec.js
web/e2e/navigation.spec.js

Closes #473 