### PR TITLE
fix: start mobile onboarding after first login with existing profile

### DIFF
--- a/android/app/src/androidTest/java/com/neph/e2e/MobileOnboardingLoginAndroidTest.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/MobileOnboardingLoginAndroidTest.kt
@@ -1,0 +1,65 @@
+package com.neph.e2e
+
+import android.content.Context
+import com.neph.core.NephAppContext
+import com.neph.core.database.NephDatabaseProvider
+import com.neph.features.auth.data.AuthRepository
+import com.neph.features.auth.data.AuthSessionStore
+import com.neph.features.auth.data.LoginDestination
+import com.neph.features.onboarding.data.MobileOnboardingStepId
+import com.neph.features.onboarding.data.MobileOnboardingStore
+import com.neph.features.operationallocation.data.OperationalLocationRepository
+import com.neph.features.profile.data.ProfileRepository
+import com.neph.features.requesthelp.data.RequestHelpRepository
+import com.neph.features.safetystatus.data.SafetyStatusRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class MobileOnboardingLoginAndroidTest {
+    private val fakeBackend = FakeNephBackend()
+
+    @get:Rule
+    val environmentRule = NephE2ETestEnvironmentRule(fakeBackend) { context, backend ->
+        backend.seedVerifiedUser(
+            email = ExistingWebProfileEmail,
+            password = Password,
+            profile = FakeProfileState(firstName = "Web", lastName = "Complete")
+        )
+        initializeLoginOnboardingDependencies(context)
+    }
+
+    @Test
+    fun firstMobileLoginWithExistingWebProfile_marksGuidePending() = runBlocking {
+        val destination = AuthRepository.login(
+            email = ExistingWebProfileEmail,
+            password = Password,
+            rememberMe = false
+        )
+
+        assertEquals(LoginDestination.PROFILE, destination)
+        assertTrue(MobileOnboardingStore.shouldShowForCurrentUser())
+        assertEquals(
+            MobileOnboardingStepId.HOME_DASHBOARD,
+            MobileOnboardingStore.currentStepForCurrentUser(isAuthenticated = true)
+        )
+    }
+
+    private fun initializeLoginOnboardingDependencies(context: Context) {
+        NephAppContext.initialize(context)
+        NephDatabaseProvider.initialize(context)
+        AuthSessionStore.initialize(context)
+        ProfileRepository.initialize(context)
+        MobileOnboardingStore.initialize(context)
+        RequestHelpRepository.initialize(context)
+        OperationalLocationRepository.initialize(context)
+        SafetyStatusRepository.initialize(context)
+    }
+
+    private companion object {
+        const val ExistingWebProfileEmail = "web.completed.mobile@example.com"
+        const val Password = "Passw0rd!"
+    }
+}

