### PR TITLE
feat: add NEPH brand logos to navbar and auth screens

### DIFF
--- a/web/src/components/layout/AuthLayout.tsx
+++ b/web/src/components/layout/AuthLayout.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import Image from "next/image";
 import { AuthCard } from "@/components/ui/display/AuthCard";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { AuthShowcase } from "@/components/feature/auth/AuthShowcase";
@@ -21,9 +22,14 @@ export function AuthLayout({ title, subtitle, children }: AuthLayoutProps) {
                     <div className="flex items-start justify-center">
                         <AuthCard className="w-full max-w-md">
                             <div className="mb-6 flex flex-col items-center text-center">
-                                <div className="mb-4 text-2xl font-bold text-[color:var(--primary-500)]">
-                                    NEPH
-                                </div>
+                                <Image
+                                    src="/neph_logo.png"
+                                    alt="NEPH logo"
+                                    width={180}
+                                    height={52}
+                                    className="mb-4 h-auto w-[180px] max-w-full"
+                                    priority
+                                />
 
                                 {title ? (
                                     <h1 className="text-3xl font-bold text-[color:var(--text-primary)]">

--- a/web/src/components/layout/TopNavbar.tsx
+++ b/web/src/components/layout/TopNavbar.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useRouter } from "next/navigation";
 import * as React from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { clearAccessToken, getAccessToken } from "@/lib/auth";
 import { useAuthSession } from "@/lib/authSession";
@@ -215,6 +216,13 @@ export function TopNavbar() {
             <PageContainer className="top-navbar-inner">
                 <Link href="/home" className="top-navbar-brand">
                     NEPH
+                    <Image
+                        src="/neph_logo_only.png"
+                        alt="NEPH icon"
+                        width={48}
+                        height={48}
+                        className="top-navbar-brand-logo"
+                    />
                 </Link>
 
                 <nav className="top-navbar-nav">

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -263,10 +263,17 @@ textarea::placeholder {
 }
 
 .top-navbar-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
     font-size: 1.25rem;
     font-weight: 800;
     letter-spacing: -0.02em;
     color: var(--text-primary);
+}
+
+.top-navbar-brand-logo {
+    border-radius: 4px;
 }
 
 .top-navbar-nav {


### PR DESCRIPTION
This PR adds NEPH logo assets to key web UI entry points for stronger brand visibility and consistency.

Changes
Added neph_logo_only.png next to the NEPH text in the top-left navbar brand area.
Increased navbar icon size to 48x48 (2x from the previous 24x24).
Replaced the text-only NEPH heading in auth/login layout with neph_logo.png.
Updated navbar brand styling for proper alignment and spacing with the new icon.
Files Updated
web/src/components/layout/TopNavbar.tsx
web/src/components/layout/AuthLayout.tsx
web/src/styles/globals.css
Notes
Logo assets are served from web/public:
/neph_logo_only.png
/neph_logo.png
No backend/API behavior changed; this is a UI-only branding update.

Closes #522 