### PR TITLE
feat: Replace current-day timestamps with Today/Yesterday labels

### DIFF
--- a/android/app/src/main/java/com/neph/core/format/TimestampFormatters.kt
+++ b/android/app/src/main/java/com/neph/core/format/TimestampFormatters.kt
@@ -1,0 +1,70 @@
+package com.neph.core.format
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+fun parseTimestampToInstant(raw: String?): Instant? {
+    val value = raw?.trim()?.takeIf { it.isNotBlank() } ?: return null
+
+    return runCatching { Instant.parse(value) }
+        .recoverCatching { OffsetDateTime.parse(value).toInstant() }
+        .recoverCatching { LocalDateTime.parse(value.replace(' ', 'T')).toInstant(ZoneOffset.UTC) }
+        .getOrNull()
+}
+
+fun relativeDayLabel(
+    instant: Instant,
+    zoneId: ZoneId = ZoneId.systemDefault(),
+    nowInstant: Instant = Instant.now()
+): String? {
+    val targetDate = instant.atZone(zoneId).toLocalDate()
+    val today = LocalDate.ofInstant(nowInstant, zoneId)
+
+    return when (targetDate) {
+        today -> "Today"
+        today.minusDays(1) -> "Yesterday"
+        else -> null
+    }
+}
+
+fun formatTimestampWithRelativeDay(
+    raw: String?,
+    fallbackFormatter: DateTimeFormatter,
+    timeFormatter: DateTimeFormatter,
+    zoneId: ZoneId = ZoneId.systemDefault(),
+    nowInstant: Instant = Instant.now(),
+    relativeSeparator: String = ", "
+): String? {
+    val instant = parseTimestampToInstant(raw) ?: return null
+    return formatInstantWithRelativeDay(
+        instant = instant,
+        fallbackFormatter = fallbackFormatter,
+        timeFormatter = timeFormatter,
+        zoneId = zoneId,
+        nowInstant = nowInstant,
+        relativeSeparator = relativeSeparator
+    )
+}
+
+fun formatInstantWithRelativeDay(
+    instant: Instant,
+    fallbackFormatter: DateTimeFormatter,
+    timeFormatter: DateTimeFormatter,
+    zoneId: ZoneId = ZoneId.systemDefault(),
+    nowInstant: Instant = Instant.now(),
+    relativeSeparator: String = ", "
+): String {
+    val zonedDateTime = instant.atZone(zoneId)
+    val relativeLabel = relativeDayLabel(instant, zoneId, nowInstant)
+
+    return if (relativeLabel != null) {
+        "$relativeLabel$relativeSeparator${timeFormatter.format(zonedDateTime)}"
+    } else {
+        fallbackFormatter.withZone(zoneId).format(instant)
+    }
+}

--- a/android/app/src/main/java/com/neph/features/helprequestmap/data/ActiveHelpRequestsRepository.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/data/ActiveHelpRequestsRepository.kt
@@ -1,14 +1,15 @@
 package com.neph.features.helprequestmap.data
 
+import com.neph.core.format.formatTimestampWithRelativeDay
 import com.neph.core.network.JsonHttpClient
 import com.neph.features.auth.data.AuthSessionStore
 import org.json.JSONArray
 import org.json.JSONObject
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
-import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.format.DateTimeFormatter
 import java.util.Locale
