### PR TITLE
fix: preserve help request edit location prefill

### DIFF
--- a/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
+++ b/android/app/src/main/java/com/neph/features/requesthelp/data/RequestHelpRepository.kt
@@ -883,11 +883,11 @@ internal fun JSONObject.toHelpRequestEntity(
         description = optString("description"),
         bloodType = optString("bloodType"),
         shareProfileHealthInfoWithVolunteer = optBoolean("shareProfileHealthInfoWithVolunteer", false),
-        country = location.optString("country"),
-        city = location.optString("city"),
-        district = location.optString("district"),
-        neighborhood = location.optString("neighborhood"),
-        extraAddress = location.optString("extraAddress"),
+        country = readLocationText(location, "country", existing?.country),
+        city = readLocationText(location, "city", existing?.city),
+        district = readLocationText(location, "district", existing?.district),
+        neighborhood = readLocationText(location, "neighborhood", existing?.neighborhood),
+        extraAddress = readLocationText(location, "extraAddress", existing?.extraAddress),
         latitude = readLocationLatitude(location, existing),
         longitude = readLocationLongitude(location, existing),
         coordinateSource = readLocationCoordinateSource(location, existing),
@@ -954,6 +954,13 @@ private fun readLocationLongitude(location: JSONObject, existing: HelpRequestEnt
     return location.optNullableDouble("longitude")
         ?: location.optJSONObject("coordinate")?.optNullableDouble("longitude")
         ?: existing?.longitude
+}
+
+private fun readLocationText(location: JSONObject, key: String, existingValue: String?): String {
+    if (location.has(key) && !location.isNull(key)) {
+        return location.optString(key)
+    }
+    return existingValue.orEmpty()
 }
 
 private fun readLocationCoordinateSource(location: JSONObject, existing: HelpRequestEntity?): String? {

--- a/android/app/src/test/java/com/neph/features/requesthelp/data/RequestHelpOfflineMappingTest.kt
+++ b/android/app/src/test/java/com/neph/features/requesthelp/data/RequestHelpOfflineMappingTest.kt
@@ -190,6 +190,57 @@ class RequestHelpOfflineMappingTest {
     }
 
     @Test
+    fun remoteMappingPreservesExistingLocationWhenRemoteLocationIsPartial() {
+        val existing = sampleSubmission().copy(
+            location = sampleSubmission().location.copy(
+                latitude = 40.987,
+                longitude = 29.025,
+                coordinateSource = "gps",
+                coordinateCapturedAt = "2026-05-02T10:00:00.000Z",
+                coordinateAccuracyMeters = 18.5
+            )
+        ).toEntity(
+            localId = "local-existing-location",
+            ownerType = LocalOwnerType.AUTHENTICATED,
+            now = 1234L,
+            syncStatus = SyncStatus.SYNCED
+        ).copy(remoteId = "req_remote_partial_location")
+
+        val entity = JSONObject().apply {
+            put("id", "req_remote_partial_location")
+            put("helpTypes", JSONArray(listOf("food_water")))
+            put("otherHelpText", "")
+            put("affectedPeopleCount", 4)
+            put("riskFlags", JSONArray(listOf("fire")))
+            put("vulnerableGroups", JSONArray(listOf("elderly")))
+            put("description", "Need support")
+            put("shareProfileHealthInfoWithVolunteer", true)
+            put("status", "SYNCED")
+            put("location", JSONObject())
+            put(
+                "contact",
+                JSONObject().put("fullName", "Ayse Yilmaz").put("phone", "5551234567")
+            )
+        }.toHelpRequestEntity(
+            ownerType = LocalOwnerType.AUTHENTICATED,
+            existing = existing,
+            guestAccessToken = null,
+            now = 5678L
+        )
+
+        assertEquals("Turkey", entity.country)
+        assertEquals("Istanbul", entity.city)
+        assertEquals("Kadikoy", entity.district)
+        assertEquals("Moda", entity.neighborhood)
+        assertEquals("Near park", entity.extraAddress)
+        assertEquals(40.987, entity.latitude ?: 0.0, 0.0)
+        assertEquals(29.025, entity.longitude ?: 0.0, 0.0)
+        assertEquals("gps", entity.coordinateSource)
+        assertEquals("2026-05-02T10:00:00.000Z", entity.coordinateCapturedAt)
+        assertEquals(18.5, entity.coordinateAccuracyMeters ?: 0.0, 0.0)
+    }
+
+    @Test
     fun emergencyDraftRequiresRealContactAndLocation() {
         assertThrows(EmergencyDraftRequirementsException::class.java) {
             buildEmergencyDraftSubmission(


### PR DESCRIPTION
## Summary
- Preserves existing Request Help location fields when a remote refresh returns partial location data
- Prevents edit forms from opening with blank country/city/district/neighborhood/extra address values
- Adds regression coverage for preserving address fields and coordinates during remote mapping

Closes #615


