### PR TITLE
fix: stabilize Android resource map UX

### DIFF
--- a/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/CompleteProfileScreen.kt
@@ -530,11 +530,20 @@ fun CompleteProfileScreen(
                     initialLongitude = mapPickerSelection?.longitude,
                     centerLatitude = mapCenterLatitude,
                     centerLongitude = mapCenterLongitude,
+                    showCenterOnCurrentLocation = true,
                     centerActionLoading = mapCenterLoading,
                     centerActionMessage = mapCenterInfo,
                     loading = mapPickerLoading,
                     onDismiss = { if (!mapPickerLoading) mapPickerOpen = false },
-                    onConfirm = ::handleMapSelection
+                    onConfirm = ::handleMapSelection,
+                    onCenterOnCurrentLocation = {
+                        if (mapLocationPermissionRequester.refreshPermissionState()) {
+                            captureCurrentLocationForProfileMap()
+                        } else {
+                            mapCenterLoading = true
+                            mapLocationPermissionRequester.requestPermission()
+                        }
+                    }
                 )
             }
 

--- a/android/app/src/main/java/com/neph/features/gatheringareas/data/GatheringAreasRepository.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/data/GatheringAreasRepository.kt
@@ -1,5 +1,7 @@
 package com.neph.features.gatheringareas.data
 
+import android.util.Log
+import com.neph.BuildConfig
 import com.neph.core.network.ApiException
 import com.neph.core.network.JsonHttpClient
 import kotlinx.coroutines.withTimeoutOrNull
@@ -39,6 +41,9 @@ data class NearbyGatheringAreasResult(
     val requestedLimit: Int,
     val returnedCount: Int,
     val skippedCount: Int,
+    val providerErrorCode: String?,
+    val stale: Boolean,
+    val fallbackReason: String?,
     val categories: List<GatheringAreaCategoryMeta>,
     val areas: List<GatheringAreaItem>
 )
