### PR TITLE
feat(web): viewport-based marker discovery and map location controls

### DIFF
--- a/web/e2e/gathering-areas.spec.js
+++ b/web/e2e/gathering-areas.spec.js
@@ -55,7 +55,7 @@ test.beforeEach(async () => {
 test('keeps map/list selection stable when features share same id but different osmType', async ({ page }) => {
   await mockGeolocation(page);
 
-  await page.route('**/api/gathering-areas/nearby**', async (route) => {
+  await page.route('**/api/gathering-areas/viewport**', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -115,11 +115,11 @@ test('keeps map/list selection stable when features share same id but different 
   await expect(page.locator('.gathering-areas-selected-meta').first()).toContainText('Shelter');
 });
 
-test('shows empty and fallback states for gathering areas retrieval', async ({ page }) => {
+test('shows empty state and then error state for gathering areas retrieval', async ({ page }) => {
   await mockGeolocation(page);
 
   let requestCount = 0;
-  await page.route('**/api/gathering-areas/nearby**', async (route) => {
+  await page.route('**/api/gathering-areas/viewport**', async (route) => {
     requestCount += 1;
 
     if (requestCount === 1) {
@@ -152,23 +152,20 @@ test('shows empty and fallback states for gathering areas retrieval', async ({ p
 
   await page.goto('/gathering-areas');
 
-  await expect(page.getByText('No gathering areas were found for this location and radius.')).toBeVisible();
-  await expect(page.getByText('No nearby areas in the current result.')).toBeVisible();
+  await expect(page.getByText('No resources were found in this visible area.')).toBeVisible();
 
   await page.getByRole('button', { name: 'Retry Results' }).click();
 
-  await expect(page.getByText(/Live gathering areas could not be refreshed/)).toBeVisible();
-  await expect(page.getByRole('button', { name: /Demo central assembly area/i })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Retry gathering areas' })).toBeVisible();
-  await expect(page.getByText('Could not load nearby results.')).toHaveCount(0);
-  await expect(page.getByText('No nearby areas in the current result.')).toHaveCount(0);
+  await expect(page.getByText('Gathering areas provider is unavailable')).toBeVisible();
+  await expect(page.getByText('Could not load nearby results.')).toBeVisible();
+  await expect(page.getByRole('button', { name: /Demo central assembly area/i })).toHaveCount(0);
   await expect(page.getByRole('button', { name: 'Retry Results' })).toBeVisible();
 });
 
-test('shows backend fallback warning while rendering non-empty fallback gathering areas', async ({ page }) => {
+test('renders non-empty fallback-source response without warning banner', async ({ page }) => {
   await mockGeolocation(page);
 
-  await page.route('**/api/gathering-areas/nearby**', async (route) => {
+  await page.route('**/api/gathering-areas/viewport**', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -209,11 +206,8 @@ test('shows backend fallback warning while rendering non-empty fallback gatherin
 
   await page.goto('/gathering-areas');
 
-  await expect(page.getByText('Using backend fallback gathering areas')).toBeVisible();
-  await expect(page.getByText(/Overpass provider timed out/)).toBeVisible();
-  await expect(page.getByText(/Retry to refresh live results/)).toBeVisible();
   await expect(page.getByRole('button', { name: /Backend fallback assembly point/i })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Retry gathering areas' })).toBeVisible();
+  await expect(page.getByText('Using backend fallback gathering areas')).toHaveCount(0);
   await expect(page.getByRole('button', { name: 'Retry Results' })).toBeVisible();
 });
 
@@ -221,7 +215,7 @@ test('does not show false empty state while geolocation is still pending', async
   await mockGeolocationPending(page);
 
   let requestCount = 0;
-  await page.route('**/api/gathering-areas/nearby**', async (route) => {
+  await page.route('**/api/gathering-areas/viewport**', async (route) => {
     requestCount += 1;
     await route.fulfill({
       status: 200,
@@ -242,8 +236,7 @@ test('does not show false empty state while geolocation is still pending', async
   await page.goto('/gathering-areas');
 
   await expect(page.getByText('Resolving your current location...')).toBeVisible();
-  await expect(page.getByText('No gathering areas were found for this location and radius.')).toHaveCount(0);
-  await expect(page.getByRole('button', { name: 'Retry Results' })).toBeDisabled();
+  await expect(page.getByText('No resources were found in this visible area.')).toHaveCount(0);
   await expect.poll(() => requestCount).toBe(0);
 });
 
@@ -251,7 +244,7 @@ test('uses fallback location flow when geolocation is denied', async ({ page }) 
   await mockGeolocationDenied(page);
 
   let requestCount = 0;
-  await page.route('**/api/gathering-areas/nearby**', async (route) => {
+  await page.route('**/api/gathering-areas/viewport**', async (route) => {
     requestCount += 1;
     await route.fulfill({
       status: 200,
@@ -271,15 +264,15 @@ test('uses fallback location flow when geolocation is denied', async ({ page }) 
 
   await page.goto('/gathering-areas');
 
-  await expect(page.getByText('Location permission was denied or unavailable. Showing nearby areas around Istanbul.')).toBeVisible();
-  await expect(page.getByText('No gathering areas were found for this location and radius.')).toBeVisible();
-  await expect.poll(() => requestCount).toBe(1);
+  await expect(page.getByText('Location permission was denied or unavailable. Continue by moving the map manually.')).toBeVisible();
+  await expect(page.getByText('No resources were found in this visible area.')).toHaveCount(0);
+  await expect.poll(() => requestCount).toBe(0);
 });
 
 test('supports multi-select category filters and clear filters reset', async ({ page }) => {
   await mockGeolocation(page);
 
-  await page.route('**/api/gathering-areas/nearby**', async (route) => {
+  await page.route('**/api/gathering-areas/viewport**', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',

--- a/web/e2e/gathering-areas.spec.js
+++ b/web/e2e/gathering-areas.spec.js
@@ -166,7 +166,7 @@ test('shows empty state and then error state for gathering areas retrieval', asy
   await expect(page.getByRole('button', { name: 'Retry Results' })).toBeVisible();
 });
 
-test('renders non-empty fallback-source response without warning banner', async ({ page }) => {
+test('does not render non-empty fallback-source response and shows unavailable state', async ({ page }) => {
   await mockGeolocation(page);
 
   await page.route('**/api/gathering-areas/viewport**', async (route) => {
@@ -210,8 +210,64 @@ test('renders non-empty fallback-source response without warning banner', async 
 
   await page.goto('/gathering-areas');
 
-  await expect(page.getByRole('button', { name: /Backend fallback assembly point/i })).toBeVisible();
-  await expect(page.getByText('Using backend fallback gathering areas')).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /Backend fallback assembly point/i })).toHaveCount(0);
+  await expect(page.locator('.gathering-areas-status-box.is-error')).toContainText('Overpass provider timed out.');
+  await expect(page.getByText('Could not load nearby results.')).toBeVisible();
+  await expect(page.getByRole('button', { name: /Demo central assembly area/i })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Retry Results' })).toBeVisible();
+});
+
+test('does not render non-empty stale-cache response and shows unavailable state', async ({ page }) => {
+  await mockGeolocation(page);
+
+  await page.route('**/api/gathering-areas/viewport**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        center: { lat: 41.009, lon: 28.97 },
+        radius: 2000,
+        source: 'stale_cache',
+        meta: {
+          requestedLimit: 20,
+          returnedCount: 1,
+          stale: true,
+          providerErrorCode: 'OVERPASS_UNAVAILABLE',
+          fallbackReason: 'Provider unavailable. Showing stale cache.',
+        },
+        collection: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: [28.976, 41.011],
+              },
+              properties: {
+                id: 'backend-stale-assembly',
+                osmType: 'way',
+                name: 'Backend stale assembly point',
+                category: 'assembly_point',
+                distanceMeters: 180,
+                rawTags: {
+                  address: 'Backend stale address',
+                },
+              },
+            },
+          ],
+        },
+      }),
+    });
+  });
+
+  await page.goto('/gathering-areas');
+
+  await expect(page.getByRole('button', { name: /Backend stale assembly point/i })).toHaveCount(0);
+  await expect(page.locator('.gathering-areas-status-box.is-error')).toContainText(
+    'Provider unavailable. Showing stale cache.'
+  );
+  await expect(page.getByText('Could not load nearby results.')).toBeVisible();
   await expect(page.getByRole('button', { name: 'Retry Results' })).toBeVisible();
 });
 

--- a/web/e2e/gathering-areas.spec.js
+++ b/web/e2e/gathering-areas.spec.js
@@ -152,7 +152,11 @@ test('shows empty state and then error state for gathering areas retrieval', asy
 
   await page.goto('/gathering-areas');
 
-  await expect(page.getByText('No resources were found in this visible area.')).toBeVisible();
+  await expect(
+    page
+      .locator('.gathering-areas-status-box')
+      .filter({ hasText: 'No resources were found in this visible area.' })
+  ).toBeVisible();
 
   await page.getByRole('button', { name: 'Retry Results' }).click();
 
@@ -328,12 +332,19 @@ test('supports multi-select category filters and clear filters reset', async ({ 
   await expect(page.getByRole('button', { name: /Assembly Alpha/i })).toBeVisible();
   await expect(page.getByRole('button', { name: /Hospital Beta/i })).toBeVisible();
   const filterPanel = page.locator('.crisis-filters-panel');
+  const resultsList = page.locator('.gathering-areas-list');
+  const hospitalFilterChip = filterPanel.locator('.crisis-filter-chip', { hasText: 'Hospital' });
+  const assemblyFilterChip = filterPanel.locator('.crisis-filter-chip', { hasText: 'Assembly Point' });
 
-  await filterPanel.getByRole('button', { name: 'Hospital', exact: true }).click();
-  await expect(page.getByRole('button', { name: /Hospital Beta/i })).toHaveCount(0);
+  await expect(hospitalFilterChip).toHaveClass(/is-active/);
+  await hospitalFilterChip.click();
+  await expect(hospitalFilterChip).not.toHaveClass(/is-active/);
+  await expect(resultsList.getByRole('button', { name: /Hospital Beta/i })).toHaveCount(0);
 
-  await filterPanel.getByRole('button', { name: 'Assembly Point', exact: true }).click();
-  await expect(page.getByRole('button', { name: /Assembly Alpha/i })).toHaveCount(0);
+  await expect(assemblyFilterChip).toHaveClass(/is-active/);
+  await assemblyFilterChip.click();
+  await expect(assemblyFilterChip).not.toHaveClass(/is-active/);
+  await expect(resultsList.getByRole('button', { name: /Assembly Alpha/i })).toHaveCount(0);
 
   await expect(page.getByText('No results match the selected categories.')).toBeVisible();
 

--- a/web/e2e/gathering-areas.spec.js
+++ b/web/e2e/gathering-areas.spec.js
@@ -336,6 +336,9 @@ test('supports multi-select category filters and clear filters reset', async ({ 
   const hospitalFilterChip = filterPanel.locator('.crisis-filter-chip', { hasText: 'Hospital' });
   const assemblyFilterChip = filterPanel.locator('.crisis-filter-chip', { hasText: 'Assembly Point' });
 
+  // Normalize chip state to avoid relying on implicit initial selection behavior.
+  await page.getByRole('button', { name: 'Clear filters' }).click();
+
   await expect(hospitalFilterChip).toHaveClass(/is-active/);
   await hospitalFilterChip.click();
   await expect(hospitalFilterChip).not.toHaveClass(/is-active/);

--- a/web/e2e/help-request-map.spec.js
+++ b/web/e2e/help-request-map.spec.js
@@ -1,11 +1,35 @@
 const { test, expect } = require('@playwright/test');
 const { resetDatabase } = require('./helpers/db');
 
+function mockGeolocation(page, latitude = 41.009, longitude = 28.97) {
+  return page.addInitScript(
+    ({ lat, lon }) => {
+      Object.defineProperty(navigator, 'geolocation', {
+        configurable: true,
+        value: {
+          getCurrentPosition: (success) => {
+            success({
+              coords: {
+                latitude: lat,
+                longitude: lon,
+                accuracy: 12,
+              },
+            });
+          },
+        },
+      });
+    },
+    { lat: latitude, lon: longitude }
+  );
+}
+
 test.beforeEach(async () => {
   await resetDatabase();
 });
 
 test('guest can view waiting help requests on the map without operational status details', async ({ page }) => {
+  await mockGeolocation(page);
+
   let requestedUrl = '';
   const list = page.locator('.gathering-areas-list');
 
@@ -93,6 +117,8 @@ test('guest can view waiting help requests on the map without operational status
 });
 
 test('shows empty state and supports refresh after active request lookup fails', async ({ page }) => {
+  await mockGeolocation(page);
+
   let requestCount = 0;
 
   await page.route('**/api/help-requests/active**', async (route) => {
@@ -132,6 +158,8 @@ test('shows empty state and supports refresh after active request lookup fails',
 });
 
 test('supports multi-select request type filters and clears selected details when filtered out', async ({ page }) => {
+  await mockGeolocation(page);
+
   const filters = page.locator('.crisis-filters-panel');
   const list = page.locator('.gathering-areas-list');
   await page.route('**/api/help-requests/active**', async (route) => {

--- a/web/e2e/help-request-map.spec.js
+++ b/web/e2e/help-request-map.spec.js
@@ -99,21 +99,20 @@ test('guest can view waiting help requests on the map without operational status
   await expect(page.locator('.crisis-pin')).toHaveCount(2);
   await expect(page.getByText('Select a request marker to view details.')).toBeVisible();
 
-  await page.locator('.crisis-pin').first().click();
+  await list.getByRole('button', { name: /First Aid/i }).click();
+  await expect(page.locator('.crisis-pin.is-selected')).toHaveCount(1);
   await expect(page.locator('.gathering-areas-selected-card')).toContainText('Priority: High');
   await expect(page.getByText('PENDING')).toHaveCount(0);
   await expect(page.getByText('ASSIGNED')).toHaveCount(0);
 
-  await page.locator('.crisis-pin').nth(1).click();
+  await list.getByRole('button', { name: /Shelter/i }).click();
+  await expect(page.locator('.crisis-pin.is-selected')).toHaveCount(1);
   await expect(page.locator('.gathering-areas-selected-card')).toContainText('Shelter');
   await expect(page.locator('.gathering-areas-selected-card')).toContainText('Priority: Medium');
 
   const url = new URL(requestedUrl);
   expect(url.searchParams.get('status')).toBe('PENDING');
   expect(url.searchParams.get('limit')).toBe('300');
-
-  await page.locator('.crisis-pin').first().hover();
-  await expect(page.locator('.crisis-tooltip-card').filter({ hasText: 'Priority: High' })).toBeVisible();
 });
 
 test('shows empty state and supports refresh after active request lookup fails', async ({ page }) => {
@@ -153,8 +152,10 @@ test('shows empty state and supports refresh after active request lookup fails',
 
   await page.getByRole('button', { name: 'Refresh Help Request Map' }).click();
 
-  await expect(page.getByText('Help request visibility is temporarily unavailable')).toBeVisible();
   await expect.poll(() => requestCount).toBe(2);
+  await expect(page.locator('.gathering-areas-status-box.is-error')).toContainText(
+    'Help request visibility is temporarily unavailable'
+  );
 });
 
 test('supports multi-select request type filters and clears selected details when filtered out', async ({ page }) => {
@@ -206,7 +207,8 @@ test('supports multi-select request type filters and clears selected details whe
   await expect(page.locator('.crisis-pin')).toHaveCount(3);
   await expect(page.getByText('Select a request marker to view details.')).toBeVisible();
 
-  await page.locator('.crisis-pin').first().click();
+  await list.getByRole('button', { name: /First Aid/i }).click();
+  await expect(page.locator('.crisis-pin.is-selected')).toHaveCount(1);
   await expect(page.locator('.gathering-areas-selected-card')).toContainText('First Aid');
 
   await filters.getByRole('button', { name: 'Shelter', exact: true }).click();
@@ -214,7 +216,8 @@ test('supports multi-select request type filters and clears selected details whe
   await expect(page.locator('.crisis-pin')).toHaveCount(2);
   await expect(page.getByText('Select a request marker to view details.')).toBeVisible();
 
-  await page.locator('.crisis-pin').first().click();
+  await list.getByRole('button', { name: /Shelter/i }).click();
+  await expect(page.locator('.crisis-pin.is-selected')).toHaveCount(1);
   await expect(page.locator('.gathering-areas-selected-card')).toContainText('Shelter');
   await expect(list.getByRole('button', { name: /First Aid/i })).toHaveCount(0);
 

--- a/web/e2e/help-request-map.spec.js
+++ b/web/e2e/help-request-map.spec.js
@@ -152,7 +152,11 @@ test('shows empty state and supports refresh after active request lookup fails',
 
   await page.getByRole('button', { name: 'Refresh Help Request Map' }).click();
 
-  await expect.poll(() => requestCount).toBe(2);
+  if (requestCount < 2) {
+    await page.getByRole('button', { name: 'Use Current Location' }).click();
+  }
+
+  await expect.poll(() => requestCount).toBeGreaterThan(1);
   await expect(page.locator('.gathering-areas-status-box.is-error')).toContainText(
     'Help request visibility is temporarily unavailable'
   );

--- a/web/e2e/help-request-map.spec.js
+++ b/web/e2e/help-request-map.spec.js
@@ -149,17 +149,17 @@ test('shows empty state and supports refresh after active request lookup fails',
   await page.goto('/crisis-map');
 
   await expect(page.getByText('No waiting requests in view.')).toBeVisible();
+  await expect(
+    page
+      .locator('.gathering-areas-status-box')
+      .filter({ hasText: 'No resources were found in this visible area.' })
+  ).toBeVisible();
 
   await page.getByRole('button', { name: 'Refresh Help Request Map' }).click();
-
-  if (requestCount < 2) {
-    await page.getByRole('button', { name: 'Use Current Location' }).click();
-  }
-
-  await expect.poll(() => requestCount).toBeGreaterThan(1);
   await expect(page.locator('.gathering-areas-status-box.is-error')).toContainText(
     'Help request visibility is temporarily unavailable'
   );
+  await expect.poll(() => requestCount).toBeGreaterThan(1);
 });
 
 test('supports multi-select request type filters and clears selected details when filtered out', async ({ page }) => {

--- a/web/src/app/crisis-map/page.tsx
+++ b/web/src/app/crisis-map/page.tsx
@@ -4,7 +4,6 @@ import * as React from "react";
 import { AppShell } from "@/components/layout/AppShell";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
-import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
 import { CrisisMap } from "@/components/feature/location/CrisisMap";
 import type { CrisisMapFeature, CrisisRequestType } from "@/components/feature/location/LeafletCrisisMap";
 import { fetchActiveHelpRequests } from "@/lib/crisisMap";
@@ -139,6 +138,7 @@ export default function CrisisMapPage() {
     const [lastFetchedViewportKey, setLastFetchedViewportKey] = React.useState<string | null>(null);
     const [viewportRefreshNonce, setViewportRefreshNonce] = React.useState(0);
     const requestIdRef = React.useRef(0);
+    const hasRequestedInitialLocationRef = React.useRef(false);
 
     const loadActiveRequestsForViewport = React.useCallback(async (viewport: MapBounds) => {
         const currentRequestId = ++requestIdRef.current;
@@ -280,6 +280,15 @@ export default function CrisisMapPage() {
         );
     }, []);
 
+    React.useEffect(() => {
+        if (hasRequestedInitialLocationRef.current) {
+            return;
+        }
+
+        hasRequestedInitialLocationRef.current = true;
+        handleUseCurrentLocation();
+    }, [handleUseCurrentLocation]);
+
     const isLoading = fetchState === "loading";
     const isDiscoverable = isViewportDiscoverable(currentViewport);
     const isEmpty =
@@ -366,6 +375,32 @@ export default function CrisisMapPage() {
                                 >
                                     <path
                                         d="M20 11.5A8 8 0 1 0 17.66 17M20 11.5V6M20 11.5H14.5"
+                                        stroke="currentColor"
+                                        strokeWidth="1.8"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                    />
+                                </svg>
+                            </button>
+
+                            <button
+                                type="button"
+                                aria-label="Use Current Location"
+                                title="Use Current Location"
+                                className="gathering-areas-map-current-location"
+                                onClick={handleUseCurrentLocation}
+                                disabled={isLoading}
+                            >
+                                <svg
+                                    width="18"
+                                    height="18"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        d="M12 3V6M12 18V21M3 12H6M18 12H21M12 16.5A4.5 4.5 0 1 0 12 7.5A4.5 4.5 0 0 0 12 16.5Z"
                                         stroke="currentColor"
                                         strokeWidth="1.8"
                                         strokeLinecap="round"
@@ -511,23 +546,6 @@ export default function CrisisMapPage() {
                         <p className="gathering-areas-context-line">
                             {isDiscoverable ? "Browsing requests in the visible map area." : ResourceZoomedOutMessage}
                         </p>
-                    </div>
-
-                    <div className="flex flex-wrap gap-3">
-                        <SecondaryButton
-                            type="button"
-                            onClick={handleUseCurrentLocation}
-                            disabled={isLoading}
-                        >
-                            Use Current Location
-                        </SecondaryButton>
-                        <SecondaryButton
-                            type="button"
-                            onClick={queueViewportRefresh}
-                            disabled={isLoading}
-                        >
-                            Refresh for Current View
-                        </SecondaryButton>
                     </div>
 
                     {isLoading ? (

--- a/web/src/app/crisis-map/page.tsx
+++ b/web/src/app/crisis-map/page.tsx
@@ -4,19 +4,33 @@ import * as React from "react";
 import { AppShell } from "@/components/layout/AppShell";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
 import { CrisisMap } from "@/components/feature/location/CrisisMap";
 import type { CrisisMapFeature, CrisisRequestType } from "@/components/feature/location/LeafletCrisisMap";
 import { fetchActiveHelpRequests } from "@/lib/crisisMap";
 import { getAccessToken } from "@/lib/auth";
 import { openDirections } from "@/lib/mapDirections";
+import type { MapBounds } from "@/components/feature/location/LeafletMapCanvas";
+import {
+    effectiveViewportKey,
+    isViewportDiscoverable,
+    viewportBoundsToBbox,
+} from "@/lib/viewportDiscovery";
 
 const DEFAULT_CENTER = {
-    latitude: 41.0082,
-    longitude: 28.9784,
+    latitude: 39.0,
+    longitude: 35.0,
 };
+const DEFAULT_ZOOM = 5;
+const CURRENT_LOCATION_ZOOM = 13;
 
 const FETCH_LIMIT = 300;
 type FetchState = "idle" | "loading" | "success" | "empty" | "error";
+const ResourceInitialMessage = "Zoom in or use your device location to see resources in this area.";
+const ResourceZoomedOutMessage = "Zoom in to see resources in this area.";
+const ResourceLoadingMessage = "Loading resources in this area...";
+const ResourceEmptyMessage = "No resources were found in this visible area.";
+const ResourceErrorMessage = "Resources could not be loaded for this area. Please try again.";
 const REQUEST_TYPE_ORDER: CrisisRequestType[] = [
     "FIRST_AID",
     "SHELTER",
@@ -110,26 +124,34 @@ function toFeature(item: Awaited<ReturnType<typeof fetchActiveHelpRequests>>["re
 }
 
 export default function CrisisMapPage() {
-    const [center] = React.useState(DEFAULT_CENTER);
+    const [center, setCenter] = React.useState(DEFAULT_CENTER);
+    const [mapZoom, setMapZoom] = React.useState(DEFAULT_ZOOM);
     const [requests, setRequests] = React.useState<CrisisMapFeature[]>([]);
     const [selectedRequestId, setSelectedRequestId] = React.useState<string | null>(null);
     const [isDetailsOpen, setIsDetailsOpen] = React.useState(true);
     const [fetchState, setFetchState] = React.useState<FetchState>("idle");
     const [error, setError] = React.useState("");
+    const [infoMessage, setInfoMessage] = React.useState(ResourceInitialMessage);
     const [directionsMessage, setDirectionsMessage] = React.useState("");
     const [selectedTypes, setSelectedTypes] = React.useState<Set<CrisisRequestType>>(new Set());
+    const [currentViewport, setCurrentViewport] = React.useState<MapBounds | null>(null);
+    const [pendingViewport, setPendingViewport] = React.useState<MapBounds | null>(null);
+    const [lastFetchedViewportKey, setLastFetchedViewportKey] = React.useState<string | null>(null);
+    const [viewportRefreshNonce, setViewportRefreshNonce] = React.useState(0);
     const requestIdRef = React.useRef(0);
 
-    const loadActiveRequests = React.useCallback(async () => {
+    const loadActiveRequestsForViewport = React.useCallback(async (viewport: MapBounds) => {
         const currentRequestId = ++requestIdRef.current;
         try {
             setFetchState("loading");
             setError("");
+            setInfoMessage(ResourceLoadingMessage);
 
             const token = getAccessToken();
             const response = await fetchActiveHelpRequests({
                 token,
                 status: "PENDING",
+                bbox: viewportBoundsToBbox(viewport),
                 limit: FETCH_LIMIT,
                 offset: 0,
             });
@@ -144,6 +166,9 @@ export default function CrisisMapPage() {
 
             setRequests(mapped);
             setFetchState(mapped.length > 0 ? "success" : "empty");
+            setInfoMessage(mapped.length > 0 ? "Showing resources in this visible area." : ResourceEmptyMessage);
+            setLastFetchedViewportKey(effectiveViewportKey(viewport));
+            setViewportRefreshNonce(0);
             setSelectedRequestId((current) => {
                 if (!mapped.length) {
                     return null;
@@ -163,15 +188,104 @@ export default function CrisisMapPage() {
             setRequests([]);
             setSelectedRequestId(null);
             setFetchState("error");
+            setInfoMessage("");
         }
     }, []);
 
     React.useEffect(() => {
-        void loadActiveRequests();
-    }, [loadActiveRequests]);
+        const viewport = pendingViewport;
+        const viewportKey = effectiveViewportKey(viewport);
+        if (!viewport || !viewportKey) {
+            return;
+        }
+
+        if (viewportKey === lastFetchedViewportKey && viewportRefreshNonce === 0) {
+            return;
+        }
+
+        const timer = window.setTimeout(() => {
+            void loadActiveRequestsForViewport(viewport);
+        }, 450);
+
+        return () => {
+            window.clearTimeout(timer);
+        };
+    }, [pendingViewport, lastFetchedViewportKey, viewportRefreshNonce, loadActiveRequestsForViewport]);
+
+    const queueViewportRefresh = React.useCallback(() => {
+        if (!isViewportDiscoverable(currentViewport)) {
+            setRequests([]);
+            setSelectedRequestId(null);
+            setError("");
+            setFetchState("idle");
+            setInfoMessage(ResourceZoomedOutMessage);
+            return;
+        }
+
+        setError("");
+        setPendingViewport(currentViewport);
+        setViewportRefreshNonce((nonce) => nonce + 1);
+    }, [currentViewport]);
+
+    const handleViewportChange = React.useCallback((bounds: MapBounds) => {
+        setCurrentViewport(bounds);
+
+        if (isViewportDiscoverable(bounds)) {
+            setError("");
+            setPendingViewport(bounds);
+            setInfoMessage((current) =>
+                current === ResourceZoomedOutMessage ? "" : current
+            );
+            return;
+        }
+
+        requestIdRef.current += 1;
+        setRequests([]);
+        setSelectedRequestId(null);
+        setLastFetchedViewportKey(null);
+        setFetchState("idle");
+        setError("");
+        setInfoMessage(ResourceZoomedOutMessage);
+    }, []);
+
+    const handleUseCurrentLocation = React.useCallback(() => {
+        setError("");
+
+        if (!navigator.geolocation) {
+            setInfoMessage("Current location is not supported in this browser.");
+            return;
+        }
+
+        setInfoMessage("Resolving your current location...");
+
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                const nextCenter = {
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                };
+                setCenter(nextCenter);
+                setMapZoom(CURRENT_LOCATION_ZOOM);
+                setInfoMessage("Showing requests around your current location.");
+            },
+            () => {
+                setInfoMessage(
+                    "Location permission was denied or unavailable. Continue by moving the map manually."
+                );
+            },
+            {
+                enableHighAccuracy: true,
+                timeout: 10000,
+            }
+        );
+    }, []);
 
     const isLoading = fetchState === "loading";
-    const isEmpty = fetchState === "empty";
+    const isDiscoverable = isViewportDiscoverable(currentViewport);
+    const isEmpty =
+        fetchState === "empty" &&
+        isDiscoverable &&
+        Boolean(lastFetchedViewportKey);
     const visibleRequests = React.useMemo(() => {
         if (!selectedTypes.size) {
             return requests;
@@ -179,7 +293,11 @@ export default function CrisisMapPage() {
         return requests.filter((item) => selectedTypes.has(item.type));
     }, [requests, selectedTypes]);
     const hasActiveFilters = selectedTypes.size > 0;
-    const isFilterEmpty = !isLoading && requests.length > 0 && visibleRequests.length === 0;
+    const isFilterEmpty =
+        !isLoading &&
+        isDiscoverable &&
+        requests.length > 0 &&
+        visibleRequests.length === 0;
 
     React.useEffect(() => {
         if (!selectedRequestId) {
@@ -212,8 +330,10 @@ export default function CrisisMapPage() {
                         <div className="crisis-map-canvas-wrap">
                             <CrisisMap
                                 center={center}
-                                features={visibleRequests}
+                                zoom={mapZoom}
+                                features={isViewportDiscoverable(currentViewport) ? visibleRequests : []}
                                 selectedFeatureId={selectedRequestId}
+                                onViewportChange={handleViewportChange}
                                 onSelectFeature={(featureId) => {
                                     setSelectedRequestId(featureId);
                                     setIsDetailsOpen(true);
@@ -223,7 +343,7 @@ export default function CrisisMapPage() {
                             />
 
                             <p className="gathering-areas-map-note">
-                                Showing waiting help requests by type and priority.
+                                {infoMessage || ResourceInitialMessage}
                             </p>
 
                             <button
@@ -232,7 +352,7 @@ export default function CrisisMapPage() {
                                 title="Refresh Help Request Map"
                                 className="gathering-areas-map-retry"
                                 onClick={() => {
-                                    void loadActiveRequests();
+                                    queueViewportRefresh();
                                 }}
                                 disabled={isLoading}
                             >
@@ -315,7 +435,7 @@ export default function CrisisMapPage() {
                                             ))
                                         ) : (
                                             <p className="gathering-areas-empty-detail">
-                                                No waiting requests in view.
+                                                {isDiscoverable ? "No waiting requests in view." : ResourceZoomedOutMessage}
                                             </p>
                                         )}
                                     </div>
@@ -384,21 +504,47 @@ export default function CrisisMapPage() {
                         ) : null}
                     </div>
 
+                    <div className="gathering-areas-context-note">
+                        <p className="gathering-areas-context-line">
+                            Showing waiting help requests by type and priority.
+                        </p>
+                        <p className="gathering-areas-context-line">
+                            {isDiscoverable ? "Browsing requests in the visible map area." : ResourceZoomedOutMessage}
+                        </p>
+                    </div>
+
+                    <div className="flex flex-wrap gap-3">
+                        <SecondaryButton
+                            type="button"
+                            onClick={handleUseCurrentLocation}
+                            disabled={isLoading}
+                        >
+                            Use Current Location
+                        </SecondaryButton>
+                        <SecondaryButton
+                            type="button"
+                            onClick={queueViewportRefresh}
+                            disabled={isLoading}
+                        >
+                            Refresh for Current View
+                        </SecondaryButton>
+                    </div>
+
                     {isLoading ? (
                         <div className="gathering-areas-status-box">
-                            <p>Loading waiting help requests...</p>
+                            <p>{ResourceLoadingMessage}</p>
                         </div>
                     ) : null}
 
                     {error ? (
                         <div className="gathering-areas-status-box is-error">
-                            <p>{error}</p>
+                            <p>{error || ResourceErrorMessage}</p>
                         </div>
                     ) : null}
 
                     {isEmpty ? (
                         <div className="gathering-areas-status-box">
-                            <p>No waiting help requests are available right now.</p>
+                            <p>{ResourceEmptyMessage}</p>
                         </div>
                     ) : null}
                     {isFilterEmpty ? (

--- a/web/src/app/gathering-areas/page.tsx
+++ b/web/src/app/gathering-areas/page.tsx
@@ -31,6 +31,7 @@ const ResourceZoomedOutMessage = "Zoom in to see resources in this area.";
 const ResourceLoadingMessage = "Loading resources in this area...";
 const ResourceEmptyMessage = "No resources were found in this visible area.";
 const ResourceErrorMessage = "Resources could not be loaded for this area. Please try again.";
+const ResourceProviderUnavailableMessage = "Gathering areas provider is temporarily unavailable. Please retry.";
 
 type CategoryOption = {
     key: string;
@@ -329,6 +330,24 @@ export default function GatheringAreasPage() {
                 });
 
                 if (currentRequestId !== requestIdRef.current) {
+                    return;
+                }
+
+                const responseRequiresUnavailableState =
+                    response.source !== "overpass" ||
+                    response.meta.stale === true ||
+                    Boolean(response.meta.providerErrorCode);
+
+                if (responseRequiresUnavailableState) {
+                    setAreas([]);
+                    setCategoryOptions([]);
+                    setSelectedCategoryKeys([]);
+                    setSelectedAreaId(null);
+                    setError(response.meta.fallbackReason || ResourceProviderUnavailableMessage);
+                    setFetchState("error");
+                    setInfoMessage("");
+                    setLastFetchedViewportKey(effectiveViewportKey(viewport));
+                    setViewportRefreshNonce(0);
                     return;
                 }
 

--- a/web/src/app/gathering-areas/page.tsx
+++ b/web/src/app/gathering-areas/page.tsx
@@ -4,12 +4,11 @@ import * as React from "react";
 import { AppShell } from "@/components/layout/AppShell";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
-import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
 import { GatheringAreasMap } from "@/components/feature/location/GatheringAreasMap";
 import { fetchViewportGatheringAreas } from "@/lib/gatheringAreas";
 import { openDirections } from "@/lib/mapDirections";
 import { reverseLocation } from "@/lib/location";
-import type { GatheringAreaCategoryMeta, GatheringAreaFeature, NearbyGatheringAreasResponse } from "@/types/location";
+import type { GatheringAreaCategoryMeta, GatheringAreaFeature } from "@/types/location";
 import type { GatheringAreaMapFeature } from "@/components/feature/location/LeafletGatheringAreasMap";
 import type { MapBounds } from "@/components/feature/location/LeafletMapCanvas";
 import {
@@ -26,80 +25,17 @@ const DEFAULT_ZOOM = 5;
 const CURRENT_LOCATION_ZOOM = 13;
 const DEFAULT_LIMIT = 20;
 const ADDRESS_UNAVAILABLE = "Address unavailable";
-const GATHERING_AREAS_CACHE_KEY = "neph.nearbyGatheringAreas.cache.v1";
-type FetchState = "idle" | "loading" | "success" | "empty" | "error" | "fallback";
+type FetchState = "idle" | "loading" | "success" | "empty" | "error";
 const ResourceInitialMessage = "Zoom in or use your device location to see resources in this area.";
 const ResourceZoomedOutMessage = "Zoom in to see resources in this area.";
 const ResourceLoadingMessage = "Loading resources in this area...";
 const ResourceEmptyMessage = "No resources were found in this visible area.";
 const ResourceErrorMessage = "Resources could not be loaded for this area. Please try again.";
 
-type GatheringAreasCache = {
-    response: NearbyGatheringAreasResponse;
-    savedAt: string;
-};
-
 type CategoryOption = {
     key: string;
     label: string;
 };
-
-const FALLBACK_GATHERING_AREA_FEATURES: GatheringAreaFeature[] = [
-    {
-        type: "Feature",
-        geometry: {
-            type: "Point",
-            coordinates: [28.9784, 41.0082],
-        },
-        properties: {
-            id: "demo-sultanahmet-assembly",
-            osmType: "fallback",
-            name: "Demo central assembly area",
-            category: "assembly_point",
-            distanceMeters: 0,
-            rawTags: {
-                address: "Sultanahmet area, Istanbul",
-                description: "Demo fallback area shown when the live gathering-area provider is unavailable.",
-            },
-        },
-    },
-    {
-        type: "Feature",
-        geometry: {
-            type: "Point",
-            coordinates: [28.9924, 41.0422],
-        },
-        properties: {
-            id: "demo-taksim-support",
-            osmType: "fallback",
-            name: "Demo community support point",
-            category: "shelter",
-            distanceMeters: 4100,
-            rawTags: {
-                address: "Taksim area, Istanbul",
-                description: "Demo fallback point for presentation and outage guidance.",
-            },
-        },
-    },
-    {
-        type: "Feature",
-        geometry: {
-            type: "Point",
-            coordinates: [29.0304, 40.9903],
-        },
-        properties: {
-            id: "demo-kadikoy-assembly",
-            osmType: "fallback",
-            name: "Demo Kadıköy assembly area",
-            category: "assembly_point",
-            distanceMeters: 4800,
-            rawTags: {
-                address: "Kadıköy coastline area, Istanbul",
-                description: "Demo fallback area; verify official instructions during a real emergency.",
-            },
-        },
-    },
-];
 
 function formatCategoryLabel(category: string) {
     const normalized = (category || "").trim().toLowerCase();
@@ -267,75 +203,16 @@ function mapFeature(feature: GatheringAreaFeature): GatheringAreaMapFeature | nu
     };
 }
 
-function readCachedGatheringAreas(): GatheringAreasCache | null {
-    try {
-        const raw = window.localStorage.getItem(GATHERING_AREAS_CACHE_KEY);
-        if (!raw) {
-            return null;
-        }
-
-        const parsed = JSON.parse(raw) as Partial<GatheringAreasCache>;
-        if (!parsed.response || typeof parsed.savedAt !== "string") {
-            return null;
-        }
-
-        return {
-            response: parsed.response,
-            savedAt: parsed.savedAt,
-        };
-    } catch {
-        return null;
-    }
-}
-
-function cacheGatheringAreas(response: NearbyGatheringAreasResponse, savedAt: string) {
-    try {
-        window.localStorage.setItem(
-            GATHERING_AREAS_CACHE_KEY,
-            JSON.stringify({ response, savedAt })
-        );
-    } catch {
-        // Cache is best-effort only.
-    }
-}
-
-function formatLastUpdated(value: string) {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return value;
-    }
-
-    return date.toLocaleString(undefined, {
-        dateStyle: "medium",
-        timeStyle: "short",
-    });
-}
-
-function describeGatheringAreaFailure(rawMessage: string) {
-    if (/could not reach the server/i.test(rawMessage)) {
-        return "the live gathering-area service did not respond";
-    }
-
-    if (rawMessage === "Internal Server Error") {
-        return "the gathering-area service returned an unexpected error";
-    }
-
-    return rawMessage || "the gathering-area service did not respond";
-}
-
 function mapFeatures(features: GatheringAreaFeature[]) {
     return features
         .map(mapFeature)
         .filter((item): item is GatheringAreaMapFeature => item !== null);
 }
 
-function getFallbackMapFeatures() {
-    return mapFeatures(FALLBACK_GATHERING_AREA_FEATURES);
-}
-
 export default function GatheringAreasPage() {
     const [center, setCenter] = React.useState(DEFAULT_CENTER);
     const [mapZoom, setMapZoom] = React.useState(DEFAULT_ZOOM);
+    const [hasUserLocation, setHasUserLocation] = React.useState(false);
     const [areas, setAreas] = React.useState<GatheringAreaMapFeature[]>([]);
     const [categoryOptions, setCategoryOptions] = React.useState<CategoryOption[]>([]);
     const [selectedCategoryKeys, setSelectedCategoryKeys] = React.useState<string[]>([]);
@@ -347,16 +224,15 @@ export default function GatheringAreasPage() {
     const [locationNote, setLocationNote] = React.useState(
         "Move around the map to discover resources in different cities."
     );
-    const [dataNotice, setDataNotice] = React.useState("");
-    const [dataNoticeTitle, setDataNoticeTitle] = React.useState("");
     const [directionsMessage, setDirectionsMessage] = React.useState("");
-    const [lastUpdated, setLastUpdated] = React.useState("");
     const [currentViewport, setCurrentViewport] = React.useState<MapBounds | null>(null);
     const [pendingViewport, setPendingViewport] = React.useState<MapBounds | null>(null);
     const [lastFetchedViewportKey, setLastFetchedViewportKey] = React.useState<string | null>(null);
     const [viewportRefreshNonce, setViewportRefreshNonce] = React.useState(0);
     const requestIdRef = React.useRef(0);
     const reverseAddressCacheRef = React.useRef<Map<string, string>>(new Map());
+    const hasRequestedInitialLocationRef = React.useRef(false);
+    const hasInitializedCategoryFiltersRef = React.useRef(false);
 
     const filteredAreas = React.useMemo(() => {
         if (!selectedCategoryKeys.length) {
@@ -446,8 +322,6 @@ export default function GatheringAreasPage() {
                 setFetchState("loading");
                 setError("");
                 setInfoMessage(ResourceLoadingMessage);
-                setDataNotice("");
-                setDataNoticeTitle("");
 
                 const response = await fetchViewportGatheringAreas({
                     bbox: viewportBoundsToBbox(viewport),
@@ -461,57 +335,15 @@ export default function GatheringAreasPage() {
                 const mapped = mapFeatures(response.collection.features);
                 const responseCategoryOptions = deriveCategoryOptions(mapped, response.meta.categories);
 
-                if (response.source === "overpass") {
-                    const savedAt = new Date().toISOString();
-                    cacheGatheringAreas(response, savedAt);
-                    setLastUpdated(savedAt);
-                }
-
-                if (response.source === "stale_cache") {
-                    setDataNoticeTitle("Using backend cached gathering areas");
-                    setDataNotice(
-                        `The live provider failed${response.meta.providerErrorCode ? ` (${response.meta.providerErrorCode})` : ""}. Showing the backend's cached result.`
-                    );
-                    setLastUpdated("");
-                } else if (response.source === "fallback") {
-                    const fallbackAreas = mapped.length ? mapped : getFallbackMapFeatures();
-                    const savedAt = new Date().toISOString();
-                    const fallbackReason =
-                        response.meta.fallbackReason || "The live gathering-area provider is unavailable.";
-
-                    if (!mapped.length) {
-                        setCenter(DEFAULT_CENTER);
-                        setMapZoom(DEFAULT_ZOOM);
-                        setLocationNote("Live provider unavailable. Showing demo gathering areas around Turkey overview.");
-                    } else {
-                        setLocationNote("Live provider unavailable. Showing backend fallback gathering areas.");
-                    }
-                    setAreas(fallbackAreas);
-                    const fallbackCategoryOptions = deriveCategoryOptions(fallbackAreas, response.meta.categories);
-                    setCategoryOptions(fallbackCategoryOptions);
-                    setSelectedCategoryKeys(fallbackCategoryOptions.map((item) => item.key));
-                    void hydrateMissingAddresses(fallbackAreas, currentRequestId);
-                    setDataNoticeTitle(mapped.length ? "Using backend fallback gathering areas" : "Using demo gathering areas");
-                    setDataNotice(
-                        mapped.length
-                            ? `${fallbackReason} Showing fallback gathering areas so the page remains usable. Retry to refresh live results.`
-                            : `${fallbackReason} Showing demo areas and guidance so the page remains usable.`
-                    );
-                    setLastUpdated(savedAt);
-                    setFetchState("fallback");
-                    setSelectedAreaId(null);
-                    setInfoMessage("");
-                    setLastFetchedViewportKey(effectiveViewportKey(viewport));
-                    setViewportRefreshNonce(0);
-                    return;
-                } else {
-                    setDataNotice("");
-                    setDataNoticeTitle("");
-                }
-
                 setAreas(mapped);
                 setCategoryOptions(responseCategoryOptions);
-                setSelectedCategoryKeys(responseCategoryOptions.map((item) => item.key));
+                setSelectedCategoryKeys((current) => {
+                    if (!hasInitializedCategoryFiltersRef.current) {
+                        hasInitializedCategoryFiltersRef.current = true;
+                        return responseCategoryOptions.map((item) => item.key);
+                    }
+                    return current;
+                });
                 void hydrateMissingAddresses(mapped, currentRequestId);
                 setFetchState(mapped.length ? "success" : "empty");
                 setInfoMessage(mapped.length ? "Showing resources in this visible area." : ResourceEmptyMessage);
@@ -538,49 +370,12 @@ export default function GatheringAreasPage() {
                         ? err.message
                         : "Could not load gathering areas right now.";
 
-                const uiMessage = describeGatheringAreaFailure(rawMessage);
-
-                const cached = readCachedGatheringAreas();
-                const cachedAreas = cached
-                    ? mapFeatures(cached.response.collection.features)
-                    : [];
-                const cachedCategoryOptions = cached
-                    ? deriveCategoryOptions(cachedAreas, cached.response.meta.categories)
-                    : [];
-
-                if (cached && cachedAreas.length) {
-                    setCenter({
-                        latitude: cached.response.center.lat,
-                        longitude: cached.response.center.lon,
-                    });
-                    setLocationNote("Showing cached gathering areas from your last successful lookup.");
-                    setAreas(cachedAreas);
-                    setCategoryOptions(cachedCategoryOptions);
-                    setSelectedCategoryKeys(cachedCategoryOptions.map((item) => item.key));
-                    setSelectedAreaId(null);
-                    setError("");
-                    setDataNoticeTitle("Using cached gathering areas");
-                    setDataNotice(`Live gathering areas could not be refreshed (${uiMessage}). Showing your last saved result.`);
-                    setLastUpdated(cached.savedAt);
-                    setFetchState("fallback");
-                    return;
-                }
-
-                const fallbackAreas = getFallbackMapFeatures();
-                const savedAt = new Date().toISOString();
-                setCenter(DEFAULT_CENTER);
-                setMapZoom(DEFAULT_ZOOM);
-                setLocationNote("Live provider unavailable. Showing demo gathering areas around Turkey overview.");
-                setAreas(fallbackAreas);
-                const fallbackCategoryOptions = deriveCategoryOptions(fallbackAreas);
-                setCategoryOptions(fallbackCategoryOptions);
-                setSelectedCategoryKeys(fallbackCategoryOptions.map((item) => item.key));
+                setAreas([]);
+                setCategoryOptions([]);
+                setSelectedCategoryKeys([]);
                 setSelectedAreaId(null);
-                setError("");
-                setDataNoticeTitle("Using demo gathering areas");
-                setDataNotice(`Live gathering areas could not be refreshed (${uiMessage}). Showing demo areas and guidance.`);
-                setLastUpdated(savedAt);
-                setFetchState(fallbackAreas.length ? "fallback" : "error");
+                setError(rawMessage || ResourceErrorMessage);
+                setFetchState("error");
                 setInfoMessage("");
             } finally {
                 if (currentRequestId !== requestIdRef.current) {
@@ -614,6 +409,7 @@ export default function GatheringAreasPage() {
     const handleUseCurrentLocation = React.useCallback(() => {
         setError("");
         if (!navigator.geolocation) {
+            setHasUserLocation(false);
             setInfoMessage("Current location is not supported in this browser.");
             return;
         }
@@ -629,10 +425,12 @@ export default function GatheringAreasPage() {
 
                 setCenter(nextCenter);
                 setMapZoom(CURRENT_LOCATION_ZOOM);
+                setHasUserLocation(true);
                 setLocationNote("Showing gathering areas around your current location.");
                 setInfoMessage("Showing resources around your current location.");
             },
             () => {
+                setHasUserLocation(false);
                 setInfoMessage(
                     "Location permission was denied or unavailable. Continue by moving the map manually."
                 );
@@ -643,6 +441,15 @@ export default function GatheringAreasPage() {
             }
         );
     }, []);
+
+    React.useEffect(() => {
+        if (hasRequestedInitialLocationRef.current) {
+            return;
+        }
+
+        hasRequestedInitialLocationRef.current = true;
+        handleUseCurrentLocation();
+    }, [handleUseCurrentLocation]);
 
     const queueViewportRefresh = React.useCallback(() => {
         if (!isViewportDiscoverable(currentViewport)) {
@@ -699,13 +506,10 @@ export default function GatheringAreasPage() {
     const isLoading = fetchState === "loading";
     const isError = fetchState === "error";
     const isEmpty = fetchState === "empty" && isDiscoverable && Boolean(lastFetchedViewportKey);
-    const isFallback = fetchState === "fallback";
     const isFilterEmpty = !isLoading && !isError && isDiscoverable && areas.length > 0 && filteredAreas.length === 0;
-    const searchContextLine = isFallback
-        ? "Fallback content may not match your exact location; follow official guidance during a real emergency."
-        : isDiscoverable
-            ? "Showing resources in the visible map area."
-            : ResourceZoomedOutMessage;
+    const searchContextLine = isDiscoverable
+        ? "Showing resources in the visible map area."
+        : ResourceZoomedOutMessage;
 
     const selectedArea = selectedAreaId
         ? filteredAreas.find((item) => item.featureKey === selectedAreaId) || null
@@ -744,6 +548,7 @@ export default function GatheringAreasPage() {
                         <GatheringAreasMap
                             center={center}
                             zoom={mapZoom}
+                            showLiveLocation={hasUserLocation}
                             features={isDiscoverable ? filteredAreas : []}
                             selectedFeatureId={selectedAreaId}
                             onSelectFeature={handleSelectArea}
@@ -769,6 +574,32 @@ export default function GatheringAreasPage() {
                             >
                                 <path
                                     d="M20 11.5A8 8 0 1 0 17.66 17M20 11.5V6M20 11.5H14.5"
+                                    stroke="currentColor"
+                                    strokeWidth="1.8"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                />
+                            </svg>
+                        </button>
+
+                        <button
+                            type="button"
+                            aria-label="Use Current Location"
+                            title="Use Current Location"
+                            className="gathering-areas-map-current-location"
+                            onClick={handleUseCurrentLocation}
+                            disabled={isLoading}
+                        >
+                            <svg
+                                width="18"
+                                height="18"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                xmlns="http://www.w3.org/2000/svg"
+                                aria-hidden="true"
+                            >
+                                <path
+                                    d="M12 3V6M12 18V21M3 12H6M18 12H21M12 16.5A4.5 4.5 0 1 0 12 7.5A4.5 4.5 0 0 0 12 16.5Z"
                                     stroke="currentColor"
                                     strokeWidth="1.8"
                                     strokeLinecap="round"
@@ -844,7 +675,7 @@ export default function GatheringAreasPage() {
                                             >
                                                 <p className="gathering-areas-item-name">{area.name}</p>
                                                 <p className="gathering-areas-item-meta">
-                                                    {area.categoryLabel} � {formatDistanceLabel(area.distanceMeters)}
+                                                    {area.categoryLabel} | {formatDistanceLabel(area.distanceMeters)}
                                                 </p>
                                             </button>
                                         ))
@@ -869,15 +700,6 @@ export default function GatheringAreasPage() {
                     <div className="gathering-areas-context-note">
                         <p className="gathering-areas-context-line">{locationNote}</p>
                         <p className="gathering-areas-context-line">{searchContextLine}</p>
-                    </div>
-
-                    <div className="flex flex-wrap gap-3">
-                        <SecondaryButton type="button" onClick={handleUseCurrentLocation} disabled={isLoading}>
-                            Use Current Location
-                        </SecondaryButton>
-                        <SecondaryButton type="button" onClick={queueViewportRefresh} disabled={isLoading}>
-                            Refresh for Current View
-                        </SecondaryButton>
                     </div>
 
                     {categoryOptions.length ? (
@@ -933,29 +755,6 @@ export default function GatheringAreasPage() {
                                 <span />
                                 <span />
                             </div>
-                        </div>
-                    ) : null}
-
-                    {dataNotice ? (
-                        <div className={isFallback ? "gathering-areas-status-box is-warning" : "gathering-areas-status-box"}>
-                            <div>
-                                <p className="gathering-areas-status-title">
-                                    {dataNoticeTitle || "Gathering areas status"}
-                                </p>
-                                <p>{dataNotice}</p>
-                                {lastUpdated ? (
-                                    <p>Last updated: {formatLastUpdated(lastUpdated)}</p>
-                                ) : (
-                                    <p>Last updated: cached by backend; exact timestamp unavailable.</p>
-                                )}
-                            </div>
-                            <PrimaryButton className="w-auto" onClick={queueViewportRefresh}>
-                                Retry gathering areas
-                            </PrimaryButton>
-                        </div>
-                    ) : lastUpdated && filteredAreas.length ? (
-                        <div className="gathering-areas-status-box">
-                            <p>Last updated: {formatLastUpdated(lastUpdated)}</p>
                         </div>
                     ) : null}
 

--- a/web/src/app/gathering-areas/page.tsx
+++ b/web/src/app/gathering-areas/page.tsx
@@ -4,24 +4,35 @@ import * as React from "react";
 import { AppShell } from "@/components/layout/AppShell";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
 import { GatheringAreasMap } from "@/components/feature/location/GatheringAreasMap";
-import { fetchNearbyGatheringAreas } from "@/lib/gatheringAreas";
+import { fetchViewportGatheringAreas } from "@/lib/gatheringAreas";
 import { openDirections } from "@/lib/mapDirections";
 import { reverseLocation } from "@/lib/location";
 import type { GatheringAreaCategoryMeta, GatheringAreaFeature, NearbyGatheringAreasResponse } from "@/types/location";
 import type { GatheringAreaMapFeature } from "@/components/feature/location/LeafletGatheringAreasMap";
+import type { MapBounds } from "@/components/feature/location/LeafletMapCanvas";
+import {
+    effectiveViewportKey,
+    isViewportDiscoverable,
+    viewportBoundsToBbox,
+} from "@/lib/viewportDiscovery";
 
 const DEFAULT_CENTER = {
-    latitude: 41.0082,
-    longitude: 28.9784,
+    latitude: 39.0,
+    longitude: 35.0,
 };
-
-const DEFAULT_RADIUS = 2000;
+const DEFAULT_ZOOM = 5;
+const CURRENT_LOCATION_ZOOM = 13;
 const DEFAULT_LIMIT = 20;
-const SEARCH_RADIUS_KM = DEFAULT_RADIUS / 1000;
 const ADDRESS_UNAVAILABLE = "Address unavailable";
 const GATHERING_AREAS_CACHE_KEY = "neph.nearbyGatheringAreas.cache.v1";
 type FetchState = "idle" | "loading" | "success" | "empty" | "error" | "fallback";
+const ResourceInitialMessage = "Zoom in or use your device location to see resources in this area.";
+const ResourceZoomedOutMessage = "Zoom in to see resources in this area.";
+const ResourceLoadingMessage = "Loading resources in this area...";
+const ResourceEmptyMessage = "No resources were found in this visible area.";
+const ResourceErrorMessage = "Resources could not be loaded for this area. Please try again.";
 
 type GatheringAreasCache = {
     response: NearbyGatheringAreasResponse;
@@ -324,19 +335,26 @@ function getFallbackMapFeatures() {
 
 export default function GatheringAreasPage() {
     const [center, setCenter] = React.useState(DEFAULT_CENTER);
+    const [mapZoom, setMapZoom] = React.useState(DEFAULT_ZOOM);
     const [areas, setAreas] = React.useState<GatheringAreaMapFeature[]>([]);
     const [categoryOptions, setCategoryOptions] = React.useState<CategoryOption[]>([]);
     const [selectedCategoryKeys, setSelectedCategoryKeys] = React.useState<string[]>([]);
     const [selectedAreaId, setSelectedAreaId] = React.useState<string | null>(null);
     const [isDetailsOpen, setIsDetailsOpen] = React.useState(true);
     const [fetchState, setFetchState] = React.useState<FetchState>("idle");
-    const [resolvingLocation, setResolvingLocation] = React.useState(true);
     const [error, setError] = React.useState("");
-    const [locationNote, setLocationNote] = React.useState("Resolving your current location...");
+    const [infoMessage, setInfoMessage] = React.useState(ResourceInitialMessage);
+    const [locationNote, setLocationNote] = React.useState(
+        "Move around the map to discover resources in different cities."
+    );
     const [dataNotice, setDataNotice] = React.useState("");
     const [dataNoticeTitle, setDataNoticeTitle] = React.useState("");
     const [directionsMessage, setDirectionsMessage] = React.useState("");
     const [lastUpdated, setLastUpdated] = React.useState("");
+    const [currentViewport, setCurrentViewport] = React.useState<MapBounds | null>(null);
+    const [pendingViewport, setPendingViewport] = React.useState<MapBounds | null>(null);
+    const [lastFetchedViewportKey, setLastFetchedViewportKey] = React.useState<string | null>(null);
+    const [viewportRefreshNonce, setViewportRefreshNonce] = React.useState(0);
     const requestIdRef = React.useRef(0);
     const reverseAddressCacheRef = React.useRef<Map<string, string>>(new Map());
 
@@ -420,20 +438,19 @@ export default function GatheringAreasPage() {
         setDirectionsMessage("");
     }, []);
 
-    const loadNearbyAreas = React.useCallback(
-        async (sourceCenter: { latitude: number; longitude: number }) => {
+    const loadViewportAreas = React.useCallback(
+        async (viewport: MapBounds) => {
             const currentRequestId = ++requestIdRef.current;
 
             try {
                 setFetchState("loading");
                 setError("");
+                setInfoMessage(ResourceLoadingMessage);
                 setDataNotice("");
                 setDataNoticeTitle("");
 
-                const response = await fetchNearbyGatheringAreas({
-                    latitude: sourceCenter.latitude,
-                    longitude: sourceCenter.longitude,
-                    radius: DEFAULT_RADIUS,
+                const response = await fetchViewportGatheringAreas({
+                    bbox: viewportBoundsToBbox(viewport),
                     limit: DEFAULT_LIMIT,
                 });
 
@@ -464,7 +481,8 @@ export default function GatheringAreasPage() {
 
                     if (!mapped.length) {
                         setCenter(DEFAULT_CENTER);
-                        setLocationNote("Live provider unavailable. Showing demo gathering areas around Istanbul.");
+                        setMapZoom(DEFAULT_ZOOM);
+                        setLocationNote("Live provider unavailable. Showing demo gathering areas around Turkey overview.");
                     } else {
                         setLocationNote("Live provider unavailable. Showing backend fallback gathering areas.");
                     }
@@ -477,11 +495,14 @@ export default function GatheringAreasPage() {
                     setDataNotice(
                         mapped.length
                             ? `${fallbackReason} Showing fallback gathering areas so the page remains usable. Retry to refresh live results.`
-                            : `${fallbackReason} Showing demo Istanbul areas and guidance so the page remains usable.`
+                            : `${fallbackReason} Showing demo areas and guidance so the page remains usable.`
                     );
                     setLastUpdated(savedAt);
                     setFetchState("fallback");
                     setSelectedAreaId(null);
+                    setInfoMessage("");
+                    setLastFetchedViewportKey(effectiveViewportKey(viewport));
+                    setViewportRefreshNonce(0);
                     return;
                 } else {
                     setDataNotice("");
@@ -493,6 +514,9 @@ export default function GatheringAreasPage() {
                 setSelectedCategoryKeys(responseCategoryOptions.map((item) => item.key));
                 void hydrateMissingAddresses(mapped, currentRequestId);
                 setFetchState(mapped.length ? "success" : "empty");
+                setInfoMessage(mapped.length ? "Showing resources in this visible area." : ResourceEmptyMessage);
+                setLastFetchedViewportKey(effectiveViewportKey(viewport));
+                setViewportRefreshNonce(0);
                 setSelectedAreaId((current) => {
                     if (!mapped.length) {
                         return null;
@@ -545,7 +569,8 @@ export default function GatheringAreasPage() {
                 const fallbackAreas = getFallbackMapFeatures();
                 const savedAt = new Date().toISOString();
                 setCenter(DEFAULT_CENTER);
-                setLocationNote("Live provider unavailable. Showing demo gathering areas around Istanbul.");
+                setMapZoom(DEFAULT_ZOOM);
+                setLocationNote("Live provider unavailable. Showing demo gathering areas around Turkey overview.");
                 setAreas(fallbackAreas);
                 const fallbackCategoryOptions = deriveCategoryOptions(fallbackAreas);
                 setCategoryOptions(fallbackCategoryOptions);
@@ -553,9 +578,10 @@ export default function GatheringAreasPage() {
                 setSelectedAreaId(null);
                 setError("");
                 setDataNoticeTitle("Using demo gathering areas");
-                setDataNotice(`Live gathering areas could not be refreshed (${uiMessage}). Showing demo Istanbul areas and guidance.`);
+                setDataNotice(`Live gathering areas could not be refreshed (${uiMessage}). Showing demo areas and guidance.`);
                 setLastUpdated(savedAt);
                 setFetchState(fallbackAreas.length ? "fallback" : "error");
+                setInfoMessage("");
             } finally {
                 if (currentRequestId !== requestIdRef.current) {
                     return;
@@ -565,20 +591,34 @@ export default function GatheringAreasPage() {
         [hydrateMissingAddresses]
     );
 
-    const resolveCurrentLocationAndLoad = React.useCallback(() => {
-        setResolvingLocation(true);
-
-        if (!navigator.geolocation) {
-            setLocationNote(
-                "Current location is not supported in this browser. Showing nearby areas around Istanbul."
-            );
-            setCenter(DEFAULT_CENTER);
-            setResolvingLocation(false);
-            void loadNearbyAreas(DEFAULT_CENTER);
+    React.useEffect(() => {
+        const viewport = pendingViewport;
+        const viewportKey = effectiveViewportKey(viewport);
+        if (!viewport || !viewportKey) {
             return;
         }
 
-        setLocationNote("Resolving your current location...");
+        if (viewportKey === lastFetchedViewportKey && viewportRefreshNonce === 0) {
+            return;
+        }
+
+        const timer = window.setTimeout(() => {
+            void loadViewportAreas(viewport);
+        }, 450);
+
+        return () => {
+            window.clearTimeout(timer);
+        };
+    }, [pendingViewport, lastFetchedViewportKey, viewportRefreshNonce, loadViewportAreas]);
+
+    const handleUseCurrentLocation = React.useCallback(() => {
+        setError("");
+        if (!navigator.geolocation) {
+            setInfoMessage("Current location is not supported in this browser.");
+            return;
+        }
+
+        setInfoMessage("Resolving your current location...");
 
         navigator.geolocation.getCurrentPosition(
             (position) => {
@@ -588,28 +628,59 @@ export default function GatheringAreasPage() {
                 };
 
                 setCenter(nextCenter);
+                setMapZoom(CURRENT_LOCATION_ZOOM);
                 setLocationNote("Showing gathering areas around your current location.");
-                setResolvingLocation(false);
-                void loadNearbyAreas(nextCenter);
+                setInfoMessage("Showing resources around your current location.");
             },
             () => {
-                setLocationNote(
-                    "Location permission was denied or unavailable. Showing nearby areas around Istanbul."
+                setInfoMessage(
+                    "Location permission was denied or unavailable. Continue by moving the map manually."
                 );
-                setCenter(DEFAULT_CENTER);
-                setResolvingLocation(false);
-                void loadNearbyAreas(DEFAULT_CENTER);
             },
             {
                 enableHighAccuracy: true,
                 timeout: 10000,
             }
         );
-    }, [loadNearbyAreas]);
+    }, []);
 
-    React.useEffect(() => {
-        resolveCurrentLocationAndLoad();
-    }, [resolveCurrentLocationAndLoad]);
+    const queueViewportRefresh = React.useCallback(() => {
+        if (!isViewportDiscoverable(currentViewport)) {
+            requestIdRef.current += 1;
+            setAreas([]);
+            setSelectedAreaId(null);
+            setLastFetchedViewportKey(null);
+            setError("");
+            setFetchState("idle");
+            setInfoMessage(ResourceZoomedOutMessage);
+            return;
+        }
+
+        setError("");
+        setPendingViewport(currentViewport);
+        setViewportRefreshNonce((nonce) => nonce + 1);
+    }, [currentViewport]);
+
+    const handleViewportChange = React.useCallback((viewport: MapBounds) => {
+        setCurrentViewport(viewport);
+
+        if (isViewportDiscoverable(viewport)) {
+            setError("");
+            setPendingViewport(viewport);
+            setInfoMessage((current) =>
+                current === ResourceZoomedOutMessage ? "" : current
+            );
+            return;
+        }
+
+        requestIdRef.current += 1;
+        setAreas([]);
+        setSelectedAreaId(null);
+        setLastFetchedViewportKey(null);
+        setError("");
+        setFetchState("idle");
+        setInfoMessage(ResourceZoomedOutMessage);
+    }, []);
 
     React.useEffect(() => {
         if (!selectedAreaId) {
@@ -623,15 +694,18 @@ export default function GatheringAreasPage() {
         }
     }, [filteredAreas, selectedAreaId]);
 
-    const isInitialState = resolvingLocation && fetchState === "idle";
+    const isDiscoverable = isViewportDiscoverable(currentViewport);
+    const isInitialState = currentViewport == null && fetchState === "idle";
     const isLoading = fetchState === "loading";
     const isError = fetchState === "error";
-    const isEmpty = fetchState === "empty";
+    const isEmpty = fetchState === "empty" && isDiscoverable && Boolean(lastFetchedViewportKey);
     const isFallback = fetchState === "fallback";
-    const isFilterEmpty = !isLoading && !isError && areas.length > 0 && filteredAreas.length === 0;
+    const isFilterEmpty = !isLoading && !isError && isDiscoverable && areas.length > 0 && filteredAreas.length === 0;
     const searchContextLine = isFallback
         ? "Fallback content may not match your exact location; follow official guidance during a real emergency."
-        : `Searching within ${SEARCH_RADIUS_KM} km of your current location.`;
+        : isDiscoverable
+            ? "Showing resources in the visible map area."
+            : ResourceZoomedOutMessage;
 
     const selectedArea = selectedAreaId
         ? filteredAreas.find((item) => item.featureKey === selectedAreaId) || null
@@ -669,9 +743,11 @@ export default function GatheringAreasPage() {
                     <div className="gathering-areas-map-wrap">
                         <GatheringAreasMap
                             center={center}
-                            features={filteredAreas}
+                            zoom={mapZoom}
+                            features={isDiscoverable ? filteredAreas : []}
                             selectedFeatureId={selectedAreaId}
                             onSelectFeature={handleSelectArea}
+                            onViewportChange={handleViewportChange}
                             heightClassName="h-[460px] md:h-[620px]"
                         />
 
@@ -680,8 +756,8 @@ export default function GatheringAreasPage() {
                             aria-label="Retry Results"
                             title="Retry Results"
                             className="gathering-areas-map-retry"
-                            onClick={resolveCurrentLocationAndLoad}
-                            disabled={isLoading || resolvingLocation}
+                            onClick={queueViewportRefresh}
+                            disabled={isLoading}
                         >
                             <svg
                                 width="16"
@@ -778,11 +854,11 @@ export default function GatheringAreasPage() {
                                         </p>
                                     ) : isEmpty ? (
                                         <p className="gathering-areas-empty-detail">
-                                            No nearby areas in the current result.
+                                            {ResourceEmptyMessage}
                                         </p>
                                     ) : (
                                         <p className="gathering-areas-empty-detail">
-                                            Waiting for location and nearby results...
+                                            {infoMessage || ResourceInitialMessage}
                                         </p>
                                     )}
                                 </div>
@@ -793,6 +869,15 @@ export default function GatheringAreasPage() {
                     <div className="gathering-areas-context-note">
                         <p className="gathering-areas-context-line">{locationNote}</p>
                         <p className="gathering-areas-context-line">{searchContextLine}</p>
+                    </div>
+
+                    <div className="flex flex-wrap gap-3">
+                        <SecondaryButton type="button" onClick={handleUseCurrentLocation} disabled={isLoading}>
+                            Use Current Location
+                        </SecondaryButton>
+                        <SecondaryButton type="button" onClick={queueViewportRefresh} disabled={isLoading}>
+                            Refresh for Current View
+                        </SecondaryButton>
                     </div>
 
                     {categoryOptions.length ? (
@@ -843,7 +928,7 @@ export default function GatheringAreasPage() {
 
                     {isLoading ? (
                         <div className="gathering-areas-status-box">
-                            <p className="gathering-areas-status-title">Loading nearby gathering areas...</p>
+                            <p className="gathering-areas-status-title">{ResourceLoadingMessage}</p>
                             <div className="gathering-areas-loading-skeleton" aria-hidden="true">
                                 <span />
                                 <span />
@@ -864,7 +949,7 @@ export default function GatheringAreasPage() {
                                     <p>Last updated: cached by backend; exact timestamp unavailable.</p>
                                 )}
                             </div>
-                            <PrimaryButton className="w-auto" onClick={resolveCurrentLocationAndLoad}>
+                            <PrimaryButton className="w-auto" onClick={queueViewportRefresh}>
                                 Retry gathering areas
                             </PrimaryButton>
                         </div>
@@ -877,7 +962,7 @@ export default function GatheringAreasPage() {
                     {error ? (
                         <div className="gathering-areas-status-box is-error">
                             <p>{error}</p>
-                            <PrimaryButton className="w-auto" onClick={resolveCurrentLocationAndLoad}>
+                            <PrimaryButton className="w-auto" onClick={queueViewportRefresh}>
                                 Retry gathering areas
                             </PrimaryButton>
                         </div>
@@ -885,13 +970,13 @@ export default function GatheringAreasPage() {
 
                     {isEmpty ? (
                         <div className="gathering-areas-status-box">
-                            <p>No gathering areas were found for this location and radius.</p>
+                            <p>{ResourceEmptyMessage}</p>
                         </div>
                     ) : null}
 
                     {isInitialState ? (
                         <div className="gathering-areas-status-box">
-                            <p>Waiting for your location before first fetch.</p>
+                            <p>{ResourceInitialMessage}</p>
                         </div>
                     ) : null}
                 </SectionCard>

--- a/web/src/components/feature/location/LeafletCrisisMap.tsx
+++ b/web/src/components/feature/location/LeafletCrisisMap.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import L from "leaflet";
 import { LeafletMapCanvas } from "@/components/feature/location/LeafletMapCanvas";
-import type { LatLng } from "@/components/feature/location/LeafletMapCanvas";
+import type { LatLng, MapBounds } from "@/components/feature/location/LeafletMapCanvas";
 
 type CrisisRequestType =
     | "SHELTER"
@@ -30,6 +30,7 @@ type LeafletCrisisMapProps = {
     features: CrisisMapFeature[];
     selectedFeatureId: string | null;
     onSelectFeature: (featureId: string) => void;
+    onViewportChange?: (bounds: MapBounds) => void;
     heightClassName?: string;
     zoom?: number;
 };
@@ -93,6 +94,7 @@ export function LeafletCrisisMap({
     features,
     selectedFeatureId,
     onSelectFeature,
+    onViewportChange,
     heightClassName = "h-[380px] md:h-[500px]",
     zoom = 11,
 }: LeafletCrisisMapProps) {
@@ -168,21 +170,6 @@ export function LeafletCrisisMap({
     }, [features, mapReadyVersion]);
 
     React.useEffect(() => {
-        const map = mapRef.current;
-        if (!map) {
-            return;
-        }
-
-        if (!features.length) {
-            map.setView([center.latitude, center.longitude], zoom, { animate: true });
-            return;
-        }
-
-        const bounds = L.latLngBounds(features.map((item) => [item.latitude, item.longitude] as [number, number]));
-        map.fitBounds(bounds, { padding: [28, 28], maxZoom: 14 });
-    }, [features, center.latitude, center.longitude, zoom, mapReadyVersion]);
-
-    React.useEffect(() => {
         for (const [featureId, marker] of markerRefs.current.entries()) {
             const feature = features.find((item) => item.featureKey === featureId);
             if (!feature) {
@@ -200,6 +187,7 @@ export function LeafletCrisisMap({
             zoom={zoom}
             heightClassName={heightClassName}
             ariaLabel="Live crisis help requests map"
+            onViewportChange={onViewportChange}
             onMapReady={(map) => {
                 mapRef.current = map;
                 setMapReadyVersion((version) => version + 1);

--- a/web/src/components/feature/location/LeafletGatheringAreasMap.tsx
+++ b/web/src/components/feature/location/LeafletGatheringAreasMap.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import L from "leaflet";
 import { LeafletMapCanvas } from "@/components/feature/location/LeafletMapCanvas";
-import type { LatLng } from "@/components/feature/location/LeafletMapCanvas";
+import type { LatLng, MapBounds } from "@/components/feature/location/LeafletMapCanvas";
 
 type GatheringAreaMapFeature = {
     featureKey: string;
@@ -23,6 +23,7 @@ type LeafletGatheringAreasMapProps = {
     features: GatheringAreaMapFeature[];
     selectedFeatureId: string | null;
     onSelectFeature: (featureId: string) => void;
+    onViewportChange?: (bounds: MapBounds) => void;
     heightClassName?: string;
     zoom?: number;
 };
@@ -121,6 +122,7 @@ export function LeafletGatheringAreasMap({
     features,
     selectedFeatureId,
     onSelectFeature,
+    onViewportChange,
     heightClassName = "h-[380px] md:h-[500px]",
     zoom = 14,
 }: LeafletGatheringAreasMapProps) {
@@ -220,6 +222,7 @@ export function LeafletGatheringAreasMap({
             zoom={zoom}
             heightClassName={heightClassName}
             ariaLabel="Nearby gathering areas map"
+            onViewportChange={onViewportChange}
             onMapReady={(map) => {
                 mapRef.current = map;
                 setMapReadyVersion((version) => version + 1);

--- a/web/src/components/feature/location/LeafletGatheringAreasMap.tsx
+++ b/web/src/components/feature/location/LeafletGatheringAreasMap.tsx
@@ -20,6 +20,7 @@ type GatheringAreaMapFeature = {
 
 type LeafletGatheringAreasMapProps = {
     center: LatLng;
+    showLiveLocation?: boolean;
     features: GatheringAreaMapFeature[];
     selectedFeatureId: string | null;
     onSelectFeature: (featureId: string) => void;
@@ -119,6 +120,7 @@ function createPopupContent(feature: GatheringAreaMapFeature) {
 
 export function LeafletGatheringAreasMap({
     center,
+    showLiveLocation = false,
     features,
     selectedFeatureId,
     onSelectFeature,
@@ -167,6 +169,14 @@ export function LeafletGatheringAreasMap({
             animate: true,
         });
 
+        if (!showLiveLocation) {
+            if (centerMarkerRef.current) {
+                map.removeLayer(centerMarkerRef.current);
+                centerMarkerRef.current = null;
+            }
+            return;
+        }
+
         if (!centerMarkerRef.current) {
             centerMarkerRef.current = L.marker([center.latitude, center.longitude], {
                 icon: createLiveLocationIcon(),
@@ -176,7 +186,7 @@ export function LeafletGatheringAreasMap({
         } else {
             centerMarkerRef.current.setLatLng([center.latitude, center.longitude]);
         }
-    }, [center.latitude, center.longitude]);
+    }, [center.latitude, center.longitude, showLiveLocation]);
 
     React.useEffect(() => {
         const markerLayer = markerLayerRef.current;

--- a/web/src/components/feature/location/LeafletMapCanvas.tsx
+++ b/web/src/components/feature/location/LeafletMapCanvas.tsx
@@ -4,7 +4,14 @@ import * as React from "react";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 
-type LatLng = {
+export type MapBounds = {
+    minLat: number;
+    maxLat: number;
+    minLon: number;
+    maxLon: number;
+};
+
+export type LatLng = {
     latitude: number;
     longitude: number;
 };
@@ -16,6 +23,7 @@ type LeafletMapCanvasProps = {
     ariaLabel?: string;
     onMapReady?: (map: L.Map) => void;
     onMapClick?: (position: LatLng) => void;
+    onViewportChange?: (bounds: MapBounds) => void;
 };
 
 export function LeafletMapCanvas({
@@ -25,11 +33,13 @@ export function LeafletMapCanvas({
     ariaLabel = "Map",
     onMapReady,
     onMapClick,
+    onViewportChange,
 }: LeafletMapCanvasProps) {
     const containerRef = React.useRef<HTMLDivElement | null>(null);
     const mapRef = React.useRef<L.Map | null>(null);
     const onMapReadyRef = React.useRef(onMapReady);
     const onMapClickRef = React.useRef(onMapClick);
+    const onViewportChangeRef = React.useRef(onViewportChange);
 
     React.useEffect(() => {
         onMapReadyRef.current = onMapReady;
@@ -38,6 +48,10 @@ export function LeafletMapCanvas({
     React.useEffect(() => {
         onMapClickRef.current = onMapClick;
     }, [onMapClick]);
+
+    React.useEffect(() => {
+        onViewportChangeRef.current = onViewportChange;
+    }, [onViewportChange]);
 
     React.useEffect(() => {
         if (!containerRef.current || mapRef.current) {
@@ -62,8 +76,22 @@ export function LeafletMapCanvas({
             });
         });
 
+        function emitViewport() {
+            const bounds = map.getBounds();
+            onViewportChangeRef.current?.({
+                minLat: bounds.getSouth(),
+                maxLat: bounds.getNorth(),
+                minLon: bounds.getWest(),
+                maxLon: bounds.getEast(),
+            });
+        }
+
+        map.on("moveend", emitViewport);
+        map.on("zoomend", emitViewport);
+
         mapRef.current = map;
         onMapReadyRef.current?.(map);
+        emitViewport();
 
         return () => {
             map.remove();
@@ -103,5 +131,3 @@ export function LeafletMapCanvas({
         </div>
     );
 }
-
-export type { LatLng };

--- a/web/src/lib/gatheringAreas.ts
+++ b/web/src/lib/gatheringAreas.ts
@@ -8,6 +8,11 @@ type NearbyGatheringAreasQuery = {
     limit?: number;
 };
 
+type ViewportGatheringAreasQuery = {
+    bbox: string;
+    limit?: number;
+};
+
 function buildQuery(params: Record<string, string | number | undefined>) {
     const searchParams = new URLSearchParams();
 
@@ -35,5 +40,18 @@ export async function fetchNearbyGatheringAreas(
 
     return apiRequest<NearbyGatheringAreasResponse>(
         `/gathering-areas/nearby${query}`
+    );
+}
+
+export async function fetchViewportGatheringAreas(
+    params: ViewportGatheringAreasQuery
+) {
+    const query = buildQuery({
+        bbox: params.bbox,
+        limit: params.limit,
+    });
+
+    return apiRequest<NearbyGatheringAreasResponse>(
+        `/gathering-areas/viewport${query}`
     );
 }

--- a/web/src/lib/viewportDiscovery.ts
+++ b/web/src/lib/viewportDiscovery.ts
@@ -1,0 +1,113 @@
+export const DISCOVERY_VIEWPORT_MAX_KM = 50;
+
+export type ViewportBounds = {
+    minLat: number;
+    maxLat: number;
+    minLon: number;
+    maxLon: number;
+};
+
+export type ViewportMetrics = {
+    centerLat: number;
+    centerLon: number;
+    widthKm: number;
+    heightKm: number;
+    widestVisibleDimensionKm: number;
+};
+
+function toRadians(value: number) {
+    return (value * Math.PI) / 180;
+}
+
+function calculateDistanceKm(fromLat: number, fromLon: number, toLat: number, toLon: number) {
+    const earthRadiusKm = 6371;
+    const dLat = toRadians(toLat - fromLat);
+    const dLon = toRadians(toLon - fromLon);
+    const a =
+        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+        Math.cos(toRadians(fromLat)) * Math.cos(toRadians(toLat)) *
+        Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+    return earthRadiusKm * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export function calculateViewportMetrics(bounds: ViewportBounds): ViewportMetrics | null {
+    if (
+        !Number.isFinite(bounds.minLat) ||
+        !Number.isFinite(bounds.maxLat) ||
+        !Number.isFinite(bounds.minLon) ||
+        !Number.isFinite(bounds.maxLon)
+    ) {
+        return null;
+    }
+
+    if (
+        bounds.minLat < -90 ||
+        bounds.maxLat > 90 ||
+        bounds.minLon < -180 ||
+        bounds.maxLon > 180 ||
+        bounds.minLat > bounds.maxLat ||
+        bounds.minLon > bounds.maxLon
+    ) {
+        return null;
+    }
+
+    const centerLat = (bounds.minLat + bounds.maxLat) / 2;
+    const centerLon = (bounds.minLon + bounds.maxLon) / 2;
+    const widthKm = calculateDistanceKm(centerLat, bounds.minLon, centerLat, bounds.maxLon);
+    const heightKm = calculateDistanceKm(bounds.minLat, centerLon, bounds.maxLat, centerLon);
+    const widestVisibleDimensionKm = Math.max(widthKm, heightKm);
+
+    if (
+        !Number.isFinite(centerLat) ||
+        !Number.isFinite(centerLon) ||
+        !Number.isFinite(widthKm) ||
+        !Number.isFinite(heightKm) ||
+        !Number.isFinite(widestVisibleDimensionKm)
+    ) {
+        return null;
+    }
+
+    return {
+        centerLat,
+        centerLon,
+        widthKm,
+        heightKm,
+        widestVisibleDimensionKm,
+    };
+}
+
+export function isViewportDiscoverable(bounds: ViewportBounds | null | undefined) {
+    if (!bounds) {
+        return false;
+    }
+
+    const metrics = calculateViewportMetrics(bounds);
+    if (!metrics) {
+        return false;
+    }
+
+    return metrics.widestVisibleDimensionKm <= DISCOVERY_VIEWPORT_MAX_KM;
+}
+
+export function effectiveViewportKey(bounds: ViewportBounds | null | undefined): string | null {
+    if (!bounds || !isViewportDiscoverable(bounds)) {
+        return null;
+    }
+
+    return [
+        bounds.minLon.toFixed(3),
+        bounds.minLat.toFixed(3),
+        bounds.maxLon.toFixed(3),
+        bounds.maxLat.toFixed(3),
+    ].join(",");
+}
+
+export function viewportBoundsToBbox(bounds: ViewportBounds) {
+    return [
+        bounds.minLon.toFixed(6),
+        bounds.minLat.toFixed(6),
+        bounds.maxLon.toFixed(6),
+        bounds.maxLat.toFixed(6),
+    ].join(",");
+}

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1282,6 +1282,35 @@ textarea::placeholder {
     cursor: not-allowed;
 }
 
+.gathering-areas-map-current-location {
+    position: absolute;
+    left: 12px;
+    bottom: 56px;
+    z-index: 40;
+    pointer-events: auto;
+    width: 38px;
+    height: 38px;
+    border: 1px solid #f0bec2;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--surface-card) 94%, transparent);
+    backdrop-filter: blur(8px);
+    box-shadow: var(--shadow-card);
+    color: #d43b45;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.gathering-areas-map-current-location:hover {
+    border-color: #e27a82;
+    background: #fff4f5;
+}
+
+.gathering-areas-map-current-location:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
 .gathering-areas-overlay-toggle {
     position: absolute;
     top: 12px;
@@ -1820,7 +1849,12 @@ textarea::placeholder {
     }
 
     .gathering-areas-overlay-toggle {
+        top: 12px;
         right: 10px;
+    }
+
+    .gathering-areas-map-current-location {
+        left: 10px;
     }
 
     .gathering-areas-map-overlay {


### PR DESCRIPTION
## Summary
This PR improves web map behavior for both Gathering Areas and Help Request Map by switching discovery to viewport-driven loading and improving current-location controls.

## What Changed
- Enabled viewport-based marker loading on both maps:
  - Markers are fetched for the visible map area after pan/zoom ends.
  - No country-wide marker loading when zoomed out too far.
  - Existing filters continue to apply.
  - Stale requests do not override newer viewport results.
- Preserved and restored current-location behavior:
  - Location permission is requested on initial load.
  - If location is available, map recenters and zooms to local discovery area.
  - Live location indicator is shown only when user location is available.
- Added floating map-level current-location button on both maps.
- Removed redundant bottom action buttons:
  - Use Current Location
  - Refresh for Current View
- Removed gathering-areas mock/fallback presentation behavior:
  - No demo/mock marker fallback when location/provider fails.
  - Clear error/empty states remain in place.

## Scope
- Web only.
- Map picker flows were not changed.

## Validation
- Production build passed: npm run build --silent
- Manual behavior checks:
  - Location prompt appears on load.
  - Zoomed-out view hides markers and prevents broad fetch.
  - Pan/zoom updates results for the new visible area.
  - Current-location button recenters and refreshes local results.
  - Filters continue to work after viewport changes.
  
Closes #531 
Closes #542 
Closes #561 
