### PR TITLE
fix: null fields and first aid expertise field 

### DIFF
--- a/android/app/src/main/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepository.kt
+++ b/android/app/src/main/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepository.kt
@@ -249,6 +249,7 @@ internal fun buildMyHelpRequestsOverview(
 
 internal fun HelpRequestEntity.toUiModel(): MyHelpRequestUiModel {
     val helpTypes = helpTypesJson.jsonArrayToStringList().map(::formatHelpType)
+    val displayDescription = buildDescriptionText(description)
     val normalizedStatus = status.trim().uppercase()
     val riskStatusLabel = when (syncStatus) {
         SyncStatus.PENDING_CREATE -> if (normalizedStatus.isTerminalRequestStatus()) {
@@ -274,28 +275,15 @@ internal fun HelpRequestEntity.toUiModel(): MyHelpRequestUiModel {
         "CANCELLED" -> "Cancelled"
         else -> null
     }
+    val fallbackResponder = AssignedResponderUiModel(
+        firstName = normalizeDisplayText(helperFirstName),
+        lastName = normalizeDisplayText(helperLastName),
+        phone = normalizeDisplayText(helperPhone),
+        profession = normalizeDisplayText(helperProfession),
+        expertise = formatHelperExpertise(helperExpertise)
+    ).takeIf { it.hasVisibleDetails }
     val responders = helpersJson.jsonArrayToAssignedResponderList()
-        .ifEmpty {
-            buildList {
-                if (
-                    helperFirstName != null ||
-                    helperLastName != null ||
-                    helperPhone != null ||
-                    helperProfession != null ||
-                    helperExpertise != null
-                ) {
-                    add(
-                        AssignedResponderUiModel(
-                            firstName = helperFirstName,
-                            lastName = helperLastName,
-                            phone = helperPhone,
-                            profession = helperProfession,
-                            expertise = helperExpertise
-                        )
-                    )
-                }
-            }
-        }
+        .ifEmpty { listOfNotNull(fallbackResponder) }
     val primaryResponder = responders.firstOrNull()
 
     return MyHelpRequestUiModel(
@@ -304,7 +292,7 @@ internal fun HelpRequestEntity.toUiModel(): MyHelpRequestUiModel {
         guestAccessToken = guestAccessToken,
         helpTypes = helpTypes,
         helpTypeSummary = buildHelpTypeSummary(helpTypes),
-        description = description,
+        description = displayDescription,
         shortDescription = buildShortDescription(description),
         locationLabel = buildLocationLabel(country, city, district, neighborhood, extraAddress),
         status = status,
@@ -343,7 +331,9 @@ private fun String.jsonArrayToAssignedResponderList(): List<AssignedResponderUiM
             buildList {
                 for (index in 0 until json.length()) {
                     val value = json.optJSONObject(index)?.toAssignedResponderUiModel() ?: continue
-                    add(value)
+                    if (value.hasVisibleDetails) {
+                        add(value)
+                    }
                 }
             }
         }
@@ -352,11 +342,11 @@ private fun String.jsonArrayToAssignedResponderList(): List<AssignedResponderUiM
 
 private fun org.json.JSONObject.toAssignedResponderUiModel(): AssignedResponderUiModel {
     return AssignedResponderUiModel(
-        firstName = optString("firstName").trim().takeIf { it.isNotBlank() },
-        lastName = optString("lastName").trim().takeIf { it.isNotBlank() },
-        phone = opt("phone")?.toString()?.takeIf { it.isNotBlank() && it != "null" },
-        profession = optString("profession").trim().takeIf { it.isNotBlank() },
-        expertise = optString("expertise").trim().takeIf { it.isNotBlank() }
+        firstName = normalizeDisplayText(opt("firstName")?.toString()),
+        lastName = normalizeDisplayText(opt("lastName")?.toString()),
+        phone = normalizeDisplayText(opt("phone")?.toString()),
+        profession = normalizeDisplayText(opt("profession")?.toString()),
+        expertise = formatHelperExpertise(opt("expertise")?.toString())
     )
 }
 
@@ -416,14 +406,103 @@ private fun Long.toIsoLikeString(): String {
     return formatter.format(java.util.Date(this))
 }
 
+private const val NoDescriptionProvided = "No description provided."
+
+private fun buildDescriptionText(description: String): String {
+    return normalizeDisplayText(description) ?: NoDescriptionProvided
+}
+
 private fun buildShortDescription(description: String): String {
-    val normalized = description.replace('\n', ' ').replace(Regex("\\s+"), " ").trim()
-    if (normalized.isBlank()) return "No description provided."
+    val normalized = buildDescriptionText(description)
     return if (normalized.length > 160) {
         normalized.take(157).trimEnd() + "..."
     } else {
         normalized
     }
+}
+
+private fun normalizeDisplayText(value: String?): String? {
+    val normalized = value
+        ?.replace('\n', ' ')
+        ?.replace(Regex("\\s+"), " ")
+        ?.trim()
+        .orEmpty()
+
+    return normalized.takeUnless { it.isBlank() || it.equals("null", ignoreCase = true) }
+}
+
+private fun formatHelperExpertise(rawValue: String?): String? {
+    val value = normalizeDisplayText(rawValue) ?: return null
+
+    if (value.startsWith("{")) {
+        return parseExpertiseObject(value)
+    }
+
+    if (value.startsWith("[")) {
+        val labels = parseExpertiseArray(value) ?: return null
+        return labels
+            .mapNotNull(::formatHelperExpertise)
+            .distinct()
+            .joinToString(", ")
+            .takeIf { it.isNotBlank() }
+    }
+
+    val normalized = value
+        .lowercase(Locale.ROOT)
+        .replace('_', ' ')
+        .replace(Regex("\\s+"), " ")
+        .trim()
+    val compact = normalized.replace(Regex("[^a-z0-9]+"), "")
+
+    if (
+        normalized.startsWith("no ") && "first aid" in normalized ||
+        "does not know first aid" in normalized ||
+        "doesn't know first aid" in normalized ||
+        "not know first aid" in normalized ||
+        compact == "firstaidfalse"
+    ) {
+        return null
+    }
+
+    if ("first aid" in normalized || compact == "firstaid" || compact == "firstaidtrue") {
+        return "Knows first aid"
+    }
+
+    if (value.endsWith("?")) {
+        return null
+    }
+
+    return value
+}
+
+private fun parseExpertiseArray(value: String): List<String>? {
+    if (!value.startsWith("[")) {
+        return null
+    }
+
+    val array = runCatching { JSONArray(value) }.getOrNull() ?: return null
+    return buildList {
+        for (index in 0 until array.length()) {
+            normalizeDisplayText(array.opt(index)?.toString())?.let(::add)
+        }
+    }
+}
+
+private fun parseExpertiseObject(value: String): String? {
+    if (!value.startsWith("{")) {
+        return null
+    }
+
+    val json = runCatching { JSONObject(value) }.getOrNull() ?: return null
+    if (json.has("firstAid")) {
+        return if (json.optBoolean("firstAid", false)) "Knows first aid" else null
+    }
+
+    if (json.has("first_aid")) {
+        return if (json.optBoolean("first_aid", false)) "Knows first aid" else null
+    }
+
+    return null
 }
 
 private fun formatEpochMillis(raw: Long): String {

--- a/android/app/src/test/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepositoryMappingTest.kt
+++ b/android/app/src/test/java/com/neph/features/myhelprequests/data/MyHelpRequestsRepositoryMappingTest.kt
@@ -7,6 +7,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -24,6 +25,49 @@ class MyHelpRequestsRepositoryMappingTest {
     @After
     fun tearDown() {
         TimeZone.setDefault(previousTimeZone)
+    }
+
+    @Test
+    fun toUiModelUsesDescriptionFallbackForBlankAndNullLikeValues() {
+        val blankDescription = helpRequestEntity(
+            localId = "local_blank_description",
+            description = ""
+        ).toUiModel()
+        val nullLikeDescription = helpRequestEntity(
+            localId = "local_null_description",
+            description = "null"
+        ).toUiModel()
+
+        assertEquals("No description provided.", blankDescription.description)
+        assertEquals("No description provided.", blankDescription.shortDescription)
+        assertEquals("No description provided.", nullLikeDescription.description)
+        assertEquals("No description provided.", nullLikeDescription.shortDescription)
+    }
+
+    @Test
+    fun toUiModelFormatsAssignedHelperExpertiseForRequester() {
+        val model = helpRequestEntity(
+            helperFirstName = "Ece",
+            helperExpertise = "Do you know first aid?"
+        ).toUiModel()
+        val firstAidAnswerModel = helpRequestEntity(
+            helpersJson = """[{"firstName":"Ece","expertise":{"firstAid":true}}]"""
+        ).toUiModel()
+
+        assertEquals("Knows first aid", model.helperExpertise)
+        assertEquals("Knows first aid", model.responders.single().expertise)
+        assertEquals("Knows first aid", firstAidAnswerModel.helperExpertise)
+        assertEquals("Knows first aid", firstAidAnswerModel.responders.single().expertise)
+    }
+
+    @Test
+    fun toUiModelDoesNotRenderUnknownRawExpertiseQuestions() {
+        val model = helpRequestEntity(
+            helpersJson = """[{"firstName":"Ece","expertise":"Do you have a car?"}]"""
+        ).toUiModel()
+
+        assertNull(model.helperExpertise)
+        assertNull(model.responders.single().expertise)
     }
 
     @Test
@@ -241,5 +285,58 @@ class MyHelpRequestsRepositoryMappingTest {
         assertEquals(1, overview.resolvedCount)
         assertEquals(1, overview.assignedResponderCount)
         assertTrue(overview.hasMultipleRequestContext)
+    }
+
+    private fun helpRequestEntity(
+        localId: String = "local_display_test",
+        remoteId: String? = "req_display_test",
+        description: String = "Need first aid support",
+        status: String = "MATCHED",
+        helperFirstName: String? = null,
+        helperLastName: String? = null,
+        helperPhone: String? = null,
+        helperProfession: String? = null,
+        helperExpertise: String? = null,
+        helpersJson: String = "[]"
+    ): HelpRequestEntity {
+        return HelpRequestEntity(
+            localId = localId,
+            remoteId = remoteId,
+            ownerType = LocalOwnerType.AUTHENTICATED,
+            guestAccessToken = null,
+            helpTypesJson = "[\"first_aid\"]",
+            otherHelpText = "",
+            affectedPeopleCount = 1,
+            riskFlagsJson = "[]",
+            vulnerableGroupsJson = "[]",
+            description = description,
+            bloodType = "",
+            country = "Turkey",
+            city = "Istanbul",
+            district = "Kadikoy",
+            neighborhood = "Moda",
+            extraAddress = "Street 1",
+            contactFullName = "Ayse",
+            contactPhone = "5550000001",
+            contactAlternativePhone = null,
+            status = status,
+            urgencyLevel = null,
+            priorityLevel = null,
+            resolvedAt = null,
+            cancelledAt = null,
+            helperFirstName = helperFirstName,
+            helperLastName = helperLastName,
+            helperPhone = helperPhone,
+            helperProfession = helperProfession,
+            helperExpertise = helperExpertise,
+            helpersJson = helpersJson,
+            syncStatus = SyncStatus.SYNCED,
+            pendingError = null,
+            createdAtEpochMillis = 1L,
+            updatedAtEpochMillis = 1L,
+            lastSyncedAtEpochMillis = null,
+            serverCreatedAt = "2026-04-26T10:00:00.000Z",
+            isDeleted = false
+        )
     }
 }


### PR DESCRIPTION
Fixes My Help Requests display polish issues on Android.
Resolves #619 

  ### Changes

  - Shows No description provided. instead of rendering blank or null descriptions.
  - Sanitizes assigned helper details before display.
  - Maps first-aid expertise/question values to requester-friendly text: Knows first aid.
  - Hides unknown raw volunteer question text from requester-facing helper details.
  - Adds regression coverage for description fallback and helper expertise formatting.