### PR TITLE
fix:  failed workflow by adding idempotent migration

### DIFF
--- a/backend/migrations/20260511_120000__ensure_help_request_health_sharing_consent.sql
+++ b/backend/migrations/20260511_120000__ensure_help_request_health_sharing_consent.sql
@@ -1,0 +1,2 @@
+ALTER TABLE help_requests
+  ADD COLUMN IF NOT EXISTS share_profile_health_info_with_volunteer BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary

- Adds a production-safe idempotent migration to ensure `help_requests.share_profile_health_info_with_volunteer` exists.
- Does not touch `infra/docker/postgres/init.sql`, so the guarded production reset step is not triggered.
- Intended to let the production migration runner apply the pending schema change safely.

## Notes

The previous `development` → `main` merge included an `init.sql` change. The production DB workflow correctly refused to run a destructive reset. This PR uses the normal migration path only.

## Verification

- [x] Only a new file under `backend/migrations/` was added.
- [x] `infra/docker/postgres/init.sql` was not modified.
- [x] `.github/workflows/db-prod-sync.yml` was not modified.
- [x] Existing migration files were not edited.