### PR TITLE
fix: stabilize map location and loading behavior

### DIFF
--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -396,6 +396,7 @@ fun GatheringAreasScreen(
         activeFilterKeys.contains(item.category.trim().lowercase())
     }.orEmpty()
     val isFilterEmpty = currentResult != null && currentResult.areas.isNotEmpty() && visibleAreas.isEmpty()
+    val mapActionsEnabled = !loading && !backgroundUpdating
 
     if (selectedAreaId != null && visibleAreas.none { it.id == selectedAreaId }) {
         selectedAreaId = null
@@ -456,7 +457,7 @@ fun GatheringAreasScreen(
                             pendingViewport = viewport
                             viewportRefreshNonce += 1
                         },
-                        enabled = !loading
+                        enabled = mapActionsEnabled
                     )
                 }
             }
@@ -477,7 +478,7 @@ fun GatheringAreasScreen(
                 loadingResources = loading,
                 updatingResources = backgroundUpdating,
                 onShowCurrentLocation = ::showCurrentLocationOnMap,
-                showCurrentLocationEnabled = !loading,
+                showCurrentLocationEnabled = mapActionsEnabled,
                 onViewportChanged = ::handleViewportChanged
             )
 
@@ -499,7 +500,8 @@ fun GatheringAreasScreen(
                                     onClick = {
                                         pendingViewport = currentViewport
                                         viewportRefreshNonce += 1
-                                    }
+                                    },
+                                    enabled = mapActionsEnabled
                                 )
                             }
                         }
@@ -519,7 +521,8 @@ fun GatheringAreasScreen(
                                     onClick = {
                                         pendingViewport = currentViewport
                                         viewportRefreshNonce += 1
-                                    }
+                                    },
+                                    enabled = mapActionsEnabled
                                 )
                             }
                         }
@@ -663,7 +666,8 @@ fun GatheringAreasScreen(
                                 onClick = {
                                     pendingViewport = currentViewport
                                     viewportRefreshNonce += 1
-                                }
+                                },
+                                enabled = mapActionsEnabled
                             )
                         }
                     }
@@ -851,11 +855,11 @@ private fun GatheringAreasMapCard(
                 HelperText(text = ResourceLoadingMessage)
             }
 
