### PR TITLE
fix: update request help edit action label

### DIFF
--- a/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/presentation/RequestHelpScreen.kt
@@ -1313,7 +1313,7 @@ fun RequestHelpScreen(
             }
 
             PrimaryButton(
-                text = "Send Help Request",
+                text = requestHelpPrimaryActionLabel(activeDraftLocalId),
                 onClick = ::handleSubmit,
                 modifier = Modifier
                     .then(
@@ -1333,6 +1333,10 @@ fun RequestHelpScreen(
             )
         }
     }
+}
+
+internal fun requestHelpPrimaryActionLabel(draftLocalId: String?): String {
+    return if (draftLocalId.isNullOrBlank()) "Send Help Request" else "Save Changes"
 }
 
 @Composable

--- a/android/app/src/test/java/com/neph/features/requesthelp/presentation/RequestHelpActionLabelTest.kt
+++ b/android/app/src/test/java/com/neph/features/requesthelp/presentation/RequestHelpActionLabelTest.kt
@@ -1,0 +1,17 @@
+package com.neph.features.requesthelp.presentation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RequestHelpActionLabelTest {
+    @Test
+    fun primaryActionLabelUsesSendHelpRequestForCreateMode() {
+        assertEquals("Send Help Request", requestHelpPrimaryActionLabel(null))
+        assertEquals("Send Help Request", requestHelpPrimaryActionLabel(""))
+    }
+
+    @Test
+    fun primaryActionLabelUsesSaveChangesForEditMode() {
+        assertEquals("Save Changes", requestHelpPrimaryActionLabel("local-request-1"))
+    }
+}


### PR DESCRIPTION
## Summary
- Updates the Android Request Help primary action label based on mode
- Shows `Save Changes` when editing an existing help request
- Keeps `Send Help Request` for creating a new help request
- Adds unit tests for create/edit label selection

Closes #612