--- a/android/app/src/main/java/com/neph/MainActivity.kt
+++ b/android/app/src/main/java/com/neph/MainActivity.kt
@@ -170,6 +170,7 @@ fun NephApp() {
         val currentBackStackEntry by navController.currentBackStackEntryAsState()
         val currentRoute = currentBackStackEntry?.destination?.route
         val accessToken by AuthSessionStore.accessTokenFlow.collectAsState()
+        val mobileOnboardingRevision by MobileOnboardingStore.revisionFlow.collectAsState()
         val isAuthenticated = !accessToken.isNullOrBlank()
         var showMobileOnboarding by remember { mutableStateOf(false) }
         var activeMobileOnboardingStepId by remember { mutableStateOf<MobileOnboardingStepId?>(null) }
@@ -211,6 +212,20 @@ fun NephApp() {
             navigateForMobileOnboarding(firstStep.route)
         }
 
+        fun showPendingMobileOnboardingAfterLogin() {
+            val shouldShow = MobileOnboardingStore.shouldShowForCurrentUser()
+            showMobileOnboarding = shouldShow
+            activeMobileOnboardingStepId = if (shouldShow) {
+                MobileOnboardingStore.currentStepForCurrentUser(isAuthenticated = true)
+            } else {
+                mobileOnboardingFeedback = null
+                null
+            }
+            activeMobileOnboardingStepId
+                ?.let { MobileOnboardingJourney.stepFor(it, isAuthenticated = true) }
+                ?.let { step -> navigateForMobileOnboarding(step.route) }
+        }
+
         fun closeMobileOnboardingAndReturnHome() {
             MobileOnboardingStore.markSeenForCurrentUser()
             showMobileOnboarding = false
@@ -246,7 +261,7 @@ fun NephApp() {
             }
         }
 
-        LaunchedEffect(accessToken, currentRoute) {
+        LaunchedEffect(accessToken, currentRoute, mobileOnboardingRevision) {
             val shouldShow = shouldShowMobileOnboardingForRoute(currentRoute)
             showMobileOnboarding = shouldShow
             activeMobileOnboardingStepId = if (shouldShow) {
@@ -295,17 +310,22 @@ fun NephApp() {
             )
         }
 
-        AppNavGraph(
-            navController = navController,
-            startDestination = when {
+        val initialStartDestination = remember {
+            when {
                 !AuthSessionStore.getAccessToken().isNullOrBlank() -> Routes.Home.route
                 AuthSessionStore.isGuestMode() && RequestHelpRepository.shouldOpenGuestRequestsOnStart() -> {
                     Routes.MyHelpRequests.route
                 }
                 AuthSessionStore.isGuestMode() -> Routes.Home.route
                 else -> Routes.Welcome.route
-            },
+            }
+        }
+
+        AppNavGraph(
+            navController = navController,
+            startDestination = initialStartDestination,
             onRestartMobileOnboarding = ::restartMobileOnboarding,
+            onAuthenticatedLoginCompleted = ::showPendingMobileOnboardingAfterLogin,
             mobileOnboardingStepId = activeMobileOnboardingStepId.takeIf { showMobileOnboarding },
             onMobileOnboardingStepCompleted = ::completeMobileOnboardingStep,
             onMobileOnboardingFeedbackChanged = ::updateMobileOnboardingFeedback,

--- a/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
+++ b/android/app/src/main/java/com/neph/features/auth/data/AuthRepository.kt
@@ -12,6 +12,7 @@ import com.neph.features.notifications.data.PushTokenSync
 import com.neph.features.notifications.data.NotificationsBadge
 import com.neph.features.notifications.data.NotificationsRepository
 import com.neph.features.nearbyusers.data.NearbyVisibleUsersRepository
+import com.neph.features.onboarding.data.MobileOnboardingStore
 import com.neph.features.operationallocation.data.OperationalLocationRepository
 import com.neph.features.profile.data.ProfileData
 import com.neph.features.profile.data.ProfileRepository
@@ -110,8 +111,9 @@ object AuthRepository {
 
         return try {
             ProfileRepository.syncPendingLocationPermissionPrivacyHintIfNeeded()
-            ProfileRepository.fetchAndCacheRemoteProfile()
+            val remoteProfile = ProfileRepository.fetchAndCacheRemoteProfile()
             AuthSessionStore.clearPendingVerificationEmail()
+            markMobileOnboardingPendingIfReady(userId = userId, email = remoteProfile.email ?: userEmail)
             NephAppContext.getOrNull()?.let { OfflineSyncScheduler.enqueueSync(it, reason = "login") }
             LoginDestination.PROFILE
         } catch (cancellationException: CancellationException) {
@@ -172,8 +174,9 @@ object AuthRepository {
 
         return try {
             ProfileRepository.syncPendingLocationPermissionPrivacyHintIfNeeded()
-            ProfileRepository.fetchAndCacheRemoteProfile()
+            val remoteProfile = ProfileRepository.fetchAndCacheRemoteProfile()
             AuthSessionStore.clearPendingVerificationEmail()
+            markMobileOnboardingPendingIfReady(userId = userId, email = remoteProfile.email ?: userEmail)
             NephAppContext.getOrNull()?.let { OfflineSyncScheduler.enqueueSync(it, reason = "google-login") }
             LoginDestination.PROFILE
         } catch (cancellationException: CancellationException) {
@@ -346,6 +349,13 @@ object AuthRepository {
                 Log.w("AuthRepository", "Failed to clear safety status on logout", error)
             }
         }
+    }
+
+    private fun markMobileOnboardingPendingIfReady(userId: String?, email: String?) {
+        NephAppContext.getOrNull()?.let { context ->
+            MobileOnboardingStore.initialize(context)
+        }
+        MobileOnboardingStore.markPendingForUserIfUnseen(userId = userId, email = email)
     }
 
     private fun extractTokenFromLink(tokenOrLink: String): String {

--- a/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
+++ b/android/app/src/main/java/com/neph/features/home/presentation/HomeScreen.kt
@@ -77,6 +77,9 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
+private const val MobileOnboardingWelcomeBlurAlpha = 0.23f
+private const val MobileOnboardingWelcomePanelAlpha = 0.50f
+
 @Composable
 fun HomeScreen(
     onRequestHelp: (String?) -> Unit,
@@ -867,7 +870,7 @@ private fun MobileOnboardingWelcomeMessage() {
                 .matchParentSize()
                 .blur(18.dp)
                 .background(
-                    color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.46f),
+                    color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = MobileOnboardingWelcomeBlurAlpha),
                     shape = RoundedCornerShape(24.dp)
                 )
         )
@@ -880,7 +883,7 @@ private fun MobileOnboardingWelcomeMessage() {
                     shape = RoundedCornerShape(24.dp)
                 ),
             shape = RoundedCornerShape(24.dp),
-            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.88f),
+            color = MaterialTheme.colorScheme.surface.copy(alpha = MobileOnboardingWelcomePanelAlpha),
             tonalElevation = 6.dp,
             shadowElevation = 2.dp
         ) {

--- a/android/app/src/main/java/com/neph/features/onboarding/data/MobileOnboardingStore.kt
+++ b/android/app/src/main/java/com/neph/features/onboarding/data/MobileOnboardingStore.kt
@@ -5,6 +5,10 @@ import android.content.SharedPreferences
 import com.neph.BuildConfig
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.profile.data.ProfileRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 object MobileOnboardingStore {
     private const val PrefsName = "neph_mobile_onboarding"
@@ -13,6 +17,8 @@ object MobileOnboardingStore {
     internal const val CurrentStepPrefix = "mobile_onboarding_current_step"
 
     private lateinit var prefs: SharedPreferences
+    private val revisionState = MutableStateFlow(0)
+    val revisionFlow: StateFlow<Int> = revisionState.asStateFlow()
 
     fun initialize(context: Context) {
         if (!::prefs.isInitialized) {
@@ -21,72 +27,183 @@ object MobileOnboardingStore {
     }
 
     fun markPendingForCurrentUser() {
-        val userKey = currentUserKey() ?: return
+        val userKeys = currentUserKeys()
+        if (userKeys.isEmpty()) return
         val firstStep = MobileOnboardingJourney.firstStep(isAuthenticated = true)
-        prefs.edit()
-            .putBoolean(MobileOnboardingKeys.scopedKey(PendingPrefix, userKey), true)
-            .putString(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey), firstStep.id.name)
-            .apply()
+        val editor = prefs.edit()
+        userKeys.forEach { userKey ->
+            editor
+                .putBoolean(MobileOnboardingKeys.scopedKey(PendingPrefix, userKey), true)
+                .putString(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey), firstStep.id.name)
+        }
+        editor.apply()
+        notifyOnboardingStateChanged()
+    }
+
+    fun markPendingForCurrentUserIfUnseen() {
+        if (!::prefs.isInitialized) return
+        val userKeys = currentUserKeys()
+        if (userKeys.isEmpty()) return
+        markPendingForUserKeysIfUnseen(userKeys)
+    }
+
+    fun markPendingForUserIfUnseen(userId: String?, email: String?) {
+        if (!::prefs.isInitialized) return
+        val userKeys = candidateUserKeys(userId = userId, email = email)
+        if (userKeys.isEmpty()) {
+            markPendingForCurrentUserIfUnseen()
+            return
+        }
+        markPendingForUserKeysIfUnseen(userKeys)
+    }
+
+    private fun markPendingForUserKeysIfUnseen(userKeys: List<String>) {
+        val normalizedUserKeys = userKeys
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .distinct()
+        if (normalizedUserKeys.isEmpty()) return
+
+        if (
+            normalizedUserKeys.any { userKey ->
+                prefs.getBoolean(MobileOnboardingKeys.scopedKey(SeenPrefix, userKey), false)
+            }
+        ) {
+            return
+        }
+
+        val storedStep = normalizedUserKeys.firstNotNullOfOrNull { userKey ->
+            prefs.getString(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey), null)
+                ?.takeIf { it.isNotBlank() }
+        }
+        val firstStep = MobileOnboardingJourney.firstStep(isAuthenticated = true)
+        val stepId = storedStep ?: firstStep.id.name
+
+        val editor = prefs.edit()
+        var changed = false
+        normalizedUserKeys.forEach { userKey ->
+            val pendingKey = MobileOnboardingKeys.scopedKey(PendingPrefix, userKey)
+            val currentStepKey = MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey)
+            if (!prefs.getBoolean(pendingKey, false)) {
+                editor.putBoolean(pendingKey, true)
+                changed = true
+            }
+            if (prefs.getString(currentStepKey, null).isNullOrBlank()) {
+                editor.putString(currentStepKey, stepId)
+                changed = true
+            }
+        }
+
+        if (!changed) return
+
+        editor.apply()
+        notifyOnboardingStateChanged()
+    }
+
+    private fun candidateUserKeys(userId: String?, email: String?): List<String> {
+        return buildList {
+            userId
+                ?.trim()
+                ?.takeIf { it.isNotBlank() }
+                ?.let { add("user:$it") }
+            email
+                ?.trim()
+                ?.lowercase()
+                ?.takeIf { it.isNotBlank() }
+                ?.let { add("email:$it") }
+        }
     }
 
     fun restartForCurrentUser() {
-        val userKey = currentUserKey() ?: return
+        val userKeys = currentUserKeys()
+        if (userKeys.isEmpty()) return
         val firstStep = MobileOnboardingJourney.firstStep(isAuthenticated = true)
-        prefs.edit()
-            .putBoolean(MobileOnboardingKeys.scopedKey(PendingPrefix, userKey), true)
-            .remove(MobileOnboardingKeys.scopedKey(SeenPrefix, userKey))
-            .putString(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey), firstStep.id.name)
-            .apply()
+        val editor = prefs.edit()
+        userKeys.forEach { userKey ->
+            editor
+                .putBoolean(MobileOnboardingKeys.scopedKey(PendingPrefix, userKey), true)
+                .remove(MobileOnboardingKeys.scopedKey(SeenPrefix, userKey))
+                .putString(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey), firstStep.id.name)
+        }
+        editor.apply()
+        notifyOnboardingStateChanged()
     }
 
     fun shouldShowForCurrentUser(): Boolean {
-        val userKey = currentUserKey() ?: return false
-        val pendingKey = MobileOnboardingKeys.scopedKey(PendingPrefix, userKey)
-        val seenKey = MobileOnboardingKeys.scopedKey(SeenPrefix, userKey)
-        val pending = prefs.getBoolean(pendingKey, false)
-        val seen = prefs.getBoolean(seenKey, false)
+        val userKeys = currentUserKeys()
+        if (userKeys.isEmpty()) return false
+
+        val pendingKeys = userKeys
+            .map { userKey -> MobileOnboardingKeys.scopedKey(PendingPrefix, userKey) }
+            .filter { pendingKey -> prefs.getBoolean(pendingKey, false) }
+        val pending = pendingKeys.isNotEmpty()
+        val seen = userKeys.any { userKey ->
+            prefs.getBoolean(MobileOnboardingKeys.scopedKey(SeenPrefix, userKey), false)
+        }
 
         if (pending && seen) {
-            prefs.edit().remove(pendingKey).apply()
+            val editor = prefs.edit()
+            userKeys.forEach { userKey ->
+                editor
+                    .remove(MobileOnboardingKeys.scopedKey(PendingPrefix, userKey))
+                    .remove(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey))
+            }
+            editor.apply()
+            notifyOnboardingStateChanged()
         }
 
         return MobileOnboardingKeys.shouldShow(pending = pending, seen = seen)
     }
 
     fun currentStepForCurrentUser(isAuthenticated: Boolean): MobileOnboardingStepId? {
-        val userKey = currentUserKey() ?: return null
-        val stored = prefs.getString(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey), null)
-        val parsed = stored?.let { runCatching { MobileOnboardingStepId.valueOf(it) }.getOrNull() }
+        val userKeys = currentUserKeys()
+        if (userKeys.isEmpty()) return null
+        val parsed = userKeys.firstNotNullOfOrNull { userKey ->
+            prefs.getString(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey), null)
+                ?.let { stored -> runCatching { MobileOnboardingStepId.valueOf(stored) }.getOrNull() }
+        }
         val valid = parsed?.takeIf { MobileOnboardingJourney.stepFor(it, isAuthenticated) != null }
-        if (valid != null) return valid
+        if (valid != null) {
+            setCurrentStepForUserKeys(userKeys, valid)
+            return valid
+        }
 
         val firstStep = MobileOnboardingJourney.firstStep(isAuthenticated)
-        setCurrentStepForCurrentUser(firstStep.id)
+        setCurrentStepForUserKeys(userKeys, firstStep.id)
         return firstStep.id
     }
 
     fun setCurrentStepForCurrentUser(stepId: MobileOnboardingStepId) {
-        val userKey = currentUserKey() ?: return
-        prefs.edit()
-            .putString(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey), stepId.name)
-            .apply()
+        val userKeys = currentUserKeys()
+        if (userKeys.isEmpty()) return
+        setCurrentStepForUserKeys(userKeys, stepId)
     }
 
     fun markSeenForCurrentUser() {
-        val userKey = currentUserKey() ?: return
-        prefs.edit()
-            .putBoolean(MobileOnboardingKeys.scopedKey(SeenPrefix, userKey), true)
-            .remove(MobileOnboardingKeys.scopedKey(PendingPrefix, userKey))
-            .remove(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey))
-            .apply()
+        val userKeys = currentUserKeys()
+        if (userKeys.isEmpty()) return
+        val editor = prefs.edit()
+        userKeys.forEach { userKey ->
+            editor
+                .putBoolean(MobileOnboardingKeys.scopedKey(SeenPrefix, userKey), true)
+                .remove(MobileOnboardingKeys.scopedKey(PendingPrefix, userKey))
+                .remove(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey))
+        }
+        editor.apply()
+        notifyOnboardingStateChanged()
     }
 
     fun clearPendingForCurrentUser() {
-        val userKey = currentUserKey() ?: return
-        prefs.edit()
-            .remove(MobileOnboardingKeys.scopedKey(PendingPrefix, userKey))
-            .remove(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey))
-            .apply()
+        val userKeys = currentUserKeys()
+        if (userKeys.isEmpty()) return
+        val editor = prefs.edit()
+        userKeys.forEach { userKey ->
+            editor
+                .remove(MobileOnboardingKeys.scopedKey(PendingPrefix, userKey))
+                .remove(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey))
+        }
+        editor.apply()
+        notifyOnboardingStateChanged()
     }
 
     fun resetForTesting() {
@@ -94,25 +211,38 @@ object MobileOnboardingStore {
         if (::prefs.isInitialized) {
             prefs.edit().clear().commit()
         }
+        notifyOnboardingStateChanged()
     }
 
-    private fun currentUserKey(): String? {
+    private fun notifyOnboardingStateChanged() {
+        revisionState.update { revision -> revision + 1 }
+    }
+
+    private fun setCurrentStepForUserKeys(userKeys: List<String>, stepId: MobileOnboardingStepId) {
+        val editor = prefs.edit()
+        userKeys.forEach { userKey ->
+            editor.putString(MobileOnboardingKeys.scopedKey(CurrentStepPrefix, userKey), stepId.name)
+        }
+        editor.apply()
+    }
+
+    private fun currentUserKeys(): List<String> {
         ensureInitialized()
         if (AuthSessionStore.getAccessToken().isNullOrBlank()) {
-            return null
+            return emptyList()
         }
 
-        AuthSessionStore.getCurrentUserId()
+        val userId = AuthSessionStore.getCurrentUserId()
             ?.trim()
             ?.takeIf { it.isNotBlank() }
-            ?.let { return "user:$it" }
 
         val email = runCatching { ProfileRepository.getProfile().email }
             .getOrNull()
             ?.trim()
             ?.lowercase()
             ?.takeIf { it.isNotBlank() }
-        return email?.let { "email:$it" }
+
+        return candidateUserKeys(userId = userId, email = email)
     }
 
     private fun ensureInitialized() {

--- a/android/app/src/main/java/com/neph/features/onboarding/presentation/MobileOnboardingTutorial.kt
+++ b/android/app/src/main/java/com/neph/features/onboarding/presentation/MobileOnboardingTutorial.kt
@@ -37,6 +37,8 @@ import com.neph.features.onboarding.data.MobileOnboardingStep
 import com.neph.ui.theme.LocalNephSpacing
 import kotlin.math.roundToInt
 
+private const val MobileOnboardingGuidePanelAlpha = 0.50f
+
 @Composable
 fun MobileOnboardingGuide(
     step: MobileOnboardingStep,
@@ -93,7 +95,7 @@ fun MobileOnboardingGuide(
                 }
                 .testTag("mobile_onboarding_dialog"),
             shape = MaterialTheme.shapes.extraLarge,
-            color = MaterialTheme.colorScheme.surface,
+            color = MaterialTheme.colorScheme.surface.copy(alpha = MobileOnboardingGuidePanelAlpha),
             tonalElevation = 8.dp,
             shadowElevation = 8.dp
         ) {

--- a/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
@@ -47,6 +47,7 @@ fun AppNavGraph(
     navController: NavHostController,
     startDestination: String = Routes.Welcome.route,
     onRestartMobileOnboarding: () -> Unit = {},
+    onAuthenticatedLoginCompleted: () -> Unit = {},
     mobileOnboardingStepId: MobileOnboardingStepId? = null,
     onMobileOnboardingStepCompleted: (String?) -> Unit = {},
     onMobileOnboardingFeedbackChanged: (String?) -> Unit = {},
@@ -564,6 +565,7 @@ fun AppNavGraph(
                         popUpTo(Routes.Welcome.route) { inclusive = true }
                         launchSingleTop = true
                     }
+                    onAuthenticatedLoginCompleted()
                 },
                 onProfileCompletionRequired = {
                     navController.navigate(Routes.CompleteProfile.route) {


### PR DESCRIPTION
  ## Summary

  This PR fixes mobile onboarding for users who completed verification/profile setup on web before logging into mobile.
  Their first mobile login now starts the onboarding guide even though the backend profile already exists.

  It also slightly lightens the onboarding UI by reducing the opacity of the guide panels.

  ## Changes

  - Mark mobile onboarding pending after successful email/password login when a remote profile exists.
  - Apply the same behavior for Google login with an existing profile.
  - Scope onboarding state by user identifiers so pending/seen state is preserved correctly.
  - Add onboarding state revision tracking so the UI reacts when onboarding state changes after login.
  - Stabilize the app start destination to avoid navigation graph resets during login state changes.
  - Add a post-login hook to show pending onboarding immediately.
  - Reduce opacity of:
    - onboarding guide panel
    - home onboarding welcome panel
    - home onboarding blur background
  - Add regression coverage for first mobile login with an existing web-completed profile.