### PR TITLE
Fix Failed Migration Workflow

### DIFF
--- a/backend/migrations/20260511_120000__ensure_help_request_health_sharing_consent.sql
+++ b/backend/migrations/20260511_120000__ensure_help_request_health_sharing_consent.sql
@@ -1,0 +1,2 @@
+ALTER TABLE help_requests
+  ADD COLUMN IF NOT EXISTS share_profile_health_info_with_volunteer BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
Previous merge was failed due to unwanted change of init.sql file. This one is meant to fix the problem.