### PR TITLE
docs: add final demo admin seed and release notes for submission read…

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,20 +229,23 @@ The signed release APK must be attached to the GitHub Release manually or by the
 Final demo data is stored in the normal backend migration flow:
 
 - `backend/migrations/20260512_120000__seed_bogazici_final_demo_data.sql`
+- `backend/migrations/20260512_130000__seed_bogazici_final_demo_admin.sql`
 
 It is applied by the normal backend migration runner. In Docker Compose, backend migrations run automatically on startup, so no separate `ENABLE_DEMO_SEED=true npm run seed:demo` command is needed for the Boğaziçi final demo data after migrations run. The old `backend/demo-migrations/` flow is optional legacy demo data only.
 
-Boğaziçi final demo accounts:
+Boğaziçi final demo accounts are applied by the normal migration flow. All listed users use password `DemoPass123!`:
 
-| Email | Password |
-| --- | --- |
-| `bogazici_reserve_1@neph.test` | `DemoPass123!` |
-| `bogazici_reserve_2@neph.test` | `DemoPass123!` |
-| `bogazici_reserve_3@neph.test` | `DemoPass123!` |
-| `bogazici_reserve_4@neph.test` | `DemoPass123!` |
-| `bogazici_assigned_1@neph.test` | `DemoPass123!` |
-| `bogazici_assigned_2@neph.test` | `DemoPass123!` |
-| `bogazici_requester_new_hall@neph.test` | `DemoPass123!` |
+| Role | Email | Password | Notes |
+| --- | --- | --- | --- |
+| Admin | `bogazici_admin@neph.test` | `DemoPass123!` | `SUPER_ADMIN` account for web/admin checks |
+| Requester | `bogazici_requester_new_hall@neph.test` | `DemoPass123!` | Active emergency request near New Hall |
+| Requester | `bogazici_requester_hisarustu@neph.test` | `DemoPass123!` | Hisarüstü request scenario |
+| Volunteer/responder | `bogazici_assigned_1@neph.test` | `DemoPass123!` | Assigned first-aid responder |
+| Volunteer/responder | `bogazici_assigned_2@neph.test` | `DemoPass123!` | Assigned logistics responder |
+| Reserve volunteer | `bogazici_reserve_1@neph.test` | `DemoPass123!` | Available first-aid volunteer |
+| Reserve volunteer | `bogazici_reserve_2@neph.test` | `DemoPass123!` | Available search-and-rescue volunteer |
+| Reserve volunteer | `bogazici_reserve_3@neph.test` | `DemoPass123!` | Available food/water volunteer |
+| Reserve volunteer | `bogazici_reserve_4@neph.test` | `DemoPass123!` | Available shelter/communications volunteer |
 
 ### Optional legacy demo data seed
 
@@ -330,7 +333,7 @@ The deployed backend API base is `https://api.neph.app/api`. The deployed web UR
 - Tag `final-milestone` points to the final `main` commit.
 - GitHub Release name is `1.0.0`.
 - GitHub Release is official, not a pre-release.
-- Release notes include the deployed web URL.
+- Release notes include the deployed web URL. A ready-to-copy draft is available at `docs/releases/final-milestone-release-notes.md`.
 - Signed APK is attached to the GitHub Release.
 
 ## Development notes

