### PR TITLE
fix(android): allow non-com emails in auth validation

### DIFF
--- a/android/app/src/main/java/com/neph/features/auth/util/AuthValidation.kt
+++ b/android/app/src/main/java/com/neph/features/auth/util/AuthValidation.kt
@@ -1,7 +1,13 @@
 package com.neph.features.auth.util
 
-import android.util.Patterns
-
 fun isValidEmail(email: String): Boolean {
-    return Patterns.EMAIL_ADDRESS.matcher(email.trim()).matches()
+    val normalized = email.trim()
+    if (normalized.isEmpty()) {
+        return false
+    }
+
+    // Keep validation permissive in UI and avoid domain-extension bias (.com-only behavior).
+    return UiEmailRegex.matches(normalized)
 }
+
+private val UiEmailRegex = Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$")

--- a/android/app/src/test/java/com/neph/features/auth/util/AuthValidationTest.kt
+++ b/android/app/src/test/java/com/neph/features/auth/util/AuthValidationTest.kt
@@ -1,0 +1,43 @@
+package com.neph.features.auth.util
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AuthValidationTest {
+    @Test
+    fun isValidEmail_acceptsComAndNonComDomains() {
+        val validEmails = listOf(
+            "user@example.com",
+            "user@example.net",
+            "user@example.org",
+            "user@example.edu",
+            "user@example.io",
+            "user@example.co.uk",
+            "first.last+tag@sub.domain.co.uk",
+            " user@trimmed.org "
+        )
+
+        validEmails.forEach { email ->
+            assertTrue("Expected valid email: $email", isValidEmail(email))
+        }
+    }
+
+    @Test
+    fun isValidEmail_rejectsInvalidFormats() {
+        val invalidEmails = listOf(
+            "",
+            "plainaddress",
+            "user@",
+            "@example.com",
+            "user@example",
+            "user@@example.com",
+            "user name@example.com",
+            "user@exa mple.com"
+        )
+
+        invalidEmails.forEach { email ->
+            assertFalse("Expected invalid email: $email", isValidEmail(email))
+        }
+    }
+}


### PR DESCRIPTION
Description  
This PR fixes mobile auth email validation that incorrectly blocked valid non-.com emails.

- Updates UI-side email validation to remove domain-extension bias.
- Ensures valid domains like .net, .org, .edu, .io, and .co.uk are accepted.
- Adds unit tests for valid non-.com emails and invalid formats.

Scope  
- Mobile auth validation utility only.
- No backend contract changes.

Closes #558 