### PR TITLE
feat: add theme toggle to navigation bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ out/
 web/.next/
 web/out/
 web/next-env.d.ts
+*.tsbuildinfo
 
 # General build outputs
 dist/

--- a/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
+++ b/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
@@ -67,6 +67,7 @@ import com.neph.ui.layout.AppDrawerScaffold
 import com.neph.ui.location.rememberForegroundLocationPermissionRequester
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
+import com.neph.ui.components.theme.ThemeIconButton
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -519,7 +520,10 @@ fun HomeScreen(
         onOpenSettings = onOpenSettings,
         onProfileClick = onProfileClick,
         profileBadgeText = profileBadgeText,
-        profileLabel = if (isAuthenticated) "Profile" else "Login / Create Account"
+        profileLabel = if (isAuthenticated) "Profile" else "Login / Create Account",
+        topBarActions = {
+            ThemeIconButton()
+        }
     ) {
         Column(
             modifier = Modifier.fillMaxWidth(),

--- a/android/app/src/main/java/com/neph/features/settings/presentation/SettingsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/settings/presentation/SettingsScreen.kt
@@ -10,10 +10,12 @@ import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.WbSunny
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -25,6 +27,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.size
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.neph.core.theme.ThemePreferenceStore
@@ -138,9 +141,13 @@ fun SettingsScreen(
                     horizontalArrangement = Arrangement.spacedBy(spacing.md)
                 ) {
                     androidx.compose.material3.Icon(
-                        imageVector = Icons.Filled.DarkMode,
+                        imageVector = if (darkThemeEnabled) Icons.Filled.DarkMode else Icons.Filled.WbSunny,
                         contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        tint = if (darkThemeEnabled) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.primary
+                        }
                     )
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
@@ -156,7 +163,27 @@ fun SettingsScreen(
                     }
                     Switch(
                         checked = darkThemeEnabled,
-                        onCheckedChange = { ThemePreferenceStore.setDarkThemeEnabled(it) }
+                        onCheckedChange = { ThemePreferenceStore.setDarkThemeEnabled(it) },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
+                            checkedTrackColor = MaterialTheme.colorScheme.primary,
+                            checkedBorderColor = MaterialTheme.colorScheme.primary,
+                            uncheckedThumbColor = MaterialTheme.colorScheme.onPrimary,
+                            uncheckedTrackColor = MaterialTheme.colorScheme.outlineVariant,
+                            uncheckedBorderColor = MaterialTheme.colorScheme.outline
+                        ),
+                        thumbContent = {
+                            androidx.compose.material3.Icon(
+                                imageVector = if (darkThemeEnabled) Icons.Filled.DarkMode else Icons.Filled.WbSunny,
+                                contentDescription = null,
+                                modifier = Modifier.size(SwitchDefaults.IconSize),
+                                tint = if (darkThemeEnabled) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.outline
+                                }
+                            )
+                        }
                     )
                 }
             }