--- a/backend/migrations/20260512_130000__seed_bogazici_final_demo_admin.sql
+++ b/backend/migrations/20260512_130000__seed_bogazici_final_demo_admin.sql
@@ -1,0 +1,179 @@
+BEGIN;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM users
+    WHERE user_id = 'demo_bogazici_admin_ops'
+      AND email <> 'bogazici_admin@neph.test'
+  ) THEN
+    RAISE EXCEPTION 'Refusing to apply Bogazici demo admin seed: demo_bogazici_admin_ops exists with a non-demo email';
+  END IF;
+END $$;
+
+INSERT INTO users (
+  user_id,
+  email,
+  password_hash,
+  is_email_verified,
+  accepted_terms,
+  is_deleted,
+  is_banned
+)
+VALUES (
+  'demo_bogazici_admin_ops',
+  'bogazici_admin@neph.test',
+  '$2b$10$jVf8XVq2zkXAelSygXMVdO7IhqK1jjL4a4KtJw8iyttPBZLVi7USG',
+  TRUE,
+  TRUE,
+  FALSE,
+  FALSE
+)
+ON CONFLICT (user_id) DO UPDATE SET
+  email = EXCLUDED.email,
+  password_hash = EXCLUDED.password_hash,
+  is_email_verified = TRUE,
+  accepted_terms = TRUE,
+  is_deleted = FALSE,
+  is_banned = FALSE,
+  ban_reason = NULL,
+  banned_at = NULL;
+
+INSERT INTO admins (
+  admin_id,
+  user_id,
+  role
+)
+VALUES (
+  'demo_bogazici_admin_ops',
+  'demo_bogazici_admin_ops',
+  'SUPER_ADMIN'
+)
+ON CONFLICT (admin_id) DO UPDATE SET
+  user_id = EXCLUDED.user_id,
+  role = EXCLUDED.role;
+
+INSERT INTO user_profiles (
+  profile_id,
+  user_id,
+  first_name,
+  last_name,
+  phone_number
+)
+VALUES (
+  'demo_bogazici_profile_admin_ops',
+  'demo_bogazici_admin_ops',
+  'Deniz',
+  'Yilmaz',
+  '5328101000'
+)
+ON CONFLICT (profile_id) DO UPDATE SET
+  user_id = EXCLUDED.user_id,
+  first_name = EXCLUDED.first_name,
+  last_name = EXCLUDED.last_name,
+  phone_number = EXCLUDED.phone_number;
+
+INSERT INTO physical_info (
+  physical_id,
+  profile_id,
+  age,
+  date_of_birth,
+  gender,
+  height,
+  weight
+)
+VALUES (
+  'demo_bogazici_physical_admin_ops',
+  'demo_bogazici_profile_admin_ops',
+  36,
+  DATE '1990-02-17',
+  'non_binary',
+  172,
+  70
+)
+ON CONFLICT (physical_id) DO UPDATE SET
+  profile_id = EXCLUDED.profile_id,
+  age = EXCLUDED.age,
+  date_of_birth = EXCLUDED.date_of_birth,
+  gender = EXCLUDED.gender,
+  height = EXCLUDED.height,
+  weight = EXCLUDED.weight;
+
+INSERT INTO health_info (
+  health_id,
+  profile_id,
+  medical_conditions,
+  chronic_diseases,
+  allergies,
+  medications,
+  blood_type
+)
+VALUES (
+  'demo_bogazici_health_admin_ops',
+  'demo_bogazici_profile_admin_ops',
+  ARRAY[]::TEXT[],
+  ARRAY[]::TEXT[],
+  ARRAY[]::TEXT[],
+  ARRAY[]::TEXT[],
+  '0Rh+'
+)
+ON CONFLICT (health_id) DO UPDATE SET
+  profile_id = EXCLUDED.profile_id,
+  medical_conditions = EXCLUDED.medical_conditions,
+  chronic_diseases = EXCLUDED.chronic_diseases,
+  allergies = EXCLUDED.allergies,
+  medications = EXCLUDED.medications,
+  blood_type = EXCLUDED.blood_type;
+
+INSERT INTO location_profiles (
+  location_profile_id,
+  profile_id,
+  address,
+  city,
+  country,
+  latitude,
+  longitude
+)
+VALUES (
+  'demo_bogazici_location_profile_admin_ops',
+  'demo_bogazici_profile_admin_ops',
+  'Bogazici University Kandilli Campus Operations Desk',
+  'Istanbul',
+  'Turkey',
+  41.06270,
+  29.05940
+)
+ON CONFLICT (location_profile_id) DO UPDATE SET
+  profile_id = EXCLUDED.profile_id,
+  address = EXCLUDED.address,
+  city = EXCLUDED.city,
+  country = EXCLUDED.country,
+  latitude = EXCLUDED.latitude,
+  longitude = EXCLUDED.longitude,
+  last_updated = CURRENT_TIMESTAMP;
+
+INSERT INTO privacy_settings (
+  settings_id,
+  profile_id,
+  profile_visibility,
+  health_info_visibility,
+  location_visibility,
+  location_sharing_enabled
+)
+VALUES (
+  'demo_bogazici_privacy_admin_ops',
+  'demo_bogazici_profile_admin_ops',
+  'PUBLIC'::visibility_level,
+  'PRIVATE'::visibility_level,
+  'EMERGENCY_ONLY'::visibility_level,
+  TRUE
+)
+ON CONFLICT (settings_id) DO UPDATE SET
+  profile_id = EXCLUDED.profile_id,
+  profile_visibility = EXCLUDED.profile_visibility,
+  health_info_visibility = EXCLUDED.health_info_visibility,
+  location_visibility = EXCLUDED.location_visibility,
+  location_sharing_enabled = EXCLUDED.location_sharing_enabled;
+
+COMMIT;

