### PR TITLE
fix: viewport loading and state info

### DIFF
--- a/android/app/src/main/java/com/neph/core/network/JsonHttpClient.kt
+++ b/android/app/src/main/java/com/neph/core/network/JsonHttpClient.kt
@@ -7,6 +7,7 @@ import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
 import java.net.HttpURLConnection
+import java.net.SocketTimeoutException
 import java.net.URL
 import java.net.UnknownHostException
 
@@ -19,12 +20,17 @@ object JsonHttpClient {
         method: String = "GET",
         body: JSONObject? = null,
         token: String? = null,
-        headers: Map<String, String> = emptyMap()
+        headers: Map<String, String> = emptyMap(),
+        connectTimeoutMillis: Int = ConnectTimeoutMillis,
+        readTimeoutMillis: Int = ReadTimeoutMillis,
+        timeoutMessage: String = "Something went wrong while connecting to the server. Please try again.",
+        timeoutStatus: Int = 0,
+        timeoutCode: String = "NETWORK_ERROR"
     ): JSONObject = withContext(Dispatchers.IO) {
         val connection = (URL(buildUrl(path)).openConnection() as HttpURLConnection).apply {
             requestMethod = method
-            connectTimeout = ConnectTimeoutMillis
-            readTimeout = ReadTimeoutMillis
+            connectTimeout = connectTimeoutMillis
+            readTimeout = readTimeoutMillis
             doInput = true
             setRequestProperty("Accept", "application/json")
 
@@ -75,6 +81,12 @@ object JsonHttpClient {
             }
         } catch (error: ApiException) {
             throw error
+        } catch (_: SocketTimeoutException) {
+            throw ApiException(
+                message = timeoutMessage,
+                status = timeoutStatus,
+                code = timeoutCode
+            )
         } catch (_: UnknownHostException) {
             throw ApiException(
                 message = "Something went wrong while connecting to the server. Please try again.",

--- a/android/app/src/main/java/com/neph/features/gatheringareas/data/GatheringAreasRepository.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/data/GatheringAreasRepository.kt
@@ -53,7 +53,10 @@ object GatheringAreasRepository {
     internal const val DefaultLimit = 50
     private const val MaxRadiusMeters = 10000
     private const val MaxLimit = 50
-    private const val NearbyRequestTimeoutMillis = 15_000L
+    private const val NearbyRequestTimeoutMillis = 12_000L
+    private const val NearbyRequestHttpTimeoutMillis = 12_000
+    private const val NearbyRequestTimeoutMessage = "Gathering areas request timed out."
+    private const val NearbyRequestTimeoutCode = "OVERPASS_TIMEOUT"
     private const val DebugLogTag = "GatheringAreasRepo"
 
     suspend fun fetchNearbyGatheringAreas(
@@ -74,12 +77,17 @@ object GatheringAreasRepository {
                     longitude,
                     normalizedRadius,
                     normalizedLimit
-                )
+                ),
+                connectTimeoutMillis = NearbyRequestHttpTimeoutMillis,
+                readTimeoutMillis = NearbyRequestHttpTimeoutMillis,
+                timeoutMessage = NearbyRequestTimeoutMessage,
+                timeoutStatus = 504,
+                timeoutCode = NearbyRequestTimeoutCode
             )
         } ?: throw ApiException(
-            message = "Gathering areas request timed out.",
+            message = NearbyRequestTimeoutMessage,
             status = 504,
-            code = "OVERPASS_TIMEOUT"
+            code = NearbyRequestTimeoutCode
         )
 
         return parseNearbyGatheringAreasResponse(
@@ -105,12 +113,17 @@ object GatheringAreasRepository {
 
         val response = withTimeoutOrNull(NearbyRequestTimeoutMillis) {
             JsonHttpClient.request(
-                path = "/gathering-areas/viewport?bbox=${urlEncode(bbox)}&limit=$normalizedLimit"
+                path = "/gathering-areas/viewport?bbox=${urlEncode(bbox)}&limit=$normalizedLimit",
+                connectTimeoutMillis = NearbyRequestHttpTimeoutMillis,
+                readTimeoutMillis = NearbyRequestHttpTimeoutMillis,
+                timeoutMessage = NearbyRequestTimeoutMessage,
+                timeoutStatus = 504,
+                timeoutCode = NearbyRequestTimeoutCode
             )
         } ?: throw ApiException(
-            message = "Gathering areas request timed out.",
+            message = NearbyRequestTimeoutMessage,
             status = 504,
-            code = "OVERPASS_TIMEOUT"
+            code = NearbyRequestTimeoutCode
         )
 
         val parsed = parseNearbyGatheringAreasResponse(

--- a/android/app/src/main/java/com/neph/features/gatheringareas/data/GatheringAreasRepository.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/data/GatheringAreasRepository.kt
@@ -53,7 +53,7 @@ object GatheringAreasRepository {
     internal const val DefaultLimit = 50
     private const val MaxRadiusMeters = 10000
     private const val MaxLimit = 50
-    private const val NearbyRequestTimeoutMillis = 8000L
+    private const val NearbyRequestTimeoutMillis = 15_000L
     private const val DebugLogTag = "GatheringAreasRepo"
 
     suspend fun fetchNearbyGatheringAreas(

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -49,6 +49,7 @@ import com.neph.ui.map.LeafletMapMarker
 import com.neph.ui.map.LeafletMarkerMap
 import com.neph.ui.map.LeafletMapInitializationTimeoutMessage
 import com.neph.ui.map.LeafletMapInitializationTimeoutMillis
+import com.neph.ui.map.LeafletMapStatusOverlay
 import com.neph.ui.map.LeafletMapViewport
 import com.neph.ui.map.MapLocationControl
 import com.neph.ui.map.NephMapIntegration
@@ -58,6 +59,7 @@ import com.neph.ui.map.isLeafletTileLoadedSignal
 import com.neph.ui.map.isLeafletViewportDiscoverable
 import com.neph.ui.map.leafletViewportBboxString
 import com.neph.ui.map.leafletMapErrorForInstance
+import com.neph.ui.map.leafletMapStatusOverlayMessage
 import com.neph.ui.map.logMapDebug
 import com.neph.ui.map.newLeafletMapInstanceId
 import com.neph.ui.map.shouldApplyLeafletMapError
@@ -170,6 +172,10 @@ internal fun shouldShowPreviousGatheringAreasDuringViewportFetch(
     return currentResult != null && !manualRefresh
 }
 
+internal fun shouldMarkGatheringAreasViewportFetched(result: NearbyGatheringAreasResult): Boolean {
+    return !isGatheringAreasProviderUnavailable(result)
+}
+
 @Composable
 @OptIn(ExperimentalLayoutApi::class)
 fun GatheringAreasScreen(
@@ -198,6 +204,7 @@ fun GatheringAreasScreen(
     var initialLocationPermissionRequestPending by remember { mutableStateOf(false) }
     var currentViewport by remember { mutableStateOf<LeafletMapViewport?>(null) }
     var pendingViewport by remember { mutableStateOf<LeafletMapViewport?>(null) }
+    var viewportUpdateQueued by remember { mutableStateOf(false) }
     var lastFetchedViewportKey by remember { mutableStateOf<String?>(null) }
     var viewportRefreshNonce by remember { mutableStateOf(0) }
     var viewportRequestSerial by remember { mutableStateOf(0) }
@@ -228,6 +235,8 @@ fun GatheringAreasScreen(
     ) {
         scope.launch {
             loading = true
+            backgroundUpdating = false
+            viewportUpdateQueued = false
             errorMessage = ""
             if (!silent) {
                 infoMessage = ""
@@ -245,6 +254,7 @@ fun GatheringAreasScreen(
                     viewportRequestSerial += 1
                     currentViewport = null
                     pendingViewport = null
+                    viewportUpdateQueued = false
                     nearbyResult = null
                     mapCenterLatitude = location.latitude
                     mapCenterLongitude = location.longitude
@@ -293,14 +303,23 @@ fun GatheringAreasScreen(
     }
 
     LaunchedEffect(pendingViewport, lastFetchedViewportKey, viewportRefreshNonce) {
-        val viewport = pendingViewport ?: return@LaunchedEffect
-        if (!isLeafletViewportDiscoverable(viewport)) return@LaunchedEffect
-        val viewportKey = effectiveLeafletViewportKey(viewport) ?: return@LaunchedEffect
+        val viewport = pendingViewport
+        if (viewport == null || !isLeafletViewportDiscoverable(viewport)) {
+            viewportUpdateQueued = false
+            return@LaunchedEffect
+        }
+        val viewportKey = effectiveLeafletViewportKey(viewport)
+        if (viewportKey == null) {
+            viewportUpdateQueued = false
+            return@LaunchedEffect
+        }
         val manualRefresh = viewportRefreshNonce > 0
         if (!shouldFetchLeafletViewport(viewportKey, lastFetchedViewportKey, manualRefresh)) {
+            viewportUpdateQueued = false
             return@LaunchedEffect
         }
         delay(450)
+        viewportUpdateQueued = false
         val requestSerial = viewportRequestSerial + 1
         viewportRequestSerial = requestSerial
         val blockingLoading = !shouldShowPreviousGatheringAreasDuringViewportFetch(
@@ -320,7 +339,9 @@ fun GatheringAreasScreen(
                 widestVisibleDimensionKm = viewport.widestVisibleDimensionKm
             )
             if (requestSerial == viewportRequestSerial) {
-                lastFetchedViewportKey = viewportKey
+                if (shouldMarkGatheringAreasViewportFetched(result)) {
+                    lastFetchedViewportKey = viewportKey
+                }
                 viewportRefreshNonce = 0
                 applyViewportResult(result)
             }
@@ -344,6 +365,7 @@ fun GatheringAreasScreen(
             }
         } finally {
             if (requestSerial == viewportRequestSerial) {
+                viewportUpdateQueued = false
                 loading = false
                 backgroundUpdating = false
             }
@@ -362,6 +384,7 @@ fun GatheringAreasScreen(
             errorMessage = ""
             loading = false
             backgroundUpdating = false
+            viewportUpdateQueued = false
             if (isInitialRequest) {
                 infoMessage = InitialNearbyPermissionDeniedMessage
             } else {
@@ -422,10 +445,18 @@ fun GatheringAreasScreen(
             if (infoMessage == ResourceZoomedOutMessage) {
                 infoMessage = ""
             }
+            val viewportKey = effectiveLeafletViewportKey(viewport)
+            viewportUpdateQueued = viewportKey != null &&
+                shouldFetchLeafletViewport(
+                    viewportKey = viewportKey,
+                    lastFetchedViewportKey = lastFetchedViewportKey,
+                    manualRefresh = false
+                )
             pendingViewport = viewport
         } else {
             viewportRequestSerial += 1
             pendingViewport = null
+            viewportUpdateQueued = false
             nearbyResult = null
             selectedAreaId = null
             lastFetchedViewportKey = null
@@ -449,7 +480,7 @@ fun GatheringAreasScreen(
         activeFilterKeys.contains(item.category.trim().lowercase())
     }.orEmpty()
     val isFilterEmpty = currentResult != null && currentResult.areas.isNotEmpty() && visibleAreas.isEmpty()
-    val mapActionsEnabled = !loading && !backgroundUpdating
+    val mapActionsEnabled = !loading && !backgroundUpdating && !viewportUpdateQueued
 
     if (selectedAreaId != null && visibleAreas.none { it.id == selectedAreaId }) {
         selectedAreaId = null
@@ -503,11 +534,13 @@ fun GatheringAreasScreen(
                             if (!isLeafletViewportDiscoverable(viewport)) {
                                 errorMessage = ""
                                 loading = false
+                                viewportUpdateQueued = false
                                 infoMessage = ""
                                 return@SecondaryButton
                             }
                             errorMessage = ""
                             pendingViewport = viewport
+                            viewportUpdateQueued = true
                             viewportRefreshNonce += 1
                         },
                         enabled = mapActionsEnabled
@@ -531,7 +564,7 @@ fun GatheringAreasScreen(
                 mapResetToken = mapResetNonce,
                 showCenterMarker = false,
                 loadingResources = loading,
-                updatingResources = backgroundUpdating,
+                updatingResources = backgroundUpdating || viewportUpdateQueued,
                 onShowCurrentLocation = ::showCurrentLocationOnMap,
                 showCurrentLocationEnabled = mapActionsEnabled,
                 onViewportChanged = ::handleViewportChanged
@@ -554,6 +587,7 @@ fun GatheringAreasScreen(
                                     text = "Retry",
                                     onClick = {
                                         pendingViewport = currentViewport
+                                        viewportUpdateQueued = true
                                         viewportRefreshNonce += 1
                                     },
                                     enabled = mapActionsEnabled
@@ -575,6 +609,7 @@ fun GatheringAreasScreen(
                                     text = "Retry",
                                     onClick = {
                                         pendingViewport = currentViewport
+                                        viewportUpdateQueued = true
                                         viewportRefreshNonce += 1
                                     },
                                     enabled = mapActionsEnabled
@@ -720,6 +755,7 @@ fun GatheringAreasScreen(
                                 text = "Retry",
                                 onClick = {
                                     pendingViewport = currentViewport
+                                    viewportUpdateQueued = true
                                     viewportRefreshNonce += 1
                                 },
                                 enabled = mapActionsEnabled
@@ -781,6 +817,12 @@ private fun GatheringAreasMapCard(
         tileLoadedInstanceId = tileLoadedInstanceIdState.value,
         errorInstanceId = errorInstanceIdState.value,
         errorMessage = mapError
+    )
+    val mapOverlayMessage = leafletMapStatusOverlayMessage(
+        mapInitialized = activeMapInitialized,
+        mapError = activeMapError,
+        loadingResources = loadingResources,
+        updatingResources = updatingResources
     )
 
     fun markMapAlive(instanceId: String, source: String) {
@@ -900,6 +942,12 @@ private fun GatheringAreasMapCard(
                             .padding(spacing.sm)
                     )
                 }
+                LeafletMapStatusOverlay(
+                    message = mapOverlayMessage,
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(spacing.sm)
+                )
             }
 
             if (!activeMapInitialized && activeMapError.isBlank()) {

--- a/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
+++ b/android/app/src/main/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreen.kt
@@ -176,6 +176,18 @@ internal fun shouldMarkGatheringAreasViewportFetched(result: NearbyGatheringArea
     return !isGatheringAreasProviderUnavailable(result)
 }
 
+internal fun shouldQueueGatheringAreasViewportFetch(
+    viewportKey: String,
+    lastFetchedViewportKey: String?,
+    manualRefresh: Boolean,
+    providerFailedViewportKey: String?
+): Boolean {
+    if (!shouldFetchLeafletViewport(viewportKey, lastFetchedViewportKey, manualRefresh)) {
+        return false
+    }
+    return manualRefresh || viewportKey != providerFailedViewportKey
+}
+
 @Composable
 @OptIn(ExperimentalLayoutApi::class)
 fun GatheringAreasScreen(
@@ -206,6 +218,7 @@ fun GatheringAreasScreen(
     var pendingViewport by remember { mutableStateOf<LeafletMapViewport?>(null) }
     var viewportUpdateQueued by remember { mutableStateOf(false) }
     var lastFetchedViewportKey by remember { mutableStateOf<String?>(null) }
+    var providerFailedViewportKey by remember { mutableStateOf<String?>(null) }
     var viewportRefreshNonce by remember { mutableStateOf(0) }
     var viewportRequestSerial by remember { mutableStateOf(0) }
     var nearbyResult by remember { mutableStateOf<NearbyGatheringAreasResult?>(null) }
@@ -227,6 +240,68 @@ fun GatheringAreasScreen(
         )
 
         infoMessage = ""
+    }
+
+    fun queueViewportFetch(
+        viewport: LeafletMapViewport?,
+        manualRefresh: Boolean = false,
+        clearResultsWhenUnavailable: Boolean = false
+    ) {
+        if (!isLeafletViewportDiscoverable(viewport)) {
+            viewportRequestSerial += 1
+            pendingViewport = null
+            viewportUpdateQueued = false
+            loading = false
+            backgroundUpdating = false
+            errorMessage = ""
+            infoMessage = ""
+            if (clearResultsWhenUnavailable) {
+                nearbyResult = null
+                selectedAreaId = null
+                lastFetchedViewportKey = null
+                providerFailedViewportKey = null
+            }
+            return
+        }
+
+        val viewportKey = effectiveLeafletViewportKey(viewport)
+        if (viewportKey == null) {
+            viewportRequestSerial += 1
+            pendingViewport = null
+            viewportUpdateQueued = false
+            loading = false
+            backgroundUpdating = false
+            return
+        }
+
+        val previousPendingViewportKey = effectiveLeafletViewportKey(pendingViewport)
+        val viewportChanged = viewportKey != previousPendingViewportKey
+        if (viewportKey != providerFailedViewportKey || manualRefresh) {
+            providerFailedViewportKey = null
+        }
+
+        val shouldQueue = shouldQueueGatheringAreasViewportFetch(
+            viewportKey = viewportKey,
+            lastFetchedViewportKey = lastFetchedViewportKey,
+            manualRefresh = manualRefresh,
+            providerFailedViewportKey = providerFailedViewportKey
+        )
+        pendingViewport = viewport
+
+        if (shouldQueue) {
+            viewportRequestSerial += 1
+            viewportUpdateQueued = true
+            if (manualRefresh) {
+                viewportRefreshNonce += 1
+            }
+        } else {
+            if (viewportChanged) {
+                viewportRequestSerial += 1
+                loading = false
+                backgroundUpdating = false
+            }
+            viewportUpdateQueued = false
+        }
     }
 
     fun requestCurrentLocationAndRefresh(
@@ -262,6 +337,7 @@ fun GatheringAreasScreen(
                     mapResetNonce += 1
                     selectedAreaId = null
                     lastFetchedViewportKey = null
+                    providerFailedViewportKey = null
                     infoMessage = ""
                     loading = false
                     backgroundUpdating = false
@@ -302,7 +378,7 @@ fun GatheringAreasScreen(
         }
     }
 
-    LaunchedEffect(pendingViewport, lastFetchedViewportKey, viewportRefreshNonce) {
+    LaunchedEffect(pendingViewport, lastFetchedViewportKey, viewportRefreshNonce, viewportRequestSerial) {
         val viewport = pendingViewport
         if (viewport == null || !isLeafletViewportDiscoverable(viewport)) {
             viewportUpdateQueued = false
@@ -314,14 +390,19 @@ fun GatheringAreasScreen(
             return@LaunchedEffect
         }
         val manualRefresh = viewportRefreshNonce > 0
-        if (!shouldFetchLeafletViewport(viewportKey, lastFetchedViewportKey, manualRefresh)) {
+        if (!shouldQueueGatheringAreasViewportFetch(
+                viewportKey = viewportKey,
+                lastFetchedViewportKey = lastFetchedViewportKey,
+                manualRefresh = manualRefresh,
+                providerFailedViewportKey = providerFailedViewportKey
+            )
+        ) {
             viewportUpdateQueued = false
             return@LaunchedEffect
         }
+        val requestSerial = viewportRequestSerial
         delay(450)
         viewportUpdateQueued = false
-        val requestSerial = viewportRequestSerial + 1
-        viewportRequestSerial = requestSerial
         val blockingLoading = !shouldShowPreviousGatheringAreasDuringViewportFetch(
             currentResult = nearbyResult,
             manualRefresh = manualRefresh
@@ -339,7 +420,10 @@ fun GatheringAreasScreen(
                 widestVisibleDimensionKm = viewport.widestVisibleDimensionKm
             )
             if (requestSerial == viewportRequestSerial) {
-                if (shouldMarkGatheringAreasViewportFetched(result)) {
+                if (isGatheringAreasProviderUnavailable(result)) {
+                    providerFailedViewportKey = viewportKey
+                } else if (shouldMarkGatheringAreasViewportFetched(result)) {
+                    providerFailedViewportKey = null
                     lastFetchedViewportKey = viewportKey
                 }
                 viewportRefreshNonce = 0
@@ -445,25 +529,12 @@ fun GatheringAreasScreen(
             if (infoMessage == ResourceZoomedOutMessage) {
                 infoMessage = ""
             }
-            val viewportKey = effectiveLeafletViewportKey(viewport)
-            viewportUpdateQueued = viewportKey != null &&
-                shouldFetchLeafletViewport(
-                    viewportKey = viewportKey,
-                    lastFetchedViewportKey = lastFetchedViewportKey,
-                    manualRefresh = false
-                )
-            pendingViewport = viewport
+            queueViewportFetch(viewport)
         } else {
-            viewportRequestSerial += 1
-            pendingViewport = null
-            viewportUpdateQueued = false
-            nearbyResult = null
-            selectedAreaId = null
-            lastFetchedViewportKey = null
-            errorMessage = ""
-            loading = false
-            backgroundUpdating = false
-            infoMessage = ""
+            queueViewportFetch(
+                viewport = null,
+                clearResultsWhenUnavailable = true
+            )
         }
     }
 
@@ -530,18 +601,11 @@ fun GatheringAreasScreen(
                     SecondaryButton(
                         text = "Refresh Visible Area",
                         onClick = {
-                            val viewport = currentViewport
-                            if (!isLeafletViewportDiscoverable(viewport)) {
-                                errorMessage = ""
-                                loading = false
-                                viewportUpdateQueued = false
-                                infoMessage = ""
-                                return@SecondaryButton
-                            }
                             errorMessage = ""
-                            pendingViewport = viewport
-                            viewportUpdateQueued = true
-                            viewportRefreshNonce += 1
+                            queueViewportFetch(
+                                viewport = currentViewport,
+                                manualRefresh = true
+                            )
                         },
                         enabled = mapActionsEnabled
                     )
@@ -586,9 +650,10 @@ fun GatheringAreasScreen(
                                 SecondaryButton(
                                     text = "Retry",
                                     onClick = {
-                                        pendingViewport = currentViewport
-                                        viewportUpdateQueued = true
-                                        viewportRefreshNonce += 1
+                                        queueViewportFetch(
+                                            viewport = currentViewport,
+                                            manualRefresh = true
+                                        )
                                     },
                                     enabled = mapActionsEnabled
                                 )
@@ -608,9 +673,10 @@ fun GatheringAreasScreen(
                                 SecondaryButton(
                                     text = "Retry",
                                     onClick = {
-                                        pendingViewport = currentViewport
-                                        viewportUpdateQueued = true
-                                        viewportRefreshNonce += 1
+                                        queueViewportFetch(
+                                            viewport = currentViewport,
+                                            manualRefresh = true
+                                        )
                                     },
                                     enabled = mapActionsEnabled
                                 )
@@ -754,9 +820,10 @@ fun GatheringAreasScreen(
                             SecondaryButton(
                                 text = "Retry",
                                 onClick = {
-                                    pendingViewport = currentViewport
-                                    viewportUpdateQueued = true
-                                    viewportRefreshNonce += 1
+                                    queueViewportFetch(
+                                        viewport = currentViewport,
+                                        manualRefresh = true
+                                    )
                                 },
                                 enabled = mapActionsEnabled
                             )

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -57,6 +57,7 @@ import com.neph.ui.location.rememberForegroundLocationPermissionRequester
 import com.neph.ui.map.LeafletMapInitializationTimeoutMessage
 import com.neph.ui.map.LeafletMapInitializationTimeoutMillis
 import com.neph.ui.map.LeafletMapMarker
+import com.neph.ui.map.LeafletMapStatusOverlay
 import com.neph.ui.map.LeafletMapViewport
 import com.neph.ui.map.LeafletMarkerMap
 import com.neph.ui.map.MapLocationControl
@@ -67,6 +68,7 @@ import com.neph.ui.map.isLeafletTileLoadedSignal
 import com.neph.ui.map.isLeafletViewportDiscoverable
 import com.neph.ui.map.leafletViewportBboxString
 import com.neph.ui.map.leafletMapErrorForInstance
+import com.neph.ui.map.leafletMapStatusOverlayMessage
 import com.neph.ui.map.logMapDebug
 import com.neph.ui.map.newLeafletMapInstanceId
 import com.neph.ui.map.shouldApplyLeafletMapError
@@ -244,6 +246,7 @@ fun HelpRequestMapScreen(
     var selectedTypes by remember { mutableStateOf(setOf<CrisisRequestType>()) }
     var currentViewport by remember { mutableStateOf<LeafletMapViewport?>(null) }
     var pendingViewport by remember { mutableStateOf<LeafletMapViewport?>(null) }
+    var viewportUpdateQueued by remember { mutableStateOf(false) }
     var lastFetchedViewportKey by remember { mutableStateOf<String?>(null) }
     var viewportRefreshNonce by remember { mutableStateOf(0) }
     var viewportRequestSerial by remember { mutableStateOf(0) }
@@ -306,11 +309,13 @@ fun HelpRequestMapScreen(
             errorMessage = ""
             loading = false
             backgroundUpdating = false
+            viewportUpdateQueued = false
             infoMessage = ""
             return
         }
         errorMessage = ""
         pendingViewport = viewport
+        viewportUpdateQueued = true
         viewportRefreshNonce += 1
     }
 
@@ -321,6 +326,7 @@ fun HelpRequestMapScreen(
         scope.launch {
             loading = true
             backgroundUpdating = false
+            viewportUpdateQueued = false
             errorMessage = ""
             if (!silent) {
                 infoMessage = ""
@@ -338,6 +344,7 @@ fun HelpRequestMapScreen(
                     viewportRequestSerial += 1
                     currentViewport = null
                     pendingViewport = null
+                    viewportUpdateQueued = false
                     requests = emptyList()
                     mapCenterLatitude = location.latitude
                     mapCenterLongitude = location.longitude
@@ -449,14 +456,23 @@ fun HelpRequestMapScreen(
     }
 
     LaunchedEffect(pendingViewport, lastFetchedViewportKey, viewportRefreshNonce) {
-        val viewport = pendingViewport ?: return@LaunchedEffect
-        if (!isLeafletViewportDiscoverable(viewport)) return@LaunchedEffect
-        val viewportKey = effectiveLeafletViewportKey(viewport) ?: return@LaunchedEffect
+        val viewport = pendingViewport
+        if (viewport == null || !isLeafletViewportDiscoverable(viewport)) {
+            viewportUpdateQueued = false
+            return@LaunchedEffect
+        }
+        val viewportKey = effectiveLeafletViewportKey(viewport)
+        if (viewportKey == null) {
+            viewportUpdateQueued = false
+            return@LaunchedEffect
+        }
         val manualRefresh = viewportRefreshNonce > 0
         if (!shouldFetchLeafletViewport(viewportKey, lastFetchedViewportKey, manualRefresh)) {
+            viewportUpdateQueued = false
             return@LaunchedEffect
         }
         delay(450)
+        viewportUpdateQueued = false
         val requestSerial = viewportRequestSerial + 1
         viewportRequestSerial = requestSerial
         val blockingLoading = !shouldShowPreviousHelpRequestsDuringViewportFetch(
@@ -495,6 +511,7 @@ fun HelpRequestMapScreen(
             }
         } finally {
             if (requestSerial == viewportRequestSerial) {
+                viewportUpdateQueued = false
                 loading = false
                 backgroundUpdating = false
             }
@@ -513,6 +530,7 @@ fun HelpRequestMapScreen(
             errorMessage = ""
             loading = false
             backgroundUpdating = false
+            viewportUpdateQueued = false
             if (isInitialRequest) {
                 infoMessage = InitialPermissionDeniedFallbackMessage
                 queueInitialFallbackFetch(InitialPermissionDeniedFallbackMessage)
@@ -556,10 +574,18 @@ fun HelpRequestMapScreen(
             if (infoMessage == ResourceZoomedOutMessage) {
                 infoMessage = ""
             }
+            val viewportKey = effectiveLeafletViewportKey(viewport)
+            viewportUpdateQueued = viewportKey != null &&
+                shouldFetchLeafletViewport(
+                    viewportKey = viewportKey,
+                    lastFetchedViewportKey = lastFetchedViewportKey,
+                    manualRefresh = false
+                )
             pendingViewport = viewport
         } else {
             viewportRequestSerial += 1
             pendingViewport = null
+            viewportUpdateQueued = false
             requests = emptyList()
             selectedRequestId = null
             lastFetchedViewportKey = null
@@ -572,7 +598,7 @@ fun HelpRequestMapScreen(
 
     val selectedRequest = visibleRequests.firstOrNull { it.requestId == selectedRequestId }
     val isFilterEmpty = !loading && requests.isNotEmpty() && visibleRequests.isEmpty()
-    val mapActionsEnabled = !loading && !backgroundUpdating
+    val mapActionsEnabled = !loading && !backgroundUpdating && !viewportUpdateQueued
     val mapEmptyMarkersMessage = helpRequestMapEmptyMessage(
         blockingLoading = loading,
         errorMessage = errorMessage,
@@ -627,7 +653,7 @@ fun HelpRequestMapScreen(
                     selectedRequestId = selectedRequest?.requestId,
                     emptyMarkersMessage = mapEmptyMarkersMessage,
                     loadingResources = loading,
-                    updatingResources = backgroundUpdating,
+                    updatingResources = backgroundUpdating || viewportUpdateQueued,
                     mapCenterLatitude = mapCenterLatitude,
                     mapCenterLongitude = mapCenterLongitude,
                     currentLocationLatitude = currentLocation?.latitude,
@@ -1041,6 +1067,12 @@ private fun CrisisRequestMapPanel(
         errorInstanceId = errorInstanceIdState.value,
         errorMessage = mapError
     )
+    val mapOverlayMessage = leafletMapStatusOverlayMessage(
+        mapInitialized = activeMapInitialized,
+        mapError = activeMapError,
+        loadingResources = loadingResources,
+        updatingResources = updatingResources
+    )
     val selectedRequest = requests.firstOrNull { it.requestId == selectedRequestId }
     val markers = helpRequestLeafletMarkers(requests)
 
@@ -1147,6 +1179,12 @@ private fun CrisisRequestMapPanel(
                         .padding(spacing.sm)
                 )
             }
+            LeafletMapStatusOverlay(
+                message = mapOverlayMessage,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(spacing.sm)
+            )
         }
 
         if (!activeMapInitialized && activeMapError.isBlank()) {

--- a/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
+++ b/android/app/src/main/java/com/neph/features/helprequestmap/presentation/HelpRequestMapScreen.kt
@@ -301,9 +301,13 @@ fun HelpRequestMapScreen(
         initialFallbackFetchRequested = true
     }
 
-    fun queueViewportRefresh() {
-        val viewport = currentViewport
+    fun queueViewportFetch(
+        viewport: LeafletMapViewport?,
+        manualRefresh: Boolean = false
+    ) {
         if (!isLeafletViewportDiscoverable(viewport)) {
+            viewportRequestSerial += 1
+            pendingViewport = null
             requests = emptyList()
             selectedRequestId = null
             errorMessage = ""
@@ -313,10 +317,48 @@ fun HelpRequestMapScreen(
             infoMessage = ""
             return
         }
+
+        val viewportKey = effectiveLeafletViewportKey(viewport)
+        if (viewportKey == null) {
+            viewportRequestSerial += 1
+            pendingViewport = null
+            viewportUpdateQueued = false
+            loading = false
+            backgroundUpdating = false
+            return
+        }
+
+        val previousPendingViewportKey = effectiveLeafletViewportKey(pendingViewport)
+        val viewportChanged = viewportKey != previousPendingViewportKey
+        val shouldQueue = shouldFetchLeafletViewport(
+            viewportKey = viewportKey,
+            lastFetchedViewportKey = lastFetchedViewportKey,
+            manualRefresh = manualRefresh
+        )
+
         errorMessage = ""
         pendingViewport = viewport
-        viewportUpdateQueued = true
-        viewportRefreshNonce += 1
+        if (shouldQueue) {
+            viewportRequestSerial += 1
+            viewportUpdateQueued = true
+            if (manualRefresh) {
+                viewportRefreshNonce += 1
+            }
+        } else {
+            if (viewportChanged) {
+                viewportRequestSerial += 1
+                loading = false
+                backgroundUpdating = false
+            }
+            viewportUpdateQueued = false
+        }
+    }
+
+    fun queueViewportRefresh() {
+        queueViewportFetch(
+            viewport = currentViewport,
+            manualRefresh = true
+        )
     }
 
     fun requestCurrentLocationAndRefresh(
@@ -455,7 +497,7 @@ fun HelpRequestMapScreen(
         }
     }
 
-    LaunchedEffect(pendingViewport, lastFetchedViewportKey, viewportRefreshNonce) {
+    LaunchedEffect(pendingViewport, lastFetchedViewportKey, viewportRefreshNonce, viewportRequestSerial) {
         val viewport = pendingViewport
         if (viewport == null || !isLeafletViewportDiscoverable(viewport)) {
             viewportUpdateQueued = false
@@ -471,10 +513,9 @@ fun HelpRequestMapScreen(
             viewportUpdateQueued = false
             return@LaunchedEffect
         }
+        val requestSerial = viewportRequestSerial
         delay(450)
         viewportUpdateQueued = false
-        val requestSerial = viewportRequestSerial + 1
-        viewportRequestSerial = requestSerial
         val blockingLoading = !shouldShowPreviousHelpRequestsDuringViewportFetch(
             requests = requests,
             manualRefresh = manualRefresh
@@ -574,25 +615,10 @@ fun HelpRequestMapScreen(
             if (infoMessage == ResourceZoomedOutMessage) {
                 infoMessage = ""
             }
-            val viewportKey = effectiveLeafletViewportKey(viewport)
-            viewportUpdateQueued = viewportKey != null &&
-                shouldFetchLeafletViewport(
-                    viewportKey = viewportKey,
-                    lastFetchedViewportKey = lastFetchedViewportKey,
-                    manualRefresh = false
-                )
-            pendingViewport = viewport
+            queueViewportFetch(viewport)
         } else {
-            viewportRequestSerial += 1
-            pendingViewport = null
-            viewportUpdateQueued = false
-            requests = emptyList()
-            selectedRequestId = null
             lastFetchedViewportKey = null
-            errorMessage = ""
-            loading = false
-            backgroundUpdating = false
-            infoMessage = ""
+            queueViewportFetch(viewport = null)
         }
     }
 

--- a/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
+++ b/android/app/src/main/java/com/neph/ui/map/LeafletMapWebView.kt
@@ -15,14 +15,22 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.neph.BuildConfig
 import org.json.JSONArray
@@ -214,6 +222,44 @@ fun leafletViewportBboxString(viewport: LeafletMapViewport): String {
         viewport.east,
         viewport.north
     )
+}
+
+internal fun leafletMapStatusOverlayMessage(
+    mapInitialized: Boolean,
+    mapError: String,
+    loadingResources: Boolean,
+    updatingResources: Boolean
+): String? {
+    return when {
+        !mapInitialized && mapError.isBlank() -> "Loading map..."
+        loadingResources -> "Loading resources in this area..."
+        updatingResources -> "Updating visible area..."
+        else -> null
+    }
+}
+
+@Composable
+internal fun LeafletMapStatusOverlay(
+    message: String?,
+    modifier: Modifier = Modifier
+) {
+    if (message.isNullOrBlank()) return
+
+    Box(
+        modifier = modifier
+            .background(
+                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f),
+                shape = RoundedCornerShape(10.dp)
+            )
+            .padding(horizontal = 10.dp, vertical = 7.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
 }
 
 @SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")

--- a/android/app/src/test/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreenTest.kt
+++ b/android/app/src/test/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreenTest.kt
@@ -110,6 +110,7 @@ class GatheringAreasScreenTest {
         )
 
         assertTrue(isGatheringAreasProviderUnavailable(fallback))
+        assertFalse(shouldMarkGatheringAreasViewportFetched(fallback))
         assertEquals(
             "Provider did not return markers for this area.",
             gatheringAreasMapEmptyMessage(
@@ -130,6 +131,7 @@ class GatheringAreasScreenTest {
             "Showing cached gathering areas; provider data may be temporarily unavailable.",
             gatheringAreasResultHelperMessage(stale)
         )
+        assertTrue(shouldMarkGatheringAreasViewportFetched(stale))
     }
 
     @Test

--- a/android/app/src/test/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreenTest.kt
+++ b/android/app/src/test/java/com/neph/features/gatheringareas/presentation/GatheringAreasScreenTest.kt
@@ -124,6 +124,36 @@ class GatheringAreasScreenTest {
     }
 
     @Test
+    fun shouldQueueGatheringAreasViewportFetch_blocksAutomaticRetryForProviderFailedViewport() {
+        val viewportKey = "29.0000,40.9000,29.1000,41.1000,z12"
+
+        assertFalse(
+            shouldQueueGatheringAreasViewportFetch(
+                viewportKey = viewportKey,
+                lastFetchedViewportKey = null,
+                manualRefresh = false,
+                providerFailedViewportKey = viewportKey
+            )
+        )
+        assertTrue(
+            shouldQueueGatheringAreasViewportFetch(
+                viewportKey = viewportKey,
+                lastFetchedViewportKey = null,
+                manualRefresh = true,
+                providerFailedViewportKey = viewportKey
+            )
+        )
+        assertTrue(
+            shouldQueueGatheringAreasViewportFetch(
+                viewportKey = "29.2000,40.9000,29.3000,41.1000,z12",
+                lastFetchedViewportKey = null,
+                manualRefresh = false,
+                providerFailedViewportKey = viewportKey
+            )
+        )
+    }
+
+    @Test
     fun gatheringAreasResultHelperMessage_distinguishesStaleCache() {
         val stale = sampleNearbyResult().copy(source = "stale_cache", stale = true)
 

--- a/android/app/src/test/java/com/neph/ui/map/LeafletMapWebViewTest.kt
+++ b/android/app/src/test/java/com/neph/ui/map/LeafletMapWebViewTest.kt
@@ -2,6 +2,7 @@ package com.neph.ui.map
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -177,6 +178,57 @@ class LeafletMapWebViewTest {
                 viewportKey = "29.0010,40.9000,29.1010,41.1000,z12",
                 lastFetchedViewportKey = "29.0004,40.9000,29.1004,41.1000,z12",
                 manualRefresh = false
+            )
+        )
+    }
+
+    @Test
+    fun leafletMapStatusOverlayMessage_prefersMapInitializationBeforeResourceStates() {
+        assertEquals(
+            "Loading map...",
+            leafletMapStatusOverlayMessage(
+                mapInitialized = false,
+                mapError = "",
+                loadingResources = true,
+                updatingResources = true
+            )
+        )
+        assertNull(
+            leafletMapStatusOverlayMessage(
+                mapInitialized = false,
+                mapError = LeafletMapInitializationTimeoutMessage,
+                loadingResources = false,
+                updatingResources = false
+            )
+        )
+    }
+
+    @Test
+    fun leafletMapStatusOverlayMessage_distinguishesLoadingAndUpdatingResources() {
+        assertEquals(
+            "Loading resources in this area...",
+            leafletMapStatusOverlayMessage(
+                mapInitialized = true,
+                mapError = "",
+                loadingResources = true,
+                updatingResources = true
+            )
+        )
+        assertEquals(
+            "Updating visible area...",
+            leafletMapStatusOverlayMessage(
+                mapInitialized = true,
+                mapError = "",
+                loadingResources = false,
+                updatingResources = true
+            )
+        )
+        assertNull(
+            leafletMapStatusOverlayMessage(
+                mapInitialized = true,
+                mapError = "",
+                loadingResources = false,
+                updatingResources = false
             )
         )
     }


### PR DESCRIPTION
## Summary

Improves Android resource map loading and update feedback for Help Request Map and Gathering Areas Map.

This PR makes map/resource loading states visible directly on top of the map and improves Gathering Areas viewport refresh reliability, especially when provider-backed results are slow, unavailable, or temporarily empty.

## Changes

- Adds visible on-map loading/updating feedback for Android resource maps.
- Shows clear map state messages:
  - `Loading map...`
  - `Loading resources in this area...`
  - `Updating visible area...`
- Shows update feedback immediately when a viewport refresh is queued after pan/zoom.
- Keeps loading/update messages from being hidden below the map while the user is interacting.
- Preserves current-location marker/startup behavior introduced by PR #620.
- Preserves Help Request Map camera stability after manual pan/zoom.
- Makes Gathering Areas provider fallback-empty results retry-friendly.
- Aligns Android Gathering Areas timeout with the slower Overpass-backed backend flow.
- Keeps existing marker rendering, filters, refresh actions, current-location actions, and mobile onboarding behavior intact.


## Verification

Recommended manual checks:

### Help Request Map

- Open Android Help Request Map.
- Pan/zoom the map.
- Verify `Updating visible area...` appears on top of the map.
- Verify refresh/current-location controls disable during update and re-enable afterward.
- Verify the map does not auto-recenter after manual pan/zoom.
- Verify current-location marker still works.

### Gathering Areas

- Open Android Gathering Areas.
- Pan/zoom into a discoverable area.
- Verify `Loading resources in this area...` or `Updating visible area...` appears on top of the map.
- Verify markers appear after loading.
- If the provider fails, verify provider unavailable/retry UI appears.
- Verify retry can attempt the same viewport again.
- Verify empty marker messages are not shown while loading/updating is in progress.

Closes #621 