### PR TITLE
fix: mobile account soft deletion and fresh re-signup handling

### DIFF
--- a/android/app/src/androidTest/java/com/neph/e2e/AuthenticatedSessionAndroidE2ETest.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/AuthenticatedSessionAndroidE2ETest.kt
@@ -112,8 +112,8 @@ class AuthenticatedSessionAndroidE2ETest {
         composeRule.onNodeWithText("Delete account?").assertIsDisplayed()
         composeRule.onAllNodes(hasText("Delete Account") and hasClickAction())[1].performClick()
 
-        waitForText("Continue as Guest")
-        composeRule.onNodeWithText("Continue as Guest").assertIsDisplayed()
+        waitForText("Welcome back")
+        composeRule.onNodeWithText("Welcome back").assertIsDisplayed()
     }
 
     private fun clickableNode(text: String) = composeRule.onNode(hasText(text) and hasClickAction())

--- a/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
@@ -426,7 +426,7 @@ fun AppNavGraph(
                     }
                 },
                 onAccountDeleted = {
-                    navController.navigate(Routes.Welcome.route) {
+                    navController.navigate(Routes.Login.route) {
                         popUpTo(navController.graph.id) { inclusive = true }
                         launchSingleTop = true
                     }

--- a/backend/src/modules/auth/repository.js
+++ b/backend/src/modules/auth/repository.js
@@ -119,6 +119,31 @@ async function createUser({ userId, email, passwordHash, acceptedTerms }) {
   return result.rows[0];
 }
 
+async function releaseDeletedUserIdentity(userId) {
+  const result = await query(
+    `
+      UPDATE users
+      SET email = CASE
+            WHEN email LIKE 'deleted+%@deleted.invalid' THEN email
+            ELSE CONCAT('deleted+', md5(user_id || ':' || clock_timestamp()::text), '@deleted.invalid')
+          END,
+          google_id = NULL,
+          password_hash = 'deleted-account-disabled',
+          is_email_verified = FALSE,
+          accepted_terms = FALSE,
+          is_banned = FALSE,
+          ban_reason = NULL,
+          banned_at = NULL
+      WHERE user_id = $1
+        AND is_deleted = TRUE
+      RETURNING user_id, email, google_id, is_deleted
+    `,
+    [userId],
+  );
+
+  return result.rows[0] || null;
+}
+
 async function markEmailVerified(userId) {
   const result = await query(
     `UPDATE users SET is_email_verified = TRUE
@@ -490,6 +515,7 @@ async function softDeleteUserAccount(userId) {
         UPDATE users
         SET is_deleted = TRUE,
             email = CONCAT('deleted+', md5(user_id || ':' || clock_timestamp()::text), '@deleted.invalid'),
+            google_id = NULL,
             password_hash = 'deleted-account-disabled',
             is_email_verified = FALSE,
             accepted_terms = FALSE,
@@ -523,6 +549,7 @@ module.exports = {
   findUserById,
   findUserAuthStateById,
   createUser,
+  releaseDeletedUserIdentity,
   markEmailVerified,
   updateUserPassword,
   findAdminByUserId,

--- a/backend/src/modules/auth/service.js
+++ b/backend/src/modules/auth/service.js
@@ -5,6 +5,7 @@ const { OAuth2Client } = require('google-auth-library');
 const {
   findUserByEmail,
   createUser,
+  releaseDeletedUserIdentity,
   markEmailVerified,
   findUserById,
   findAdminByUserId,
@@ -66,9 +67,13 @@ async function signupUser({ email, password, acceptedTerms }) {
   const existingUser = await findUserByEmail(normalizedEmail);
 
   if (existingUser) {
-    const error = new Error('Email already exists');
-    error.code = 'EMAIL_ALREADY_EXISTS';
-    throw error;
+    if (existingUser.is_deleted) {
+      await releaseDeletedUserIdentity(existingUser.user_id);
+    } else {
+      const error = new Error('Email already exists');
+      error.code = 'EMAIL_ALREADY_EXISTS';
+      throw error;
+    }
   }
 
   const passwordHash = await bcrypt.hash(password, 10);
@@ -349,36 +354,34 @@ async function loginWithGoogle({ idToken, mode = 'login', acceptedTerms = false 
   }
 
   const normalizedEmail = email.toLowerCase().trim();
-  const existingByGoogleId = await findUserByGoogleId(googleId);
+  let existingByGoogleId = await findUserByGoogleId(googleId);
   let existingByEmail = null;
 
   if (existingByGoogleId) {
     if (existingByGoogleId.is_deleted) {
-      const error = new Error('This account has been deleted');
-      error.code = 'ACCOUNT_DELETED';
-      throw error;
-    }
-    if (existingByGoogleId.is_banned) {
+      await releaseDeletedUserIdentity(existingByGoogleId.user_id);
+      existingByGoogleId = null;
+      existingByEmail = await findUserByEmail(normalizedEmail);
+    } else if (existingByGoogleId.is_banned) {
       const error = new Error('Your account is banned. Please contact support.');
       error.code = 'USER_BANNED';
       throw error;
-    }
-    if (mode === 'signup') {
+    } else if (mode === 'signup') {
       const error = new Error('An account with this Google email already exists. Please sign in instead.');
       error.code = 'GOOGLE_ACCOUNT_EXISTS';
       throw error;
     }
-  } else {
+  }
+
+  if (!existingByGoogleId && !existingByEmail) {
     existingByEmail = await findUserByEmail(normalizedEmail);
   }
 
   if (existingByEmail) {
     if (existingByEmail.is_deleted) {
-      const error = new Error('This account has been deleted');
-      error.code = 'ACCOUNT_DELETED';
-      throw error;
-    }
-    if (existingByEmail.is_banned) {
+      await releaseDeletedUserIdentity(existingByEmail.user_id);
+      existingByEmail = null;
+    } else if (existingByEmail.is_banned) {
       const error = new Error('Your account is banned. Please contact support.');
       error.code = 'USER_BANNED';
       throw error;

--- a/backend/tests/integration/modules/auth/auth.integration.test.js
+++ b/backend/tests/integration/modules/auth/auth.integration.test.js
@@ -462,6 +462,21 @@ describe('DELETE /api/auth/me', () => {
     expect(deletedUser.rows[0].email).not.toBe(validUser.email);
     expect(deletedUser.rows[0].email).toMatch(/^deleted\+[a-f0-9]{32}@deleted\.invalid$/);
 
+    const signupAfterDeletion = await request(app).post('/api/auth/signup').send(validUser);
+    expect(signupAfterDeletion.status).toBe(201);
+    expect(signupAfterDeletion.body.user.email).toBe(validUser.email);
+    expect(signupAfterDeletion.body.user.userId).not.toBe(userId);
+
+    const freshUser = await query(
+      `SELECT user_id, is_deleted FROM users WHERE email = $1`,
+      [validUser.email],
+    );
+    expect(freshUser.rows).toHaveLength(1);
+    expect(freshUser.rows[0]).toEqual(expect.objectContaining({
+      user_id: signupAfterDeletion.body.user.userId,
+      is_deleted: false,
+    }));
+
     const deletedProfile = await query(
       `SELECT first_name, last_name, phone_number FROM user_profiles WHERE user_id = $1`,
       [userId],
@@ -999,7 +1014,7 @@ describe('POST /api/auth/google', () => {
     expect(res.body.code).toBe('USER_BANNED');
   });
 
-  test('403 - deleted account cannot sign in with Google', async () => {
+  test('404 - deleted Google identity is not reused for login', async () => {
     const app = createTestApp();
 
     await request(app)
@@ -1011,8 +1026,51 @@ describe('POST /api/auth/google', () => {
       .post('/api/auth/google')
       .send({ idToken: 'valid-google-id-token', mode: 'login' });
 
-    expect(res.status).toBe(403);
-    expect(res.body.code).toBe('ACCOUNT_DELETED');
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('GOOGLE_ACCOUNT_NOT_FOUND');
+
+    const deletedRow = await query('SELECT email, google_id, is_deleted FROM users WHERE is_deleted = TRUE');
+    expect(deletedRow.rows[0]).toEqual(expect.objectContaining({
+      google_id: null,
+      is_deleted: true,
+    }));
+    expect(deletedRow.rows[0].email).toMatch(/^deleted\+[a-f0-9]{32}@deleted\.invalid$/);
+  });
+
+  test('200 - signup after deleted Google account creates a fresh user row', async () => {
+    const app = createTestApp();
+
+    await request(app)
+      .post('/api/auth/google')
+      .send({ idToken: 'valid-google-id-token', mode: 'signup', acceptedTerms: true });
+
+    const oldUser = await query('SELECT user_id FROM users WHERE email = $1', [GOOGLE_EMAIL]);
+    const oldUserId = oldUser.rows[0].user_id;
+    await query('UPDATE users SET is_deleted = TRUE WHERE user_id = $1', [oldUserId]);
+
+    const res = await request(app)
+      .post('/api/auth/google')
+      .send({ idToken: 'valid-google-id-token', mode: 'signup', acceptedTerms: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.accessToken).toBeDefined();
+    expect(res.body.user.email).toBe(GOOGLE_EMAIL);
+    expect(res.body.user.userId).not.toBe(oldUserId);
+
+    const activeRows = await query('SELECT user_id, google_id, is_deleted FROM users WHERE email = $1', [GOOGLE_EMAIL]);
+    expect(activeRows.rows).toHaveLength(1);
+    expect(activeRows.rows[0]).toEqual(expect.objectContaining({
+      user_id: res.body.user.userId,
+      google_id: FAKE_GOOGLE_ID,
+      is_deleted: false,
+    }));
+
+    const deletedRows = await query('SELECT email, google_id, is_deleted FROM users WHERE user_id = $1', [oldUserId]);
+    expect(deletedRows.rows[0]).toEqual(expect.objectContaining({
+      google_id: null,
+      is_deleted: true,
+    }));
+    expect(deletedRows.rows[0].email).toMatch(/^deleted\+[a-f0-9]{32}@deleted\.invalid$/);
   });
 
   test('401 - Google-only account cannot login with password endpoint', async () => {

--- a/backend/tests/unit/modules/auth/service.test.js
+++ b/backend/tests/unit/modules/auth/service.test.js
@@ -23,6 +23,7 @@ const {
 const {
   findUserByEmail,
   createUser,
+  releaseDeletedUserIdentity,
   markEmailVerified,
   findUserById,
   findAdminByUserId,
@@ -74,6 +75,41 @@ describe('signupUser', () => {
       password: '12345678',
       acceptedTerms: true,
     })).rejects.toMatchObject({ code: 'EMAIL_ALREADY_EXISTS' });
+  });
+
+  test('creates a fresh account after releasing a deleted email identity', async () => {
+    findUserByEmail.mockResolvedValue({
+      user_id: 'deleted-uuid',
+      email: 'test@test.com',
+      is_deleted: true,
+    });
+    releaseDeletedUserIdentity.mockResolvedValue({
+      user_id: 'deleted-uuid',
+      email: 'deleted+abc@deleted.invalid',
+      google_id: null,
+      is_deleted: true,
+    });
+    createUser.mockResolvedValue({
+      user_id: 'uuid-1',
+      email: 'test@test.com',
+      is_email_verified: false,
+      accepted_terms: true,
+      created_at: new Date(),
+    });
+    sendVerificationEmail.mockResolvedValue();
+
+    const result = await signupUser({
+      email: 'test@test.com',
+      password: '12345678',
+      acceptedTerms: true,
+    });
+
+    expect(releaseDeletedUserIdentity).toHaveBeenCalledWith('deleted-uuid');
+    expect(createUser).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'test-uuid-1234',
+      email: 'test@test.com',
+    }));
+    expect(result.user.email).toBe('test@test.com');
   });
 
   test('throws if email sending fails', async () => {


### PR DESCRIPTION
Related to the issue [#554](https://github.com/bounswe/bounswe2026group6/issues/554).

This PR fixes account deletion behavior for mobile and tightens backend soft-delete identity handling.

### Changes

- Navigate mobile users to the login screen after successful account deletion.
- Clear google_id during backend soft deletion so deleted Google accounts do not keep owning the OAuth identity.
- Allow signup to create a fresh user row when the matching existing account is already soft-deleted.
- Add backend coverage for re-signup after deleted email/Google accounts.
- Update Android e2e expectation for the post-delete destination.