### PR TITLE
fix: notification page timezone handling

### DIFF
--- a/backend/src/modules/notifications/service.js
+++ b/backend/src/modules/notifications/service.js
@@ -74,6 +74,32 @@ function decodeCursor(cursor) {
   }
 }
 
+const DATE_TIME_WITHOUT_OFFSET_PATTERN = /^\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}/;
+const TIMEZONE_OFFSET_PATTERN = /(?:[zZ]|[+-]\d{2}:?\d{2})$/;
+
+function toClientTimestamp(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  const normalizedValue = String(value).trim();
+  if (!normalizedValue) {
+    return null;
+  }
+
+  const parseValue =
+    DATE_TIME_WITHOUT_OFFSET_PATTERN.test(normalizedValue) && !TIMEZONE_OFFSET_PATTERN.test(normalizedValue)
+      ? `${normalizedValue.replace(' ', 'T')}Z`
+      : normalizedValue;
+  const date = new Date(parseValue);
+
+  return Number.isNaN(date.getTime()) ? normalizedValue : date.toISOString();
+}
+
 function mapNotificationForClient(notification) {
   return {
     id: notification.id,
@@ -81,8 +107,8 @@ function mapNotificationForClient(notification) {
     title: notification.title,
     body: notification.body,
     isRead: notification.isRead,
-    readAt: notification.readAt,
-    createdAt: notification.createdAt,
+    readAt: toClientTimestamp(notification.readAt),
+    createdAt: toClientTimestamp(notification.createdAt),
     actorUserId: notification.actorUserId,
     entity: notification.entity,
     data: notification.data,

--- a/backend/tests/unit/modules/notifications/service.test.js
+++ b/backend/tests/unit/modules/notifications/service.test.js
@@ -95,6 +95,8 @@ describe('notifications service', () => {
       title: 'Title',
       body: 'Body',
       isRead: false,
+      readAt: null,
+      createdAt: '2026-04-22T20:00:00.000Z',
     });
     expect(repository.insertNotificationDelivery).toHaveBeenCalled();
   });
@@ -136,8 +138,35 @@ describe('notifications service', () => {
       cursorNotificationId: null,
     });
     expect(result.items).toHaveLength(2);
+    expect(result.items[0]).toMatchObject({
+      id: 'notif_2',
+      createdAt: '2026-04-22T20:00:00.000Z',
+    });
     expect(result.unreadCount).toBe(3);
     expect(typeof result.nextCursor).toBe('string');
+  });
+
+  test('listMyNotifications normalizes offsetless notification timestamps as UTC ISO strings', async () => {
+    const rows = [
+      createStoredNotification({
+        id: 'notif_1',
+        createdAt: '2026-04-22 20:00:00',
+        readAt: '2026-04-22T20:05:00',
+      }),
+    ];
+    repository.listNotificationsByRecipient.mockResolvedValue(rows);
+    repository.countUnreadNotifications.mockResolvedValue(1);
+
+    const result = await listMyNotifications('user_1', {
+      limit: 20,
+      unreadOnly: false,
+      cursor: null,
+    });
+
+    expect(result.items[0]).toMatchObject({
+      createdAt: '2026-04-22T20:00:00.000Z',
+      readAt: '2026-04-22T20:05:00.000Z',
+    });
   });
 
   test('listMyNotifications rejects malformed cursor', async () => {

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -13,14 +13,23 @@ export function formatOperationalLabel(value: string | null | undefined) {
         .join(" ");
 }
 
+const dateTimeWithoutOffsetPattern = /^\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}/;
+const timezoneOffsetPattern = /(?:[zZ]|[+-]\d{2}:?\d{2})$/;
+
 function parseTimestamp(value: string) {
-    const dateOnlyMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    const normalizedValue = value.trim();
+    const dateOnlyMatch = normalizedValue.match(/^(\d{4})-(\d{2})-(\d{2})$/);
     if (dateOnlyMatch) {
         const [, year, month, day] = dateOnlyMatch;
         return new Date(Number(year), Number(month) - 1, Number(day));
     }
 
-    const date = new Date(value);
+    const parseValue =
+        dateTimeWithoutOffsetPattern.test(normalizedValue) && !timezoneOffsetPattern.test(normalizedValue)
+            ? `${normalizedValue.replace(" ", "T")}Z`
+            : normalizedValue;
+
+    const date = new Date(parseValue);
     return Number.isNaN(date.getTime()) ? null : date;
 }
 


### PR DESCRIPTION
### Description

This PR fixes the remaining timezone issue reported in [#405](https://github.com/bounswe/bounswe2026group6/issues/405) for notification timestamps on the notifications page.

### Changes

- Normalize notification createdAt and readAt values in the backend response to explicit UTC ISO strings.
- Update the shared web timestamp formatter to treat offset-less date-time strings as UTC before formatting them in the user’s local timezone.
- Add unit coverage for notification timestamp normalization, including offset-less timestamp inputs.
