### PR TITLE
fix: align current location and viewport refresh behavior

### DIFF
--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -260,7 +260,7 @@ fun GatheringAreasScreen(
         }
     }
 
-    LaunchedEffect(effectiveLeafletViewportKey(pendingViewport), viewportRefreshNonce) {
+    LaunchedEffect(pendingViewport, lastFetchedViewportKey, viewportRefreshNonce) {
         val viewport = pendingViewport ?: return@LaunchedEffect
         if (!isLeafletViewportDiscoverable(viewport)) return@LaunchedEffect
         val viewportKey = effectiveLeafletViewportKey(viewport) ?: return@LaunchedEffect

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -373,7 +373,7 @@ fun HelpRequestMapScreen(
         }
     }
 
-    LaunchedEffect(effectiveLeafletViewportKey(pendingViewport), viewportRefreshNonce) {
+    LaunchedEffect(pendingViewport, lastFetchedViewportKey, viewportRefreshNonce) {
         val viewport = pendingViewport ?: return@LaunchedEffect
         if (!isLeafletViewportDiscoverable(viewport)) return@LaunchedEffect
         val viewportKey = effectiveLeafletViewportKey(viewport) ?: return@LaunchedEffect

--- a/web/e2e/profile-and-privacy.spec.js
+++ b/web/e2e/profile-and-privacy.spec.js
@@ -1,5 +1,5 @@
 const { test, expect } = require('@playwright/test');
-const { createCompletedUser, fetchMyProfile } = require('./helpers/api');
+const { createCompletedUser, createVerifiedUser, fetchMyProfile } = require('./helpers/api');
 const { resetDatabase } = require('./helpers/db');
 const { getStoredAccessToken, loginThroughUi } = require('./helpers/ui');
 
@@ -68,6 +68,10 @@ async function mockGeolocationError(page, { code, message, permissionState = 'pr
   }, { code, message, permissionState });
 }
 
+async function expectNoWrittenCurrentLocationButton(page) {
+  await expect(page.locator('button', { hasText: 'Use Current Location' })).toHaveCount(0);
+}
+
 test.beforeEach(async () => {
   await resetDatabase();
 });
@@ -104,6 +108,7 @@ test('profile edit no longer exposes Share Current Location control', async ({ p
   await loginToProtectedRoute(page, '/profile', { email, password });
 
   await expect(page.getByRole('button', { name: 'Share Current Location' })).toHaveCount(0);
+  await expectNoWrittenCurrentLocationButton(page);
 
   await page.locator('#height').fill('180');
   await page.locator('#extraAddress').fill('Updated Address 42');
@@ -114,6 +119,24 @@ test('profile edit no longer exposes Share Current Location control', async ({ p
     const profile = await fetchMyProfile(accessToken);
     return profile.privacySettings.locationSharingEnabled;
   }).toBe(false);
+});
+
+test('complete profile location picker initializes from current location without written button', async ({ page }) => {
+  const email = `complete-profile-map-${Date.now()}@example.com`;
+  const password = 'Passw0rd!';
+
+  await createVerifiedUser({ email, password });
+  await mockGeolocationSuccess(page, {
+    latitude: 41.0136,
+    longitude: 28.955,
+    accuracy: 7,
+  });
+
+  await loginToProtectedRoute(page, '/complete-profile', { email, password });
+
+  await expectNoWrittenCurrentLocationButton(page);
+  await expect(page.getByRole('button', { name: 'Use Current Location' })).toBeVisible();
+  await expect(page.getByText('Selected:')).toBeVisible();
 });
 
 test('privacy page enables sharing after profile saves real current-device metadata', async ({ page }) => {
@@ -131,6 +154,7 @@ test('privacy page enables sharing after profile saves real current-device metad
 
   await loginToProtectedRoute(page, '/profile', { email, password });
 
+  await expectNoWrittenCurrentLocationButton(page);
   await page.getByRole('button', { name: 'Use Current Location' }).click();
   await expect(page.getByText('Selected:')).toBeVisible();
 
@@ -200,6 +224,7 @@ test('shows denied geolocation error on current location action', async ({ page 
   });
 
   await loginToProtectedRoute(page, '/profile', { email, password });
+  await expectNoWrittenCurrentLocationButton(page);
   await page.getByRole('button', { name: 'Use Current Location' }).click();
 
   await expect(page.getByText('Location permission is denied. Enable location access in your browser settings.')).toBeVisible();
@@ -217,6 +242,7 @@ test('shows position unavailable geolocation error on current location action', 
   });
 
   await loginToProtectedRoute(page, '/profile', { email, password });
+  await expectNoWrittenCurrentLocationButton(page);
   await page.getByRole('button', { name: 'Use Current Location' }).click();
 
   await expect(page.getByText('Current location is unavailable right now. Please try again or select from map.')).toBeVisible();
@@ -234,6 +260,7 @@ test('shows timeout geolocation error on current location action', async ({ page
   });
 
   await loginToProtectedRoute(page, '/profile', { email, password });
+  await expectNoWrittenCurrentLocationButton(page);
   await page.getByRole('button', { name: 'Use Current Location' }).click();
 
   await expect(page.getByText('Location request timed out. Please try again.')).toBeVisible();

--- a/web/src/app/crisis-map/page.tsx
+++ b/web/src/app/crisis-map/page.tsx
@@ -21,7 +21,7 @@ const DEFAULT_CENTER = {
     longitude: 35.0,
 };
 const DEFAULT_ZOOM = 5;
-const CURRENT_LOCATION_ZOOM = 13;
+const CURRENT_LOCATION_ZOOM = 15;
 
 const FETCH_LIMIT = 300;
 type FetchState = "idle" | "loading" | "success" | "empty" | "error";
@@ -125,6 +125,7 @@ function toFeature(item: Awaited<ReturnType<typeof fetchActiveHelpRequests>>["re
 export default function CrisisMapPage() {
     const [center, setCenter] = React.useState(DEFAULT_CENTER);
     const [mapZoom, setMapZoom] = React.useState(DEFAULT_ZOOM);
+    const [mapViewResetToken, setMapViewResetToken] = React.useState(0);
     const [requests, setRequests] = React.useState<CrisisMapFeature[]>([]);
     const [selectedRequestId, setSelectedRequestId] = React.useState<string | null>(null);
     const [isDetailsOpen, setIsDetailsOpen] = React.useState(true);
@@ -266,6 +267,7 @@ export default function CrisisMapPage() {
                 };
                 setCenter(nextCenter);
                 setMapZoom(CURRENT_LOCATION_ZOOM);
+                setMapViewResetToken((token) => token + 1);
                 setInfoMessage("Showing requests around your current location.");
             },
             () => {
@@ -340,6 +342,7 @@ export default function CrisisMapPage() {
                             <CrisisMap
                                 center={center}
                                 zoom={mapZoom}
+                                viewResetToken={mapViewResetToken}
                                 features={isViewportDiscoverable(currentViewport) ? visibleRequests : []}
                                 selectedFeatureId={selectedRequestId}
                                 onViewportChange={handleViewportChange}

--- a/web/src/app/crisis-map/page.tsx
+++ b/web/src/app/crisis-map/page.tsx
@@ -4,11 +4,12 @@ import * as React from "react";
 import { AppShell } from "@/components/layout/AppShell";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
+import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
 import { CrisisMap } from "@/components/feature/location/CrisisMap";
 import type { CrisisMapFeature, CrisisRequestType } from "@/components/feature/location/LeafletCrisisMap";
 import { fetchActiveHelpRequests } from "@/lib/crisisMap";
 import { getAccessToken } from "@/lib/auth";
-import { openDirections } from "@/lib/mapDirections";
+import { openDirections, openMapLocation } from "@/lib/mapDirections";
 import type { MapBounds } from "@/components/feature/location/LeafletMapCanvas";
 import {
     effectiveViewportKey,
@@ -333,6 +334,13 @@ export default function CrisisMapPage() {
         );
     }, []);
 
+    const handleOpenInMap = React.useCallback((request: CrisisMapFeature) => {
+        const opened = openMapLocation(request.latitude, request.longitude, request.typeLabel);
+        setDirectionsMessage(
+            opened ? "" : "Map application is unavailable for this request location."
+        );
+    }, []);
+
     return (
         <AppShell title="Help Request Map" containerClassName="gathering-areas-page-container">
             <div className="gathering-areas-page-grid">
@@ -435,13 +443,22 @@ export default function CrisisMapPage() {
                                             <p className="gathering-areas-selected-meta">
                                                 Opened: {formatRelative(selectedRequest.createdAt)}
                                             </p>
-                                            <PrimaryButton
-                                                type="button"
-                                                className="mt-1 h-10 w-auto"
-                                                onClick={() => handleGetDirections(selectedRequest)}
-                                            >
-                                                Get Directions
-                                            </PrimaryButton>
+                                            <div className="gathering-areas-selected-actions">
+                                                <PrimaryButton
+                                                    type="button"
+                                                    className="h-10 w-auto"
+                                                    onClick={() => handleGetDirections(selectedRequest)}
+                                                >
+                                                    Get Directions
+                                                </PrimaryButton>
+                                                <SecondaryButton
+                                                    type="button"
+                                                    className="h-10 w-auto"
+                                                    onClick={() => handleOpenInMap(selectedRequest)}
+                                                >
+                                                    Open in Map
+                                                </SecondaryButton>
+                                            </div>
                                             {directionsMessage ? (
                                                 <p className="gathering-areas-selected-meta">{directionsMessage}</p>
                                             ) : null}

--- a/web/src/app/gathering-areas/page.tsx
+++ b/web/src/app/gathering-areas/page.tsx
@@ -22,7 +22,7 @@ const DEFAULT_CENTER = {
     longitude: 35.0,
 };
 const DEFAULT_ZOOM = 5;
-const CURRENT_LOCATION_ZOOM = 13;
+const CURRENT_LOCATION_ZOOM = 15;
 const DEFAULT_LIMIT = 20;
 const ADDRESS_UNAVAILABLE = "Address unavailable";
 type FetchState = "idle" | "loading" | "success" | "empty" | "error";
@@ -213,6 +213,7 @@ function mapFeatures(features: GatheringAreaFeature[]) {
 export default function GatheringAreasPage() {
     const [center, setCenter] = React.useState(DEFAULT_CENTER);
     const [mapZoom, setMapZoom] = React.useState(DEFAULT_ZOOM);
+    const [mapViewResetToken, setMapViewResetToken] = React.useState(0);
     const [hasUserLocation, setHasUserLocation] = React.useState(false);
     const [areas, setAreas] = React.useState<GatheringAreaMapFeature[]>([]);
     const [categoryOptions, setCategoryOptions] = React.useState<CategoryOption[]>([]);
@@ -446,6 +447,7 @@ export default function GatheringAreasPage() {
                 geolocationDeniedRef.current = false;
                 setCenter(nextCenter);
                 setMapZoom(CURRENT_LOCATION_ZOOM);
+                setMapViewResetToken((token) => token + 1);
                 setHasUserLocation(true);
                 setLocationNote("Showing gathering areas around your current location.");
                 setInfoMessage("Showing resources around your current location.");
@@ -574,6 +576,7 @@ export default function GatheringAreasPage() {
                         <GatheringAreasMap
                             center={center}
                             zoom={mapZoom}
+                            viewResetToken={mapViewResetToken}
                             showLiveLocation={hasUserLocation}
                             features={isDiscoverable ? filteredAreas : []}
                             selectedFeatureId={selectedAreaId}

--- a/web/src/components/feature/location/LeafletCrisisMap.tsx
+++ b/web/src/components/feature/location/LeafletCrisisMap.tsx
@@ -33,6 +33,7 @@ type LeafletCrisisMapProps = {
     onViewportChange?: (bounds: MapBounds) => void;
     heightClassName?: string;
     zoom?: number;
+    viewResetToken?: number;
 };
 
 const TYPE_STYLES: Record<CrisisRequestType, { fill: string; stroke: string; glyph: string }> = {
@@ -97,6 +98,7 @@ export function LeafletCrisisMap({
     onViewportChange,
     heightClassName = "h-[380px] md:h-[500px]",
     zoom = 11,
+    viewResetToken = 0,
 }: LeafletCrisisMapProps) {
     const mapRef = React.useRef<L.Map | null>(null);
     const markerLayerRef = React.useRef<L.LayerGroup | null>(null);
@@ -185,6 +187,7 @@ export function LeafletCrisisMap({
         <LeafletMapCanvas
             center={center}
             zoom={zoom}
+            viewResetToken={viewResetToken}
             heightClassName={heightClassName}
             ariaLabel="Live crisis help requests map"
             onViewportChange={onViewportChange}

--- a/web/src/components/feature/location/LeafletGatheringAreasMap.tsx
+++ b/web/src/components/feature/location/LeafletGatheringAreasMap.tsx
@@ -27,6 +27,7 @@ type LeafletGatheringAreasMapProps = {
     onViewportChange?: (bounds: MapBounds) => void;
     heightClassName?: string;
     zoom?: number;
+    viewResetToken?: number;
 };
 
 function formatCategoryLabel(category: string) {
@@ -127,6 +128,7 @@ export function LeafletGatheringAreasMap({
     onViewportChange,
     heightClassName = "h-[380px] md:h-[500px]",
     zoom = 14,
+    viewResetToken = 0,
 }: LeafletGatheringAreasMapProps) {
     const mapRef = React.useRef<L.Map | null>(null);
     const centerMarkerRef = React.useRef<L.Marker | null>(null);
@@ -230,6 +232,7 @@ export function LeafletGatheringAreasMap({
         <LeafletMapCanvas
             center={center}
             zoom={zoom}
+            viewResetToken={viewResetToken}
             heightClassName={heightClassName}
             ariaLabel="Nearby gathering areas map"
             onViewportChange={onViewportChange}

--- a/web/src/components/feature/location/LeafletLocationMap.tsx
+++ b/web/src/components/feature/location/LeafletLocationMap.tsx
@@ -11,10 +11,13 @@ import type { LatLng } from "@/components/feature/location/LeafletMapCanvas";
 type LeafletLocationMapProps = {
     center: LatLng;
     zoom?: number;
+    viewResetToken?: number;
     selectedPosition: LatLng | null;
     heightClassName?: string;
     interactionMode?: "selectable" | "readonly";
     onSelectPosition?: (position: LatLng) => void;
+    onUseCurrentLocation?: () => void;
+    currentLocationDisabled?: boolean;
 };
 
 function toAssetUrl(asset: string | { src: string }) {
@@ -34,10 +37,13 @@ const locationMarkerIcon = L.icon({
 export function LeafletLocationMap({
     center,
     zoom = 12,
+    viewResetToken = 0,
     selectedPosition,
     heightClassName = "h-72",
     interactionMode = "selectable",
     onSelectPosition,
+    onUseCurrentLocation,
+    currentLocationDisabled = false,
 }: LeafletLocationMapProps) {
     const mapRef = React.useRef<L.Map | null>(null);
     const markerRef = React.useRef<L.Marker | null>(null);
@@ -117,26 +123,57 @@ export function LeafletLocationMap({
     }, [selectedPosition, interactionMode, mapReadyVersion]);
 
     return (
-        <LeafletMapCanvas
-            center={center}
-            zoom={zoom}
-            heightClassName={heightClassName}
-            ariaLabel={
-                interactionMode === "readonly"
-                    ? "Saved location preview map"
-                    : "Location picker map"
-            }
-            onMapReady={(map) => {
-                mapRef.current = map;
-                setMapReadyVersion((version) => version + 1);
-            }}
-            onMapClick={
-                interactionMode === "selectable"
-                    ? (position) => {
-                        onSelectPositionRef.current?.(position);
-                    }
-                    : undefined
-            }
-        />
+        <div className="location-picker-map-wrap">
+            <LeafletMapCanvas
+                center={center}
+                zoom={zoom}
+                viewResetToken={viewResetToken}
+                heightClassName={heightClassName}
+                ariaLabel={
+                    interactionMode === "readonly"
+                        ? "Saved location preview map"
+                        : "Location picker map"
+                }
+                onMapReady={(map) => {
+                    mapRef.current = map;
+                    setMapReadyVersion((version) => version + 1);
+                }}
+                onMapClick={
+                    interactionMode === "selectable"
+                        ? (position) => {
+                            onSelectPositionRef.current?.(position);
+                        }
+                        : undefined
+                }
+            />
+
+            {interactionMode === "selectable" && onUseCurrentLocation ? (
+                <button
+                    type="button"
+                    aria-label="Use Current Location"
+                    title="Use Current Location"
+                    className="location-picker-map-current-location"
+                    onClick={onUseCurrentLocation}
+                    disabled={currentLocationDisabled}
+                >
+                    <svg
+                        width="18"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        aria-hidden="true"
+                    >
+                        <path
+                            d="M12 3V6M12 18V21M3 12H6M18 12H21M12 16.5A4.5 4.5 0 1 0 12 7.5A4.5 4.5 0 0 0 12 16.5Z"
+                            stroke="currentColor"
+                            strokeWidth="1.8"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        />
+                    </svg>
+                </button>
+            ) : null}
+        </div>
     );
 }

--- a/web/src/components/feature/location/LeafletMapCanvas.tsx
+++ b/web/src/components/feature/location/LeafletMapCanvas.tsx
@@ -19,6 +19,7 @@ export type LatLng = {
 type LeafletMapCanvasProps = {
     center: LatLng;
     zoom?: number;
+    viewResetToken?: number;
     heightClassName?: string;
     ariaLabel?: string;
     onMapReady?: (map: L.Map) => void;
@@ -29,6 +30,7 @@ type LeafletMapCanvasProps = {
 export function LeafletMapCanvas({
     center,
     zoom = 12,
+    viewResetToken = 0,
     heightClassName = "h-72",
     ariaLabel = "Map",
     onMapReady,
@@ -105,21 +107,11 @@ export function LeafletMapCanvas({
             return;
         }
 
-        if (map.getZoom() !== zoom) {
-            map.setZoom(zoom);
-        }
-    }, [zoom]);
-
-    React.useEffect(() => {
-        const map = mapRef.current;
-        if (!map) {
-            return;
-        }
-
-        map.setView([center.latitude, center.longitude], map.getZoom(), {
+        map.setView([center.latitude, center.longitude], zoom, {
             animate: true,
         });
-    }, [center.latitude, center.longitude]);
+        map.invalidateSize();
+    }, [center.latitude, center.longitude, zoom, viewResetToken]);
 
     return (
         <div

--- a/web/src/components/feature/location/LocationPicker.tsx
+++ b/web/src/components/feature/location/LocationPicker.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import { TextInput } from "@/components/ui/inputs/TextInput";
-import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
 import { HelperText } from "@/components/ui/display/HelperText";
 import { LocationPickerMap } from "@/components/feature/location/LocationPickerMap";
 import { reverseLocation, searchLocations } from "@/lib/location";
@@ -30,6 +29,8 @@ const DEFAULT_CENTER = {
     latitude: 39.0,
     longitude: 35.0,
 };
+const DEFAULT_MAP_ZOOM = 6;
+const SELECTED_LOCATION_ZOOM = 15;
 
 function toPickerValue(item: LocationSearchItem): LocationPickerValue {
     return {
@@ -85,6 +86,7 @@ export function LocationPicker({
     const [resolving, setResolving] = React.useState(false);
     const [results, setResults] = React.useState<LocationSearchItem[]>([]);
     const [error, setError] = React.useState("");
+    const [mapViewResetToken, setMapViewResetToken] = React.useState(0);
     const skipNextSearchRef = React.useRef(false);
     const searchRequestIdRef = React.useRef(0);
     const reverseRequestIdRef = React.useRef(0);
@@ -207,6 +209,7 @@ export function LocationPicker({
                                 : null,
                         capturedAt: new Date(position.timestamp).toISOString(),
                     });
+                    setMapViewResetToken((token) => token + 1);
 
                     void handleResolveCoordinates(
                         position.coords.latitude,
@@ -266,7 +269,7 @@ export function LocationPicker({
         <div className="location-picker-wrap flex flex-col gap-3">
             <HelperText className="text-sm text-[color:var(--text-primary)]">{label}</HelperText>
 
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <div className="flex flex-col gap-2">
                 <TextInput
                     id={searchInputId}
                     label="Search location"
@@ -274,15 +277,6 @@ export function LocationPicker({
                     value={query}
                     onChange={(event) => setQuery(event.target.value)}
                 />
-
-                <PrimaryButton
-                    type="button"
-                    className="sm:w-52"
-                    onClick={handleUseCurrentLocation}
-                    loading={resolving}
-                >
-                    Use Current Location
-                </PrimaryButton>
             </div>
 
             {results.length > 0 ? (
@@ -298,6 +292,7 @@ export function LocationPicker({
                                     source: "search",
                                     capturedAt: new Date().toISOString(),
                                 });
+                                setMapViewResetToken((token) => token + 1);
                                 skipNextSearchRef.current = true;
                                 setResults([]);
                                 setQuery(item.displayName);
@@ -311,6 +306,8 @@ export function LocationPicker({
 
             <LocationPickerMap
                 center={center}
+                zoom={value ? SELECTED_LOCATION_ZOOM : DEFAULT_MAP_ZOOM}
+                viewResetToken={mapViewResetToken}
                 selectedPosition={
                     value
                         ? {
@@ -326,12 +323,15 @@ export function LocationPicker({
                         accuracyMeters: null,
                         capturedAt: new Date().toISOString(),
                     });
+                    setMapViewResetToken((token) => token + 1);
 
                     void handleResolveCoordinates(position.latitude, position.longitude, {
                         source: "map_pin",
                         accuracyMeters: null,
                     });
                 }}
+                onUseCurrentLocation={handleUseCurrentLocation}
+                currentLocationDisabled={resolving}
             />
 
             {searching ? <HelperText>Searching locations...</HelperText> : null}

--- a/web/src/components/feature/location/LocationPicker.tsx
+++ b/web/src/components/feature/location/LocationPicker.tsx
@@ -90,10 +90,25 @@ export function LocationPicker({
     const skipNextSearchRef = React.useRef(false);
     const searchRequestIdRef = React.useRef(0);
     const reverseRequestIdRef = React.useRef(0);
+    const hasAttemptedInitialLocationRef = React.useRef(false);
+    const userSelectionVersionRef = React.useRef(0);
+    const latestValueRef = React.useRef<LocationPickerValue | null>(value);
+
+    React.useEffect(() => {
+        latestValueRef.current = value;
+    }, [value]);
 
     const center = value
         ? { latitude: value.latitude, longitude: value.longitude }
         : DEFAULT_CENTER;
+
+    const markUserSelection = React.useCallback(() => {
+        userSelectionVersionRef.current += 1;
+    }, []);
+
+    const invalidatePendingReverseLookup = React.useCallback(() => {
+        reverseRequestIdRef.current += 1;
+    }, []);
 
     const handleSearch = React.useCallback(async () => {
         if (query.trim().length < 2) {
@@ -144,6 +159,9 @@ export function LocationPicker({
                 source?: string | null;
                 accuracyMeters?: number | null;
                 capturedAt?: string | null;
+            },
+            options?: {
+                shouldApplyResult?: () => boolean;
             }
         ) => {
             const currentReverseRequestId = ++reverseRequestIdRef.current;
@@ -157,6 +175,9 @@ export function LocationPicker({
                 if (currentReverseRequestId !== reverseRequestIdRef.current) {
                     return;
                 }
+                if (options?.shouldApplyResult && !options.shouldApplyResult()) {
+                    return;
+                }
 
                 onChange({
                     ...toPickerValue(response.item),
@@ -166,6 +187,9 @@ export function LocationPicker({
                 });
             } catch (err) {
                 if (currentReverseRequestId !== reverseRequestIdRef.current) {
+                    return;
+                }
+                if (options?.shouldApplyResult && !options.shouldApplyResult()) {
                     return;
                 }
 
@@ -185,7 +209,14 @@ export function LocationPicker({
         [onChange]
     );
 
-    const handleUseCurrentLocation = React.useCallback(() => {
+    const requestCurrentLocation = React.useCallback((options?: { initial?: boolean }) => {
+        const isInitial = options?.initial === true;
+        const initialSelectionVersion = userSelectionVersionRef.current;
+
+        if (isInitial && latestValueRef.current) {
+            return;
+        }
+
         if (!navigator.geolocation) {
             setError("Geolocation is not supported in this browser.");
             return;
@@ -197,31 +228,58 @@ export function LocationPicker({
 
             navigator.geolocation.getCurrentPosition(
                 (position) => {
-                    onChange({
-                        ...toManualPickerValue(
-                            position.coords.latitude,
-                            position.coords.longitude
-                        ),
+                    if (
+                        isInitial &&
+                        (
+                            userSelectionVersionRef.current !== initialSelectionVersion ||
+                            (
+                                latestValueRef.current !== null &&
+                                latestValueRef.current.source !== "current_device"
+                            )
+                        )
+                    ) {
+                        setResolving(false);
+                        return;
+                    }
+
+                    const metadata = {
                         source: "current_device",
                         accuracyMeters:
                             typeof position.coords.accuracy === "number"
                                 ? position.coords.accuracy
                                 : null,
                         capturedAt: new Date(position.timestamp).toISOString(),
+                    };
+
+                    onChange({
+                        ...toManualPickerValue(
+                            position.coords.latitude,
+                            position.coords.longitude
+                        ),
+                        ...metadata,
                     });
                     setMapViewResetToken((token) => token + 1);
 
                     void handleResolveCoordinates(
                         position.coords.latitude,
                         position.coords.longitude,
-                        {
-                            source: "current_device",
-                            accuracyMeters:
-                                typeof position.coords.accuracy === "number"
-                                    ? position.coords.accuracy
-                                    : null,
-                            capturedAt: new Date(position.timestamp).toISOString(),
-                        }
+                        metadata,
+                        isInitial
+                            ? {
+                                shouldApplyResult: () => {
+                                    const current = latestValueRef.current;
+                                    return userSelectionVersionRef.current === initialSelectionVersion &&
+                                        (
+                                            current === null ||
+                                            (
+                                                current.source === "current_device" &&
+                                                Math.abs(current.latitude - position.coords.latitude) < 0.000001 &&
+                                                Math.abs(current.longitude - position.coords.longitude) < 0.000001
+                                            )
+                                        );
+                                },
+                            }
+                            : undefined
                     );
                 },
                 (geoError) => {
@@ -257,6 +315,20 @@ export function LocationPicker({
             });
     }, [handleResolveCoordinates]);
 
+    const handleUseCurrentLocation = React.useCallback(() => {
+        markUserSelection();
+        requestCurrentLocation();
+    }, [markUserSelection, requestCurrentLocation]);
+
+    React.useEffect(() => {
+        if (hasAttemptedInitialLocationRef.current || value) {
+            return;
+        }
+
+        hasAttemptedInitialLocationRef.current = true;
+        requestCurrentLocation({ initial: true });
+    }, [requestCurrentLocation, value]);
+
     React.useEffect(() => {
         const timeout = setTimeout(() => {
             void handleSearch();
@@ -287,6 +359,8 @@ export function LocationPicker({
                             type="button"
                             className="w-full border-b border-[color:var(--divider)] px-3 py-2 text-left text-sm text-[color:var(--text-primary)] transition-colors hover:bg-[color:var(--surface-soft)]"
                             onClick={() => {
+                                markUserSelection();
+                                invalidatePendingReverseLookup();
                                 onChange({
                                     ...toPickerValue(item),
                                     source: "search",
@@ -317,6 +391,7 @@ export function LocationPicker({
                         : null
                 }
                 onSelectPosition={(position) => {
+                    markUserSelection();
                     onChange({
                         ...toManualPickerValue(position.latitude, position.longitude),
                         source: "map_pin",

--- a/web/src/lib/mapDirections.ts
+++ b/web/src/lib/mapDirections.ts
@@ -23,6 +23,20 @@ export function buildDirectionsUrl(
     return `https://www.google.com/maps/dir/?api=1&destination=${latitude},${longitude}`;
 }
 
+export function buildMapLocationUrl(
+    latitude: number,
+    longitude: number,
+    label?: string
+): string | null {
+    // Map search is coordinate-based; label is reserved for future destination UI integrations.
+    if (!isValidDestinationCoordinates(latitude, longitude)) {
+        return null;
+    }
+
+    // Google Maps search opens the coordinate without starting turn-by-turn directions.
+    return `https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}`;
+}
+
 export function openDirections(
     latitude: number,
     longitude: number,
@@ -34,6 +48,25 @@ export function openDirections(
     }
 
     const openedWindow = window.open(directionsUrl, "_blank");
+    if (!openedWindow) {
+        return false;
+    }
+
+    openedWindow.opener = null;
+    return true;
+}
+
+export function openMapLocation(
+    latitude: number,
+    longitude: number,
+    label?: string
+): boolean {
+    const mapUrl = buildMapLocationUrl(latitude, longitude, label);
+    if (!mapUrl || typeof window === "undefined") {
+        return false;
+    }
+
+    const openedWindow = window.open(mapUrl, "_blank");
     if (!openedWindow) {
         return false;
     }

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1990,6 +1990,13 @@ textarea::placeholder {
     color: var(--text-secondary);
 }
 
+.gathering-areas-selected-actions {
+    margin-top: 4px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
 .gathering-areas-empty-detail {
     margin: 0;
     font-size: 0.875rem;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1723,6 +1723,39 @@ textarea::placeholder {
     z-index: 1;
 }
 
+.location-picker-map-wrap {
+    position: relative;
+}
+
+.location-picker-map-current-location {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 40;
+    pointer-events: auto;
+    width: 38px;
+    height: 38px;
+    border: 1px solid #f0bec2;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--surface-card) 94%, transparent);
+    backdrop-filter: blur(8px);
+    box-shadow: var(--shadow-card);
+    color: #d43b45;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.location-picker-map-current-location:hover {
+    border-color: #e27a82;
+    background: #fff4f5;
+}
+
+.location-picker-map-current-location:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
 .location-picker-wrap .leaflet-top,
 .location-picker-wrap .leaflet-bottom,
 .location-picker-wrap .leaflet-pane,


### PR DESCRIPTION
## Summary

Fixes map behavior consistency across web and Android.

## Changes

- Removes the remaining visible **Use Current Location** button from the web LocationPicker.
- Moves web LocationPicker current-location behavior into the map-based icon control.
- Fixes web icon-only current-location controls so they move/zoom the map correctly.
- Aligns web current-location zoom behavior with the intended mobile feel.
- Fixes Android Gathering Areas automatic viewport refresh so visible resources load after panning/zooming into a discoverable area.
- Keeps manual refresh as a fallback instead of requiring it for normal map usage.

## Expected Behavior

- Web location forms no longer show a standalone written **Use Current Location** button.
- Web current-location icon controls work consistently.
- Android Gathering Areas loads resources automatically when the user moves/zooms into a valid visible area.
- Last loaded markers may remain visible while zoomed out, matching the accepted web behavior.
- Existing manual/search/map-click location selection remains working.

## Testing

- Verified web LocationPicker current-location behavior.
- Verified web Gathering Areas current-location icon behavior.
- Verified Android Gathering Areas automatic viewport refresh.
- Verified **Refresh Visible Area** still works as a fallback.
- Verified Android Request Help current-location action was not modified.

Closes #580
Closes #583