-            if (updatingResources && markers.isNotEmpty()) {
+            if (updatingResources) {
                 HelperText(text = ResourceUpdatingMessage)
             }
 
-            if (markers.isEmpty() && !loadingResources) {
+            if (markers.isEmpty() && !loadingResources && !updatingResources) {
                 HelperText(
                     text = emptyMarkersMessage
                 )

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -246,8 +246,18 @@ fun HelpRequestMapScreen(
     var mapCenterLongitude by remember { mutableStateOf(TurkeyOverviewLongitude) }
     var mapZoom by remember { mutableStateOf(TurkeyOverviewZoom) }
     var mapResetNonce by remember { mutableStateOf(0) }
+    var initialMarkerFitApplied by remember { mutableStateOf(false) }
+    var markerFitBoundsToken by remember { mutableStateOf<Int?>(null) }
 
     fun applyRequestResult(result: ActiveHelpRequestsResult, viewportKey: String?) {
+        if (
+            !initialMarkerFitApplied &&
+            viewportKey == null &&
+            result.requests.any { it.hasValidMapCoordinates() }
+        ) {
+            markerFitBoundsToken = (markerFitBoundsToken ?: 0) + 1
+            initialMarkerFitApplied = true
+        }
         requests = result.requests
         viewportKey?.let { lastFetchedViewportKey = it }
         viewportRefreshNonce = 0
@@ -300,6 +310,7 @@ fun HelpRequestMapScreen(
                     mapCenterLongitude = location.longitude
                     mapZoom = HelpRequestMapCurrentLocationZoom
                     mapResetNonce += 1
+                    markerFitBoundsToken = null
                     selectedRequestId = null
                     lastFetchedViewportKey = null
                     loading = false
@@ -535,6 +546,7 @@ fun HelpRequestMapScreen(
                     mapCenterLongitude = mapCenterLongitude,
                     mapZoom = mapZoom,
                     mapResetToken = mapResetNonce,
+                    fitBoundsRequestToken = markerFitBoundsToken,
                     onShowCurrentLocation = ::showCurrentLocationOnMap,
                     showCurrentLocationEnabled = mapActionsEnabled,
                     onViewportChanged = ::handleViewportChanged,
@@ -908,6 +920,7 @@ private fun CrisisRequestMapPanel(
     mapCenterLongitude: Double = TurkeyOverviewLongitude,
     mapZoom: Int = TurkeyOverviewZoom,
     mapResetToken: Int = 0,
+    fitBoundsRequestToken: Int? = null,
     onShowCurrentLocation: (() -> Unit)? = null,
     showCurrentLocationEnabled: Boolean = true,
     onViewportChanged: (LeafletMapViewport) -> Unit,
@@ -1002,6 +1015,7 @@ private fun CrisisRequestMapPanel(
                 zoom = effectiveZoom,
                 showCenterMarker = false,
                 fitBoundsToMarkers = shouldFitRequestMarkers,
+                fitBoundsRequestToken = fitBoundsRequestToken,
                 onMarkerSelected = { markerInstanceId, markerId ->
                     if (markerInstanceId == currentMapInstanceIdState.value) {
                         onSelectRequest(markerId)

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -475,6 +475,7 @@ fun HelpRequestMapScreen(
 
     val selectedRequest = visibleRequests.firstOrNull { it.requestId == selectedRequestId }
     val isFilterEmpty = !loading && requests.isNotEmpty() && visibleRequests.isEmpty()
+    val mapActionsEnabled = !loading && !backgroundUpdating
     val mapEmptyMarkersMessage = helpRequestMapEmptyMessage(
         blockingLoading = loading,
         errorMessage = errorMessage,
@@ -518,7 +519,7 @@ fun HelpRequestMapScreen(
                     SecondaryButton(
                         text = "Refresh Help Request Map",
                         onClick = { queueViewportRefresh() },
-                        enabled = !loading
+                        enabled = mapActionsEnabled
                     )
                 }
             }
@@ -535,7 +536,7 @@ fun HelpRequestMapScreen(
                     mapZoom = mapZoom,
                     mapResetToken = mapResetNonce,
                     onShowCurrentLocation = ::showCurrentLocationOnMap,
-                    showCurrentLocationEnabled = !loading,
+                    showCurrentLocationEnabled = mapActionsEnabled,
                     onViewportChanged = ::handleViewportChanged,
                     onSelectRequest = { selectedRequestId = it }
                 )
@@ -557,7 +558,8 @@ fun HelpRequestMapScreen(
                                 )
                                 SecondaryButton(
                                     text = "Retry",
-                                    onClick = { queueViewportRefresh() }
+                                    onClick = { queueViewportRefresh() },
+                                    enabled = mapActionsEnabled
                                 )
                             }
                         }
@@ -643,7 +645,8 @@ fun HelpRequestMapScreen(
                         HelperText(text = errorMessage)
                         SecondaryButton(
                             text = "Retry",
-                            onClick = { queueViewportRefresh() }
+                            onClick = { queueViewportRefresh() },
+                            enabled = mapActionsEnabled
                         )
                     }
                 }
@@ -920,7 +923,7 @@ private fun CrisisRequestMapPanel(
     val effectiveCenterLatitude = if (shouldFitRequestMarkers) mapInstanceKey.centerLatitude else mapCenterLatitude
     val effectiveCenterLongitude = if (shouldFitRequestMarkers) mapInstanceKey.centerLongitude else mapCenterLongitude
     val effectiveZoom = if (shouldFitRequestMarkers) 13 else mapZoom
-    val mapInstanceId = remember(mapResetToken, mapInstanceKey) {
+    val mapInstanceId = remember(mapResetToken) {
         newLeafletMapInstanceId()
     }
     val currentMapInstanceIdState = remember { mutableStateOf(mapInstanceId) }
@@ -1052,11 +1055,11 @@ private fun CrisisRequestMapPanel(
             HelperText(text = ResourceLoadingMessage)
         }
 
-        if (updatingResources && markers.isNotEmpty()) {
+        if (updatingResources) {
             HelperText(text = ResourceUpdatingMessage)
         }
 
-        if (markers.isEmpty() && !loadingResources) {
+        if (markers.isEmpty() && !loadingResources && !updatingResources) {
             HelperText(text = emptyMarkersMessage)
         }
 

--- a/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
+++ b/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
@@ -663,6 +663,7 @@ internal fun buildLeafletMarkerMapHtml(
                     });
                     areaMarkersById = {};
                     bounds = [center];
+                    var markerBounds = [];
 
                     markerData.forEach(function(marker) {
                         var selected = marker.id === selectedMarkerId;
@@ -685,6 +686,7 @@ internal fun buildLeafletMarkerMapHtml(
                             data: marker
                         };
                         bounds.push([marker.latitude, marker.longitude]);
+                        markerBounds.push([marker.latitude, marker.longitude]);
                     });
 
                     var normalizedFitBoundsRequestToken =
@@ -695,8 +697,10 @@ internal fun buildLeafletMarkerMapHtml(
                         normalizedFitBoundsRequestToken !== null &&
                         normalizedFitBoundsRequestToken !== lastAppliedFitBoundsRequestToken
                     ) {
-                        if (bounds.length > 1) {
-                            map.fitBounds(bounds, { padding: [24, 24], maxZoom: 15 });
+                        if (markerBounds.length > 1) {
+                            map.fitBounds(markerBounds, { padding: [24, 24], maxZoom: 15 });
+                        } else if (markerBounds.length === 1) {
+                            map.setView(markerBounds[0], 15);
                         }
                         lastAppliedFitBoundsRequestToken = normalizedFitBoundsRequestToken;
                     }

--- a/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
+++ b/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
@@ -292,6 +292,7 @@ fun LeafletMarkerMap(
     zoom: Int = 13,
     showCenterMarker: Boolean = true,
     fitBoundsToMarkers: Boolean = true,
+    fitBoundsRequestToken: Int? = null,
     onMarkerSelected: (String, String) -> Unit,
     onMapReady: (String, String) -> Unit,
     onMapError: (String, String) -> Unit,
@@ -345,17 +346,26 @@ fun LeafletMarkerMap(
         html = html,
         bridgeName = LeafletMarkerMapBridgeName,
         bridge = bridge,
-        javaScriptUpdate = buildMarkerMapUpdateScript(markers, selectedMarkerId),
+        javaScriptUpdate = buildMarkerMapUpdateScript(
+            markers = markers,
+            selectedMarkerId = selectedMarkerId,
+            fitBoundsRequestToken = fitBoundsRequestToken
+        ),
         modifier = modifier
     )
 }
 
-private fun buildMarkerMapUpdateScript(markers: List<LeafletMapMarker>, selectedMarkerId: String?): String {
+private fun buildMarkerMapUpdateScript(
+    markers: List<LeafletMapMarker>,
+    selectedMarkerId: String?,
+    fitBoundsRequestToken: Int?
+): String {
     val markersJson = leafletMarkersJson(markers)
     val selectedMarkerJson = selectedMarkerId?.let(JSONObject::quote) ?: "null"
+    val fitBoundsRequestTokenJson = fitBoundsRequestToken?.toString() ?: "null"
     return """
         if (window.nephSetMarkers) {
-            window.nephSetMarkers($markersJson, $selectedMarkerJson);
+            window.nephSetMarkers($markersJson, $selectedMarkerJson, $fitBoundsRequestTokenJson);
         } else if (window.nephSelectMarker) {
             window.nephSelectMarker($selectedMarkerJson);
         }
@@ -576,6 +586,7 @@ internal fun buildLeafletMarkerMapHtml(
                 var markerData = $markersJson;
                 var selectedMarkerId = $selectedMarkerJson;
                 var fitBoundsToMarkers = $fitBoundsToMarkersJson;
+                var lastAppliedFitBoundsRequestToken = null;
                 var mapElement = document.getElementById('map');
                 if (!mapElement) {
                     failMap('Map failed to load.');
@@ -644,7 +655,7 @@ internal fun buildLeafletMarkerMapHtml(
                     });
                 };
 
-                window.nephSetMarkers = function(nextMarkers, nextSelectedMarkerId) {
+                window.nephSetMarkers = function(nextMarkers, nextSelectedMarkerId, fitBoundsRequestToken) {
                     markerData = Array.isArray(nextMarkers) ? nextMarkers : [];
                     selectedMarkerId = nextSelectedMarkerId || null;
                     Object.keys(areaMarkersById).forEach(function(id) {
@@ -675,6 +686,20 @@ internal fun buildLeafletMarkerMapHtml(
                         };
                         bounds.push([marker.latitude, marker.longitude]);
                     });
+
+                    var normalizedFitBoundsRequestToken =
+                        fitBoundsRequestToken === null || typeof fitBoundsRequestToken === 'undefined'
+                            ? null
+                            : String(fitBoundsRequestToken);
+                    if (
+                        normalizedFitBoundsRequestToken !== null &&
+                        normalizedFitBoundsRequestToken !== lastAppliedFitBoundsRequestToken
+                    ) {
+                        if (bounds.length > 1) {
+                            map.fitBounds(bounds, { padding: [24, 24], maxZoom: 15 });
+                        }
+                        lastAppliedFitBoundsRequestToken = normalizedFitBoundsRequestToken;
+                    }
                 };
 
                 window.nephSetMarkers(markerData, selectedMarkerId);

--- a/web/src/components/feature/location/LocationPicker.tsx
+++ b/web/src/components/feature/location/LocationPicker.tsx
@@ -31,15 +31,24 @@ const DEFAULT_CENTER = {
 const DEFAULT_MAP_ZOOM = 6;
 const SELECTED_LOCATION_ZOOM = 15;
 
-function toPickerValue(item: LocationSearchItem): LocationPickerValue {
+function toReverseEnrichedPickerValue(
+    latitude: number,
+    longitude: number,
+    item: LocationSearchItem,
+    metadata?: {
+        source?: string | null;
+        accuracyMeters?: number | null;
+        capturedAt?: string | null;
+    }
+): LocationPickerValue {
     return {
         placeId: item.placeId,
         displayName: item.displayName,
-        latitude: item.latitude,
-        longitude: item.longitude,
-        accuracyMeters: null,
-        source: "search",
-        capturedAt: new Date().toISOString(),
+        latitude,
+        longitude,
+        accuracyMeters: metadata?.accuracyMeters ?? null,
+        source: metadata?.source ?? "map_pin",
+        capturedAt: metadata?.capturedAt ?? new Date().toISOString(),
         administrative: item.administrative,
     };
 }
@@ -126,12 +135,7 @@ export function LocationPicker({
                     return;
                 }
 
-                onChange({
-                    ...toPickerValue(response.item),
-                    source: metadata?.source ?? "map_pin",
-                    accuracyMeters: metadata?.accuracyMeters ?? null,
-                    capturedAt: metadata?.capturedAt ?? new Date().toISOString(),
-                });
+                onChange(toReverseEnrichedPickerValue(latitude, longitude, response.item, metadata));
             } catch (err) {
                 if (currentReverseRequestId !== reverseRequestIdRef.current) {
                     return;


### PR DESCRIPTION
## Summary

- Fixes web `LocationPicker` so reverse geocoding no longer overwrites the original GPS or clicked map coordinates.
- Stabilizes Android Help Request Map camera behavior so marker/data refreshes do not force unexpected zoom/recenter after user pan/zoom.
- Improves Android map loading/updating feedback for Help Request Map and Gathering Areas.
- Disables map refresh/current-location controls while loading or background updates are in progress.

## Changes

### Web

- Keeps the original browser GPS or clicked map coordinate as the source of truth.
- Uses reverse-geocode response only to enrich display/address/admin fields.
- Prevents reverse-geocode item coordinates from moving the selected marker/map center.

### Android Help Request Map

- Prevents marker/data refreshes from recreating the map instance solely because marker center changed.
- Preserves user-controlled pan/zoom during viewport-based marker refreshes.
- Keeps explicit recenter behavior for current-location/reset actions.

### Android Gathering Areas / Map UX

- Shows clearer loading/updating feedback while visible-area data is being fetched.
- Makes refresh/current-location disabled states more consistent during loading/background updates.
- Preserves existing marker rendering, filtering, refresh, and current-location behavior.

## Verification

- [ ] Web Profile location map keeps the actual browser GPS coordinate after pressing **Use Current Location**.
- [ ] Web map-pin selection keeps the clicked coordinate after reverse geocoding.
- [ ] Android Help Request Map does not auto-zoom/recenter after manual pan/zoom and marker refresh.
- [ ] Android Help Request Map current-location button still explicitly recenters the map.
- [ ] Android Help Request Map still updates markers for the visible viewport.
- [ ] Android Gathering Areas shows loading/updating feedback while fetching new visible-area results.
- [ ] Android Gathering Areas refresh/current-location controls disable during loading/background updates.
- [ ] Existing map markers, filters, refresh actions, and error/empty states still work.

Closes #597 