### PR TITLE
fix(android): current-location behavior

### DIFF
--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -86,6 +86,10 @@ private const val ResourceProviderUnavailableMessage =
     "Gathering area provider is unavailable. Please try again."
 private const val ResourceStaleCacheMessage =
     "Showing cached gathering areas; provider data may be temporarily unavailable."
+private const val InitialNearbyPermissionDeniedMessage =
+    "Location permission was denied. Showing the default map area."
+private const val InitialNearbyLocationUnavailableMessage =
+    "Current location is unavailable. Showing the default map area."
 internal const val GatheringAreasVisibleCategoriesTitle = "Visible Categories"
 internal const val GatheringAreasVisibleCategoriesSubtitle =
     "Selected categories are shown on the map and in the list."
@@ -218,7 +222,10 @@ fun GatheringAreasScreen(
         infoMessage = ""
     }
 
-    fun requestCurrentLocationAndRefresh(silent: Boolean = false) {
+    fun requestCurrentLocationAndRefresh(
+        silent: Boolean = false,
+        isInitialAttempt: Boolean = false
+    ) {
         scope.launch {
             loading = true
             errorMessage = ""
@@ -252,21 +259,34 @@ fun GatheringAreasScreen(
                 }
 
                 loading = false
-                if (!silent) {
-                    infoMessage = when (attempt.warning) {
-                        CurrentLocationShareWarning.PERMISSION_DENIED ->
+                val locationMessage = when (attempt.warning) {
+                    CurrentLocationShareWarning.PERMISSION_DENIED ->
+                        if (isInitialAttempt) {
+                            InitialNearbyPermissionDeniedMessage
+                        } else {
                             "Location permission was denied. Nearby results were not updated."
+                        }
 
-                        CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
-                        null -> "Current location is unavailable. Nearby results were not updated."
+                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
+                    null -> if (isInitialAttempt) {
+                        InitialNearbyLocationUnavailableMessage
+                    } else {
+                        "Current location is unavailable. Nearby results were not updated."
                     }
+                }
+                if (isInitialAttempt || !silent) {
+                    infoMessage = locationMessage
                 }
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (_: Exception) {
                 loading = false
-                if (!silent) {
-                    infoMessage = "Current location is unavailable. Nearby results were not updated."
+                if (isInitialAttempt || !silent) {
+                    infoMessage = if (isInitialAttempt) {
+                        InitialNearbyLocationUnavailableMessage
+                    } else {
+                        "Current location is unavailable. Nearby results were not updated."
+                    }
                 }
             }
         }
@@ -334,12 +354,17 @@ fun GatheringAreasScreen(
         val isInitialRequest = initialLocationPermissionRequestPending
         initialLocationPermissionRequestPending = false
         if (result.granted) {
-            requestCurrentLocationAndRefresh(silent = isInitialRequest)
+            requestCurrentLocationAndRefresh(
+                silent = false,
+                isInitialAttempt = isInitialRequest
+            )
         } else {
             errorMessage = ""
             loading = false
             backgroundUpdating = false
-            if (!isInitialRequest) {
+            if (isInitialRequest) {
+                infoMessage = InitialNearbyPermissionDeniedMessage
+            } else {
                 infoMessage = "Location permission was denied. Nearby results were not updated."
             }
         }
@@ -357,7 +382,7 @@ fun GatheringAreasScreen(
         if (attemptedInitialLocation) return@LaunchedEffect
         attemptedInitialLocation = true
         if (locationPermissionRequester.refreshPermissionState()) {
-            requestCurrentLocationAndRefresh(silent = true)
+            requestCurrentLocationAndRefresh(silent = false, isInitialAttempt = true)
         } else {
             initialLocationPermissionRequestPending = true
             locationPermissionRequester.requestPermission()

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -33,6 +33,7 @@ import com.neph.features.gatheringareas.data.GatheringAreaItem
 import com.neph.features.gatheringareas.data.GatheringAreaCategoryMeta
 import com.neph.features.gatheringareas.data.GatheringAreasRepository
 import com.neph.features.gatheringareas.data.NearbyGatheringAreasResult
+import com.neph.features.profile.data.CurrentDeviceLocation
 import com.neph.features.profile.data.CurrentLocationShareWarning
 import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.features.onboarding.data.MobileOnboardingStepId
@@ -188,6 +189,9 @@ fun GatheringAreasScreen(
     var mapCenterLongitude by remember { mutableStateOf(TurkeyOverviewLongitude) }
     var mapZoom by remember { mutableStateOf(TurkeyOverviewZoom) }
     var mapResetNonce by remember { mutableStateOf(0) }
+    var currentLocation by remember { mutableStateOf<CurrentDeviceLocation?>(null) }
+    var attemptedInitialLocation by remember { mutableStateOf(false) }
+    var initialLocationPermissionRequestPending by remember { mutableStateOf(false) }
     var currentViewport by remember { mutableStateOf<LeafletMapViewport?>(null) }
     var pendingViewport by remember { mutableStateOf<LeafletMapViewport?>(null) }
     var lastFetchedViewportKey by remember { mutableStateOf<String?>(null) }
@@ -214,11 +218,13 @@ fun GatheringAreasScreen(
         infoMessage = ""
     }
 
-    fun requestCurrentLocationAndRefresh() {
+    fun requestCurrentLocationAndRefresh(silent: Boolean = false) {
         scope.launch {
             loading = true
             errorMessage = ""
-            infoMessage = ""
+            if (!silent) {
+                infoMessage = ""
+            }
 
             try {
                 val attempt = DeviceLocationProvider.captureCurrentLocationForSharing(
@@ -228,6 +234,7 @@ fun GatheringAreasScreen(
 
                 val location = attempt.location
                 if (location != null) {
+                    currentLocation = location
                     viewportRequestSerial += 1
                     currentViewport = null
                     pendingViewport = null
@@ -238,24 +245,29 @@ fun GatheringAreasScreen(
                     mapResetNonce += 1
                     selectedAreaId = null
                     lastFetchedViewportKey = null
+                    infoMessage = ""
                     loading = false
                     backgroundUpdating = false
                     return@launch
                 }
 
                 loading = false
-                infoMessage = when (attempt.warning) {
-                    CurrentLocationShareWarning.PERMISSION_DENIED ->
-                        "Location permission was denied. Nearby results were not updated."
+                if (!silent) {
+                    infoMessage = when (attempt.warning) {
+                        CurrentLocationShareWarning.PERMISSION_DENIED ->
+                            "Location permission was denied. Nearby results were not updated."
 
-                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
-                    null -> "Current location is unavailable. Nearby results were not updated."
+                        CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
+                        null -> "Current location is unavailable. Nearby results were not updated."
+                    }
                 }
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (_: Exception) {
                 loading = false
-                infoMessage = "Current location is unavailable. Nearby results were not updated."
+                if (!silent) {
+                    infoMessage = "Current location is unavailable. Nearby results were not updated."
+                }
             }
         }
     }
@@ -319,13 +331,17 @@ fun GatheringAreasScreen(
     }
 
     val locationPermissionRequester = rememberForegroundLocationPermissionRequester { result ->
+        val isInitialRequest = initialLocationPermissionRequestPending
+        initialLocationPermissionRequestPending = false
         if (result.granted) {
-            requestCurrentLocationAndRefresh()
+            requestCurrentLocationAndRefresh(silent = isInitialRequest)
         } else {
             errorMessage = ""
             loading = false
             backgroundUpdating = false
-            infoMessage = "Location permission was denied. Nearby results were not updated."
+            if (!isInitialRequest) {
+                infoMessage = "Location permission was denied. Nearby results were not updated."
+            }
         }
     }
 
@@ -333,6 +349,17 @@ fun GatheringAreasScreen(
         if (locationPermissionRequester.refreshPermissionState()) {
             requestCurrentLocationAndRefresh()
         } else {
+            locationPermissionRequester.requestPermission()
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        if (attemptedInitialLocation) return@LaunchedEffect
+        attemptedInitialLocation = true
+        if (locationPermissionRequester.refreshPermissionState()) {
+            requestCurrentLocationAndRefresh(silent = true)
+        } else {
+            initialLocationPermissionRequestPending = true
             locationPermissionRequester.requestPermission()
         }
     }
@@ -373,6 +400,7 @@ fun GatheringAreasScreen(
             pendingViewport = viewport
         } else {
             viewportRequestSerial += 1
+            pendingViewport = null
             nearbyResult = null
             selectedAreaId = null
             lastFetchedViewportKey = null
@@ -472,6 +500,8 @@ fun GatheringAreasScreen(
                 emptyMarkersMessage = mapEmptyMarkersMessage,
                 mapCenterLatitude = mapCenterLatitude,
                 mapCenterLongitude = mapCenterLongitude,
+                currentLocationLatitude = currentLocation?.latitude,
+                currentLocationLongitude = currentLocation?.longitude,
                 mapZoom = mapZoom,
                 mapResetToken = mapResetNonce,
                 showCenterMarker = false,
@@ -695,6 +725,8 @@ private fun GatheringAreasMapCard(
     emptyMarkersMessage: String = "No gathering area markers are available for this search center.",
     mapCenterLatitude: Double = result.centerLatitude,
     mapCenterLongitude: Double = result.centerLongitude,
+    currentLocationLatitude: Double? = null,
+    currentLocationLongitude: Double? = null,
     mapZoom: Int = 13,
     mapResetToken: Int = 0,
     showCenterMarker: Boolean = true,
@@ -796,6 +828,8 @@ private fun GatheringAreasMapCard(
                     currentMapInstanceId = { currentMapInstanceIdState.value },
                     centerLatitude = mapCenterLatitude,
                     centerLongitude = mapCenterLongitude,
+                    currentLocationLatitude = currentLocationLatitude,
+                    currentLocationLongitude = currentLocationLongitude,
                     markers = markers,
                     selectedMarkerId = selectedAreaId,
                     mapHeightCssPx = GatheringAreasMapHeightCssPx,

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -43,6 +43,7 @@ import com.neph.features.helprequestmap.data.ActiveHelpRequestsResult
 import com.neph.features.helprequestmap.data.ActiveHelpRequestsRepository
 import com.neph.features.helprequestmap.data.CrisisRequestType
 import com.neph.features.onboarding.data.MobileOnboardingStepId
+import com.neph.features.profile.data.CurrentDeviceLocation
 import com.neph.features.profile.data.CurrentLocationShareWarning
 import com.neph.features.profile.data.DeviceLocationProvider
 import com.neph.navigation.Routes
@@ -246,6 +247,9 @@ fun HelpRequestMapScreen(
     var mapCenterLongitude by remember { mutableStateOf(TurkeyOverviewLongitude) }
     var mapZoom by remember { mutableStateOf(TurkeyOverviewZoom) }
     var mapResetNonce by remember { mutableStateOf(0) }
+    var currentLocation by remember { mutableStateOf<CurrentDeviceLocation?>(null) }
+    var attemptedInitialLocation by remember { mutableStateOf(false) }
+    var initialLocationPermissionRequestPending by remember { mutableStateOf(false) }
     var initialMarkerFitApplied by remember { mutableStateOf(false) }
     var markerFitBoundsToken by remember { mutableStateOf<Int?>(null) }
 
@@ -287,12 +291,14 @@ fun HelpRequestMapScreen(
         viewportRefreshNonce += 1
     }
 
-    fun requestCurrentLocationAndRefresh() {
+    fun requestCurrentLocationAndRefresh(silent: Boolean = false) {
         scope.launch {
             loading = true
             backgroundUpdating = false
             errorMessage = ""
-            infoMessage = ""
+            if (!silent) {
+                infoMessage = ""
+            }
 
             try {
                 val attempt = DeviceLocationProvider.captureCurrentLocationForSharing(
@@ -302,6 +308,7 @@ fun HelpRequestMapScreen(
 
                 val location = attempt.location
                 if (location != null) {
+                    currentLocation = location
                     viewportRequestSerial += 1
                     currentViewport = null
                     pendingViewport = null
@@ -313,24 +320,29 @@ fun HelpRequestMapScreen(
                     markerFitBoundsToken = null
                     selectedRequestId = null
                     lastFetchedViewportKey = null
+                    infoMessage = ""
                     loading = false
                     backgroundUpdating = false
                     return@launch
                 }
 
                 loading = false
-                infoMessage = when (attempt.warning) {
-                    CurrentLocationShareWarning.PERMISSION_DENIED ->
-                        "Location permission was denied. Help request map was not recentered."
+                if (!silent) {
+                    infoMessage = when (attempt.warning) {
+                        CurrentLocationShareWarning.PERMISSION_DENIED ->
+                            "Location permission was denied. Help request map was not recentered."
 
-                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
-                    null -> "Current location is unavailable. Help request map was not recentered."
+                        CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
+                        null -> "Current location is unavailable. Help request map was not recentered."
+                    }
                 }
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (_: Exception) {
                 loading = false
-                infoMessage = "Current location is unavailable. Help request map was not recentered."
+                if (!silent) {
+                    infoMessage = "Current location is unavailable. Help request map was not recentered."
+                }
             }
         }
     }
@@ -438,13 +450,17 @@ fun HelpRequestMapScreen(
     }
 
     val locationPermissionRequester = rememberForegroundLocationPermissionRequester { result ->
+        val isInitialRequest = initialLocationPermissionRequestPending
+        initialLocationPermissionRequestPending = false
         if (result.granted) {
-            requestCurrentLocationAndRefresh()
+            requestCurrentLocationAndRefresh(silent = isInitialRequest)
         } else {
             errorMessage = ""
             loading = false
             backgroundUpdating = false
-            infoMessage = "Location permission was denied. Help request map was not recentered."
+            if (!isInitialRequest) {
+                infoMessage = "Location permission was denied. Help request map was not recentered."
+            }
         }
     }
 
@@ -452,6 +468,17 @@ fun HelpRequestMapScreen(
         if (locationPermissionRequester.refreshPermissionState()) {
             requestCurrentLocationAndRefresh()
         } else {
+            locationPermissionRequester.requestPermission()
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        if (attemptedInitialLocation) return@LaunchedEffect
+        attemptedInitialLocation = true
+        if (locationPermissionRequester.refreshPermissionState()) {
+            requestCurrentLocationAndRefresh(silent = true)
+        } else {
+            initialLocationPermissionRequestPending = true
             locationPermissionRequester.requestPermission()
         }
     }
@@ -474,6 +501,7 @@ fun HelpRequestMapScreen(
             pendingViewport = viewport
         } else {
             viewportRequestSerial += 1
+            pendingViewport = null
             requests = emptyList()
             selectedRequestId = null
             lastFetchedViewportKey = null
@@ -544,6 +572,8 @@ fun HelpRequestMapScreen(
                     updatingResources = backgroundUpdating,
                     mapCenterLatitude = mapCenterLatitude,
                     mapCenterLongitude = mapCenterLongitude,
+                    currentLocationLatitude = currentLocation?.latitude,
+                    currentLocationLongitude = currentLocation?.longitude,
                     mapZoom = mapZoom,
                     mapResetToken = mapResetNonce,
                     fitBoundsRequestToken = markerFitBoundsToken,
@@ -918,6 +948,8 @@ private fun CrisisRequestMapPanel(
     updatingResources: Boolean = false,
     mapCenterLatitude: Double = TurkeyOverviewLatitude,
     mapCenterLongitude: Double = TurkeyOverviewLongitude,
+    currentLocationLatitude: Double? = null,
+    currentLocationLongitude: Double? = null,
     mapZoom: Int = TurkeyOverviewZoom,
     mapResetToken: Int = 0,
     fitBoundsRequestToken: Int? = null,
@@ -1009,6 +1041,8 @@ private fun CrisisRequestMapPanel(
                 currentMapInstanceId = { currentMapInstanceIdState.value },
                 centerLatitude = effectiveCenterLatitude,
                 centerLongitude = effectiveCenterLongitude,
+                currentLocationLatitude = currentLocationLatitude,
+                currentLocationLongitude = currentLocationLongitude,
                 markers = markers,
                 selectedMarkerId = selectedRequestId,
                 mapHeightCssPx = HelpRequestMapHeightCssPx,

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -91,6 +91,10 @@ private const val ResourceUpdatingMessage = "Updating visible area..."
 private const val ResourceEmptyMessage = "No resources were found in this visible area."
 private const val ResourceErrorMessage = "Resources could not be loaded for this area. Please try again."
 private const val ResourceFilterEmptyMessage = "No help requests match the selected request type filters."
+private const val InitialPermissionDeniedFallbackMessage =
+    "Location permission was denied. Showing default help request results."
+private const val InitialLocationUnavailableFallbackMessage =
+    "Current location is unavailable. Showing default help request results."
 
 private val RequestTypeFilterOrder = listOf(
     CrisisRequestType.FIRST_AID,
@@ -250,10 +254,17 @@ fun HelpRequestMapScreen(
     var currentLocation by remember { mutableStateOf<CurrentDeviceLocation?>(null) }
     var attemptedInitialLocation by remember { mutableStateOf(false) }
     var initialLocationPermissionRequestPending by remember { mutableStateOf(false) }
+    var initialFallbackFetchRequested by remember { mutableStateOf(false) }
+    var initialFallbackFetchCompleted by remember { mutableStateOf(false) }
+    var initialFallbackInfoMessage by remember { mutableStateOf<String?>(null) }
     var initialMarkerFitApplied by remember { mutableStateOf(false) }
     var markerFitBoundsToken by remember { mutableStateOf<Int?>(null) }
 
-    fun applyRequestResult(result: ActiveHelpRequestsResult, viewportKey: String?) {
+    fun applyRequestResult(
+        result: ActiveHelpRequestsResult,
+        viewportKey: String?,
+        infoOverride: String? = null
+    ) {
         if (
             !initialMarkerFitApplied &&
             viewportKey == null &&
@@ -268,11 +279,23 @@ fun HelpRequestMapScreen(
         selectedRequestId = selectedRequestId
             ?.takeIf { selected -> result.requests.any { it.requestId == selected } }
         infoMessage = when {
+            !infoOverride.isNullOrBlank() -> infoOverride
             result.requests.isEmpty() -> ResourceEmptyMessage
             result.skippedCount > 0 ->
                 "${result.skippedCount} inactive or malformed request entries were hidden."
             else -> ""
         }
+    }
+
+    fun queueInitialFallbackFetch(message: String) {
+        if (initialFallbackFetchCompleted || initialFallbackFetchRequested) {
+            if (infoMessage.isBlank()) {
+                infoMessage = message
+            }
+            return
+        }
+        initialFallbackInfoMessage = message
+        initialFallbackFetchRequested = true
     }
 
     fun queueViewportRefresh() {
@@ -291,7 +314,10 @@ fun HelpRequestMapScreen(
         viewportRefreshNonce += 1
     }
 
-    fun requestCurrentLocationAndRefresh(silent: Boolean = false) {
+    fun requestCurrentLocationAndRefresh(
+        silent: Boolean = false,
+        isInitialAttempt: Boolean = false
+    ) {
         scope.launch {
             loading = true
             backgroundUpdating = false
@@ -327,20 +353,35 @@ fun HelpRequestMapScreen(
                 }
 
                 loading = false
-                if (!silent) {
-                    infoMessage = when (attempt.warning) {
-                        CurrentLocationShareWarning.PERMISSION_DENIED ->
+                val fallbackMessage = when (attempt.warning) {
+                    CurrentLocationShareWarning.PERMISSION_DENIED ->
+                        if (isInitialAttempt) {
+                            InitialPermissionDeniedFallbackMessage
+                        } else {
                             "Location permission was denied. Help request map was not recentered."
+                        }
 
-                        CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
-                        null -> "Current location is unavailable. Help request map was not recentered."
+                    CurrentLocationShareWarning.LOCATION_UNAVAILABLE,
+                    null -> if (isInitialAttempt) {
+                        InitialLocationUnavailableFallbackMessage
+                    } else {
+                        "Current location is unavailable. Help request map was not recentered."
                     }
+                }
+                if (isInitialAttempt) {
+                    queueInitialFallbackFetch(fallbackMessage)
+                    infoMessage = fallbackMessage
+                } else if (!silent) {
+                    infoMessage = fallbackMessage
                 }
             } catch (cancellationException: CancellationException) {
                 throw cancellationException
             } catch (_: Exception) {
                 loading = false
-                if (!silent) {
+                if (isInitialAttempt) {
+                    queueInitialFallbackFetch(InitialLocationUnavailableFallbackMessage)
+                    infoMessage = InitialLocationUnavailableFallbackMessage
+                } else if (!silent) {
                     infoMessage = "Current location is unavailable. Help request map was not recentered."
                 }
             }
@@ -371,28 +412,39 @@ fun HelpRequestMapScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(initialFallbackFetchRequested) {
+        if (!initialFallbackFetchRequested) return@LaunchedEffect
         loading = true
+        backgroundUpdating = false
         errorMessage = ""
-        infoMessage = ResourceLoadingMessage
 
         try {
             val result = ActiveHelpRequestsRepository.fetchWaitingHelpRequests()
-            applyRequestResult(result, viewportKey = null)
+            applyRequestResult(
+                result = result,
+                viewportKey = null,
+                infoOverride = initialFallbackInfoMessage
+            )
         } catch (cancellationException: CancellationException) {
             throw cancellationException
         } catch (error: ApiException) {
             errorMessage = error.message.ifBlank { ResourceErrorMessage }
             requests = emptyList()
             selectedRequestId = null
-            infoMessage = ""
+            if (infoMessage.isBlank()) {
+                infoMessage = initialFallbackInfoMessage.orEmpty()
+            }
         } catch (_: Exception) {
             errorMessage = ResourceErrorMessage
             requests = emptyList()
             selectedRequestId = null
-            infoMessage = ""
+            if (infoMessage.isBlank()) {
+                infoMessage = initialFallbackInfoMessage.orEmpty()
+            }
         } finally {
             loading = false
+            initialFallbackFetchRequested = false
+            initialFallbackFetchCompleted = true
         }
     }
 
@@ -453,12 +505,18 @@ fun HelpRequestMapScreen(
         val isInitialRequest = initialLocationPermissionRequestPending
         initialLocationPermissionRequestPending = false
         if (result.granted) {
-            requestCurrentLocationAndRefresh(silent = isInitialRequest)
+            requestCurrentLocationAndRefresh(
+                silent = false,
+                isInitialAttempt = isInitialRequest
+            )
         } else {
             errorMessage = ""
             loading = false
             backgroundUpdating = false
-            if (!isInitialRequest) {
+            if (isInitialRequest) {
+                infoMessage = InitialPermissionDeniedFallbackMessage
+                queueInitialFallbackFetch(InitialPermissionDeniedFallbackMessage)
+            } else {
                 infoMessage = "Location permission was denied. Help request map was not recentered."
             }
         }
@@ -476,7 +534,7 @@ fun HelpRequestMapScreen(
         if (attemptedInitialLocation) return@LaunchedEffect
         attemptedInitialLocation = true
         if (locationPermissionRequester.refreshPermissionState()) {
-            requestCurrentLocationAndRefresh(silent = true)
+            requestCurrentLocationAndRefresh(silent = false, isInitialAttempt = true)
         } else {
             initialLocationPermissionRequestPending = true
             locationPermissionRequester.requestPermission()

--- a/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
+++ b/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
@@ -188,11 +188,12 @@ fun effectiveLeafletViewportKey(viewport: LeafletMapViewport?): String? {
     val current = viewport ?: return null
     return String.format(
         Locale.US,
-        "%.3f,%.3f,%.3f,%.3f",
+        "%.4f,%.4f,%.4f,%.4f,z%d",
         current.west,
         current.south,
         current.east,
-        current.north
+        current.north,
+        current.zoom
     )
 }
 
@@ -286,6 +287,8 @@ fun LeafletMarkerMap(
     currentMapInstanceId: () -> String,
     centerLatitude: Double,
     centerLongitude: Double,
+    currentLocationLatitude: Double? = null,
+    currentLocationLongitude: Double? = null,
     markers: List<LeafletMapMarker>,
     selectedMarkerId: String?,
     mapHeightCssPx: Int = LeafletMapFallbackHeightCssPx,
@@ -316,6 +319,8 @@ fun LeafletMarkerMap(
             mapInstanceId = mapInstanceId,
             centerLatitude = centerLatitude,
             centerLongitude = centerLongitude,
+            currentLocationLatitude = currentLocationLatitude,
+            currentLocationLongitude = currentLocationLongitude,
             markers = markers,
             selectedMarkerId = selectedMarkerId,
             bridgeName = LeafletMarkerMapBridgeName,
@@ -349,6 +354,8 @@ fun LeafletMarkerMap(
         javaScriptUpdate = buildMarkerMapUpdateScript(
             markers = markers,
             selectedMarkerId = selectedMarkerId,
+            currentLocationLatitude = currentLocationLatitude,
+            currentLocationLongitude = currentLocationLongitude,
             fitBoundsRequestToken = fitBoundsRequestToken
         ),
         modifier = modifier
@@ -358,10 +365,13 @@ fun LeafletMarkerMap(
 private fun buildMarkerMapUpdateScript(
     markers: List<LeafletMapMarker>,
     selectedMarkerId: String?,
+    currentLocationLatitude: Double?,
+    currentLocationLongitude: Double?,
     fitBoundsRequestToken: Int?
 ): String {
     val markersJson = leafletMarkersJson(markers)
     val selectedMarkerJson = selectedMarkerId?.let(JSONObject::quote) ?: "null"
+    val currentLocationJson = leafletLatLngJson(currentLocationLatitude, currentLocationLongitude)
     val fitBoundsRequestTokenJson = fitBoundsRequestToken?.toString() ?: "null"
     return """
         if (window.nephSetMarkers) {
@@ -369,7 +379,19 @@ private fun buildMarkerMapUpdateScript(
         } else if (window.nephSelectMarker) {
             window.nephSelectMarker($selectedMarkerJson);
         }
+        if (window.nephSetCurrentLocation) {
+            window.nephSetCurrentLocation($currentLocationJson);
+        }
     """.trimIndent()
+}
+
+private fun leafletLatLngJson(latitude: Double?, longitude: Double?): String {
+    val lat = latitude ?: return "null"
+    val lon = longitude ?: return "null"
+    if (!lat.isFinite() || !lon.isFinite() || lat !in -90.0..90.0 || lon !in -180.0..180.0) {
+        return "null"
+    }
+    return JSONArray(listOf(lat, lon)).toString()
 }
 
 private fun leafletMarkersJson(markers: List<LeafletMapMarker>): String {
@@ -544,6 +566,8 @@ internal fun buildLeafletMarkerMapHtml(
     mapInstanceId: String,
     centerLatitude: Double,
     centerLongitude: Double,
+    currentLocationLatitude: Double?,
+    currentLocationLongitude: Double?,
     markers: List<LeafletMapMarker>,
     selectedMarkerId: String?,
     bridgeName: String,
@@ -556,6 +580,7 @@ internal fun buildLeafletMarkerMapHtml(
     val formattedLon = String.format(Locale.US, "%.6f", centerLongitude)
     val markersJson = leafletMarkersJson(markers)
     val selectedMarkerJson = selectedMarkerId?.let(JSONObject::quote) ?: "null"
+    val currentLocationJson = leafletLatLngJson(currentLocationLatitude, currentLocationLongitude)
     val fitBoundsToMarkersJson = if (fitBoundsToMarkers) "true" else "false"
     val centerMarkerScript = if (showCenterMarker) {
         """
@@ -585,8 +610,11 @@ internal fun buildLeafletMarkerMapHtml(
                 var center = [$formattedLat, $formattedLon];
                 var markerData = $markersJson;
                 var selectedMarkerId = $selectedMarkerJson;
+                var currentLocation = $currentLocationJson;
                 var fitBoundsToMarkers = $fitBoundsToMarkersJson;
                 var lastAppliedFitBoundsRequestToken = null;
+                var currentLocationMarker = null;
+                var currentLocationRing = null;
                 var mapElement = document.getElementById('map');
                 if (!mapElement) {
                     failMap('Map failed to load.');
@@ -706,7 +734,47 @@ internal fun buildLeafletMarkerMapHtml(
                     }
                 };
 
+                window.nephSetCurrentLocation = function(nextCurrentLocation) {
+                    if (currentLocationMarker) {
+                        map.removeLayer(currentLocationMarker);
+                        currentLocationMarker = null;
+                    }
+                    if (currentLocationRing) {
+                        map.removeLayer(currentLocationRing);
+                        currentLocationRing = null;
+                    }
+
+                    if (
+                        !Array.isArray(nextCurrentLocation) ||
+                        nextCurrentLocation.length !== 2 ||
+                        typeof nextCurrentLocation[0] !== 'number' ||
+                        typeof nextCurrentLocation[1] !== 'number'
+                    ) {
+                        currentLocation = null;
+                        return;
+                    }
+
+                    currentLocation = [nextCurrentLocation[0], nextCurrentLocation[1]];
+                    currentLocationRing = L.circle(currentLocation, {
+                        radius: 24,
+                        color: '#16A34A',
+                        weight: 1,
+                        fillColor: '#22C55E',
+                        fillOpacity: 0.18,
+                        interactive: false
+                    }).addTo(map);
+                    currentLocationMarker = L.circleMarker(currentLocation, {
+                        radius: 6,
+                        color: '#FFFFFF',
+                        weight: 2,
+                        fillColor: '#16A34A',
+                        fillOpacity: 1,
+                        interactive: false
+                    }).addTo(map);
+                };
+
                 window.nephSetMarkers(markerData, selectedMarkerId);
+                window.nephSetCurrentLocation(currentLocation);
 
                 if (fitBoundsToMarkers && bounds.length > 1) {
                     map.fitBounds(bounds, { padding: [24, 24], maxZoom: 15 });

--- a/android/app/src/test/java/com/neph/ui/map/LeafletMapWebViewTest.kt
+++ b/android/app/src/test/java/com/neph/ui/map/LeafletMapWebViewTest.kt
@@ -149,33 +149,33 @@ class LeafletMapWebViewTest {
 
     @Test
     fun effectiveLeafletViewportKey_roundsBoundsForDuplicateSuppression() {
-        val first = viewport(widthKm = 20.0, heightKm = 20.0, west = 29.0004, east = 29.1004)
-        val sameEffectiveViewport = viewport(widthKm = 20.0, heightKm = 20.0, west = 29.00049, east = 29.10049)
+        val first = viewport(widthKm = 20.0, heightKm = 20.0, west = 29.00044, east = 29.10044)
+        val sameEffectiveViewport = viewport(widthKm = 20.0, heightKm = 20.0, west = 29.000449, east = 29.100449)
 
         assertEquals(effectiveLeafletViewportKey(first), effectiveLeafletViewportKey(sameEffectiveViewport))
-        assertEquals("29.000,40.900,29.100,41.100", effectiveLeafletViewportKey(first))
+        assertEquals("29.0004,40.9000,29.1004,41.1000,z12", effectiveLeafletViewportKey(first))
     }
 
     @Test
     fun shouldFetchLeafletViewport_skipsSameViewportUnlessManualRefresh() {
         assertFalse(
             shouldFetchLeafletViewport(
-                viewportKey = "29.000,40.900,29.100,41.100",
-                lastFetchedViewportKey = "29.000,40.900,29.100,41.100",
+                viewportKey = "29.0004,40.9000,29.1004,41.1000,z12",
+                lastFetchedViewportKey = "29.0004,40.9000,29.1004,41.1000,z12",
                 manualRefresh = false
             )
         )
         assertTrue(
             shouldFetchLeafletViewport(
-                viewportKey = "29.000,40.900,29.100,41.100",
-                lastFetchedViewportKey = "29.000,40.900,29.100,41.100",
+                viewportKey = "29.0004,40.9000,29.1004,41.1000,z12",
+                lastFetchedViewportKey = "29.0004,40.9000,29.1004,41.1000,z12",
                 manualRefresh = true
             )
         )
         assertTrue(
             shouldFetchLeafletViewport(
-                viewportKey = "29.001,40.900,29.101,41.100",
-                lastFetchedViewportKey = "29.000,40.900,29.100,41.100",
+                viewportKey = "29.0010,40.9000,29.1010,41.1000,z12",
+                lastFetchedViewportKey = "29.0004,40.9000,29.1004,41.1000,z12",
                 manualRefresh = false
             )
         )
@@ -242,6 +242,8 @@ class LeafletMapWebViewTest {
             mapInstanceId = "test-map-1",
             centerLatitude = 41.0,
             centerLongitude = 29.0,
+            currentLocationLatitude = null,
+            currentLocationLongitude = null,
             markers = listOf(
                 LeafletMapMarker(
                     id = "area-1",
@@ -274,6 +276,8 @@ class LeafletMapWebViewTest {
             mapInstanceId = "test-map-no-center",
             centerLatitude = 39.0,
             centerLongitude = 35.0,
+            currentLocationLatitude = null,
+            currentLocationLongitude = null,
             markers = emptyList(),
             selectedMarkerId = null,
             bridgeName = "AndroidLeafletMarkerMap",
@@ -290,6 +294,8 @@ class LeafletMapWebViewTest {
             mapInstanceId = "test-map-2",
             centerLatitude = 41.0,
             centerLongitude = 29.0,
+            currentLocationLatitude = null,
+            currentLocationLongitude = null,
             markers = emptyList(),
             selectedMarkerId = null,
             bridgeName = "AndroidLeafletMarkerMap",
@@ -333,6 +339,8 @@ class LeafletMapWebViewTest {
             mapInstanceId = "test-map-discovery",
             centerLatitude = 39.0,
             centerLongitude = 35.0,
+            currentLocationLatitude = null,
+            currentLocationLongitude = null,
             markers = emptyList(),
             selectedMarkerId = null,
             bridgeName = "AndroidLeafletMarkerMap",


### PR DESCRIPTION
Summary
- Align map startup behavior on Android to use current location flow consistently on both Help Request Map and Gathering Areas Map.
- Add and wire live current-location marker support in shared Leaflet map layer.

What Changed
- Shared map component now accepts optional current location coordinates and renders a live marker.
- Help Request Map and Gathering Areas screens:
  - Track current device location state.
  - Run initial one-time current-location flow with silent first-run permission handling.
  - Pass current location into map renderer.

Validation
- Android build check passed with compileDebugKotlin.
- No IDE errors on modified files.

Closes #614 