@@ -49,6 +54,7 @@ object GatheringAreasRepository {
     private const val MaxRadiusMeters = 10000
     private const val MaxLimit = 50
     private const val NearbyRequestTimeoutMillis = 8000L
+    private const val DebugLogTag = "GatheringAreasRepo"
 
     suspend fun fetchNearbyGatheringAreas(
         latitude: Double,
@@ -107,13 +113,15 @@ object GatheringAreasRepository {
             code = "OVERPASS_TIMEOUT"
         )
 
-        return parseNearbyGatheringAreasResponse(
+        val parsed = parseNearbyGatheringAreasResponse(
             response = response,
             fallbackLatitude = centerLatitude,
             fallbackLongitude = centerLongitude,
             fallbackRadius = normalizedRadiusMeters,
             fallbackLimit = normalizedLimit
         )
+        logViewportFetchResult(bbox = bbox, result = parsed)
+        return parsed
     }
 
     internal fun parseNearbyGatheringAreasResponse(
@@ -132,6 +140,9 @@ object GatheringAreasRepository {
 
         val metaJson = response.optJSONObject("meta") ?: JSONObject()
         val requestedLimit = metaJson.optPositiveInt("requestedLimit") ?: fallbackLimit
+        val providerErrorCode = metaJson.optNullableString("providerErrorCode")
+        val stale = metaJson.optBoolean("stale", false) || source == "stale_cache"
+        val fallbackReason = metaJson.optNullableString("fallbackReason")
         val categories = parseCategoryMetadata(metaJson.optJSONArray("categories"))
 
         val features = response
@@ -173,8 +184,20 @@ object GatheringAreasRepository {
             requestedLimit = requestedLimit,
             returnedCount = sortedAreas.size,
             skippedCount = skippedCount,
+            providerErrorCode = providerErrorCode,
+            stale = stale,
+            fallbackReason = fallbackReason,
             categories = categories,
             areas = sortedAreas
+        )
+    }
+
+    private fun logViewportFetchResult(bbox: String, result: NearbyGatheringAreasResult) {
+        if (!BuildConfig.DEBUG) return
+        val providerCode = result.providerErrorCode?.let { " providerErrorCode=$it" }.orEmpty()
+        Log.d(
+            DebugLogTag,
+            "viewport bbox=$bbox source=${result.source} returned=${result.returnedCount}$providerCode"
         )
     }
 
@@ -317,4 +340,9 @@ private fun JSONObject.optNonNegativeInt(key: String): Int? {
     if (!has(key)) return null
     val value = optInt(key)
     return value.takeIf { it >= 0 }
+}
+
+private fun JSONObject.optNullableString(key: String): String? {
+    if (!has(key) || isNull(key)) return null
+    return optString(key).trim().ifBlank { null }
 }

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -153,6 +153,13 @@ internal fun gatheringAreasMapEmptyMessage(
     }
 }
 
+internal fun shouldShowPreviousGatheringAreasDuringViewportFetch(
+    currentResult: NearbyGatheringAreasResult?,
+    manualRefresh: Boolean
+): Boolean {
+    return currentResult != null && !manualRefresh
+}
+
 @Composable
 @OptIn(ExperimentalLayoutApi::class)
 fun GatheringAreasScreen(
@@ -214,6 +221,10 @@ fun GatheringAreasScreen(
 
                 val location = attempt.location
                 if (location != null) {
+                    viewportRequestSerial += 1
+                    currentViewport = null
+                    pendingViewport = null
+                    nearbyResult = null
                     mapCenterLatitude = location.latitude
                     mapCenterLongitude = location.longitude
                     mapZoom = GatheringAreasCurrentLocationZoom
@@ -221,6 +232,7 @@ fun GatheringAreasScreen(
                     selectedAreaId = null
                     lastFetchedViewportKey = null
                     loading = false
+                    backgroundUpdating = false
                     return@launch
                 }
 
@@ -252,7 +264,10 @@ fun GatheringAreasScreen(
         delay(450)
         val requestSerial = viewportRequestSerial + 1
         viewportRequestSerial = requestSerial
-        val blockingLoading = nearbyResult == null || manualRefresh
+        val blockingLoading = !shouldShowPreviousGatheringAreasDuringViewportFetch(
+            currentResult = nearbyResult,
+            manualRefresh = manualRefresh
+        )
         loading = blockingLoading
         backgroundUpdating = !blockingLoading
         errorMessage = ""
@@ -302,6 +317,7 @@ fun GatheringAreasScreen(
         } else {
             errorMessage = ""
             loading = false
+            backgroundUpdating = false
             infoMessage = "Location permission was denied. Nearby results were not updated."
         }
     }

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -1,12 +1,14 @@
 package com.neph.features.gatheringareas.presentation
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
@@ -20,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -45,6 +48,7 @@ import com.neph.ui.map.LeafletMarkerMap
 import com.neph.ui.map.LeafletMapInitializationTimeoutMessage
 import com.neph.ui.map.LeafletMapInitializationTimeoutMillis
 import com.neph.ui.map.LeafletMapViewport
+import com.neph.ui.map.MapLocationControl
 import com.neph.ui.map.NephMapIntegration
 import com.neph.ui.map.effectiveLeafletViewportKey
 import com.neph.ui.map.isLeafletMapInitializedForInstance
@@ -322,6 +326,14 @@ fun GatheringAreasScreen(
         }
     }
 
+    fun showCurrentLocationOnMap() {
+        if (locationPermissionRequester.refreshPermissionState()) {
+            requestCurrentLocationAndRefresh()
+        } else {
+            locationPermissionRequester.requestPermission()
+        }
+    }
+
     fun openAreaInMap(item: GatheringAreaItem) {
         val opened = NephMapIntegration.openCoordinates(
             context = context,
@@ -426,18 +438,6 @@ fun GatheringAreasScreen(
                     )
 
                     SecondaryButton(
-                        text = "Use Current Location",
-                        onClick = {
-                            if (locationPermissionRequester.refreshPermissionState()) {
-                                requestCurrentLocationAndRefresh()
-                            } else {
-                                locationPermissionRequester.requestPermission()
-                            }
-                        },
-                        enabled = !loading
-                    )
-
-                    SecondaryButton(
                         text = "Refresh Visible Area",
                         onClick = {
                             val viewport = currentViewport
@@ -471,6 +471,8 @@ fun GatheringAreasScreen(
                 showCenterMarker = false,
                 loadingResources = loading,
                 updatingResources = backgroundUpdating,
+                onShowCurrentLocation = ::showCurrentLocationOnMap,
+                showCurrentLocationEnabled = !loading,
                 onViewportChanged = ::handleViewportChanged
             )
 
@@ -688,7 +690,9 @@ private fun GatheringAreasMapCard(
     mapResetToken: Int = 0,
     showCenterMarker: Boolean = true,
     loadingResources: Boolean = false,
-    updatingResources: Boolean = false
+    updatingResources: Boolean = false,
+    onShowCurrentLocation: (() -> Unit)? = null,
+    showCurrentLocationEnabled: Boolean = true
 ) {
     val spacing = LocalNephSpacing.current
     val initializedInstanceIdState = remember { mutableStateOf<String?>(null) }
@@ -777,47 +781,58 @@ private fun GatheringAreasMapCard(
                 }
             )
 
-            LeafletMarkerMap(
-                mapInstanceId = mapInstanceId,
-                currentMapInstanceId = { currentMapInstanceIdState.value },
-                centerLatitude = mapCenterLatitude,
-                centerLongitude = mapCenterLongitude,
-                markers = markers,
-                selectedMarkerId = selectedAreaId,
-                mapHeightCssPx = GatheringAreasMapHeightCssPx,
-                zoom = mapZoom,
-                showCenterMarker = showCenterMarker,
-                fitBoundsToMarkers = false,
-                onMarkerSelected = { markerInstanceId, markerId ->
-                    if (markerInstanceId == currentMapInstanceIdState.value) {
-                        onAreaSelected(markerId)
-                    }
-                },
-                onMapReady = { initializedInstanceId, source ->
-                    markMapAlive(initializedInstanceId, source)
-                },
-                onMapError = { errorInstanceId, message ->
-                    if (
-                        shouldApplyLeafletMapError(
-                            activeInstanceId = errorInstanceId,
-                            currentInstanceId = currentMapInstanceIdState.value,
-                            tileLoadedInstanceId = tileLoadedInstanceIdState.value,
-                            errorMessage = message
-                        )
-                    ) {
-                        errorInstanceIdState.value = errorInstanceId
-                        mapError = message.ifBlank { "Map failed to load. Check your connection and try again." }
-                    }
-                },
-                onViewportChanged = { viewportInstanceId, viewport ->
-                    if (viewportInstanceId == currentMapInstanceIdState.value) {
-                        onViewportChanged(viewport)
-                    }
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(GatheringAreasMapHeightCssPx.dp)
-            )
+            Box {
+                LeafletMarkerMap(
+                    mapInstanceId = mapInstanceId,
+                    currentMapInstanceId = { currentMapInstanceIdState.value },
+                    centerLatitude = mapCenterLatitude,
+                    centerLongitude = mapCenterLongitude,
+                    markers = markers,
+                    selectedMarkerId = selectedAreaId,
+                    mapHeightCssPx = GatheringAreasMapHeightCssPx,
+                    zoom = mapZoom,
+                    showCenterMarker = showCenterMarker,
+                    fitBoundsToMarkers = false,
+                    onMarkerSelected = { markerInstanceId, markerId ->
+                        if (markerInstanceId == currentMapInstanceIdState.value) {
+                            onAreaSelected(markerId)
+                        }
+                    },
+                    onMapReady = { initializedInstanceId, source ->
+                        markMapAlive(initializedInstanceId, source)
+                    },
+                    onMapError = { errorInstanceId, message ->
+                        if (
+                            shouldApplyLeafletMapError(
+                                activeInstanceId = errorInstanceId,
+                                currentInstanceId = currentMapInstanceIdState.value,
+                                tileLoadedInstanceId = tileLoadedInstanceIdState.value,
+                                errorMessage = message
+                            )
+                        ) {
+                            errorInstanceIdState.value = errorInstanceId
+                            mapError = message.ifBlank { "Map failed to load. Check your connection and try again." }
+                        }
+                    },
+                    onViewportChanged = { viewportInstanceId, viewport ->
+                        if (viewportInstanceId == currentMapInstanceIdState.value) {
+                            onViewportChanged(viewport)
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(GatheringAreasMapHeightCssPx.dp)
+                )
+                onShowCurrentLocation?.let { showCurrentLocation ->
+                    MapLocationControl(
+                        onClick = showCurrentLocation,
+                        enabled = showCurrentLocationEnabled,
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(spacing.sm)
+                    )
+                }
+            }
 
             if (!activeMapInitialized && activeMapError.isBlank()) {
                 HelperText(text = "Loading map...")

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -57,6 +57,7 @@ import com.neph.ui.map.newLeafletMapInstanceId
 import com.neph.ui.map.shouldApplyLeafletMapError
 import com.neph.ui.map.shouldApplyLeafletMapTimeout
 import com.neph.ui.map.shouldClearLeafletMapErrorForSignal
+import com.neph.ui.map.shouldFetchLeafletViewport
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
 import kotlinx.coroutines.CancellationException
@@ -68,11 +69,17 @@ private const val GatheringAreasMapHeightCssPx = 280
 private const val TurkeyOverviewLatitude = 39.0
 private const val TurkeyOverviewLongitude = 35.0
 private const val TurkeyOverviewZoom = 5
+internal const val GatheringAreasCurrentLocationZoom = 15
 private const val ResourceInitialMessage = "Zoom in or use your device location to see resources in this area."
 private const val ResourceZoomedOutMessage = "Zoom in to see resources in this area."
 private const val ResourceLoadingMessage = "Loading resources in this area..."
-private const val ResourceEmptyMessage = "No resources were found in this visible area."
+private const val ResourceUpdatingMessage = "Updating visible area..."
 private const val ResourceErrorMessage = "Resources could not be loaded for this area. Please try again."
+private const val ResourceFilterEmptyMessage = "No results match the selected categories."
+private const val ResourceProviderUnavailableMessage =
+    "Gathering area provider is unavailable. Please try again."
+private const val ResourceStaleCacheMessage =
+    "Showing cached gathering areas; provider data may be temporarily unavailable."
 internal const val GatheringAreasVisibleCategoriesTitle = "Visible Categories"
 internal const val GatheringAreasVisibleCategoriesSubtitle =
     "Selected categories are shown on the map and in the list."
@@ -112,6 +119,40 @@ internal fun reconcileGatheringAreaCategoryFilters(
     return (previousSelectedKeys intersect nextOptionKeys) + newlyAvailableKeys
 }
 
+internal fun isGatheringAreasProviderUnavailable(result: NearbyGatheringAreasResult?): Boolean {
+    val current = result ?: return false
+    return current.source == "fallback" &&
+        current.areas.isEmpty() &&
+        !current.providerErrorCode.isNullOrBlank()
+}
+
+internal fun gatheringAreasResultHelperMessage(result: NearbyGatheringAreasResult): String {
+    return when {
+        result.stale -> ResourceStaleCacheMessage
+        result.skippedCount > 0 -> "${result.skippedCount} malformed provider entries were skipped."
+        else -> ""
+    }
+}
+
+internal fun gatheringAreasMapEmptyMessage(
+    blockingLoading: Boolean,
+    errorMessage: String,
+    currentViewport: LeafletMapViewport?,
+    isFilterEmpty: Boolean,
+    currentResult: NearbyGatheringAreasResult?
+): String {
+    return when {
+        blockingLoading -> ResourceLoadingMessage
+        errorMessage.isNotBlank() -> "Markers are unavailable for this area."
+        currentViewport == null -> ResourceInitialMessage
+        !isLeafletViewportDiscoverable(currentViewport) -> ResourceZoomedOutMessage
+        isFilterEmpty -> "No markers to display with these categories."
+        isGatheringAreasProviderUnavailable(currentResult) -> "Provider did not return markers for this area."
+        currentResult?.areas?.isEmpty() == true -> "No markers to display in this visible area."
+        else -> ResourceInitialMessage
+    }
+}
+
 @Composable
 @OptIn(ExperimentalLayoutApi::class)
 fun GatheringAreasScreen(
@@ -126,11 +167,9 @@ fun GatheringAreasScreen(
     val context = LocalContext.current
 
     var loading by remember { mutableStateOf(false) }
+    var backgroundUpdating by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf("") }
     var infoMessage by remember { mutableStateOf("") }
-    var sourceLabel by remember { mutableStateOf("") }
-    var lastCenterLatitude by remember { mutableStateOf<Double?>(null) }
-    var lastCenterLongitude by remember { mutableStateOf<Double?>(null) }
     var mapCenterLatitude by remember { mutableStateOf(TurkeyOverviewLatitude) }
     var mapCenterLongitude by remember { mutableStateOf(TurkeyOverviewLongitude) }
     var mapZoom by remember { mutableStateOf(TurkeyOverviewZoom) }
@@ -143,16 +182,12 @@ fun GatheringAreasScreen(
     var nearbyResult by remember { mutableStateOf<NearbyGatheringAreasResult?>(null) }
     var selectedAreaId by remember { mutableStateOf<String?>(null) }
     var categoryFilters by remember { mutableStateOf<Set<String>>(emptySet()) }
-    val hasSearchCenter = lastCenterLatitude != null && lastCenterLongitude != null
 
     fun applyViewportResult(result: NearbyGatheringAreasResult) {
         val previousOptions = resolveCategoryOptions(nearbyResult).map { it.key }.toSet()
         val nextOptions = resolveCategoryOptions(result).map { it.key }.toSet()
         nearbyResult = result
         errorMessage = ""
-        sourceLabel = "visible area"
-        lastCenterLatitude = result.centerLatitude
-        lastCenterLongitude = result.centerLongitude
         selectedAreaId = selectedAreaId
             ?.takeIf { selected -> result.areas.any { it.id == selected } }
             ?: result.areas.firstOrNull()?.id
@@ -162,11 +197,7 @@ fun GatheringAreasScreen(
             nextOptionKeys = nextOptions
         )
 
-        infoMessage = when {
-            result.areas.isEmpty() -> ResourceEmptyMessage
-            result.skippedCount > 0 -> "${result.skippedCount} malformed provider entries were skipped."
-            else -> ""
-        }
+        infoMessage = ""
     }
 
     fun requestCurrentLocationAndRefresh() {
@@ -185,10 +216,8 @@ fun GatheringAreasScreen(
                 if (location != null) {
                     mapCenterLatitude = location.latitude
                     mapCenterLongitude = location.longitude
-                    mapZoom = 13
+                    mapZoom = GatheringAreasCurrentLocationZoom
                     mapResetNonce += 1
-                    sourceLabel = "your current location"
-                    nearbyResult = null
                     selectedAreaId = null
                     lastFetchedViewportKey = null
                     loading = false
@@ -216,15 +245,18 @@ fun GatheringAreasScreen(
         val viewport = pendingViewport ?: return@LaunchedEffect
         if (!isLeafletViewportDiscoverable(viewport)) return@LaunchedEffect
         val viewportKey = effectiveLeafletViewportKey(viewport) ?: return@LaunchedEffect
-        if (viewportKey == lastFetchedViewportKey && viewportRefreshNonce == 0) {
+        val manualRefresh = viewportRefreshNonce > 0
+        if (!shouldFetchLeafletViewport(viewportKey, lastFetchedViewportKey, manualRefresh)) {
             return@LaunchedEffect
         }
         delay(450)
         val requestSerial = viewportRequestSerial + 1
         viewportRequestSerial = requestSerial
-        loading = true
+        val blockingLoading = nearbyResult == null || manualRefresh
+        loading = blockingLoading
+        backgroundUpdating = !blockingLoading
         errorMessage = ""
-        infoMessage = ResourceLoadingMessage
+        infoMessage = ""
 
         try {
             val result = GatheringAreasRepository.fetchViewportGatheringAreas(
@@ -244,15 +276,22 @@ fun GatheringAreasScreen(
             if (requestSerial == viewportRequestSerial) {
                 errorMessage = mapGatheringAreasErrorMessage(error).ifBlank { ResourceErrorMessage }
                 infoMessage = ""
+                if (nearbyResult == null) {
+                    selectedAreaId = null
+                }
             }
         } catch (_: Exception) {
             if (requestSerial == viewportRequestSerial) {
                 errorMessage = ResourceErrorMessage
                 infoMessage = ""
+                if (nearbyResult == null) {
+                    selectedAreaId = null
+                }
             }
         } finally {
             if (requestSerial == viewportRequestSerial) {
                 loading = false
+                backgroundUpdating = false
             }
         }
     }
@@ -308,7 +347,8 @@ fun GatheringAreasScreen(
             lastFetchedViewportKey = null
             errorMessage = ""
             loading = false
-            infoMessage = ResourceZoomedOutMessage
+            backgroundUpdating = false
+            infoMessage = ""
         }
     }
 
@@ -331,15 +371,13 @@ fun GatheringAreasScreen(
     }
     val selectedArea = visibleAreas.firstOrNull { it.id == selectedAreaId }
     val mapResult = currentResult ?: turkeyOverviewGatheringAreasResult()
-    val mapEmptyMarkersMessage = when {
-        loading -> ResourceLoadingMessage
-        errorMessage.isNotBlank() -> ResourceErrorMessage
-        currentViewport == null -> ResourceInitialMessage
-        !isLeafletViewportDiscoverable(currentViewport) -> ResourceZoomedOutMessage
-        isFilterEmpty -> "No results match the selected categories."
-        currentResult?.areas?.isEmpty() == true -> ResourceEmptyMessage
-        else -> ResourceEmptyMessage
-    }
+    val mapEmptyMarkersMessage = gatheringAreasMapEmptyMessage(
+        blockingLoading = loading,
+        errorMessage = errorMessage,
+        currentViewport = currentViewport,
+        isFilterEmpty = isFilterEmpty,
+        currentResult = currentResult
+    )
 
     AppDrawerScaffold(
         title = "Gathering Areas",
@@ -371,18 +409,6 @@ fun GatheringAreasScreen(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
 
-                    if (loading) {
-                        HelperText(text = ResourceLoadingMessage)
-                    } else if (currentViewport == null) {
-                        HelperText(text = ResourceInitialMessage)
-                    } else if (!isLeafletViewportDiscoverable(currentViewport)) {
-                        HelperText(text = ResourceZoomedOutMessage)
-                    } else if (hasSearchCenter && lastCenterLatitude != null && lastCenterLongitude != null) {
-                        HelperText(text = "Showing resources in the visible area.")
-                    } else {
-                        HelperText(text = ResourceInitialMessage)
-                    }
-
                     SecondaryButton(
                         text = "Use Current Location",
                         onClick = {
@@ -402,7 +428,7 @@ fun GatheringAreasScreen(
                             if (!isLeafletViewportDiscoverable(viewport)) {
                                 errorMessage = ""
                                 loading = false
-                                infoMessage = ResourceZoomedOutMessage
+                                infoMessage = ""
                                 return@SecondaryButton
                             }
                             errorMessage = ""
@@ -422,19 +448,39 @@ fun GatheringAreasScreen(
                 onOpenAreaInMap = ::openAreaInMap,
                 onGetDirections = ::openAreaDirections,
                 emptyMarkersMessage = mapEmptyMarkersMessage,
-                emptyMapSubtitle = mapEmptyMarkersMessage,
                 mapCenterLatitude = mapCenterLatitude,
                 mapCenterLongitude = mapCenterLongitude,
                 mapZoom = mapZoom,
                 mapResetToken = mapResetNonce,
                 showCenterMarker = false,
                 loadingResources = loading,
+                updatingResources = backgroundUpdating,
                 onViewportChanged = ::handleViewportChanged
             )
 
             when {
                 nearbyResult == null -> {
                     Unit
+                }
+
+                isGatheringAreasProviderUnavailable(nearbyResult) -> {
+                    SectionCard {
+                        Column(verticalArrangement = Arrangement.spacedBy(spacing.md)) {
+                            SectionHeader(
+                                title = "Gathering Area Provider Unavailable",
+                                subtitle = ResourceProviderUnavailableMessage
+                            )
+                            if (isLeafletViewportDiscoverable(currentViewport)) {
+                                SecondaryButton(
+                                    text = "Retry",
+                                    onClick = {
+                                        pendingViewport = currentViewport
+                                        viewportRefreshNonce += 1
+                                    }
+                                )
+                            }
+                        }
+                    }
                 }
 
                 nearbyResult?.areas?.isEmpty() == true -> {
@@ -475,8 +521,8 @@ fun GatheringAreasScreen(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
 
-                            if (result.skippedCount > 0) {
-                                HelperText(text = "${result.skippedCount} malformed provider entries were skipped.")
+                            gatheringAreasResultHelperMessage(result).takeIf { it.isNotBlank() }?.let {
+                                HelperText(text = it)
                             }
                         }
                     }
@@ -521,7 +567,7 @@ fun GatheringAreasScreen(
                                 )
                             }
                             if (isFilterEmpty) {
-                                HelperText(text = "No results match the selected categories.")
+                                HelperText(text = ResourceFilterEmptyMessage)
                             }
                             GatheringAreasLegend(categoryOptions = categoryOptions)
                         }
@@ -620,13 +666,13 @@ private fun GatheringAreasMapCard(
     onGetDirections: (GatheringAreaItem) -> Unit,
     onViewportChanged: (LeafletMapViewport) -> Unit,
     emptyMarkersMessage: String = "No gathering area markers are available for this search center.",
-    emptyMapSubtitle: String = "Showing the searched area. No gathering area markers were returned.",
     mapCenterLatitude: Double = result.centerLatitude,
     mapCenterLongitude: Double = result.centerLongitude,
     mapZoom: Int = 13,
     mapResetToken: Int = 0,
     showCenterMarker: Boolean = true,
-    loadingResources: Boolean = false
+    loadingResources: Boolean = false,
+    updatingResources: Boolean = false
 ) {
     val spacing = LocalNephSpacing.current
     val initializedInstanceIdState = remember { mutableStateOf<String?>(null) }
@@ -709,7 +755,7 @@ private fun GatheringAreasMapCard(
             SectionHeader(
                 title = "Gathering Areas Map",
                 subtitle = if (markers.isEmpty()) {
-                    emptyMapSubtitle
+                    "Map markers appear after a discoverable area loads."
                 } else {
                     "Tap a marker to preview that gathering area."
                 }
@@ -769,7 +815,11 @@ private fun GatheringAreasMapCard(
                 HelperText(text = ResourceLoadingMessage)
             }
 
-            if (markers.isEmpty()) {
+            if (updatingResources && markers.isNotEmpty()) {
+                HelperText(text = ResourceUpdatingMessage)
+            }
+
+            if (markers.isEmpty() && !loadingResources) {
                 HelperText(
                     text = emptyMarkersMessage
                 )
@@ -909,6 +959,9 @@ private fun turkeyOverviewGatheringAreasResult(): NearbyGatheringAreasResult {
         requestedLimit = 0,
         returnedCount = 0,
         skippedCount = 0,
+        providerErrorCode = null,
+        stale = false,
+        fallbackReason = null,
         categories = emptyList(),
         areas = emptyList()
     )

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FilterChip
@@ -25,6 +24,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,6 +38,8 @@ import com.neph.core.network.ApiException
 import com.neph.features.helprequestmap.data.ActiveHelpRequestMapItem
 import com.neph.features.helprequestmap.data.ActiveHelpRequestsRepository
 import com.neph.features.helprequestmap.data.CrisisRequestType
+import com.neph.features.profile.data.CurrentLocationShareWarning
+import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.navigation.Routes
 import com.neph.ui.components.buttons.SecondaryButton
 import com.neph.ui.components.buttons.TextActionButton
@@ -45,6 +47,7 @@ import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.display.SectionCard
 import com.neph.ui.components.display.SectionHeader
 import com.neph.ui.layout.AppDrawerScaffold
+import com.neph.ui.location.rememberForegroundLocationPermissionRequester
 import com.neph.ui.map.LeafletMapInitializationTimeoutMessage
 import com.neph.ui.map.LeafletMapInitializationTimeoutMillis
 import com.neph.ui.map.LeafletMapMarker
@@ -62,20 +65,25 @@ import com.neph.ui.map.newLeafletMapInstanceId
 import com.neph.ui.map.shouldApplyLeafletMapError
 import com.neph.ui.map.shouldApplyLeafletMapTimeout
 import com.neph.ui.map.shouldClearLeafletMapErrorForSignal
+import com.neph.ui.map.shouldFetchLeafletViewport
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 private const val HelpRequestMapHeightCssPx = 280
 private const val TurkeyOverviewLatitude = 39.0
 private const val TurkeyOverviewLongitude = 35.0
 private const val TurkeyOverviewZoom = 5
+internal const val HelpRequestMapCurrentLocationZoom = 15
 private const val ResourceInitialMessage = "Zoom in or use your device location to see resources in this area."
 private const val ResourceZoomedOutMessage = "Zoom in to see resources in this area."
 private const val ResourceLoadingMessage = "Loading resources in this area..."
+private const val ResourceUpdatingMessage = "Updating visible area..."
 private const val ResourceEmptyMessage = "No resources were found in this visible area."
 private const val ResourceErrorMessage = "Resources could not be loaded for this area. Please try again."
+private const val ResourceFilterEmptyMessage = "No help requests match the selected request type filters."
 
 private val RequestTypeFilterOrder = listOf(
     CrisisRequestType.FIRST_AID,
@@ -163,6 +171,24 @@ internal fun helpRequestMapInstanceKey(
     )
 }
 
+internal fun helpRequestMapEmptyMessage(
+    blockingLoading: Boolean,
+    errorMessage: String,
+    currentViewport: LeafletMapViewport?,
+    isFilterEmpty: Boolean,
+    hasFetchedViewport: Boolean
+): String {
+    return when {
+        blockingLoading -> ResourceLoadingMessage
+        errorMessage.isNotBlank() -> "Request markers are unavailable for this area."
+        currentViewport == null -> ResourceInitialMessage
+        !isLeafletViewportDiscoverable(currentViewport) -> ResourceZoomedOutMessage
+        isFilterEmpty -> "No request markers to display with these filters."
+        hasFetchedViewport -> "No request markers to display in this visible area."
+        else -> ResourceInitialMessage
+    }
+}
+
 private fun ActiveHelpRequestMapItem.hasValidMapCoordinates(): Boolean {
     return latitude.isFinite() &&
         longitude.isFinite() &&
@@ -180,8 +206,10 @@ fun HelpRequestMapScreen(
 ) {
     val spacing = LocalNephSpacing.current
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
 
     var loading by remember { mutableStateOf(false) }
+    var backgroundUpdating by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf("") }
     var infoMessage by remember { mutableStateOf("") }
     var requests by remember { mutableStateOf(emptyList<ActiveHelpRequestMapItem>()) }
@@ -192,6 +220,10 @@ fun HelpRequestMapScreen(
     var lastFetchedViewportKey by remember { mutableStateOf<String?>(null) }
     var viewportRefreshNonce by remember { mutableStateOf(0) }
     var viewportRequestSerial by remember { mutableStateOf(0) }
+    var mapCenterLatitude by remember { mutableStateOf(TurkeyOverviewLatitude) }
+    var mapCenterLongitude by remember { mutableStateOf(TurkeyOverviewLongitude) }
+    var mapZoom by remember { mutableStateOf(TurkeyOverviewZoom) }
+    var mapResetNonce by remember { mutableStateOf(0) }
 
     fun queueViewportRefresh() {
         val viewport = currentViewport
@@ -200,12 +232,55 @@ fun HelpRequestMapScreen(
             selectedRequestId = null
             errorMessage = ""
             loading = false
-            infoMessage = ResourceZoomedOutMessage
+            backgroundUpdating = false
+            infoMessage = ""
             return
         }
         errorMessage = ""
         pendingViewport = viewport
         viewportRefreshNonce += 1
+    }
+
+    fun requestCurrentLocationAndRefresh() {
+        scope.launch {
+            loading = true
+            backgroundUpdating = false
+            errorMessage = ""
+            infoMessage = ""
+
+            try {
+                val attempt = DeviceLocationProvider.captureCurrentLocationForSharing(
+                    context = context,
+                    sharingEnabled = true
+                )
+
+                val location = attempt.location
+                if (location != null) {
+                    mapCenterLatitude = location.latitude
+                    mapCenterLongitude = location.longitude
+                    mapZoom = HelpRequestMapCurrentLocationZoom
+                    mapResetNonce += 1
+                    selectedRequestId = null
+                    lastFetchedViewportKey = null
+                    loading = false
+                    return@launch
+                }
+
+                loading = false
+                infoMessage = when (attempt.warning) {
+                    CurrentLocationShareWarning.PERMISSION_DENIED ->
+                        "Location permission was denied. Help request map was not recentered."
+
+                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
+                    null -> "Current location is unavailable. Help request map was not recentered."
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                loading = false
+                infoMessage = "Current location is unavailable. Help request map was not recentered."
+            }
+        }
     }
 
     fun openRequestInMap(item: ActiveHelpRequestMapItem) {
@@ -236,15 +311,18 @@ fun HelpRequestMapScreen(
         val viewport = pendingViewport ?: return@LaunchedEffect
         if (!isLeafletViewportDiscoverable(viewport)) return@LaunchedEffect
         val viewportKey = effectiveLeafletViewportKey(viewport) ?: return@LaunchedEffect
-        if (viewportKey == lastFetchedViewportKey && viewportRefreshNonce == 0) {
+        val manualRefresh = viewportRefreshNonce > 0
+        if (!shouldFetchLeafletViewport(viewportKey, lastFetchedViewportKey, manualRefresh)) {
             return@LaunchedEffect
         }
         delay(450)
         val requestSerial = viewportRequestSerial + 1
         viewportRequestSerial = requestSerial
-        loading = true
+        val blockingLoading = requests.isEmpty() || manualRefresh
+        loading = blockingLoading
+        backgroundUpdating = !blockingLoading
         errorMessage = ""
-        infoMessage = ResourceLoadingMessage
+        infoMessage = ""
 
         try {
             val result = ActiveHelpRequestsRepository.fetchWaitingHelpRequests(
@@ -257,7 +335,6 @@ fun HelpRequestMapScreen(
                 selectedRequestId = selectedRequestId
                     ?.takeIf { selected -> result.requests.any { it.requestId == selected } }
                 infoMessage = when {
-                    result.requests.isEmpty() -> ResourceEmptyMessage
                     result.skippedCount > 0 ->
                         "${result.skippedCount} inactive or malformed request entries were hidden."
                     else -> ""
@@ -268,21 +345,35 @@ fun HelpRequestMapScreen(
         } catch (error: ApiException) {
             if (requestSerial == viewportRequestSerial) {
                 errorMessage = error.message.ifBlank { ResourceErrorMessage }
-                requests = emptyList()
-                selectedRequestId = null
                 infoMessage = ""
+                if (requests.isEmpty()) {
+                    selectedRequestId = null
+                }
             }
         } catch (_: Exception) {
             if (requestSerial == viewportRequestSerial) {
                 errorMessage = ResourceErrorMessage
-                requests = emptyList()
-                selectedRequestId = null
                 infoMessage = ""
+                if (requests.isEmpty()) {
+                    selectedRequestId = null
+                }
             }
         } finally {
             if (requestSerial == viewportRequestSerial) {
                 loading = false
+                backgroundUpdating = false
             }
+        }
+    }
+
+    val locationPermissionRequester = rememberForegroundLocationPermissionRequester { result ->
+        if (result.granted) {
+            requestCurrentLocationAndRefresh()
+        } else {
+            errorMessage = ""
+            loading = false
+            backgroundUpdating = false
+            infoMessage = "Location permission was denied. Help request map was not recentered."
         }
     }
 
@@ -294,6 +385,8 @@ fun HelpRequestMapScreen(
 
     fun handleViewportChanged(viewport: LeafletMapViewport) {
         currentViewport = viewport
+        mapCenterLatitude = viewport.centerLatitude
+        mapCenterLongitude = viewport.centerLongitude
         if (isLeafletViewportDiscoverable(viewport)) {
             errorMessage = ""
             if (infoMessage == ResourceZoomedOutMessage) {
@@ -307,21 +400,20 @@ fun HelpRequestMapScreen(
             lastFetchedViewportKey = null
             errorMessage = ""
             loading = false
-            infoMessage = ResourceZoomedOutMessage
+            backgroundUpdating = false
+            infoMessage = ""
         }
     }
 
     val selectedRequest = visibleRequests.firstOrNull { it.requestId == selectedRequestId }
     val isFilterEmpty = !loading && requests.isNotEmpty() && visibleRequests.isEmpty()
-    val mapEmptyMarkersMessage = when {
-        loading -> ResourceLoadingMessage
-        errorMessage.isNotBlank() -> ResourceErrorMessage
-        currentViewport == null -> ResourceInitialMessage
-        !isLeafletViewportDiscoverable(currentViewport) -> ResourceZoomedOutMessage
-        isFilterEmpty -> "No help requests match the selected request type filters."
-        lastFetchedViewportKey != null -> ResourceEmptyMessage
-        else -> ResourceInitialMessage
-    }
+    val mapEmptyMarkersMessage = helpRequestMapEmptyMessage(
+        blockingLoading = loading,
+        errorMessage = errorMessage,
+        currentViewport = currentViewport,
+        isFilterEmpty = isFilterEmpty,
+        hasFetchedViewport = lastFetchedViewportKey != null
+    )
 
     AppDrawerScaffold(
         title = "Help Request Map",
@@ -354,6 +446,18 @@ fun HelpRequestMapScreen(
                     )
 
                     SecondaryButton(
+                        text = "Use Current Location",
+                        onClick = {
+                            if (locationPermissionRequester.refreshPermissionState()) {
+                                requestCurrentLocationAndRefresh()
+                            } else {
+                                locationPermissionRequester.requestPermission()
+                            }
+                        },
+                        enabled = !loading
+                    )
+
+                    SecondaryButton(
                         text = "Refresh Help Request Map",
                         onClick = { queueViewportRefresh() },
                         enabled = !loading
@@ -367,6 +471,11 @@ fun HelpRequestMapScreen(
                     selectedRequestId = selectedRequest?.requestId,
                     emptyMarkersMessage = mapEmptyMarkersMessage,
                     loadingResources = loading,
+                    updatingResources = backgroundUpdating,
+                    mapCenterLatitude = mapCenterLatitude,
+                    mapCenterLongitude = mapCenterLongitude,
+                    mapZoom = mapZoom,
+                    mapResetToken = mapResetNonce,
                     onViewportChanged = ::handleViewportChanged,
                     onSelectRequest = { selectedRequestId = it }
                 )
@@ -464,7 +573,7 @@ fun HelpRequestMapScreen(
 
             if (isFilterEmpty) {
                 SectionCard {
-                    HelperText(text = "No help requests match the selected request type filters.")
+                    HelperText(text = ResourceFilterEmptyMessage)
                 }
             }
 
@@ -585,6 +694,7 @@ private fun RequestTypeFiltersCard(
 }
 
 @Composable
+@OptIn(ExperimentalLayoutApi::class)
 private fun RequestDetails(
     item: ActiveHelpRequestMapItem,
     onOpenMap: () -> Unit,
@@ -622,9 +732,10 @@ private fun RequestDetails(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
 
-        Row(
+        FlowRow(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End
+            horizontalArrangement = Arrangement.End,
+            verticalArrangement = Arrangement.spacedBy(spacing.xs)
         ) {
             TextActionButton(
                 text = "Get Directions",
@@ -639,6 +750,7 @@ private fun RequestDetails(
 }
 
 @Composable
+@OptIn(ExperimentalLayoutApi::class)
 private fun RequestListItem(
     item: ActiveHelpRequestMapItem,
     selected: Boolean,
@@ -666,31 +778,57 @@ private fun RequestListItem(
         verticalArrangement = Arrangement.spacedBy(spacing.xs)
     ) {
         Spacer(modifier = Modifier.height(spacing.sm))
-        Row(
+        Column(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(spacing.md),
-            verticalAlignment = Alignment.CenterVertically
+            verticalArrangement = Arrangement.spacedBy(spacing.sm)
         ) {
-            PinGlyph(type = item.type)
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = item.typeLabel,
-                    style = MaterialTheme.typography.titleSmall,
-                    color = textColor,
-                    fontWeight = FontWeight.SemiBold
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing.md),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                PinGlyph(type = item.type)
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = item.typeLabel,
+                        style = MaterialTheme.typography.titleSmall,
+                        color = textColor,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = "Priority: ${ActiveHelpRequestsRepository.formatPriority(item.priorityLevel)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (selected) {
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        }
+                    )
+                    Text(
+                        text = "${item.district}, ${item.city}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (selected) {
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        }
+                    )
+                }
+            }
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalArrangement = Arrangement.spacedBy(spacing.xs)
+            ) {
+                TextActionButton(
+                    text = "Get Directions",
+                    onClick = onGetDirections
                 )
-                Text(
-                    text = "Priority: ${ActiveHelpRequestsRepository.formatPriority(item.priorityLevel)} | ${item.district}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = if (selected) {
-                        MaterialTheme.colorScheme.onPrimaryContainer
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    }
+                TextActionButton(
+                    text = "Open in Map",
+                    onClick = onOpenMap
                 )
             }
-            TextActionButton(text = "Get Directions", onClick = onGetDirections)
-            TextActionButton(text = "Open in Map", onClick = onOpenMap)
         }
         Spacer(modifier = Modifier.height(spacing.sm))
     }
@@ -702,6 +840,11 @@ private fun CrisisRequestMapPanel(
     selectedRequestId: String?,
     emptyMarkersMessage: String = ResourceEmptyMessage,
     loadingResources: Boolean = false,
+    updatingResources: Boolean = false,
+    mapCenterLatitude: Double = TurkeyOverviewLatitude,
+    mapCenterLongitude: Double = TurkeyOverviewLongitude,
+    mapZoom: Int = TurkeyOverviewZoom,
+    mapResetToken: Int = 0,
     onViewportChanged: (LeafletMapViewport) -> Unit,
     onSelectRequest: (String) -> Unit
 ) {
@@ -710,8 +853,7 @@ private fun CrisisRequestMapPanel(
     val tileLoadedInstanceIdState = remember { mutableStateOf<String?>(null) }
     val errorInstanceIdState = remember { mutableStateOf<String?>(null) }
     var mapError by remember { mutableStateOf("") }
-    val mapInstanceKey = HelpRequestMapInstanceKey(TurkeyOverviewLatitude, TurkeyOverviewLongitude)
-    val mapInstanceId = remember(mapInstanceKey) {
+    val mapInstanceId = remember(mapResetToken) {
         newLeafletMapInstanceId()
     }
     val currentMapInstanceIdState = remember { mutableStateOf(mapInstanceId) }
@@ -772,7 +914,7 @@ private fun CrisisRequestMapPanel(
         SectionHeader(
             title = "Live Help Request Map",
             subtitle = if (markers.isEmpty()) {
-                "No request markers match the selected filters."
+                "Map markers appear after a discoverable area loads."
             } else {
                 "Tap a marker to preview that help request."
             }
@@ -781,12 +923,12 @@ private fun CrisisRequestMapPanel(
         LeafletMarkerMap(
             mapInstanceId = mapInstanceId,
             currentMapInstanceId = { currentMapInstanceIdState.value },
-            centerLatitude = mapInstanceKey.centerLatitude,
-            centerLongitude = mapInstanceKey.centerLongitude,
+            centerLatitude = mapCenterLatitude,
+            centerLongitude = mapCenterLongitude,
             markers = markers,
             selectedMarkerId = selectedRequestId,
             mapHeightCssPx = HelpRequestMapHeightCssPx,
-            zoom = if (markers.isEmpty()) TurkeyOverviewZoom else 13,
+            zoom = mapZoom,
             showCenterMarker = false,
             fitBoundsToMarkers = false,
             onMarkerSelected = { markerInstanceId, markerId ->
@@ -832,7 +974,11 @@ private fun CrisisRequestMapPanel(
             HelperText(text = ResourceLoadingMessage)
         }
 
-        if (markers.isEmpty()) {
+        if (updatingResources && markers.isNotEmpty()) {
+            HelperText(text = ResourceUpdatingMessage)
+        }
+
+        if (markers.isEmpty() && !loadingResources) {
             HelperText(text = emptyMarkersMessage)
         }
 

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FilterChip
@@ -53,6 +54,7 @@ import com.neph.ui.map.LeafletMapInitializationTimeoutMillis
 import com.neph.ui.map.LeafletMapMarker
 import com.neph.ui.map.LeafletMapViewport
 import com.neph.ui.map.LeafletMarkerMap
+import com.neph.ui.map.MapLocationControl
 import com.neph.ui.map.NephMapIntegration
 import com.neph.ui.map.effectiveLeafletViewportKey
 import com.neph.ui.map.isLeafletMapInitializedForInstance
@@ -392,6 +394,14 @@ fun HelpRequestMapScreen(
         }
     }
 
+    fun showCurrentLocationOnMap() {
+        if (locationPermissionRequester.refreshPermissionState()) {
+            requestCurrentLocationAndRefresh()
+        } else {
+            locationPermissionRequester.requestPermission()
+        }
+    }
+
     val visibleRequests = filterVisibleRequests(requests, selectedTypes)
 
     LaunchedEffect(visibleRequests, selectedRequestId) {
@@ -461,18 +471,6 @@ fun HelpRequestMapScreen(
                     )
 
                     SecondaryButton(
-                        text = "Use Current Location",
-                        onClick = {
-                            if (locationPermissionRequester.refreshPermissionState()) {
-                                requestCurrentLocationAndRefresh()
-                            } else {
-                                locationPermissionRequester.requestPermission()
-                            }
-                        },
-                        enabled = !loading
-                    )
-
-                    SecondaryButton(
                         text = "Refresh Help Request Map",
                         onClick = { queueViewportRefresh() },
                         enabled = !loading
@@ -491,6 +489,8 @@ fun HelpRequestMapScreen(
                     mapCenterLongitude = mapCenterLongitude,
                     mapZoom = mapZoom,
                     mapResetToken = mapResetNonce,
+                    onShowCurrentLocation = ::showCurrentLocationOnMap,
+                    showCurrentLocationEnabled = !loading,
                     onViewportChanged = ::handleViewportChanged,
                     onSelectRequest = { selectedRequestId = it }
                 )
@@ -860,6 +860,8 @@ private fun CrisisRequestMapPanel(
     mapCenterLongitude: Double = TurkeyOverviewLongitude,
     mapZoom: Int = TurkeyOverviewZoom,
     mapResetToken: Int = 0,
+    onShowCurrentLocation: (() -> Unit)? = null,
+    showCurrentLocationEnabled: Boolean = true,
     onViewportChanged: (LeafletMapViewport) -> Unit,
     onSelectRequest: (String) -> Unit
 ) {
@@ -935,47 +937,58 @@ private fun CrisisRequestMapPanel(
             }
         )
 
-        LeafletMarkerMap(
-            mapInstanceId = mapInstanceId,
-            currentMapInstanceId = { currentMapInstanceIdState.value },
-            centerLatitude = mapCenterLatitude,
-            centerLongitude = mapCenterLongitude,
-            markers = markers,
-            selectedMarkerId = selectedRequestId,
-            mapHeightCssPx = HelpRequestMapHeightCssPx,
-            zoom = mapZoom,
-            showCenterMarker = false,
-            fitBoundsToMarkers = false,
-            onMarkerSelected = { markerInstanceId, markerId ->
-                if (markerInstanceId == currentMapInstanceIdState.value) {
-                    onSelectRequest(markerId)
-                }
-            },
-            onMapReady = { initializedInstanceId, source ->
-                markMapAlive(initializedInstanceId, source)
-            },
-            onMapError = { errorInstanceId, message ->
-                if (
-                    shouldApplyLeafletMapError(
-                        activeInstanceId = errorInstanceId,
-                        currentInstanceId = currentMapInstanceIdState.value,
-                        tileLoadedInstanceId = tileLoadedInstanceIdState.value,
-                        errorMessage = message
-                    )
-                ) {
-                    errorInstanceIdState.value = errorInstanceId
-                    mapError = message.ifBlank { "Map failed to load. Check your connection and try again." }
-                }
-            },
-            onViewportChanged = { viewportInstanceId, viewport ->
-                if (viewportInstanceId == currentMapInstanceIdState.value) {
-                    onViewportChanged(viewport)
-                }
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(HelpRequestMapHeightCssPx.dp)
-        )
+        Box {
+            LeafletMarkerMap(
+                mapInstanceId = mapInstanceId,
+                currentMapInstanceId = { currentMapInstanceIdState.value },
+                centerLatitude = mapCenterLatitude,
+                centerLongitude = mapCenterLongitude,
+                markers = markers,
+                selectedMarkerId = selectedRequestId,
+                mapHeightCssPx = HelpRequestMapHeightCssPx,
+                zoom = mapZoom,
+                showCenterMarker = false,
+                fitBoundsToMarkers = false,
+                onMarkerSelected = { markerInstanceId, markerId ->
+                    if (markerInstanceId == currentMapInstanceIdState.value) {
+                        onSelectRequest(markerId)
+                    }
+                },
+                onMapReady = { initializedInstanceId, source ->
+                    markMapAlive(initializedInstanceId, source)
+                },
+                onMapError = { errorInstanceId, message ->
+                    if (
+                        shouldApplyLeafletMapError(
+                            activeInstanceId = errorInstanceId,
+                            currentInstanceId = currentMapInstanceIdState.value,
+                            tileLoadedInstanceId = tileLoadedInstanceIdState.value,
+                            errorMessage = message
+                        )
+                    ) {
+                        errorInstanceIdState.value = errorInstanceId
+                        mapError = message.ifBlank { "Map failed to load. Check your connection and try again." }
+                    }
+                },
+                onViewportChanged = { viewportInstanceId, viewport ->
+                    if (viewportInstanceId == currentMapInstanceIdState.value) {
+                        onViewportChanged(viewport)
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(HelpRequestMapHeightCssPx.dp)
+            )
+            onShowCurrentLocation?.let { showCurrentLocation ->
+                MapLocationControl(
+                    onClick = showCurrentLocation,
+                    enabled = showCurrentLocationEnabled,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(spacing.sm)
+                )
+            }
+        }
 
         if (!activeMapInitialized && activeMapError.isBlank()) {
             HelperText(text = "Loading map...")

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -189,6 +189,13 @@ internal fun helpRequestMapEmptyMessage(
     }
 }
 
+internal fun shouldShowPreviousHelpRequestsDuringViewportFetch(
+    requests: List<ActiveHelpRequestMapItem>,
+    manualRefresh: Boolean
+): Boolean {
+    return requests.isNotEmpty() && !manualRefresh
+}
+
 private fun ActiveHelpRequestMapItem.hasValidMapCoordinates(): Boolean {
     return latitude.isFinite() &&
         longitude.isFinite() &&
@@ -256,6 +263,10 @@ fun HelpRequestMapScreen(
 
                 val location = attempt.location
                 if (location != null) {
+                    viewportRequestSerial += 1
+                    currentViewport = null
+                    pendingViewport = null
+                    requests = emptyList()
                     mapCenterLatitude = location.latitude
                     mapCenterLongitude = location.longitude
                     mapZoom = HelpRequestMapCurrentLocationZoom
@@ -263,6 +274,7 @@ fun HelpRequestMapScreen(
                     selectedRequestId = null
                     lastFetchedViewportKey = null
                     loading = false
+                    backgroundUpdating = false
                     return@launch
                 }
 
@@ -318,7 +330,10 @@ fun HelpRequestMapScreen(
         delay(450)
         val requestSerial = viewportRequestSerial + 1
         viewportRequestSerial = requestSerial
-        val blockingLoading = requests.isEmpty() || manualRefresh
+        val blockingLoading = !shouldShowPreviousHelpRequestsDuringViewportFetch(
+            requests = requests,
+            manualRefresh = manualRefresh
+        )
         loading = blockingLoading
         backgroundUpdating = !blockingLoading
         errorMessage = ""

--- a/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
+++ b/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.view.MotionEvent
 import android.webkit.ConsoleMessage
 import android.webkit.JavascriptInterface
 import android.webkit.WebChromeClient
@@ -194,6 +195,14 @@ fun effectiveLeafletViewportKey(viewport: LeafletMapViewport?): String? {
     )
 }
 
+fun shouldFetchLeafletViewport(
+    viewportKey: String,
+    lastFetchedViewportKey: String?,
+    manualRefresh: Boolean
+): Boolean {
+    return manualRefresh || viewportKey != lastFetchedViewportKey
+}
+
 fun leafletViewportBboxString(viewport: LeafletMapViewport): String {
     return String.format(
         Locale.US,
@@ -205,7 +214,7 @@ fun leafletViewportBboxString(viewport: LeafletMapViewport): String {
     )
 }
 
-@SuppressLint("SetJavaScriptEnabled")
+@SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
 @Composable
 internal fun LeafletMapWebView(
     mapInstanceId: String,
@@ -232,6 +241,22 @@ internal fun LeafletMapWebView(
                     settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
                     webViewClient = LeafletMapWebViewClient()
                     webChromeClient = LeafletMapWebChromeClient()
+                    setOnTouchListener { view, event ->
+                        when (event.actionMasked) {
+                            MotionEvent.ACTION_DOWN,
+                            MotionEvent.ACTION_MOVE,
+                            MotionEvent.ACTION_POINTER_DOWN,
+                            MotionEvent.ACTION_POINTER_UP -> {
+                                view.parent?.requestDisallowInterceptTouchEvent(true)
+                            }
+
+                            MotionEvent.ACTION_UP,
+                            MotionEvent.ACTION_CANCEL -> {
+                                view.parent?.requestDisallowInterceptTouchEvent(false)
+                            }
+                        }
+                        false
+                    }
                     addJavascriptInterface(bridge, bridgeName)
                     loadDataWithBaseURL(LeafletMapBaseUrl, html, "text/html", "utf-8", null)
                 }
@@ -363,6 +388,10 @@ internal fun buildLeafletDocumentHead(mapHeightCssPx: Int = LeafletMapFallbackHe
                 margin: 0;
                 padding: 0;
                 overflow: hidden;
+                overscroll-behavior: contain;
+                touch-action: none;
+                -webkit-user-select: none;
+                user-select: none;
             }
             #map {
                 width: 100%;
@@ -370,6 +399,10 @@ internal fun buildLeafletDocumentHead(mapHeightCssPx: Int = LeafletMapFallbackHe
                 min-height: ${coercedMapHeightCssPx}px;
                 margin: 0;
                 padding: 0;
+                overscroll-behavior: contain;
+                touch-action: none;
+                -webkit-user-select: none;
+                user-select: none;
             }
         </style>
     """.trimIndent()

--- a/android/app/src/main/java/com/neph/ui/map/MapLocationControl.kt
+++ b/android/app/src/main/java/com/neph/ui/map/MapLocationControl.kt
@@ -1,0 +1,49 @@
+package com.neph.ui.map
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+internal const val MapLocationControlContentDescription = "Show my location"
+internal const val MapLocationControlTestTag = "map_location_control"
+
+@Composable
+fun MapLocationControl(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.surface,
+        tonalElevation = 4.dp,
+        shadowElevation = 4.dp
+    ) {
+        IconButton(
+            onClick = onClick,
+            enabled = enabled,
+            modifier = Modifier
+                .size(44.dp)
+                .testTag(MapLocationControlTestTag)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.MyLocation,
+                contentDescription = MapLocationControlContentDescription,
+                tint = if (enabled) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                }
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
+++ b/android/app/src/main/java/com/neph/ui/map/MapPickerDialog.kt
@@ -5,6 +5,7 @@ import android.os.Handler
 import android.os.Looper
 import android.webkit.JavascriptInterface
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -20,6 +21,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -152,6 +154,8 @@ fun MapPickerDialog(
                     currentMapInstanceId = { currentMapInstanceIdState.value },
                     initialLatitude = effectiveInitialLatitude,
                     initialLongitude = effectiveInitialLongitude,
+                    onShowCurrentLocation = onCenterOnCurrentLocation.takeIf { showCenterOnCurrentLocation },
+                    showCurrentLocationEnabled = !loading && !centerActionLoading,
                     onLocationSelected = { lat, lon ->
                         selection = MapPickerSelection(lat, lon)
                     },
@@ -185,14 +189,6 @@ fun MapPickerDialog(
 
                 if (loading) {
                     HelperText(text = "Resolving selected location...")
-                }
-
-                if (showCenterOnCurrentLocation && onCenterOnCurrentLocation != null) {
-                    SecondaryButton(
-                        text = "Center on my location",
-                        onClick = onCenterOnCurrentLocation,
-                        enabled = !loading && !centerActionLoading
-                    )
                 }
 
                 if (centerActionLoading) {
@@ -231,6 +227,8 @@ private fun MapPickerMap(
     currentMapInstanceId: () -> String,
     initialLatitude: Double?,
     initialLongitude: Double?,
+    onShowCurrentLocation: (() -> Unit)?,
+    showCurrentLocationEnabled: Boolean,
     onLocationSelected: (Double, Double) -> Unit,
     onMapReady: (String, String) -> Unit,
     onMapError: (String, String) -> Unit
@@ -256,15 +254,26 @@ private fun MapPickerMap(
         )
     }
 
-    LeafletMapWebView(
-        mapInstanceId = mapInstanceId,
-        html = html,
-        bridgeName = MapPickerBridgeName,
-        bridge = bridge,
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(MapPickerMapHeightCssPx.dp)
-    )
+    Box {
+        LeafletMapWebView(
+            mapInstanceId = mapInstanceId,
+            html = html,
+            bridgeName = MapPickerBridgeName,
+            bridge = bridge,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(MapPickerMapHeightCssPx.dp)
+        )
+        onShowCurrentLocation?.let { showCurrentLocation ->
+            MapLocationControl(
+                onClick = showCurrentLocation,
+                enabled = showCurrentLocationEnabled,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(LocalNephSpacing.current.sm)
+            )
+        }
+    }
 }
 
 private class MapPickerBridge(

--- a/android/app/src/test/java/com/neph/features/gatheringareas/data/GatheringAreasRepositoryTest.kt
+++ b/android/app/src/test/java/com/neph/features/gatheringareas/data/GatheringAreasRepositoryTest.kt
@@ -24,6 +24,9 @@ class GatheringAreasRepositoryTest {
               "meta": {
                 "requestedLimit": 10,
                 "returnedCount": 3,
+                "providerErrorCode": "OVERPASS_TIMEOUT",
+                "stale": true,
+                "fallbackReason": "Provider temporarily unavailable",
                 "categories": [
                   { "key": "assembly_point", "label": "Assembly Point" },
                   { "key": "shelter", "label": "Shelter" },
@@ -81,6 +84,9 @@ class GatheringAreasRepositoryTest {
         assertEquals(1500, parsed.radiusMeters)
         assertEquals("overpass", parsed.source)
         assertEquals(10, parsed.requestedLimit)
+        assertEquals("OVERPASS_TIMEOUT", parsed.providerErrorCode)
+        assertEquals(true, parsed.stale)
+        assertEquals("Provider temporarily unavailable", parsed.fallbackReason)
         assertEquals(3, parsed.categories.size)
 
         assertEquals("node-1", parsed.areas[0].id)

--- a/android/app/src/test/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreenTest.kt
+++ b/android/app/src/test/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreenTest.kt
@@ -133,6 +133,28 @@ class GatheringAreasScreenTest {
     }
 
     @Test
+    fun shouldShowPreviousGatheringAreasDuringViewportFetch_keepsMarkersForNormalPanOnly() {
+        assertTrue(
+            shouldShowPreviousGatheringAreasDuringViewportFetch(
+                currentResult = sampleNearbyResult(),
+                manualRefresh = false
+            )
+        )
+        assertFalse(
+            shouldShowPreviousGatheringAreasDuringViewportFetch(
+                currentResult = sampleNearbyResult(),
+                manualRefresh = true
+            )
+        )
+        assertFalse(
+            shouldShowPreviousGatheringAreasDuringViewportFetch(
+                currentResult = null,
+                manualRefresh = false
+            )
+        )
+    }
+
+    @Test
     fun reconcileGatheringAreaCategoryFilters_whenPreviouslyShowingAll_selectsAllNewCategories() {
         val reconciled = reconcileGatheringAreaCategoryFilters(
             previousOptionKeys = setOf("assembly_point", "shelter"),

--- a/android/app/src/test/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreenTest.kt
+++ b/android/app/src/test/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreenTest.kt
@@ -3,7 +3,10 @@ package com.neph.features.gatheringareas.presentation
 import com.neph.core.network.ApiException
 import com.neph.features.gatheringareas.data.GatheringAreaItem
 import com.neph.features.gatheringareas.data.NearbyGatheringAreasResult
+import com.neph.ui.map.LeafletMapViewport
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class GatheringAreasScreenTest {
@@ -80,6 +83,56 @@ class GatheringAreasScreenTest {
     }
 
     @Test
+    fun gatheringAreasCurrentLocationZoom_usesDiscoverableLocalZoom() {
+        assertEquals(15, GatheringAreasCurrentLocationZoom)
+    }
+
+    @Test
+    fun gatheringAreasMapEmptyMessage_zoomedOutDoesNotUseTrueEmptyOrFilterEmptyCopy() {
+        val message = gatheringAreasMapEmptyMessage(
+            blockingLoading = false,
+            errorMessage = "",
+            currentViewport = viewport(widthKm = 60.0, heightKm = 20.0),
+            isFilterEmpty = true,
+            currentResult = emptyNearbyResult(source = "overpass")
+        )
+
+        assertEquals("Zoom in to see resources in this area.", message)
+        assertFalse(message.contains("No Gathering Areas Found"))
+        assertFalse(message.contains("selected categories"))
+    }
+
+    @Test
+    fun gatheringAreasProviderFallbackEmpty_isNotTrueEmptyResult() {
+        val fallback = emptyNearbyResult(
+            source = "fallback",
+            providerErrorCode = "OVERPASS_UNAVAILABLE"
+        )
+
+        assertTrue(isGatheringAreasProviderUnavailable(fallback))
+        assertEquals(
+            "Provider did not return markers for this area.",
+            gatheringAreasMapEmptyMessage(
+                blockingLoading = false,
+                errorMessage = "",
+                currentViewport = viewport(widthKm = 20.0, heightKm = 20.0),
+                isFilterEmpty = false,
+                currentResult = fallback
+            )
+        )
+    }
+
+    @Test
+    fun gatheringAreasResultHelperMessage_distinguishesStaleCache() {
+        val stale = sampleNearbyResult().copy(source = "stale_cache", stale = true)
+
+        assertEquals(
+            "Showing cached gathering areas; provider data may be temporarily unavailable.",
+            gatheringAreasResultHelperMessage(stale)
+        )
+    }
+
+    @Test
     fun reconcileGatheringAreaCategoryFilters_whenPreviouslyShowingAll_selectsAllNewCategories() {
         val reconciled = reconcileGatheringAreaCategoryFilters(
             previousOptionKeys = setOf("assembly_point", "shelter"),
@@ -135,8 +188,46 @@ class GatheringAreasScreenTest {
             requestedLimit = 50,
             returnedCount = areas.size,
             skippedCount = 0,
+            providerErrorCode = null,
+            stale = false,
+            fallbackReason = null,
             categories = emptyList(),
             areas = areas
+        )
+    }
+
+    private fun emptyNearbyResult(
+        source: String,
+        providerErrorCode: String? = null
+    ): NearbyGatheringAreasResult {
+        return NearbyGatheringAreasResult(
+            centerLatitude = 41.0,
+            centerLongitude = 29.0,
+            radiusMeters = 10_000,
+            source = source,
+            requestedLimit = 50,
+            returnedCount = 0,
+            skippedCount = 0,
+            providerErrorCode = providerErrorCode,
+            stale = false,
+            fallbackReason = null,
+            categories = emptyList(),
+            areas = emptyList()
+        )
+    }
+
+    private fun viewport(widthKm: Double, heightKm: Double): LeafletMapViewport {
+        return LeafletMapViewport(
+            centerLatitude = 41.0,
+            centerLongitude = 29.0,
+            north = 41.1,
+            south = 40.9,
+            east = 29.1,
+            west = 29.0,
+            zoom = 12,
+            widthKm = widthKm,
+            heightKm = heightKm,
+            widestVisibleDimensionKm = maxOf(widthKm, heightKm)
         )
     }
 }

--- a/android/app/src/test/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreenFilterLogicTest.kt
+++ b/android/app/src/test/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreenFilterLogicTest.kt
@@ -2,7 +2,9 @@ package com.neph.features.helprequestmap.presentation
 
 import com.neph.features.helprequestmap.data.ActiveHelpRequestMapItem
 import com.neph.features.helprequestmap.data.CrisisRequestType
+import com.neph.ui.map.LeafletMapViewport
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -163,6 +165,38 @@ class HelpRequestMapScreenFilterLogicTest {
         assertEquals("?", requestMarkerStyle(CrisisRequestType.OTHER).glyph)
     }
 
+    @Test
+    fun helpRequestCurrentLocationZoom_usesDiscoverableLocalZoom() {
+        assertEquals(15, HelpRequestMapCurrentLocationZoom)
+    }
+
+    @Test
+    fun helpRequestMapEmptyMessage_zoomedOutDoesNotUseFilterEmptyCopy() {
+        val message = helpRequestMapEmptyMessage(
+            blockingLoading = false,
+            errorMessage = "",
+            currentViewport = viewport(widthKm = 60.0, heightKm = 20.0),
+            isFilterEmpty = true,
+            hasFetchedViewport = true
+        )
+
+        assertEquals("Zoom in to see resources in this area.", message)
+        assertFalse(message.contains("selected request type filters"))
+    }
+
+    @Test
+    fun helpRequestMapEmptyMessage_filterEmptyIsSeparateFromZoomedOut() {
+        val message = helpRequestMapEmptyMessage(
+            blockingLoading = false,
+            errorMessage = "",
+            currentViewport = viewport(widthKm = 20.0, heightKm = 20.0),
+            isFilterEmpty = true,
+            hasFetchedViewport = true
+        )
+
+        assertEquals("No request markers to display with these filters.", message)
+    }
+
     private fun request(
         requestId: String,
         type: CrisisRequestType,
@@ -179,6 +213,21 @@ class HelpRequestMapScreenFilterLogicTest {
             longitude = 29.0,
             city = "istanbul",
             district = "sisli"
+        )
+    }
+
+    private fun viewport(widthKm: Double, heightKm: Double): LeafletMapViewport {
+        return LeafletMapViewport(
+            centerLatitude = 41.0,
+            centerLongitude = 29.0,
+            north = 41.1,
+            south = 40.9,
+            east = 29.1,
+            west = 29.0,
+            zoom = 12,
+            widthKm = widthKm,
+            heightKm = heightKm,
+            widestVisibleDimensionKm = maxOf(widthKm, heightKm)
         )
     }
 }

--- a/android/app/src/test/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreenFilterLogicTest.kt
+++ b/android/app/src/test/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreenFilterLogicTest.kt
@@ -197,6 +197,31 @@ class HelpRequestMapScreenFilterLogicTest {
         assertEquals("No request markers to display with these filters.", message)
     }
 
+    @Test
+    fun shouldShowPreviousHelpRequestsDuringViewportFetch_keepsMarkersForNormalPanOnly() {
+        assertEquals(
+            true,
+            shouldShowPreviousHelpRequestsDuringViewportFetch(
+                requests = listOf(firstAid),
+                manualRefresh = false
+            )
+        )
+        assertEquals(
+            false,
+            shouldShowPreviousHelpRequestsDuringViewportFetch(
+                requests = listOf(firstAid),
+                manualRefresh = true
+            )
+        )
+        assertEquals(
+            false,
+            shouldShowPreviousHelpRequestsDuringViewportFetch(
+                requests = emptyList(),
+                manualRefresh = false
+            )
+        )
+    }
+
     private fun request(
         requestId: String,
         type: CrisisRequestType,

--- a/android/app/src/test/java/com/neph/ui/map/LeafletMapWebViewTest.kt
+++ b/android/app/src/test/java/com/neph/ui/map/LeafletMapWebViewTest.kt
@@ -157,6 +157,31 @@ class LeafletMapWebViewTest {
     }
 
     @Test
+    fun shouldFetchLeafletViewport_skipsSameViewportUnlessManualRefresh() {
+        assertFalse(
+            shouldFetchLeafletViewport(
+                viewportKey = "29.000,40.900,29.100,41.100",
+                lastFetchedViewportKey = "29.000,40.900,29.100,41.100",
+                manualRefresh = false
+            )
+        )
+        assertTrue(
+            shouldFetchLeafletViewport(
+                viewportKey = "29.000,40.900,29.100,41.100",
+                lastFetchedViewportKey = "29.000,40.900,29.100,41.100",
+                manualRefresh = true
+            )
+        )
+        assertTrue(
+            shouldFetchLeafletViewport(
+                viewportKey = "29.001,40.900,29.101,41.100",
+                lastFetchedViewportKey = "29.000,40.900,29.100,41.100",
+                manualRefresh = false
+            )
+        )
+    }
+
+    @Test
     fun buildLeafletDocumentHead_allowsLeafletOriginWithoutQuotedUrlSources() {
         val head = buildLeafletDocumentHead()
 
@@ -167,6 +192,9 @@ class LeafletMapWebViewTest {
         assertFalse(head.contains("navigate-to"))
         assertTrue(head.contains("min-height: ${LeafletMapFallbackHeightCssPx}px"))
         assertTrue(head.contains("height: ${LeafletMapFallbackHeightCssPx}px"))
+        assertTrue(head.contains("touch-action: none;"))
+        assertTrue(head.contains("overscroll-behavior: contain;"))
+        assertTrue(head.contains("user-select: none;"))
     }
 
     @Test


### PR DESCRIPTION
### Summary

This PR fixes Android resource map UX regressions observed after viewport-based marker discovery was added.

The changes focus on making the Android Gathering Areas and Help Request Map screens demo-safe and usable on real devices by improving map gestures, map state messages, current-location behavior, loading behavior, and responsive request card layout.

### Changes

#### Shared Android map behavior

- Fixed mobile map gesture handling so dragging or pinching inside the map does not scroll the parent page.
- Kept Leaflet/WebView touch events working while preventing parent scroll interception.
- Preserved existing WebView lifecycle, tile loading, initialization handling, and JavaScript marker updates.

#### Gathering Areas map

- Removed duplicated helper/status messages such as repeated `Zoom in to see resources in this area.`
- Improved zoomed-out, loading, empty, provider-error, and retry state separation.
- Moved current-location actions into map overlay controls and improved its recenter zoom behavior.
- Avoided misleading “No Gathering Areas Found” messaging when the actual state is zoomed out or provider unavailable.
- Improved provider fallback/stale metadata handling so provider failures are not treated as true empty results.
- Reduced noisy loading behavior during viewport panning.

#### Help Request Map

- Added or restored a current-location shortcut for the Android Help Request Map where it was missing.
- Removed misleading filter-empty text when the map is actually zoomed out.
- Reduced duplicated map helper/loading messages.
- Improved viewport update behavior so panning does not feel like a full screen reload.
- Fixed small-screen request detail/list card layout so text does not collapse horizontally.
- Preserved request filters, marker selection, `Get Directions`, and `Open in Map`.

### Related issues

Closes #543  
Closes #548  
Closes #542  

### Testing

- Verified Android resource map state messages are no longer duplicated.
- Verified zoomed-out state is not shown as filter-empty or true-empty.
- Verified map touch gestures no longer cause parent page scrolling.
- Verified Gathering Areas `Use Current Location` recenters with a closer local zoom.
- Verified Help Request Map current-location shortcut behavior.
- Verified Help Request Map request cards remain readable on small screens.
- Verified marker selection, filters, `Get Directions`, and `Open in Map` still work.
- Verified map picker flows were not intentionally changed.