### PR TITLE
fix: prevent state restoration on Home navigation

### DIFF
--- a/android/app/src/androidTest/java/com/neph/e2e/AuthenticatedSessionAndroidE2ETest.kt
+++ b/android/app/src/androidTest/java/com/neph/e2e/AuthenticatedSessionAndroidE2ETest.kt
@@ -14,6 +14,11 @@ import com.neph.MainActivity
 import com.neph.features.auth.data.AuthSessionStore
 import com.neph.features.profile.data.ProfileData
 import com.neph.features.profile.data.ProfileRepository
+import com.neph.features.requesthelp.data.RequestHelpContactSubmission
+import com.neph.features.requesthelp.data.RequestHelpLocationSubmission
+import com.neph.features.requesthelp.data.RequestHelpRepository
+import com.neph.features.requesthelp.data.RequestHelpSubmission
+import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -115,6 +120,62 @@ class AuthenticatedSessionAndroidE2ETest {
 
         waitForText("Welcome back")
         composeRule.onNodeWithText("Welcome back").assertIsDisplayed()
+    }
+
+    @Test
+    fun systemBackFromHelpRequestEdit_homeBottomNavReturnsHome() {
+        waitForText("I need help now")
+        seedActiveHelpRequest()
+
+        waitForClickable("Requests")
+        clickableNode("Requests").performClick()
+        waitForClickable("Edit Request")
+
+        clickableNode("Edit Request").performClick()
+        waitForText("Edit help request?")
+        clickableNode("Edit").performClick()
+
+        waitForText("Request Help")
+        composeRule.activityRule.scenario.onActivity { activity ->
+            activity.onBackPressedDispatcher.onBackPressed()
+        }
+
+        waitForText("My Help Requests")
+        waitForClickable("Home")
+        clickableNode("Home").performClick()
+
+        waitForText("I need help now")
+        composeRule.onNodeWithText("I need help now").assertIsDisplayed()
+    }
+
+    private fun seedActiveHelpRequest() {
+        RequestHelpRepository.initialize(composeRule.activity.applicationContext)
+        runBlocking {
+            RequestHelpRepository.createHelpRequest(
+                token = "access-token-1",
+                submission = RequestHelpSubmission(
+                    helpTypes = listOf("Search & Rescue"),
+                    otherHelpText = "",
+                    affectedPeopleCount = 2,
+                    description = "Need help after structural damage.",
+                    riskFlags = listOf("Fire"),
+                    vulnerableGroups = listOf("Children"),
+                    shareProfileHealthInfoWithVolunteer = true,
+                    location = RequestHelpLocationSubmission(
+                        country = "Turkey",
+                        city = "Istanbul",
+                        district = "Kadıköy",
+                        neighborhood = "Bostancı",
+                        extraAddress = "Existing Street 5"
+                    ),
+                    contact = RequestHelpContactSubmission(
+                        fullName = "Alex Helper",
+                        phone = 905551112233
+                    ),
+                    consentGiven = true
+                )
+            )
+        }
     }
 
     private fun clickableNode(text: String) = composeRule.onNode(hasText(text) and hasClickAction())

--- a/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
+++ b/android/app/src/main/java/com/neph/navigation/AppNavGraph.kt
@@ -86,6 +86,31 @@ fun AppNavGraph(
             return
         }
 
+        if (route == Routes.Home.route) {
+            if (navController.currentBackStackEntry?.destination?.route == Routes.Home.route) {
+                return
+            }
+
+            // Home is the root tab: do not save/restore the popped request stack
+            // under the Home route, or the restored stack can put Requests back
+            // on top immediately after the user taps Home.
+            val poppedToExistingHome = navController.popBackStack(
+                route = Routes.Home.route,
+                inclusive = false
+            )
+            if (!poppedToExistingHome) {
+                navController.navigate(Routes.Home.route) {
+                    popUpTo(navController.graph.id) {
+                        inclusive = true
+                        saveState = false
+                    }
+                    launchSingleTop = true
+                    restoreState = false
+                }
+            }
+            return
+        }
+
         navController.navigate(route) {
             popUpTo(Routes.Home.route) {
                 saveState = true


### PR DESCRIPTION
  ## Summary

  Fixes an Android navigation bug where users could get stuck on `My Help Requests` after using the Android system back
  button during the help-request edit flow. Tapping the bottom-nav Home tab now reliably returns the user to the Home
  screen.

Resolves #549 
  ## Root Cause

  The top-level drawer/bottom-nav navigation helper treated `Home` the same as other destinations and used `saveState =
  true` / `restoreState = true`.

  When navigating from `My Help Requests` back to `Home`, the popped request stack could be saved under the Home route and
  immediately restored, causing `My Help Requests` to remain on top even after the user tapped Home.

  ## Changes

  - Special-cased Home navigation in `AppNavGraph`.
  - Home now behaves as the root destination:
    - first tries to pop back to an existing Home route;
    - if Home is not in the stack, resets the graph to Home;
    - avoids saving/restoring the request stack when Home is selected.
  - Added an Android E2E regression test covering:
    - active help request exists;
    - user opens Requests;
    - user opens Edit Request;
    - user presses Android system back;
    - user taps Home bottom nav;
    - Home content is displayed.
