### PR TITLE
fix(android): navigate after edited help request submission

### DIFF
--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -934,8 +934,10 @@ fun RequestHelpScreen(
         loading = true
         scope.launch {
             try {
+                val editLocalId = activeDraftLocalId.takeIf { it.isNotBlank() }
+                val existingDraft = editLocalId?.let { RequestHelpRepository.getLocalHelpRequest(it) }
                 if (isLoggedIn) {
-                    val hasActiveRequest = activeDraftLocalId.isBlank() && RequestHelpRepository.hasActiveHelpRequest(sessionToken)
+                    val hasActiveRequest = existingDraft == null && RequestHelpRepository.hasActiveHelpRequest(sessionToken)
                     if (hasActiveRequest) {
                         errorMessage = "You can only have one active help request at a time."
                         return@launch
@@ -948,10 +950,10 @@ fun RequestHelpScreen(
                 }
 
                 val submission = buildSubmission(formState, availableLocationData)
-                val result = if (activeDraftLocalId.isNotBlank()) {
+                val result = if (editLocalId != null && existingDraft != null) {
                     RequestHelpRepository.updateHelpRequest(
                         token = sessionToken,
-                        localId = activeDraftLocalId,
+                        localId = editLocalId,
                         submission = submission,
                         preserveExistingCoordinates = !formState.locationWasManuallyChanged
                     )
@@ -961,7 +963,7 @@ fun RequestHelpScreen(
                         submission = submission
                     )
                 }
-                activeDraftLocalId = result.requestId
+                activeDraftLocalId = if (existingDraft != null) "" else result.requestId
                 infoMessage = "Help request saved on this device and queued for sync."
                 if (isSendOnboardingTarget) {
                     completeRequestHelpOnboardingStep(MobileOnboardingStepId.REQUEST_HELP_SEND)

--- a/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
@@ -502,9 +502,13 @@ fun AppNavGraph(
                     navigateToLogin()
                 },
                 onNavigateToMyHelpRequests = {
-                    val popped = navController.popBackStack(Routes.MyHelpRequests.route, inclusive = false)
-                    if (!popped) {
-                        navigateToDrawerRoute(Routes.MyHelpRequests.route)
+                    navController.navigate(Routes.MyHelpRequests.route) {
+                        popUpTo(Routes.Home.route) {
+                            inclusive = false
+                            saveState = false
+                        }
+                        launchSingleTop = true
+                        restoreState = false
                     }
                 },
                 mobileOnboardingStepId = mobileOnboardingStepId,


### PR DESCRIPTION
## Summary

Fixes the Android help request edit flow.

When an existing help request was edited and submitted, the app could stay on the request form and later restore the unfinished edit flow when navigating back through Home. This PR makes edited request submission complete visibly and clears the transient request form navigation state.

## Changes

- Handles edited help request submission as an explicit update flow.
- Uses the existing local-first update behavior so the edited request is saved locally and queued for sync.
- Navigates to `My Help Requests` after a successful local edit update.
- Clears the `request_help?draftLocalId=...` edit route from navigation state after submit.
- Avoids restoring the old edit screen when the user later presses Home.
- Keeps new request creation, guest flow, offline sync behavior, and onboarding flow unchanged.

Closes #590