-import java.util.TimeZone
 
 enum class CrisisRequestType {
     SHELTER,
@@ -161,33 +162,27 @@ object ActiveHelpRequestsRepository {
         return priority.trim().lowercase(Locale.ROOT).replaceFirstChar { it.uppercase() }
     }
 
-    fun formatOpenedAt(createdAt: String): String {
-        val parsed = runCatching {
-            IsoDateFormat.get().parse(createdAt)
-        }.getOrNull() ?: return createdAt
-
-        return DisplayDateFormat.get().format(parsed)
+    fun formatOpenedAt(
+        createdAt: String,
+        nowInstant: Instant = Instant.now()
+    ): String {
+        return formatTimestampWithRelativeDay(
+            raw = createdAt,
+            fallbackFormatter = DisplayDateFormatter,
+            timeFormatter = DisplayTimeFormatter,
+            nowInstant = nowInstant
+        ) ?: createdAt
     }
 
     private fun urlEncode(value: String): String {
         return URLEncoder.encode(value, StandardCharsets.UTF_8.toString())
     }
 
-    private val IsoDateFormat = object : ThreadLocal<SimpleDateFormat>() {
-        override fun initialValue(): SimpleDateFormat {
-            return SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
-                timeZone = TimeZone.getTimeZone("UTC")
-            }
-        }
-    }
+    private val DisplayDateFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("MMM d, yyyy, HH:mm", Locale.US)
 
-    private val DisplayDateFormat = object : ThreadLocal<SimpleDateFormat>() {
-        override fun initialValue(): SimpleDateFormat {
-            return SimpleDateFormat("MMM d, yyyy, HH:mm", Locale.US).apply {
-                timeZone = TimeZone.getDefault()
-            }
-        }
-    }
+    private val DisplayTimeFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("HH:mm", Locale.US)
 }
 
 private fun JSONObject.optFiniteDouble(key: String): Double? {

--- a/android/app/src/main/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepository.kt
+++ b/android/app/src/main/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepository.kt
@@ -4,6 +4,7 @@ import com.neph.core.NephAppContext
 import com.neph.core.database.HelpRequestEntity
 import com.neph.core.database.NephDatabaseProvider
 import com.neph.core.database.SyncOperationEntity
+import com.neph.core.format.formatInstantWithRelativeDay
 import com.neph.core.network.JsonHttpClient
 import com.neph.core.sync.LocalOwnerType
 import com.neph.core.sync.OfflineSyncScheduler
@@ -20,6 +21,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.json.JSONArray
 import org.json.JSONObject
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 data class MyHelpRequestUiModel(
     val id: String,
@@ -423,9 +427,19 @@ private fun buildShortDescription(description: String): String {
 }
 
 private fun formatEpochMillis(raw: Long): String {
-    val formatter = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", java.util.Locale.US)
-    return formatter.format(java.util.Date(raw))
+    return formatInstantWithRelativeDay(
+        instant = Instant.ofEpochMilli(raw),
+        fallbackFormatter = EpochDisplayFormatter,
+        timeFormatter = EpochTimeFormatter,
+        relativeSeparator = " "
+    )
 }
+
+private val EpochDisplayFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm", Locale.US)
+
+private val EpochTimeFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("HH:mm", Locale.US)
 
 @Suppress("unused")
 private fun JSONArray?.toStringList(): List<String> {

--- a/android/app/src/main/java/com/neph/features/nearbyusers/presentation/NearbyVisibleUsersScreen.kt
+++ b/android/app/src/main/java/com/neph/features/nearbyusers/presentation/NearbyVisibleUsersScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.neph.core.format.formatInstantWithRelativeDay
 import com.neph.core.network.ApiException
 import com.neph.features.auth.data.AuthRepository
 import com.neph.features.auth.data.AuthSessionStore
@@ -48,8 +49,8 @@ import com.neph.ui.location.rememberForegroundLocationPermissionRequester
 import com.neph.ui.theme.LocalNephSpacing
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.Instant
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @Composable
@@ -388,5 +389,16 @@ private fun formatSafetyStatus(status: String): String {
 }
 
 private fun formatEpoch(epochMillis: Long): String {
-    return SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US).format(Date(epochMillis))
+    return formatInstantWithRelativeDay(
+        instant = Instant.ofEpochMilli(epochMillis),
+        fallbackFormatter = EpochDisplayFormatter,
+        timeFormatter = EpochTimeFormatter,
+        relativeSeparator = " "
+    )
 }
+
+private val EpochDisplayFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm", Locale.US)
+
+private val EpochTimeFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("HH:mm", Locale.US)

--- a/android/app/src/main/java/com/neph/features/notifications/presentation/NotificationsScreen.kt
+++ b/android/app/src/main/java/com/neph/features/notifications/presentation/NotificationsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import com.neph.core.format.formatTimestampWithRelativeDay
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.notifications.data.NotificationUiModel
 import com.neph.features.notifications.data.NotificationsBadge
@@ -40,9 +41,8 @@ import com.neph.ui.layout.AppDrawerScaffold
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephTheme
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
 import java.util.Locale
-import java.util.TimeZone
 
 @Composable
 fun NotificationsScreen(
@@ -291,40 +291,18 @@ fun NotificationsScreen(
 }
 
 private fun formatNotificationTimestamp(raw: String): String {
-    val isoWithMillis = requireNotNull(NotificationIsoWithMillis.get())
-    val isoNoMillis = requireNotNull(NotificationIsoNoMillis.get())
-    val displayFormatter = requireNotNull(NotificationDisplayFormat.get())
-
-    val parsed = runCatching {
-        isoWithMillis.parse(raw)
-    }.recoverCatching {
-        isoNoMillis.parse(raw)
-    }.getOrNull() ?: return raw
-
-    return displayFormatter.format(parsed)
+    return formatTimestampWithRelativeDay(
+        raw = raw,
+        fallbackFormatter = NotificationDisplayFormatter,
+        timeFormatter = NotificationTimeFormatter
+    ) ?: raw
 }
 
-private val NotificationIsoWithMillis = object : ThreadLocal<SimpleDateFormat>() {
-    override fun initialValue(): SimpleDateFormat {
-        return SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX", Locale.US).apply {
-            timeZone = TimeZone.getTimeZone("UTC")
-        }
-    }
-}
+private val NotificationDisplayFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("MMM d, yyyy, HH:mm", Locale.US)
 
-private val NotificationIsoNoMillis = object : ThreadLocal<SimpleDateFormat>() {
-    override fun initialValue(): SimpleDateFormat {
-        return SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX", Locale.US).apply {
-            timeZone = TimeZone.getTimeZone("UTC")
-        }
-    }
-}
-
-private val NotificationDisplayFormat = object : ThreadLocal<SimpleDateFormat>() {
-    override fun initialValue(): SimpleDateFormat {
-        return SimpleDateFormat("MMM d, yyyy, HH:mm", Locale.US)
-    }
-}
+private val NotificationTimeFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("HH:mm", Locale.US)
 
 @Preview(showBackground = true, showSystemUi = true)
 @Composable

--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestLifecycleFormatting.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestLifecycleFormatting.kt
@@ -1,10 +1,8 @@
 package com.neph.features.requesthelp.data
 
+import com.neph.core.format.formatTimestampWithRelativeDay
+import com.neph.core.format.parseTimestampToInstant
 import java.time.Instant
-import java.time.LocalDateTime
-import java.time.OffsetDateTime
-import java.time.ZoneId
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
@@ -19,34 +17,32 @@ internal fun formatOperationalLevel(value: String?): String? {
         }
 }
 
