### PR TITLE
feat:Refactor privacy settings and remove health visibility control

### DIFF
--- a/android/app/src/main/java/com/neph/features/privacysecurity/presentation/PrivacySecurityScreen.kt
+++ b/android/app/src/main/java/com/neph/features/privacysecurity/presentation/PrivacySecurityScreen.kt
@@ -207,7 +207,7 @@ fun PrivacySecurityScreen(
                         verticalArrangement = Arrangement.spacedBy(spacing.md)
                     ) {
                         Text(
-                            text = "Choose who can see profile, health, and location details.",
+                            text = "Choose who can see profile and location details.",
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -216,14 +216,6 @@ fun PrivacySecurityScreen(
                             value = profileVisibility,
                             onValueChange = { profileVisibility = it },
                             label = "Profile visibility",
-                            options = visibilityOptions,
-                            vertical = true
-                        )
-
-                        AppRadioGroup(
-                            value = healthInfoVisibility,
-                            onValueChange = { healthInfoVisibility = it },
-                            label = "Health information visibility",
                             options = visibilityOptions,
                             vertical = true
                         )
@@ -240,7 +232,7 @@ fun PrivacySecurityScreen(
                             checked = shareLocation,
                             onCheckedChange = { shareLocation = it },
                             label = "Share Current Location",
-                            description = "Allow emergency coordination flows to use your saved current-location status."
+                            description = "Used to make your current or saved location available for emergency coordination features, such as nearby visibility and location-aware support. This is a sharing preference, not where you edit your saved address."
                         )
                     }
                 }

--- a/android/app/src/main/java/com/neph/features/profile/presentation/ProfileScreen.kt
+++ b/android/app/src/main/java/com/neph/features/profile/presentation/ProfileScreen.kt
@@ -155,10 +155,6 @@ fun ProfileScreen(
                     ProfileFieldRow(label = "District", value = profile.district)
                     ProfileFieldRow(label = "Neighborhood", value = profile.neighborhood)
                     ProfileFieldRow(label = "Extra address", value = profile.extraAddress)
-                    ProfileFieldRow(
-                        label = "Share current location",
-                        value = profile.shareLocation?.let { if (it) "Enabled" else "Disabled" }
-                    )
                 }
             }
         }

--- a/web/e2e/profile-and-privacy.spec.js
+++ b/web/e2e/profile-and-privacy.spec.js
@@ -72,20 +72,42 @@ test.beforeEach(async () => {
   await resetDatabase();
 });
 