--- a/web/src/app/gathering-areas/page.tsx
+++ b/web/src/app/gathering-areas/page.tsx
@@ -234,6 +234,7 @@ export default function GatheringAreasPage() {
     const reverseAddressCacheRef = React.useRef<Map<string, string>>(new Map());
     const hasRequestedInitialLocationRef = React.useRef(false);
     const hasInitializedCategoryFiltersRef = React.useRef(false);
+    const geolocationDeniedRef = React.useRef(false);
 
     const filteredAreas = React.useMemo(() => {
         if (!selectedCategoryKeys.length) {
@@ -442,6 +443,7 @@ export default function GatheringAreasPage() {
                     longitude: position.coords.longitude,
                 };
 
+                geolocationDeniedRef.current = false;
                 setCenter(nextCenter);
                 setMapZoom(CURRENT_LOCATION_ZOOM);
                 setHasUserLocation(true);
@@ -449,6 +451,7 @@ export default function GatheringAreasPage() {
                 setInfoMessage("Showing resources around your current location.");
             },
             () => {
+                geolocationDeniedRef.current = true;
                 setHasUserLocation(false);
                 setInfoMessage(
                     "Location permission was denied or unavailable. Continue by moving the map manually."
@@ -478,7 +481,9 @@ export default function GatheringAreasPage() {
             setLastFetchedViewportKey(null);
             setError("");
             setFetchState("idle");
-            setInfoMessage(ResourceZoomedOutMessage);
+            setInfoMessage((current) =>
+                geolocationDeniedRef.current ? current : ResourceZoomedOutMessage
+            );
             return;
         }
 
@@ -505,7 +510,9 @@ export default function GatheringAreasPage() {
         setLastFetchedViewportKey(null);
         setError("");
         setFetchState("idle");
-        setInfoMessage(ResourceZoomedOutMessage);
+        setInfoMessage((current) =>
+            geolocationDeniedRef.current ? current : ResourceZoomedOutMessage
+        );
     }, []);
 
     React.useEffect(() => {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,7 +2,7 @@ import "../styles/globals.css";
 import type { Metadata } from "next";
 import { SiteFooter } from "@/components/layout/SiteFooter";
 import { ThemeProvider } from "@/components/theme/ThemeProvider";
-import { ThemeToggle } from "@/components/theme/ThemeToggle";
+import { GuestThemeToggle } from "@/components/theme/GuestThemeToggle";
 import { getThemeInitScript } from "@/lib/theme";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 
@@ -44,7 +44,7 @@ export default function RootLayout({
             <body className="root-layout-body">
                 <ConditionalGoogleProvider clientId={GOOGLE_CLIENT_ID}>
                     <ThemeProvider>
-                        <ThemeToggle />
+                        <GuestThemeToggle />
                         <main className="root-layout-content">{children}</main>
                         <SiteFooter />
                     </ThemeProvider>

--- a/web/src/components/layout/TopNavbar.tsx
+++ b/web/src/components/layout/TopNavbar.tsx
@@ -9,6 +9,7 @@ import { clearAccessToken, getAccessToken } from "@/lib/auth";
 import { useAuthSession } from "@/lib/authSession";
 import { fetchUnreadNotificationCount } from "@/lib/notifications";
 import { fetchMyProfile } from "@/lib/profile";
+import { ThemeToggle } from "@/components/theme/ThemeToggle";
 
 const navItemsOrdered = [
     { label: "Home", href: "/home" },
@@ -244,6 +245,7 @@ export function TopNavbar() {
                 </nav>
 
                 <div className="top-navbar-right">
+                    {isAuthenticated ? <ThemeToggle variant="navbar" /> : null}
                     <Link
                         href="/notifications"
                         className={`top-navbar-notification-button${pathname === "/notifications" || pathname.startsWith("/notifications/") ? " is-active" : ""}`}

--- a/web/src/components/theme/GuestThemeToggle.tsx
+++ b/web/src/components/theme/GuestThemeToggle.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useAuthSession } from "@/lib/authSession";
+import { ThemeToggle } from "@/components/theme/ThemeToggle";
+
+export function GuestThemeToggle() {
+    const { state } = useAuthSession();
+    const isAuthenticated = state.phase === "authenticated";
+
+    if (isAuthenticated) {
+        return null;
+    }
+
+    return <ThemeToggle variant="corner" />;
+}

--- a/web/src/components/theme/ThemeToggle.tsx
+++ b/web/src/components/theme/ThemeToggle.tsx
@@ -3,18 +3,23 @@
 import { useTheme } from "@/components/theme/ThemeProvider";
 import { cn } from "@/lib/cn";
 
+type ThemeToggleVariant = "corner" | "navbar";
+
 type ThemeToggleProps = {
     className?: string;
+    variant?: ThemeToggleVariant;
 };
 
-export function ThemeToggle({ className }: ThemeToggleProps) {
+export function ThemeToggle({ className, variant = "corner" }: ThemeToggleProps) {
     const { isDarkTheme, setTheme } = useTheme();
     const nextTheme = isDarkTheme ? "light" : "dark";
+
+    const baseClass = variant === "navbar" ? "theme-toggle-navbar" : "theme-toggle-corner";
 
     return (
         <button
             type="button"
-            className={cn("theme-toggle-corner", className)}
+            className={cn(baseClass, className)}
             aria-label={isDarkTheme ? "Switch to light theme" : "Switch to dark theme"}
             title={isDarkTheme ? "Switch to light theme" : "Switch to dark theme"}
             onClick={() => setTheme(nextTheme)}

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -203,6 +203,25 @@ textarea::placeholder {
     transform: translateY(-1px);
 }
 
+.theme-toggle-navbar {
+    display: inline-flex;
+    height: 40px;
+    width: 40px;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-pill);
+    border: 1px solid var(--border-subtle);
+    background: var(--surface-card);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: color 180ms ease, background-color 180ms ease, border-color 180ms ease;
+}
+
+.theme-toggle-navbar:hover {
+    color: var(--primary-500);
+    background: var(--surface-soft);
+}
+
 .page-bg {
     background: var(--background-page);
 }


### PR DESCRIPTION
### Changes Made

1. **Web — Toggle next to notifications (logged in)**
   - Added a `"navbar"` variant to `ThemeToggle` with styling matching the notification icon
   - Placed it in `TopNavbar` before the notification bell, visible only for authenticated users
   - Created `GuestThemeToggle` component that shows the fixed bottom-right toggle only for guests

2. **Mobile — Theme toggle on Home screen top-right**
   - Added `ThemeIconButton()` (sun/crescent moon) to the `topBarActions` of the Home screen's `AppDrawerScaffold`

3. **Mobile — Redesigned Settings toggle for light mode**
   - Replaced the plain `Switch` with one using explicit `SwitchDefaults.colors()` — `outlineVariant` track with `outline` border in light mode for clear visibility
   - Added sun/moon icons inside the switch thumb

#### Note:
- Resolves #544 