-internal fun formatLifecycleTimestamp(raw: String?): String? {
+internal fun formatLifecycleTimestamp(
+    raw: String?,
+    nowInstant: Instant = Instant.now()
+): String? {
     val value = raw
         ?.trim()
         ?.takeIf { it.isNotBlank() }
         ?: return null
 
-    val instant = parseTimestampToInstant(value)
-        ?: return value
+    return formatTimestampWithRelativeDay(
+        raw = value,
+        fallbackFormatter = LifecycleDisplayFormatter,
+        timeFormatter = LifecycleTimeFormatter,
+        nowInstant = nowInstant,
+        relativeSeparator = " "
+    ) ?: value
             .replace('T', ' ')
             .substringBefore('.')
             .substringBefore('Z')
-
-    return LifecycleDisplayFormatter
-        .withZone(ZoneId.systemDefault())
-        .format(instant)
 }
 
 private val LifecycleDisplayFormatter: DateTimeFormatter =
     DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.US)
 
-private fun parseTimestampToInstant(raw: String): Instant? {
-    val value = raw.trim().takeIf { it.isNotBlank() } ?: return null
-
-    return runCatching { Instant.parse(value) }
-        .recoverCatching { OffsetDateTime.parse(value).toInstant() }
-        .recoverCatching { LocalDateTime.parse(value.replace(' ', 'T')).toInstant(ZoneOffset.UTC) }
-        .getOrNull()
-}
+private val LifecycleTimeFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("HH:mm:ss", Locale.US)
 
 internal fun buildDurationLabel(
     openedAtRaw: String?,

--- a/android/app/src/test/java/com/neph/features/helprequestmap/data/ActiveHelpRequestsRepositoryTest.kt
+++ b/android/app/src/test/java/com/neph/features/helprequestmap/data/ActiveHelpRequestsRepositoryTest.kt
@@ -4,6 +4,8 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.time.Instant
+import java.util.TimeZone
 
 class ActiveHelpRequestsRepositoryTest {
     @Test
@@ -199,5 +201,35 @@ class ActiveHelpRequestsRepositoryTest {
         assertEquals(CrisisRequestType.SEARCH_AND_RESCUE, ActiveHelpRequestsRepository.normalizeRequestType("search_rescue"))
         assertEquals(CrisisRequestType.SEARCH_AND_RESCUE, ActiveHelpRequestsRepository.normalizeRequestType("search_and_rescue"))
         assertEquals(CrisisRequestType.OTHER, ActiveHelpRequestsRepository.normalizeRequestType("unknown"))
+    }
+
+    @Test
+    fun formatOpenedAtUsesRelativeDayLabels() {
+        withDefaultTimeZone("Europe/Istanbul") {
+            assertEquals(
+                "Today, 13:15",
+                ActiveHelpRequestsRepository.formatOpenedAt(
+                    createdAt = "2026-05-11T10:15:00.000Z",
+                    nowInstant = Instant.parse("2026-05-11T18:00:00.000Z")
+                )
+            )
+            assertEquals(
+                "Yesterday, 23:30",
+                ActiveHelpRequestsRepository.formatOpenedAt(
+                    createdAt = "2026-05-10T20:30:00.000Z",
+                    nowInstant = Instant.parse("2026-05-11T10:00:00.000Z")
+                )
+            )
+        }
+    }
+
+    private fun withDefaultTimeZone(id: String, block: () -> Unit) {
+        val previous = TimeZone.getDefault()
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone(id))
+            block()
+        } finally {
+            TimeZone.setDefault(previous)
+        }
     }
 }

