### PR TITLE
fix: prevent duplicate navigation stack entries

### DIFF
--- a/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
@@ -471,7 +471,10 @@ fun AppNavGraph(
                     navigateToLogin()
                 },
                 onNavigateToMyHelpRequests = {
-                    navigateToDrawerRoute(Routes.MyHelpRequests.route)
+                    val popped = navController.popBackStack(Routes.MyHelpRequests.route, inclusive = false)
+                    if (!popped) {
+                        navigateToDrawerRoute(Routes.MyHelpRequests.route)
+                    }
                 }
             )
         }


### PR DESCRIPTION
# Fix navigation after editing a help request

## Context
When a user edited an existing help request and clicked the "Send Help Request" button, the app failed to navigate back to the "My Help Requests" page, appearing to be stuck on the form.

Resolves #546 

## Root Cause
The `RequestHelpScreen` used `navigateToDrawerRoute(Routes.MyHelpRequests.route)` to return to the list. Because the user had navigated from `MyHelpRequests` to `RequestHelpScreen`, the `navigateToDrawerRoute` logic (which relies on `saveState = true` and `restoreState = true` for tab switching) saved the `RequestHelpScreen` in the back stack state and restored it immediately, trapping the user on the screen.

## Fix
Updated `AppNavGraph.kt` to handle the return routing intelligently:
- The graph now attempts to pop the back stack to `MyHelpRequests` using `navController.popBackStack(Routes.MyHelpRequests.route, inclusive = false)`.
- If the user was editing (came from "My Help Requests"), it correctly clears the edit screen from the stack.
- If the user was creating a new request and "My Help Requests" isn't in the back stack, `popBackStack` returns `false`, and the app falls back to the standard `navigateToDrawerRoute` behavior.

## Testing Instructions
1. Navigate to **My Help Requests**.
2. Tap on a request to edit it.
3. Submit the form by clicking **Send Help Request**.
4. Verify you are immediately returned to the **My Help Requests** page.
5. Create a new help request from the Home page and verify that submitting it routes you to the **My Help Requests** page correctly as well.
