### PR TITLE
feat(android): improve home safety status UX

### DIFF
--- a/android/app/src/androidTest/java/com/neph/e2e/FakeNephBackend.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/FakeNephBackend.kt
@@ -208,6 +208,8 @@ class FakeNephBackend {
             route == "/availability/status" && method == "GET" -> handleAvailabilityStatus(token)
             route == "/availability/my-assignment" && method == "GET" -> handleCurrentAssignment(token)
             route == "/help-requests" && method == "GET" -> handleHelpRequestList(token)
+            route.startsWith("/help-requests/") && route.endsWith("/status") && method == "PATCH" ->
+                handlePatchHelpRequestStatus(token, route, body)
             route == "/help-requests/active" && method == "GET" -> handleActiveHelpRequests(uri)
             route == "/location/tree" && method == "GET" -> handleLocationTree(uri)
             route == "/gathering-areas/nearby" && method == "GET" -> handleNearbyGatheringAreas(uri)
@@ -753,6 +755,28 @@ class FakeNephBackend {
     private fun handleHelpRequestList(token: String?): JSONObject {
         requireAuthorizedUser(token)
         return JSONObject().put("requests", JSONArray())
+    }
+
+    private fun handlePatchHelpRequestStatus(token: String?, route: String, body: JSONObject?): JSONObject {
+        requireAuthorizedUser(token)
+        val requestId = route
+            .removePrefix("/help-requests/")
+            .removeSuffix("/status")
+            .trim()
+        val status = body?.requiredString("status") ?: "SYNCED"
+        return JSONObject().put(
+            "request",
+            JSONObject()
+                .put("id", requestId)
+                .put("status", status)
+                .put("helpTypes", JSONArray())
+                .put("affectedPeopleCount", 1)
+                .put("riskFlags", JSONArray())
+                .put("vulnerableGroups", JSONArray())
+                .put("location", JSONObject())
+                .put("contact", JSONObject())
+                .put("cancelledAt", if (status == "CANCELLED") Instant.now().toString() else JSONObject.NULL)
+        )
     }
 
     private fun profileResponseJson(user: FakeUserState, profile: FakeProfileState): JSONObject {

--- a/android/app/src/androidTest/java/com/neph/e2e/SafetyStatusRepositoryAndroidTest.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/SafetyStatusRepositoryAndroidTest.kt
@@ -194,11 +194,11 @@ class SafetyStatusRepositoryAndroidTest {
     }
 
     @Test
-    fun cancelActiveAuthenticatedHelpRequestsForMarkSafeQueuesCancelledStatus() = runBlocking {
+    fun cancelActiveAuthenticatedHelpRequestsForMarkSafeRequiresConfirmedRemoteCancellation() = runBlocking {
         val database = NephDatabaseProvider.requireInstance()
         database.helpRequestDao().upsert(activeHelpRequestEntity())
 
-        val cancelledCount = RequestHelpRepository.cancelActiveAuthenticatedHelpRequestsForMarkSafe("access-token-1")
+        val result = RequestHelpRepository.cancelActiveAuthenticatedHelpRequestsForMarkSafe("access-token-1")
         val request = database.helpRequestDao().getByLocalId("local_help_1")
         val operation = database.syncOperationDao().getLatestPendingOperation(
             entityType = SyncEntityType.HELP_REQUEST,
@@ -206,11 +206,43 @@ class SafetyStatusRepositoryAndroidTest {
             operationType = SyncOperationType.UPDATE_HELP_REQUEST_STATUS
         )
 
-        assertEquals(1, cancelledCount)
+        assertTrue(result.canMarkSafe)
+        assertEquals(1, result.confirmedCount)
+        assertEquals(0, result.pendingCount)
+        assertEquals(0, result.failedCount)
         assertEquals("CANCELLED", request?.status)
-        assertEquals(SyncStatus.PENDING_UPDATE, request?.syncStatus)
+        assertEquals(SyncStatus.SYNCED, request?.syncStatus)
         assertTrue(request?.cancelledAt.orEmpty().isNotBlank())
-        assertTrue(operation?.payloadJson.orEmpty().contains("\"status\":\"CANCELLED\""))
+        assertNull(operation)
+    }
+
+    @Test
+    fun cancelActiveAuthenticatedHelpRequestsForMarkSafeLeavesPendingCreateActive() = runBlocking {
+        val database = NephDatabaseProvider.requireInstance()
+        database.helpRequestDao().upsert(
+            activeHelpRequestEntity(
+                localId = "local_pending_help_1",
+                remoteId = null,
+                syncStatus = SyncStatus.PENDING_CREATE
+            )
+        )
+
+        val result = RequestHelpRepository.cancelActiveAuthenticatedHelpRequestsForMarkSafe("access-token-1")
+        val request = database.helpRequestDao().getByLocalId("local_pending_help_1")
+        val operation = database.syncOperationDao().getLatestPendingOperation(
+            entityType = SyncEntityType.HELP_REQUEST,
+            entityId = "local_pending_help_1",
+            operationType = SyncOperationType.UPDATE_HELP_REQUEST_STATUS
+        )
+
+        assertFalse(result.canMarkSafe)
+        assertEquals(0, result.confirmedCount)
+        assertEquals(1, result.pendingCount)
+        assertEquals(0, result.failedCount)
+        assertEquals("SYNCED", request?.status)
+        assertEquals(SyncStatus.PENDING_CREATE, request?.syncStatus)
+        assertNull(request?.cancelledAt)
+        assertNull(operation)
     }
 
     private fun initializeSafetyStatusTestDependencies(context: Context) {
@@ -253,10 +285,14 @@ class SafetyStatusRepositoryAndroidTest {
         )
     }
 
-    private fun activeHelpRequestEntity(): HelpRequestEntity {
+    private fun activeHelpRequestEntity(
+        localId: String = "local_help_1",
+        remoteId: String? = "remote_help_1",
+        syncStatus: String = SyncStatus.SYNCED
+    ): HelpRequestEntity {
         return HelpRequestEntity(
-            localId = "local_help_1",
-            remoteId = "remote_help_1",
+            localId = localId,
+            remoteId = remoteId,
             ownerType = LocalOwnerType.AUTHENTICATED,
             guestAccessToken = null,
             helpTypesJson = """["other"]""",
@@ -281,6 +317,7 @@ class SafetyStatusRepositoryAndroidTest {
             helperProfession = null,
             helperExpertise = null,
             helpersJson = "[]",
+            syncStatus = syncStatus,
             createdAtEpochMillis = 1000L,
             updatedAtEpochMillis = 1000L
         )

--- a/android/app/src/androidTest/java/com/neph/e2e/SafetyStatusRepositoryAndroidTest.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/SafetyStatusRepositoryAndroidTest.kt
@@ -2,9 +2,11 @@ package com.neph.e2e
 
 import android.content.Context
 import com.neph.core.NephAppContext
+import com.neph.core.database.HelpRequestEntity
 import com.neph.core.database.NephDatabaseProvider
 import com.neph.core.database.SafetyStatusEntity
 import com.neph.core.database.SyncOperationEntity
+import com.neph.core.sync.LocalOwnerType
 import com.neph.core.sync.SyncEntityType
 import com.neph.core.sync.SyncOperationStatus
 import com.neph.core.sync.SyncOperationType
@@ -15,6 +17,7 @@ import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.profile.data.CurrentDeviceLocation
 import com.neph.features.profile.data.ProfileData
 import com.neph.features.profile.data.ProfileRepository
+import com.neph.features.requesthelp.data.RequestHelpRepository
 import com.neph.features.safetystatus.data.SafetyStatusRepository
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -190,11 +193,32 @@ class SafetyStatusRepositoryAndroidTest {
         assertEquals(LoginDestination.PROFILE, destination)
     }
 
+    @Test
+    fun cancelActiveAuthenticatedHelpRequestsForMarkSafeQueuesCancelledStatus() = runBlocking {
+        val database = NephDatabaseProvider.requireInstance()
+        database.helpRequestDao().upsert(activeHelpRequestEntity())
+
+        val cancelledCount = RequestHelpRepository.cancelActiveAuthenticatedHelpRequestsForMarkSafe("access-token-1")
+        val request = database.helpRequestDao().getByLocalId("local_help_1")
+        val operation = database.syncOperationDao().getLatestPendingOperation(
+            entityType = SyncEntityType.HELP_REQUEST,
+            entityId = "local_help_1",
+            operationType = SyncOperationType.UPDATE_HELP_REQUEST_STATUS
+        )
+
+        assertEquals(1, cancelledCount)
+        assertEquals("CANCELLED", request?.status)
+        assertEquals(SyncStatus.PENDING_UPDATE, request?.syncStatus)
+        assertTrue(request?.cancelledAt.orEmpty().isNotBlank())
+        assertTrue(operation?.payloadJson.orEmpty().contains("\"status\":\"CANCELLED\""))
+    }
+
     private fun initializeSafetyStatusTestDependencies(context: Context) {
         NephAppContext.initialize(context)
         NephDatabaseProvider.initialize(context)
         AuthSessionStore.initialize(context)
         ProfileRepository.initialize(context)
+        RequestHelpRepository.initialize(context)
         SafetyStatusRepository.initialize(context)
     }
 
@@ -226,6 +250,39 @@ class SafetyStatusRepositoryAndroidTest {
             accuracyMeters = 12.5,
             capturedAt = "2026-05-03T10:20:30.000Z",
             source = "DEVICE_GPS"
+        )
+    }
+
+    private fun activeHelpRequestEntity(): HelpRequestEntity {
+        return HelpRequestEntity(
+            localId = "local_help_1",
+            remoteId = "remote_help_1",
+            ownerType = LocalOwnerType.AUTHENTICATED,
+            guestAccessToken = null,
+            helpTypesJson = """["other"]""",
+            otherHelpText = "Need help",
+            affectedPeopleCount = 1,
+            riskFlagsJson = "[]",
+            vulnerableGroupsJson = "[]",
+            description = "Need help",
+            bloodType = "",
+            country = "Turkey",
+            city = "Istanbul",
+            district = "Kadikoy",
+            neighborhood = "Moda",
+            extraAddress = "",
+            contactFullName = "Safe Tester",
+            contactPhone = "5551234567",
+            contactAlternativePhone = null,
+            status = "SYNCED",
+            helperFirstName = null,
+            helperLastName = null,
+            helperPhone = null,
+            helperProfession = null,
+            helperExpertise = null,
+            helpersJson = "[]",
+            createdAtEpochMillis = 1000L,
+            updatedAtEpochMillis = 1000L
         )
     }
 }

--- a/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
+++ b/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
@@ -426,8 +426,16 @@ fun HomeScreen(
                 }
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
+            } catch (error: ApiException) {
+                if (error.status == 401) {
+                    AuthRepository.logout()
+                    emergencyError = "Your session expired. Please log in again before marking yourself safe."
+                    onNavigateToLogin()
+                } else {
+                    emergencyError = "Could not verify your active help request status. Please try again."
+                }
             } catch (_: Exception) {
-                showMarkSafeLocationConsentDialog = true
+                emergencyError = "Could not verify your active help request status. Please try again."
             } finally {
                 markSafeLoading = false
             }
@@ -467,7 +475,13 @@ fun HomeScreen(
         scope.launch {
             try {
                 if (shouldCancelActiveHelpRequest) {
-                    RequestHelpRepository.cancelActiveAuthenticatedHelpRequestsForMarkSafe(safeSessionToken)
+                    val cancellationResult =
+                        RequestHelpRepository.cancelActiveAuthenticatedHelpRequestsForMarkSafe(safeSessionToken)
+                    if (!cancellationResult.canMarkSafe) {
+                        emergencyError =
+                            "Your active help request could not be cancelled yet. Please try again once it syncs before marking yourself safe."
+                        return@launch
+                    }
                 }
                 val locationAttempt = if (shareLocation && !permissionDeniedBeforeCapture) {
                     DeviceLocationProvider.captureCurrentLocationForSharing(
@@ -502,12 +516,20 @@ fun HomeScreen(
                     emergencyError = "Your session expired. Please log in again before marking yourself safe."
                     onNavigateToLogin()
                 } else {
-                    emergencyError = error.message.ifBlank { "Could not mark you safe. Please try again." }
+                    emergencyError = if (shouldCancelActiveHelpRequest) {
+                        "Your active help request could not be cancelled yet. Please try again once it syncs before marking yourself safe."
+                    } else {
+                        error.message.ifBlank { "Could not mark you safe. Please try again." }
+                    }
                 }
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (_: Exception) {
-                emergencyError = "Could not mark you safe. Please try again."
+                emergencyError = if (shouldCancelActiveHelpRequest) {
+                    "Your active help request could not be cancelled yet. Please try again once it syncs before marking yourself safe."
+                } else {
+                    "Could not mark you safe. Please try again."
+                }
             } finally {
                 pendingCancelActiveHelpRequestForMarkSafe = false
                 markSafeLoading = false

--- a/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
+++ b/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
@@ -129,6 +129,7 @@ fun HomeScreen(
     var requestHelpError by remember { mutableStateOf("") }
     var markSafeLoading by remember { mutableStateOf(false) }
     var showMarkSafeLocationConsentDialog by remember { mutableStateOf(false) }
+    var showActiveHelpRequestMarkSafeDialog by remember { mutableStateOf(false) }
     var emergencyInfo by remember { mutableStateOf("") }
     var emergencyError by remember { mutableStateOf("") }
     var locationPermissionInfo by remember { mutableStateOf("") }
@@ -410,7 +411,59 @@ fun HomeScreen(
             return
         }
 
-        showMarkSafeLocationConsentDialog = true
+        val safeSessionToken = sessionToken
+        markSafeLoading = true
+        scope.launch {
+            try {
+                val hasActiveRequest = RequestHelpRepository.hasActiveHelpRequest(safeSessionToken)
+                if (hasActiveRequest) {
+                    showActiveHelpRequestMarkSafeDialog = true
+                } else {
+                    showMarkSafeLocationConsentDialog = true
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                showMarkSafeLocationConsentDialog = true
+            } finally {
+                markSafeLoading = false
+            }
+        }
+    }
+
+    fun confirmMarkSafeWithActiveHelpRequest() {
+        val safeSessionToken = sessionToken
+        if (!isAuthenticated || safeSessionToken.isNullOrBlank()) {
+            showActiveHelpRequestMarkSafeDialog = false
+            emergencyError = "Please log in before marking yourself safe."
+            onNavigateToLogin()
+            return
+        }
+
+        markSafeLoading = true
+        scope.launch {
+            try {
+                RequestHelpRepository.cancelActiveAuthenticatedHelpRequestsForMarkSafe(safeSessionToken)
+                showActiveHelpRequestMarkSafeDialog = false
+                showMarkSafeLocationConsentDialog = true
+            } catch (error: ApiException) {
+                showActiveHelpRequestMarkSafeDialog = false
+                if (error.status == 401) {
+                    AuthRepository.logout()
+                    emergencyError = "Your session expired. Please log in again before marking yourself safe."
+                    onNavigateToLogin()
+                } else {
+                    emergencyError = "Could not update your active help request. Please try again."
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                showActiveHelpRequestMarkSafeDialog = false
+                emergencyError = "Could not update your active help request. Please try again."
+            } finally {
+                markSafeLoading = false
+            }
+        }
     }
 
     fun handleMarkSafeWithOptionalLocation(
@@ -494,6 +547,30 @@ fun HomeScreen(
         } else {
             locationPermissionRequester.requestPermission()
         }
+    }
+
+    if (showActiveHelpRequestMarkSafeDialog) {
+        AlertDialog(
+            onDismissRequest = { showActiveHelpRequestMarkSafeDialog = false },
+            title = {
+                Text(text = "Mark yourself safe?")
+            },
+            text = {
+                Text(
+                    text = "You have an active help request. Marking yourself safe will cancel or update that request. Are you sure you want to continue?"
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = ::confirmMarkSafeWithActiveHelpRequest) {
+                    Text("Mark safe")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showActiveHelpRequestMarkSafeDialog = false }) {
+                    Text("Keep request active")
+                }
+            }
+        )
     }
 
     if (showMarkSafeLocationConsentDialog) {
@@ -662,7 +739,7 @@ private fun HomeGreetingHero(
     val safetyTone = when (safetyStatus.lowercase()) {
         "safe" -> Triple(MaterialTheme.colorScheme.tertiary, MaterialTheme.colorScheme.onTertiary, "You're marked safe")
         "not_safe", "needs_help" -> Triple(MaterialTheme.colorScheme.error, MaterialTheme.colorScheme.onError, "Help requested")
-        else -> Triple(MaterialTheme.colorScheme.surfaceVariant, MaterialTheme.colorScheme.onSurfaceVariant, "Status unknown")
+        else -> Triple(MaterialTheme.colorScheme.surfaceVariant, MaterialTheme.colorScheme.onSurfaceVariant, "No safety status yet")
     }
     val greetingPrimary = if (isAuthenticated) "Hello" else "Welcome"
     val greetingDetail = if (isAuthenticated) {

--- a/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
+++ b/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
@@ -130,6 +130,7 @@ fun HomeScreen(
     var markSafeLoading by remember { mutableStateOf(false) }
     var showMarkSafeLocationConsentDialog by remember { mutableStateOf(false) }
     var showActiveHelpRequestMarkSafeDialog by remember { mutableStateOf(false) }
+    var pendingCancelActiveHelpRequestForMarkSafe by remember { mutableStateOf(false) }
     var emergencyInfo by remember { mutableStateOf("") }
     var emergencyError by remember { mutableStateOf("") }
     var locationPermissionInfo by remember { mutableStateOf("") }
@@ -407,10 +408,12 @@ fun HomeScreen(
         emergencyInfo = ""
 
         if (!isAuthenticated || sessionToken.isNullOrBlank()) {
+            pendingCancelActiveHelpRequestForMarkSafe = false
             emergencyError = "Please log in to mark yourself safe."
             return
         }
 
+        pendingCancelActiveHelpRequestForMarkSafe = false
         val safeSessionToken = sessionToken
         markSafeLoading = true
         scope.launch {
@@ -440,30 +443,9 @@ fun HomeScreen(
             return
         }
 
-        markSafeLoading = true
-        scope.launch {
-            try {
-                RequestHelpRepository.cancelActiveAuthenticatedHelpRequestsForMarkSafe(safeSessionToken)
-                showActiveHelpRequestMarkSafeDialog = false
-                showMarkSafeLocationConsentDialog = true
-            } catch (error: ApiException) {
-                showActiveHelpRequestMarkSafeDialog = false
-                if (error.status == 401) {
-                    AuthRepository.logout()
-                    emergencyError = "Your session expired. Please log in again before marking yourself safe."
-                    onNavigateToLogin()
-                } else {
-                    emergencyError = "Could not update your active help request. Please try again."
-                }
-            } catch (cancellationException: CancellationException) {
-                throw cancellationException
-            } catch (_: Exception) {
-                showActiveHelpRequestMarkSafeDialog = false
-                emergencyError = "Could not update your active help request. Please try again."
-            } finally {
-                markSafeLoading = false
-            }
-        }
+        pendingCancelActiveHelpRequestForMarkSafe = true
+        showActiveHelpRequestMarkSafeDialog = false
+        showMarkSafeLocationConsentDialog = true
     }
 
     fun handleMarkSafeWithOptionalLocation(
@@ -473,15 +455,20 @@ fun HomeScreen(
         val safeSessionToken = sessionToken
         if (!isAuthenticated || safeSessionToken.isNullOrBlank()) {
             showMarkSafeLocationConsentDialog = false
+            pendingCancelActiveHelpRequestForMarkSafe = false
             emergencyError = "Please log in before marking yourself safe."
             onNavigateToLogin()
             return
         }
 
+        val shouldCancelActiveHelpRequest = pendingCancelActiveHelpRequestForMarkSafe
         showMarkSafeLocationConsentDialog = false
         markSafeLoading = true
         scope.launch {
             try {
+                if (shouldCancelActiveHelpRequest) {
+                    RequestHelpRepository.cancelActiveAuthenticatedHelpRequestsForMarkSafe(safeSessionToken)
+                }
                 val locationAttempt = if (shareLocation && !permissionDeniedBeforeCapture) {
                     DeviceLocationProvider.captureCurrentLocationForSharing(
                         context = context,
@@ -522,6 +509,7 @@ fun HomeScreen(
             } catch (_: Exception) {
                 emergencyError = "Could not mark you safe. Please try again."
             } finally {
+                pendingCancelActiveHelpRequestForMarkSafe = false
                 markSafeLoading = false
             }
         }
@@ -551,7 +539,10 @@ fun HomeScreen(
 
     if (showActiveHelpRequestMarkSafeDialog) {
         AlertDialog(
-            onDismissRequest = { showActiveHelpRequestMarkSafeDialog = false },
+            onDismissRequest = {
+                pendingCancelActiveHelpRequestForMarkSafe = false
+                showActiveHelpRequestMarkSafeDialog = false
+            },
             title = {
                 Text(text = "Mark yourself safe?")
             },
@@ -566,7 +557,12 @@ fun HomeScreen(
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showActiveHelpRequestMarkSafeDialog = false }) {
+                TextButton(
+                    onClick = {
+                        pendingCancelActiveHelpRequestForMarkSafe = false
+                        showActiveHelpRequestMarkSafeDialog = false
+                    }
+                ) {
                     Text("Keep request active")
                 }
             }
@@ -575,7 +571,10 @@ fun HomeScreen(
 
     if (showMarkSafeLocationConsentDialog) {
         AlertDialog(
-            onDismissRequest = { showMarkSafeLocationConsentDialog = false },
+            onDismissRequest = {
+                pendingCancelActiveHelpRequestForMarkSafe = false
+                showMarkSafeLocationConsentDialog = false
+            },
             title = {
                 Text(text = "Share location with your safe status?")
             },

--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
@@ -94,6 +94,15 @@ data class CreateHelpRequestResult(
     val recordedLocally: Boolean = true
 )
 
+data class MarkSafeHelpRequestCancellationResult(
+    val confirmedCount: Int = 0,
+    val pendingCount: Int = 0,
+    val failedCount: Int = 0
+) {
+    val canMarkSafe: Boolean
+        get() = pendingCount == 0 && failedCount == 0
+}
+
 data class GuestTrackedHelpRequest(
     val requestId: String,
     val guestAccessToken: String
@@ -142,9 +151,11 @@ object RequestHelpRepository {
         return database.helpRequestDao().countActiveByOwner(ownerTypeForToken(token)) > 0
     }
 
-    suspend fun cancelActiveAuthenticatedHelpRequestsForMarkSafe(token: String): Int {
+    suspend fun cancelActiveAuthenticatedHelpRequestsForMarkSafe(
+        token: String
+    ): MarkSafeHelpRequestCancellationResult {
         ensureInitialized()
-        if (token.isBlank()) return 0
+        if (token.isBlank()) return MarkSafeHelpRequestCancellationResult()
 
         try {
             refreshAuthenticatedHelpRequests(token)
@@ -160,48 +171,41 @@ object RequestHelpRepository {
             .getByOwner(LocalOwnerType.AUTHENTICATED)
             .filter { it.isActiveHelpRequestForStatusUpdate() }
 
-        if (activeRequests.isEmpty()) return 0
+        if (activeRequests.isEmpty()) return MarkSafeHelpRequestCancellationResult()
 
-        val now = System.currentTimeMillis()
+        var confirmedCount = 0
+        var pendingCount = 0
+        var failedCount = 0
         activeRequests.forEach { request ->
-            val payload = JSONObject().put("status", "CANCELLED")
-            database.helpRequestDao().upsert(
-                request.copy(
-                    status = "CANCELLED",
-                    cancelledAt = now.toIsoLikeString(),
-                    syncStatus = if (request.syncStatus == SyncStatus.PENDING_CREATE) {
-                        SyncStatus.PENDING_CREATE
-                    } else {
-                        SyncStatus.PENDING_UPDATE
-                    },
-                    pendingError = null,
-                    updatedAtEpochMillis = now
-                )
-            )
+            val remoteId = resolveRemoteRequestIdForSync(request)
+            if (remoteId.isNullOrBlank()) {
+                pendingCount += 1
+                return@forEach
+            }
 
-            val existingOperation = database.syncOperationDao().getLatestPendingOperation(
-                entityType = SyncEntityType.HELP_REQUEST,
-                entityId = request.localId,
-                operationType = SyncOperationType.UPDATE_HELP_REQUEST_STATUS
+            val response = JsonHttpClient.request(
+                path = "/help-requests/$remoteId/status",
+                method = "PATCH",
+                token = token,
+                body = JSONObject().put("status", "CANCELLED")
             )
-            database.syncOperationDao().upsert(
-                existingOperation?.copy(
-                    payloadJson = payload.toString(),
-                    status = SyncOperationStatus.PENDING,
-                    attemptCount = 0,
-                    lastAttemptAtEpochMillis = null,
-                    error = null
-                ) ?: SyncOperationEntity(
-                    entityType = SyncEntityType.HELP_REQUEST,
-                    entityId = request.localId,
-                    operationType = SyncOperationType.UPDATE_HELP_REQUEST_STATUS,
-                    payloadJson = payload.toString(),
-                    createdAtEpochMillis = now
+            val remoteRequest = response.optJSONObject("request")
+            if (remoteRequest?.optString("status")?.trim()?.uppercase(Locale.ROOT) == "CANCELLED") {
+                upsertRemoteHelpRequest(
+                    ownerType = LocalOwnerType.AUTHENTICATED,
+                    request = remoteRequest,
+                    guestAccessToken = null
                 )
-            )
+                confirmedCount += 1
+            } else {
+                failedCount += 1
+            }
         }
-        OfflineSyncScheduler.enqueueSync(NephAppContext.get(), reason = "mark-safe-cancels-help-request")
-        return activeRequests.size
+        return MarkSafeHelpRequestCancellationResult(
+            confirmedCount = confirmedCount,
+            pendingCount = pendingCount,
+            failedCount = failedCount
+        )
     }
 
     suspend fun createHelpRequest(
@@ -664,12 +668,6 @@ object RequestHelpRepository {
         return status.trim().uppercase(Locale.ROOT) !in setOf("RESOLVED", "CANCELLED") &&
             syncStatus != SyncStatus.CONFLICTED &&
             !isDeleted
-    }
-
-    private fun Long.toIsoLikeString(): String {
-        val formatter = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
-        formatter.timeZone = java.util.TimeZone.getTimeZone("UTC")
-        return formatter.format(java.util.Date(this))
     }
 }
 

--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
@@ -142,6 +142,68 @@ object RequestHelpRepository {
         return database.helpRequestDao().countActiveByOwner(ownerTypeForToken(token)) > 0
     }
 
+    suspend fun cancelActiveAuthenticatedHelpRequestsForMarkSafe(token: String): Int {
+        ensureInitialized()
+        if (token.isBlank()) return 0
+
+        try {
+            refreshAuthenticatedHelpRequests(token)
+        } catch (error: ApiException) {
+            if (error.status == 401) {
+                throw error
+            }
+        } catch (_: Exception) {
+            // Fall back to local active requests so marking safe can still proceed offline.
+        }
+
+        val activeRequests = database.helpRequestDao()
+            .getByOwner(LocalOwnerType.AUTHENTICATED)
+            .filter { it.isActiveHelpRequestForStatusUpdate() }
+
+        if (activeRequests.isEmpty()) return 0
+
+        val now = System.currentTimeMillis()
+        activeRequests.forEach { request ->
+            val payload = JSONObject().put("status", "CANCELLED")
+            database.helpRequestDao().upsert(
+                request.copy(
+                    status = "CANCELLED",
+                    cancelledAt = now.toIsoLikeString(),
+                    syncStatus = if (request.syncStatus == SyncStatus.PENDING_CREATE) {
+                        SyncStatus.PENDING_CREATE
+                    } else {
+                        SyncStatus.PENDING_UPDATE
+                    },
+                    pendingError = null,
+                    updatedAtEpochMillis = now
+                )
+            )
+
+            val existingOperation = database.syncOperationDao().getLatestPendingOperation(
+                entityType = SyncEntityType.HELP_REQUEST,
+                entityId = request.localId,
+                operationType = SyncOperationType.UPDATE_HELP_REQUEST_STATUS
+            )
+            database.syncOperationDao().upsert(
+                existingOperation?.copy(
+                    payloadJson = payload.toString(),
+                    status = SyncOperationStatus.PENDING,
+                    attemptCount = 0,
+                    lastAttemptAtEpochMillis = null,
+                    error = null
+                ) ?: SyncOperationEntity(
+                    entityType = SyncEntityType.HELP_REQUEST,
+                    entityId = request.localId,
+                    operationType = SyncOperationType.UPDATE_HELP_REQUEST_STATUS,
+                    payloadJson = payload.toString(),
+                    createdAtEpochMillis = now
+                )
+            )
+        }
+        OfflineSyncScheduler.enqueueSync(NephAppContext.get(), reason = "mark-safe-cancels-help-request")
+        return activeRequests.size
+    }
+
     suspend fun createHelpRequest(
         token: String?,
         submission: RequestHelpSubmission
@@ -596,6 +658,18 @@ object RequestHelpRepository {
             ?.takeIf { it.isNotBlank() }
             ?.let { mapOf("x-help-request-access-token" to it) }
             ?: emptyMap()
+    }
+
+    private fun HelpRequestEntity.isActiveHelpRequestForStatusUpdate(): Boolean {
+        return status.trim().uppercase(Locale.ROOT) !in setOf("RESOLVED", "CANCELLED") &&
+            syncStatus != SyncStatus.CONFLICTED &&
+            !isDeleted
+    }
+
+    private fun Long.toIsoLikeString(): String {
+        val formatter = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+        formatter.timeZone = java.util.TimeZone.getTimeZone("UTC")
+        return formatter.format(java.util.Date(this))
     }
 }
 


### PR DESCRIPTION
## Summary

Improves Android Home safety status UX.

## Changes

- Replaces the neutral `Status unknown` badge with `No safety status yet`.
- Adds a confirmation step when marking safe while an active help request exists.
- Keeps guest and normal authenticated mark-safe flows unchanged where applicable.

## Testing

- Verified neutral Home badge behavior.
- Verified guest `I'm safe` behavior stays on Home with login-required message.
- Verified authenticated mark-safe flow with and without active help requests.

Closes #581 