--- a/android/app/src/test/java/com/neph/features/requesthelp/data/RequestLifecycleFormattingTest.kt
+++ b/android/app/src/test/java/com/neph/features/requesthelp/data/RequestLifecycleFormattingTest.kt
@@ -2,6 +2,7 @@ package com.neph.features.requesthelp.data
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.time.Instant
 import java.util.TimeZone
 
 class RequestLifecycleFormattingTest {
@@ -21,6 +22,32 @@ class RequestLifecycleFormattingTest {
             assertEquals(
                 "2026-04-26 13:00:00",
                 formatLifecycleTimestamp("2026-04-26T12:00:00+02:00")
+            )
+        }
+    }
+
+    @Test
+    fun formatLifecycleTimestampUsesTodayForCurrentLocalDate() {
+        withDefaultTimeZone("Europe/Istanbul") {
+            assertEquals(
+                "Today 13:00:00",
+                formatLifecycleTimestamp(
+                    raw = "2026-05-11T10:00:00.000Z",
+                    nowInstant = Instant.parse("2026-05-11T18:00:00.000Z")
+                )
+            )
+        }
+    }
+
+    @Test
+    fun formatLifecycleTimestampUsesYesterdayForPreviousLocalDate() {
+        withDefaultTimeZone("Europe/Istanbul") {
+            assertEquals(
+                "Yesterday 23:30:00",
+                formatLifecycleTimestamp(
+                    raw = "2026-05-10T20:30:00.000Z",
+                    nowInstant = Instant.parse("2026-05-11T10:00:00.000Z")
+                )
             )
         }
     }

--- a/web/src/app/crisis-map/page.tsx
+++ b/web/src/app/crisis-map/page.tsx
@@ -15,6 +15,7 @@ import {
     isViewportDiscoverable,
     viewportBoundsToBbox,
 } from "@/lib/viewportDiscovery";
