### PR TITLE
Fix/Replace heart icon with NEPH app logo on Android auth screens

### DIFF
--- a/android/app/src/main/java/com/neph/features/auth/presentation/LoginScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/LoginScreen.kt
@@ -43,7 +43,7 @@ import com.neph.features.auth.util.isValidEmail
 import com.neph.ui.components.buttons.PrimaryButton
 import com.neph.ui.components.buttons.SecondaryButton
 import com.neph.ui.components.buttons.TextActionButton
-import com.neph.ui.components.display.BrandLogo
+import com.neph.ui.components.display.AuthHeaderAppLogo
 import com.neph.ui.components.display.Divider
 import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.inputs.AppTextField
@@ -212,10 +212,7 @@ fun LoginScreen(
         title = "Welcome back",
         subtitle = "Log in to manage your emergency information and stay ready.",
         logoContent = {
-            BrandLogo(
-                size = 64.dp,
-                showWordmark = false
-            )
+            AuthHeaderAppLogo(size = 64.dp)
         },
         footerContent = {
             AuthFooterLinks(

--- a/android/app/src/main/java/com/neph/features/auth/presentation/SignupScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/SignupScreen.kt
@@ -43,7 +43,7 @@ import com.neph.features.auth.presentation.components.SocialAuthMode
 import com.neph.features.auth.util.isValidEmail
 import com.neph.ui.components.buttons.PrimaryButton
 import com.neph.ui.components.buttons.SecondaryButton
-import com.neph.ui.components.display.BrandLogo
+import com.neph.ui.components.display.AuthHeaderAppLogo
 import com.neph.ui.components.display.Divider
 import com.neph.ui.components.display.HelperText
 import com.neph.ui.components.inputs.AppTextField
@@ -260,10 +260,7 @@ fun SignupScreen(
         title = "Create Account",
         subtitle = "Set up your account and get ready before emergencies happen.",
         logoContent = {
-            BrandLogo(
-                size = 64.dp,
-                showWordmark = false
-            )
+            AuthHeaderAppLogo(size = 64.dp)
         },
         footerContent = {
             AuthFooterLinks(

--- a/android/app/src/main/java/com/neph/features/auth/presentation/WelcomeScreen.kt
+++ b/android/app/src/main/java/com/neph/features/auth/presentation/WelcomeScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.unit.dp
 import com.neph.ui.components.buttons.PrimaryButton
 import com.neph.ui.components.buttons.SecondaryButton
 import com.neph.ui.components.buttons.TextActionButton
-import com.neph.ui.components.display.BrandLogo
+import com.neph.ui.components.display.AuthHeaderAppLogo
 import com.neph.ui.layout.AuthScaffold
 import com.neph.ui.theme.LocalNephSpacing
 
@@ -23,10 +23,7 @@ fun WelcomeScreen(
         title = "Welcome to NEPH",
         subtitle = "Prepare, connect, and stay ready with your neighborhood emergency hub.",
         logoContent = {
-            BrandLogo(
-                size = 72.dp,
-                showWordmark = false
-            )
+            AuthHeaderAppLogo(size = 72.dp)
         }
     ) {
         Column(

--- a/android/app/src/main/java/com/neph/ui/components/display/BrandLogo.kt
+++ b/android/app/src/main/java/com/neph/ui/components/display/BrandLogo.kt
@@ -1,5 +1,6 @@
 package com.neph.ui.components.display
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,9 +15,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.neph.R
 import com.neph.ui.theme.LocalNephSpacing
 import com.neph.ui.theme.NephShapeTokens
 
@@ -112,4 +116,17 @@ fun BrandLogoCompact(
             color = MaterialTheme.colorScheme.onSurface
         )
     }
+}
+
+@Composable
+fun AuthHeaderAppLogo(
+    modifier: Modifier = Modifier,
+    size: Dp = 64.dp
+) {
+    Image(
+        painter = painterResource(id = R.mipmap.ic_launcher_round),
+        contentDescription = "NEPH",
+        modifier = modifier.size(size),
+        contentScale = ContentScale.Fit
+    )
 }


### PR DESCRIPTION
 Summary
- Replaced the heart icon in Android auth header areas with the NEPH app logo.
- Applied the change consistently across Login, Create Account, and Welcome screens.
- Kept the change visual-only with no auth flow logic changes.

What changed
- Login screen now uses the app logo in the auth header.
- Create Account screen now uses the app logo in the auth header.
- Welcome screen now uses the app logo in the auth header.
- Added and reused a shared auth-header logo component to keep sizing and alignment consistent.

Why
- Improve product branding consistency and remove the old heart icon from auth entry screens.

Validation
- Android build check passed: app compileDebugKotlin

Impact
- Visual/UI change only.
- No functional behavior changes in login, signup, or guest flow.

Closes #606 