### PR TITLE
fix: safety circle check-in timestamp formatting

### DIFF
--- a/android/app/src/main/java/com/neph/features/safetycircles/presentation/SafetyCirclesScreen.kt
+++ b/android/app/src/main/java/com/neph/features/safetycircles/presentation/SafetyCirclesScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.neph.core.format.formatTimestampWithRelativeDay
 import com.neph.core.network.ApiException
 import com.neph.features.auth.data.AuthRepository
 import com.neph.features.auth.data.AuthSessionStore
@@ -45,6 +46,9 @@ import com.neph.ui.layout.AppDrawerScaffold
 import com.neph.ui.theme.LocalNephSpacing
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun SafetyCirclesScreen(
@@ -558,7 +562,7 @@ private fun MemberRow(
             text = listOf(
                 formatSafetyStatus(member.status),
                 member.emergencyContactPhone?.let { "Contact: $it" },
-                member.lastCheckedInAt?.let { "Last checked in: $it" },
+                formatLastCheckedInLabel(member.lastCheckedInAt),
                 if (member.hasSharedLocation) "Location shared" else null
             ).filterNotNull().joinToString(" · "),
             style = MaterialTheme.typography.bodySmall,
@@ -588,4 +592,19 @@ private fun formatSafetyStatus(status: String): String {
         "not_safe" -> "Needs help"
         else -> "No response"
     }
+}
+
+internal fun formatLastCheckedInLabel(
+    rawTimestamp: String?,
+    zoneId: ZoneId = ZoneId.systemDefault(),
+    nowInstant: Instant = Instant.now()
+): String? {
+    val formatted = formatTimestampWithRelativeDay(
+        raw = rawTimestamp,
+        fallbackFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy, HH:mm"),
+        timeFormatter = DateTimeFormatter.ofPattern("HH:mm"),
+        zoneId = zoneId,
+        nowInstant = nowInstant
+    ) ?: return null
+    return "Last checked in: $formatted"
 }

--- a/android/app/src/test/java/com/neph/features/safetycircles/presentation/SafetyCirclesFormattingTest.kt
+++ b/android/app/src/test/java/com/neph/features/safetycircles/presentation/SafetyCirclesFormattingTest.kt
@@ -1,0 +1,26 @@
+package com.neph.features.safetycircles.presentation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.Instant
+import java.time.ZoneId
+
+class SafetyCirclesFormattingTest {
+    @Test
+    fun formatLastCheckedInLabelUsesRelativeLocalTimeForToday() {
+        assertEquals(
+            "Last checked in: Today, 16:52",
+            formatLastCheckedInLabel(
+                rawTimestamp = "2026-05-11T13:52:27.755Z",
+                zoneId = ZoneId.of("Europe/Istanbul"),
+                nowInstant = Instant.parse("2026-05-11T18:00:00.000Z")
+            )
+        )
+    }
+
+    @Test
+    fun formatLastCheckedInLabelIgnoresInvalidTimestamps() {
+        assertNull(formatLastCheckedInLabel("not-a-timestamp"))
+    }
+}


### PR DESCRIPTION
## Summary
- Formats Safety Circles "Last checked in" timestamps using the shared timestamp formatter
- Prevents raw ISO timestamps like `2026-05-11T13:52:27.755Z` from appearing in the UI
- Adds unit tests for local timezone formatting and invalid timestamp handling

Closes #591