+import { formatTimestampDateTime } from "@/lib/formatters";
 
 const DEFAULT_CENTER = {
     latitude: 39.0,
@@ -79,14 +80,7 @@ function typeLabel(type: CrisisRequestType) {
 }
 
 function formatRelative(createdAt: string) {
-    const date = new Date(createdAt);
-    if (Number.isNaN(date.getTime())) {
-        return createdAt;
-    }
-    return new Intl.DateTimeFormat("en-US", {
-        dateStyle: "medium",
-        timeStyle: "short",
-    }).format(date);
+    return formatTimestampDateTime(createdAt);
 }
 
 function formatPriority(priority: CrisisMapFeature["priorityLevel"]) {

--- a/web/src/app/home/page.tsx
+++ b/web/src/app/home/page.tsx
@@ -18,6 +18,7 @@ import {
     readCachedAnnouncements,
     type NewsItem,
 } from "@/lib/news";
+import { formatTimestampDateTime } from "@/lib/formatters";
 
 type HeroSlide = {
     title: string;
@@ -75,15 +76,7 @@ function describeNewsPreviewFailure(err: unknown) {
 }
 
 function formatLastUpdated(value: string) {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return value;
-    }
-
-    return date.toLocaleString(undefined, {
-        dateStyle: "medium",
-        timeStyle: "short",
-    });
+    return formatTimestampDateTime(value);
 }
 
 export default function HomePage() {

--- a/web/src/app/news/page.tsx
+++ b/web/src/app/news/page.tsx
@@ -14,17 +14,10 @@ import {
     readCachedAnnouncements,
     type NewsItem,
 } from "@/lib/news";
+import { formatTimestampDateTime } from "@/lib/formatters";
 
 function formatLastUpdated(value: string) {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return value;
-    }
-
-    return date.toLocaleString(undefined, {
-        dateStyle: "medium",
-        timeStyle: "short",
-    });
+    return formatTimestampDateTime(value);
 }
 
 function buildFailureMessage(err: unknown, sourceLabel: string) {

--- a/web/src/app/notifications/page.tsx
+++ b/web/src/app/notifications/page.tsx
@@ -15,18 +15,7 @@ import {
     updateNotificationPreferences,
     type NotificationItem,
 } from "@/lib/notifications";
-
-function formatDateTime(value: string) {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return value;
-    }
-
-    return date.toLocaleString(undefined, {
-        dateStyle: "medium",
-        timeStyle: "short",
-    });
-}
+import { formatTimestampDateTime } from "@/lib/formatters";
 
 function formatTypeLabel(value: string) {
     const normalized = (value || "").trim().toLowerCase();
@@ -240,7 +229,7 @@ export default function NotificationsPage() {
                                             <span className="notifications-item-type-chip">
                                                 {formatTypeLabel(item.type)}
                                             </span>
-                                            <span className="news-item-date">{formatDateTime(item.createdAt)}</span>
+                                            <span className="news-item-date">{formatTimestampDateTime(item.createdAt)}</span>
                                         </div>
 
                                         <h3 className="notifications-item-title">
@@ -255,7 +244,7 @@ export default function NotificationsPage() {
                                             </p>
                                             <p>
                                                 <strong>Status:</strong> {item.isRead ? "Read" : "Unread"}
-                                                {item.readAt ? ` - Read at ${formatDateTime(item.readAt)}` : ""}
+                                                {item.readAt ? ` - Read at ${formatTimestampDateTime(item.readAt)}` : ""}
                                             </p>
                                         </div>
 

--- a/web/src/components/feature/admin/AdminEmergencyHistoryView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyHistoryView.tsx
@@ -8,7 +8,7 @@ import {
     fetchAdminEmergencyHistory,
     type EmergencyHistoryItem,
 } from "@/lib/admin";
-import { formatOperationalLabel } from "@/lib/formatters";
+import { formatOperationalLabel, formatTimestampDateTime } from "@/lib/formatters";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { SectionHeader } from "@/components/ui/display/SectionHeader";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
@@ -39,7 +39,7 @@ function formatDateTime(value: string | null) {
         return value;
     }
 
-    return date.toLocaleString();
+    return formatTimestampDateTime(value);
 }
 
 export default function AdminEmergencyHistoryView() {

--- a/web/src/components/feature/admin/AdminEmergencyInsightsView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyInsightsView.tsx
@@ -9,7 +9,7 @@ import {
     type EmergencyAnalytics,
     type EmergencyAnalyticsComparisonMetric,
 } from "@/lib/admin";
-import { formatOperationalLabel } from "@/lib/formatters";
+import { formatOperationalLabel, formatTimestampDate } from "@/lib/formatters";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { SectionHeader } from "@/components/ui/display/SectionHeader";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
@@ -466,7 +466,7 @@ export default function AdminEmergencyInsightsView() {
                                     <tbody>
                                         {dailyTrend.map((row) => (
                                             <tr key={row.date}>
-                                                <td>{row.date}</td>
+                                                <td>{formatTimestampDate(row.date)}</td>
                                                 <td>{row.created}</td>
                                                 <td>{row.resolved}</td>
                                                 <td>{row.cancelled}</td>

--- a/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
+++ b/web/src/components/feature/admin/AdminEmergencyOverviewView.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { ApiError } from "@/lib/api";
 import { getAccessToken, clearAccessToken } from "@/lib/auth";
 import { fetchAdminEmergencyOverview, type EmergencyOverview } from "@/lib/admin";
-import { formatOperationalLabel } from "@/lib/formatters";
+import { formatOperationalLabel, formatTimestampDateTime } from "@/lib/formatters";
 import { SectionCard } from "@/components/ui/display/SectionCard";
 import { SectionHeader } from "@/components/ui/display/SectionHeader";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
@@ -38,7 +38,7 @@ function formatDateTime(value: string | null) {
         return value;
     }
 
-    return date.toLocaleString();
+    return formatTimestampDateTime(value);
 }
 
 export default function AdminEmergencyOverviewView() {

--- a/web/src/components/feature/admin/AdminUsersView.tsx
+++ b/web/src/components/feature/admin/AdminUsersView.tsx
@@ -16,6 +16,7 @@ import { SectionHeader } from "@/components/ui/display/SectionHeader";
 import { PrimaryButton } from "@/components/ui/buttons/PrimaryButton";
 import { SecondaryButton } from "@/components/ui/buttons/SecondaryButton";
 import { TextArea } from "@/components/ui/inputs/TextArea";
+import { formatTimestampDateTime } from "@/lib/formatters";
 
 type VerifiedFilter = "ALL" | "VERIFIED" | "UNVERIFIED";
 type BannedFilter = "ALL" | "BANNED" | "ACTIVE";
@@ -62,7 +63,7 @@ function formatDateTime(value: string | null) {
     if (Number.isNaN(date.getTime())) {
         return value;
     }
-    return date.toLocaleString();
+    return formatTimestampDateTime(value);
 }
 
 function StatusBadge({

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -12,3 +12,72 @@ export function formatOperationalLabel(value: string | null | undefined) {
         .map((word) => (word ? word[0].toLocaleUpperCase("en-US") + word.slice(1) : word))
         .join(" ");
 }
+
+function parseTimestamp(value: string) {
+    const dateOnlyMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (dateOnlyMatch) {
+        const [, year, month, day] = dateOnlyMatch;
+        return new Date(Number(year), Number(month) - 1, Number(day));
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function startOfLocalDay(date: Date) {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function getRelativeDayLabel(date: Date, now = new Date()) {
+    const targetDay = startOfLocalDay(date).getTime();
+    const today = startOfLocalDay(now).getTime();
+    const yesterday = today - 24 * 60 * 60 * 1000;
+
+    if (targetDay === today) {
+        return "Today";
+    }
+
+    if (targetDay === yesterday) {
+        return "Yesterday";
+    }
+
+    return null;
+}
+
+export function formatTimestampDate(value: string, now = new Date()) {
+    const date = parseTimestamp(value);
+    if (!date) {
+        return value;
+    }
+
+    const relativeLabel = getRelativeDayLabel(date, now);
+    if (relativeLabel) {
+        return relativeLabel;
+    }
+
+    return date.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+    });
+}
+
+export function formatTimestampDateTime(value: string, now = new Date()) {
+    const date = parseTimestamp(value);
+    if (!date) {
+        return value;
+    }
+
+    const relativeLabel = getRelativeDayLabel(date, now);
+    if (relativeLabel) {
+        return `${relativeLabel}, ${date.toLocaleTimeString(undefined, {
+            hour: "numeric",
+            minute: "2-digit",
+        })}`;
+    }
+
+    return date.toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+    });
+}

--- a/web/src/lib/news.ts
+++ b/web/src/lib/news.ts
@@ -1,4 +1,5 @@
 import { apiRequest } from "@/lib/api";
+import { formatTimestampDate } from "@/lib/formatters";
 
 export type Announcement = {
     id: string;
@@ -71,16 +72,7 @@ function buildAnnouncementsPath(options: { limit?: number } = {}) {
 }
 
 export function formatAnnouncementDate(value: string) {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return value;
-    }
-
-    return date.toLocaleDateString(undefined, {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-    });
+    return formatTimestampDate(value);
 }
 
 export function summarizeAnnouncementContent(content: string, maxLength = 180) {


### PR DESCRIPTION
### Description
Implements the issue [#547](https://github.com/bounswe/bounswe2026group6/issues/547) by adding shared relative-day timestamp formatting across web and Android.

### Changes

- Added web timestamp helpers for date-only and date-time labels.
- Added Android timestamp helpers for parsed timestamps and epoch-based labels.
- Updated news, notifications, crisis map, admin views, request lifecycle, help request map, my requests, and nearby-user cache timestamp displays.
- Preserved time for date-time labels, e.g. Today, 14:30 / Yesterday, 14:30.
- Added Android unit coverage for Today/Yesterday formatting.