--- a/docs/releases/final-milestone-release-notes.md
+++ b/docs/releases/final-milestone-release-notes.md
@@ -1,0 +1,44 @@
+# NEPH 1.0.0 Final Release Notes
+
+Live deployment:
+
+- Web application: https://neph.app/
+- Backend API: https://api.neph.app/api
+
+Release tag: `final-milestone`
+
+## Summary
+
+NEPH 1.0.0 is the final production release for the emergency help coordination platform. It includes the deployed web admin/dashboard experience, the Android mobile application for requesters and volunteers, production Docker setup, database migrations with final demo seed data, and release-ready setup documentation.
+
+## Highlights
+
+- Web application for administration, deployment monitoring, user management, emergency history, and assignment visibility.
+- Android mobile application for onboarding, profile completion, availability, emergency help request creation/editing, assigned requests, resource maps, gathering areas, emergency numbers, and settings.
+- Backend API with authentication, profile, help request, volunteer, assignment, notification, map/resource, and admin routes.
+- Docker Compose based local deployment with PostgreSQL, backend, and web services.
+- Normal migration flow seeds Boğaziçi final demo data so evaluators can log in immediately after setup.
+- Environment examples are included for backend, web, Docker Compose overrides, and Android mobile builds.
+
+## Default demo credentials
+
+All listed demo users use password: `DemoPass123!`
+
+- Admin: `bogazici_admin@neph.test`
+- Requester: `bogazici_requester_new_hall@neph.test`
+- Volunteer/responder: `bogazici_assigned_1@neph.test`
+- Additional demo users are documented in the root `README.md`.
+
+## Mobile artifact
+
+Attach the signed Android release APK generated from the Android release workflow or local Gradle release build to this GitHub Release before publishing it as the official, non-pre-release `1.0.0` release.
+
+## Verification checklist before publishing
+
+- The final commit is merged to the default `main` branch.
+- The tag `final-milestone` points to the final commit on `main`.
+- The GitHub Release name is `1.0.0`.
+- The release is marked as an official release, not as a pre-release.
+- The signed Android `.apk` is attached to the GitHub Release.
+- https://neph.app/ loads successfully.
+- https://api.neph.app/health returns a healthy response.


### PR DESCRIPTION

  ### Summary

  This PR prepares the repo-side final submission requirements by ensuring the normal migration flow includes a working demo admin account and by
  documenting final release credentials and notes.

Resolves #624 

  ### Changes

  - Added a normal backend migration that seeds:
      - bogazici_admin@neph.test
      - password: DemoPass123!
      - role: SUPER_ADMIN
  - Updated README.md with final demo credentials for admin, requester, and volunteer users.
  - Added docs/releases/final-milestone-release-notes.md as a ready-to-copy GitHub Release description for 1.0.0.

  ### Validation

  - Ran migrations against an isolated temporary Postgres database.
  - Verified the admin row is created with SUPER_ADMIN.
  - Verified real login through POST /api/auth/login returns 200 and an access token for bogazici_admin@neph.test.
  - Ran docker compose config --quiet.
  - Ran git diff --check.

  ### Notes

  External release steps are still required separately: merge to main, create/push final-milestone, create the official 1.0.0 GitHub Release, and
  attach the signed Android APK.