-test('privacy page blocks first-time share enable until profile captures current location', async ({ page }) => {
-  const email = `privacy-block-${Date.now()}@example.com`;
+test('privacy page owns location sharing and hides health visibility', async ({ page }) => {
+  const email = `privacy-location-${Date.now()}@example.com`;
   const password = 'Passw0rd!';
 
   await createCompletedUser({ email, password });
   await loginToProtectedRoute(page, '/privacy-security', { email, password });
+
+  await expect(page.getByText('Health information visibility')).toHaveCount(0);
+  await expect(page.getByText(/Used to make your current or saved location available/i)).toBeVisible();
 
   const locationToggle = page.getByRole('button', { name: 'Share Current Location' });
   await expect(locationToggle).toHaveAttribute('aria-pressed', 'false');
 
   await locationToggle.click();
   await page.getByRole('button', { name: 'Save Privacy Settings' }).click();
+  await expect(locationToggle).toHaveAttribute('aria-pressed', 'true');
 
-  await expect(page.getByText('To enable Share Current Location, go to Profile, click Use Current Location, and save there first.')).toBeVisible();
+  const accessToken = await getStoredAccessToken(page);
+  await expect.poll(async () => {
+    const profile = await fetchMyProfile(accessToken);
+    return profile.privacySettings.locationSharingEnabled;
+  }).toBe(true);
+});
+
+test('profile edit no longer exposes Share Current Location control', async ({ page }) => {
+  const email = `profile-no-share-toggle-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createCompletedUser({ email, password });
+  await loginToProtectedRoute(page, '/profile', { email, password });
+
+  await expect(page.getByRole('button', { name: 'Share Current Location' })).toHaveCount(0);
+
+  await page.locator('#height').fill('180');
+  await page.locator('#extraAddress').fill('Updated Address 42');
+  await page.getByRole('button', { name: 'Save Changes' }).click();
 
   const accessToken = await getStoredAccessToken(page);
   await expect.poll(async () => {
@@ -94,28 +116,7 @@ test('privacy page blocks first-time share enable until profile captures current
   }).toBe(false);
 });
 
-test('profile save blocks first-time share enable until Use Current Location is used', async ({ page }) => {
-  const email = `profile-block-${Date.now()}@example.com`;
-  const password = 'Passw0rd!';
-
-  await createCompletedUser({ email, password });
-  await loginToProtectedRoute(page, '/profile', { email, password });
-
-  const locationToggle = page.getByRole('button', { name: 'Share Current Location' });
-  await locationToggle.click();
-  await expect.poll(async () => locationToggle.getAttribute('aria-pressed')).toBe('true');
-
-  await page.locator('#height').fill('180');
-  await page.locator('#extraAddress').fill('Updated Address 42');
-
-  await page.getByRole('button', { name: 'Save Changes' }).click();
-
-  await expect(
-    page.getByText(/To enable Share Current Location, click Use Current Location first/i)
-  ).toBeVisible();
-});
-
-test('persists real current-device metadata when sharing is enabled after fresh capture', async ({ page }) => {
+test('privacy page enables sharing after profile saves real current-device metadata', async ({ page }) => {
   const email = `profile-${Date.now()}@example.com`;
   const password = 'Passw0rd!';
   const captureTimestamp = Date.now();
@@ -133,9 +134,6 @@ test('persists real current-device metadata when sharing is enabled after fresh 
   await page.getByRole('button', { name: 'Use Current Location' }).click();
   await expect(page.getByText('Selected:')).toBeVisible();
 
-  const locationToggle = page.getByRole('button', { name: 'Share Current Location' });
-  await locationToggle.click();
-
   const heightInput = page.locator('#height');
   await heightInput.fill('');
   await heightInput.fill('180');
@@ -144,8 +142,6 @@ test('persists real current-device metadata when sharing is enabled after fresh 
 
   const accessToken = await getStoredAccessToken(page);
 
-  // Success banner text can be flaky in CI timing; assert the persisted backend
-  // state instead, which is the real contract this scenario verifies.
   await expect
     .poll(async () => {
       const profile = await fetchMyProfile(accessToken);
@@ -159,12 +155,23 @@ test('persists real current-device metadata when sharing is enabled after fresh 
     }, { timeout: 20_000 })
     .toMatchObject({
       height: 180,
-      locationSharingEnabled: true,
+      locationSharingEnabled: false,
       source: 'current_device',
       accuracyMeters: 7,
     });
 
+  await page.goto('/privacy-security');
+  await expect(page.getByText(/Used to make your current or saved location available/i)).toBeVisible();
+
+  const locationToggle = page.getByRole('button', { name: 'Share Current Location' });
+  await locationToggle.click();
+  await page.getByRole('button', { name: 'Save Privacy Settings' }).click();
   await expect(locationToggle).toHaveAttribute('aria-pressed', 'true');
+
+  await expect.poll(async () => {
+    const profile = await fetchMyProfile(accessToken);
+    return profile.privacySettings.locationSharingEnabled;
+  }).toBe(true);
 
   const profile = await fetchMyProfile(accessToken);
   expect((profile.locationProfile.address || '').trim().length).toBeGreaterThan(0);

--- a/web/src/components/feature/auth/CompleteProfileForm.tsx
+++ b/web/src/components/feature/auth/CompleteProfileForm.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import { TextInput } from "@/components/ui/inputs/TextInput";
 import { SelectInput } from "@/components/ui/inputs/SelectInput";
 import { TextArea } from "@/components/ui/inputs/TextArea";
-import { ToggleSwitch } from "@/components/ui/selection/ToggleSwitch";
 import { Checkbox } from "@/components/ui/selection/Checkbox";
 import { ProfileInfoRow } from "../../ui/display/ProfileInfoRow";
 import { SaveActionBar } from "../../ui/display/SaveActionBar";
@@ -35,7 +34,6 @@ import {
     patchMyHealth,
     patchMyLocation,
     patchMyPhysical,
-    patchMyPrivacy,
     patchMyProfile,
     putMyExpertiseAreas,
     validateExpertiseAreas,
@@ -60,7 +58,6 @@ type ProfileForm = {
     district: string;
     neighborhood: string;
     extraAddress: string;
-    shareLocation: boolean;
 };
 
 const initialForm: ProfileForm = {
@@ -82,27 +79,7 @@ const initialForm: ProfileForm = {
     district: "",
     neighborhood: "",
     extraAddress: "",
-    shareLocation: false,
 };
-
-const FRESH_DEVICE_CAPTURE_MAX_AGE_MS = 5 * 60 * 1000;
-
-function isFreshCurrentDeviceSelection(value: LocationPickerValue | null) {
-    if (!value || value.source !== "current_device") {
-        return false;
-    }
-
-    if (!value.capturedAt) {
-        return false;
-    }
-
-    const capturedAtMs = Date.parse(value.capturedAt);
-    if (Number.isNaN(capturedAtMs)) {
-        return false;
-    }
-
-    return Date.now() - capturedAtMs <= FRESH_DEVICE_CAPTURE_MAX_AGE_MS;
-}
 
 function toPickerValueFromSearchItem(item: {
     placeId: string;
@@ -448,13 +425,6 @@ export default function CompleteProfileForm() {
             return;
         }
 
-        if (form.shareLocation && !isFreshCurrentDeviceSelection(locationPickerValue)) {
-            setError(
-                "To enable Share Current Location, click Use Current Location first so we can save a fresh device location."
-            );
-            return;
-        }
-
         const token = getAccessToken();
 
         if (!token) {
@@ -522,10 +492,6 @@ export default function CompleteProfileForm() {
                             new Date().toISOString(),
                     }
                     : undefined,
-            });
-
-            await patchMyPrivacy(token, {
-                locationSharingEnabled: form.shareLocation,
             });
 
             await putMyExpertiseAreas(token, {
@@ -820,18 +786,6 @@ export default function CompleteProfileForm() {
                     <HelperText className="text-[color:var(--primary-500)]">{locationTreeError}</HelperText>
                 ) : null}
             </ProfileInfoRow>
-
-            <div className="flex items-center justify-between">
-                <span className="text-sm">Share Current Location</span>
-
-                <ToggleSwitch
-                    aria-label="Share Current Location"
-                    checked={form.shareLocation}
-                    onCheckedChange={(value) =>
-                        setForm({ ...form, shareLocation: value })
-                    }
-                />
-            </div>
 
             {error ? <HelperText className="text-[color:var(--primary-500)]">{error}</HelperText> : null}
 

--- a/web/src/components/feature/profile/ProfileView.tsx
+++ b/web/src/components/feature/profile/ProfileView.tsx
@@ -8,7 +8,6 @@ import { SectionHeader } from "@/components/ui/display/SectionHeader";
 import { TextInput } from "@/components/ui/inputs/TextInput";
 import { SelectInput } from "@/components/ui/inputs/SelectInput";
 import { TextArea } from "@/components/ui/inputs/TextArea";
-import { ToggleSwitch } from "@/components/ui/selection/ToggleSwitch";
 import { Checkbox } from "@/components/ui/selection/Checkbox";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
 import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
@@ -50,31 +49,11 @@ import {
     patchMyHealth,
     patchMyLocation,
     patchMyPhysical,
-    patchMyPrivacy,
     validateExpertiseAreas,
     putMyExpertiseAreas,
 } from "@/lib/profile";
 type EmptyStateAction = "login" | "complete-profile" | null;
 type ProfileData = EditableProfileData;
-
-const FRESH_DEVICE_CAPTURE_MAX_AGE_MS = 5 * 60 * 1000;
-
-function isFreshCurrentDeviceSelection(value: LocationPickerValue | null) {
-    if (!value || value.source !== "current_device") {
-        return false;
-    }
-
-    if (!value.capturedAt) {
-        return false;
-    }
-
-    const capturedAtMs = Date.parse(value.capturedAt);
-    if (Number.isNaN(capturedAtMs)) {
-        return false;
-    }
-
-    return Date.now() - capturedAtMs <= FRESH_DEVICE_CAPTURE_MAX_AGE_MS;
-}
 
 function toPickerValueFromSearchItem(item: {
     placeId: string;
@@ -136,8 +115,6 @@ export default function ProfileView() {
     const [deletingAccount, setDeletingAccount] = React.useState(false);
     const [error, setError] = React.useState("");
     const [info, setInfo] = React.useState("");
-    const [initialShareLocation, setInitialShareLocation] =
-        React.useState(false);
     const [emptyStateAction, setEmptyStateAction] =
         React.useState<EmptyStateAction>(null);
     const dropdownSyncRequestIdRef = React.useRef(0);
@@ -148,10 +125,6 @@ export default function ProfileView() {
                 fetchCurrentUser(token),
                 fetchMyProfile(token),
             ]);
-
-            setInitialShareLocation(
-                backendProfile.privacySettings.locationSharingEnabled
-            );
 
             setProfile((currentProfile) => {
                 const refreshedProfile = toProfileData(
@@ -234,9 +207,6 @@ export default function ProfileView() {
                 );
 
                 setProfile(mappedProfile);
-                setInitialShareLocation(
-                    backendProfile.privacySettings.locationSharingEnabled
-                );
                 if (
                     backendProfile.locationProfile.latitude !== null &&
                     backendProfile.locationProfile.longitude !== null
@@ -508,17 +478,6 @@ export default function ProfileView() {
             }
         }
 
-        if (
-            !initialShareLocation &&
-            profile.shareLocation &&
-            !isFreshCurrentDeviceSelection(locationPickerValue)
-        ) {
-            setError(
-                "To enable Share Current Location, click Use Current Location first so we can save a fresh device location."
-            );
-            return;
-        }
-
         const token = getAccessToken();
 
         if (!token) {
@@ -638,10 +597,6 @@ export default function ProfileView() {
                             new Date().toISOString(),
                     }
                     : undefined,
-            });
-
-            await patchMyPrivacy(token, {
-                locationSharingEnabled: profile.shareLocation,
             });
 
             await putMyExpertiseAreas(token, {
@@ -1195,20 +1150,6 @@ export default function ProfileView() {
                         </div>
                     </div>
 
-                    <div className="mt-4 flex items-center justify-between">
-                        <span className="text-sm">Share Current Location</span>
-                        <ToggleSwitch
-                            aria-label="Share Current Location"
-                            checked={profile.shareLocation}
-                            onCheckedChange={(value) =>
-                                setProfile((currentProfile) =>
-                                    currentProfile
-                                        ? { ...currentProfile, shareLocation: value }
-                                        : currentProfile
-                                )
-                            }
-                        />
-                    </div>
                 </SectionCard>
 
                 {error ? <HelperText className="text-[color:var(--primary-500)]">{error}</HelperText> : null}

--- a/web/src/components/feature/settings/PrivacySecurityView.tsx
+++ b/web/src/components/feature/settings/PrivacySecurityView.tsx
@@ -31,7 +31,6 @@ export default function PrivacySecurityView() {
     const [loading, setLoading] = React.useState(true);
     const [saving, setSaving] = React.useState(false);
     const [profileVisibility, setProfileVisibility] = React.useState("PRIVATE");
-    const [healthInfoVisibility, setHealthInfoVisibility] = React.useState("PRIVATE");
     const [locationVisibility, setLocationVisibility] = React.useState("PRIVATE");
     const [shareLocation, setShareLocation] = React.useState(false);
     const [initialShareLocation, setInitialShareLocation] = React.useState(false);
@@ -60,7 +59,6 @@ export default function PrivacySecurityView() {
             try {
                 const profile = await fetchMyProfile(token);
                 setProfileVisibility(profile.privacySettings.profileVisibility || "PRIVATE");
-                setHealthInfoVisibility(profile.privacySettings.healthInfoVisibility || "PRIVATE");
                 setLocationVisibility(profile.privacySettings.locationVisibility || "PRIVATE");
                 setShareLocation(profile.privacySettings.locationSharingEnabled);
                 setInitialShareLocation(profile.privacySettings.locationSharingEnabled);
@@ -108,16 +106,15 @@ export default function PrivacySecurityView() {
             setError("");
             setInfo("");
 
-            if (!initialShareLocation && shareLocation) {
+            if (!initialShareLocation && shareLocation && !locationPreview) {
                 setError(
-                    "To enable Share Current Location, go to Profile, click Use Current Location, and save there first."
+                    "To enable Share Current Location, save your profile location first."
                 );
                 return;
             }
 
             await patchMyPrivacy(token, {
                 profileVisibility,
-                healthInfoVisibility,
                 locationVisibility,
                 locationSharingEnabled: shareLocation,
             });
@@ -154,7 +151,7 @@ export default function PrivacySecurityView() {
             <SectionCard>
                 <SectionHeader
                     title="Privacy"
-                    subtitle="Choose who can see profile, health, and location details."
+                    subtitle="Choose who can see profile and location details."
                 />
 
                 <div className="mt-4 grid gap-5">
@@ -164,15 +161,6 @@ export default function PrivacySecurityView() {
                         value={profileVisibility}
                         options={visibilityOptions}
                         onValueChange={setProfileVisibility}
-                        direction="column"
-                    />
-
-                    <RadioGroup
-                        label="Health information visibility"
-                        name="healthInfoVisibility"
-                        value={healthInfoVisibility}
-                        options={visibilityOptions}
-                        onValueChange={setHealthInfoVisibility}
                         direction="column"
                     />
 
@@ -192,8 +180,10 @@ export default function PrivacySecurityView() {
                             Share Current Location
                         </p>
                         <p className="mt-1 text-sm text-[color:var(--text-secondary)]">
-                            Allow your profile to expose live location-sharing status for
-                            emergency coordination.
+                            Used to make your current or saved location available for
+                            emergency coordination features, such as nearby visibility and
+                            location-aware support. This is a sharing preference, not the
+                            place where you edit your saved address.
                         </p>
                     </div>
 


### PR DESCRIPTION
## Summary
Moves location sharing controls fully into Privacy & Security and removes health visibility controls from the UI.

## Changes
- Removed `Share Current Location` controls from:
  - Web profile edit flow
  - Web complete profile flow
  - Android profile screens
- Kept `Share Current Location` in Privacy & Security.
- Added explanatory copy clarifying that location sharing is used for emergency coordination features and is separate from editing the saved address.
- Removed `Health information visibility` controls from Privacy & Security UI on Web and Android.
- Preserved backend compatibility for existing privacy settings fields.
- Updated E2E tests to reflect the new ownership of location sharing settings.

## Behavior
- Users manage location sharing only from Privacy & Security.
- Profile screens still allow editing saved address and profile health information.
- Health information sharing is now expected to be controlled through explicit request-level consent flows instead of global privacy settings.
- Existing backend privacy fields remain compatible.

## Testing
```bash
npm run test:e2e -- profile-and-privacy.spec.js


Closes #569